### PR TITLE
Perform a full rebuild of all sets

### DIFF
--- a/json/10E.json
+++ b/json/10E.json
@@ -1113,11 +1113,11 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Beacon of Immortality’s effect counts as life gain (or life loss, if the life total was negative) for effects that trigger on or replace life gain (or life loss)."
+          "text": "Beacon of Immortality's effect counts as life gain (or life loss, if the life total was negative) for effects that trigger on or replace life gain (or life loss)."
         },
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Double target player's life total. Shuffle Beacon of Immortality into its owner's library.",
@@ -1135,7 +1135,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"We called them ‘armored lightning.'\"\n—Gerrard of the Weatherlight",
+      "flavor": "\"We called them 'armored lightning.'\"\n—Gerrard of the Weatherlight",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -1443,7 +1443,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The affected creature’s last known existence on the battlefield is checked to determine its toughness."
+          "text": "The affected creature's last known existence on the battlefield is checked to determine its toughness."
         }
       ],
       "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
@@ -1973,7 +1973,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "You choose how the damage will be divided among the target creatures at the time you cast Hail of Arrows. Each target must be dealt at least 1 damage. If any of those creatures becomes an illegal target before Hail of Arrows resolves, the division of damage among the remaining creatures doesn’t change."
+          "text": "You choose how the damage will be divided among the target creatures at the time you cast Hail of Arrows. Each target must be dealt at least 1 damage. If any of those creatures becomes an illegal target before Hail of Arrows resolves, the division of damage among the remaining creatures doesn't change."
         }
       ],
       "text": "Hail of Arrows deals X damage divided as you choose among any number of target attacking creatures.",
@@ -2182,11 +2182,11 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "High Ground’s effect is cumulative. If you have a creature that can already block an additional creature, now it can block three creatures."
+          "text": "High Ground's effect is cumulative. If you have a creature that can already block an additional creature, now it can block three creatures."
         },
         {
           "date": "2007-07-15",
-          "text": "High Ground allows you to make some complicated blocks. For example, if you’re being attacked by three creatures (call them A, B, and C) and you control three creatures (X, Y, and Z), you can have X block A and B, Y block B and C, and Z block just C, among many other possible options. The defending player chooses how each blocking creature’s combat damage will be divided among the creatures it’s blocking."
+          "text": "High Ground allows you to make some complicated blocks. For example, if you're being attacked by three creatures (call them A, B, and C) and you control three creatures (X, Y, and Z), you can have X block A and B, Y block B and C, and Z block just C, among many other possible options. The defending player chooses how each blocking creature's combat damage will be divided among the creatures it's blocking."
         }
       ],
       "text": "Each creature you control can block an additional creature each combat.",
@@ -2723,7 +2723,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won’t be redirected. It will be dealt to you as normal."
+          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won't be redirected. It will be dealt to you as normal."
         }
       ],
       "subtypes": [
@@ -3245,11 +3245,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t choose which creature the Aura will enter the battlefield attached to until the ability resolves. You must choose a creature the Aura can legally enchant. (For example, you can’t choose a creature with protection from black if the targeted Aura card is black.) If you don’t control any creatures that the Aura can enchant, it remains in the graveyard."
+          "text": "You don't choose which creature the Aura will enter the battlefield attached to until the ability resolves. You must choose a creature the Aura can legally enchant. (For example, you can't choose a creature with protection from black if the targeted Aura card is black.) If you don't control any creatures that the Aura can enchant, it remains in the graveyard."
         },
         {
           "date": "2007-07-15",
-          "text": "Nomad Mythmaker’s ability can target an Aura card in any graveyard, not just yours."
+          "text": "Nomad Mythmaker's ability can target an Aura card in any graveyard, not just yours."
         }
       ],
       "subtypes": [
@@ -3609,7 +3609,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can attach this to an opponent’s creature, and all damage done to you is instead done to their creature."
+          "text": "You can attach this to an opponent's creature, and all damage done to you is instead done to their creature."
         },
         {
           "date": "2004-10-04",
@@ -3941,7 +3941,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -4837,7 +4837,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other’s ability to trigger."
+          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other's ability to trigger."
         },
         {
           "date": "2005-08-01",
@@ -6355,7 +6355,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Warrior’s Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won’t get the bonus."
+          "text": "Warrior's Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won't get the bonus."
         }
       ],
       "text": "Creatures you control get +1/+1 until end of turn.",
@@ -6578,7 +6578,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -6912,7 +6912,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "You can’t put an Aura card from your hand onto the battlefield this way if that Aura can’t legally enchant Academy Researchers. For example, you can’t put an Aura with “enchant land” or “enchant green creature” onto the battlefield attached to Academy Researchers (unless Academy Researchers somehow turned into a land or a green creature before the ability resolved)."
+          "text": "You can't put an Aura card from your hand onto the battlefield this way if that Aura can't legally enchant Academy Researchers. For example, you can't put an Aura with \"enchant land\" or \"enchant green creature\" onto the battlefield attached to Academy Researchers (unless Academy Researchers somehow turned into a land or a green creature before the ability resolved)."
         }
       ],
       "subtypes": [
@@ -7257,7 +7257,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Arcanis’s last ability can only be activated while it’s on the battlefield."
+          "text": "Arcanis's last ability can only be activated while it's on the battlefield."
         }
       ],
       "subtypes": [
@@ -7370,11 +7370,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If there is no legal place to move the enchantment, then it doesn’t move but you still control it."
+          "text": "If there is no legal place to move the enchantment, then it doesn't move but you still control it."
         },
         {
           "date": "2007-07-15",
-          "text": "Aura Graft’s effect has no duration. You’ll retain control of the Aura until the game ends, the Aura leaves the battlefield, or an effect causes someone else to gain control of the Aura."
+          "text": "Aura Graft's effect has no duration. You'll retain control of the Aura until the game ends, the Aura leaves the battlefield, or an effect causes someone else to gain control of the Aura."
         },
         {
           "date": "2007-07-15",
@@ -7774,6 +7774,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -7795,6 +7799,10 @@
         },
         {
           "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -8065,7 +8073,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -8073,11 +8081,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -8085,7 +8093,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -8512,7 +8520,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you increase the power of the targeted creature after the ability resolves, it still can’t be blocked that turn."
+          "text": "If you increase the power of the targeted creature after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -8844,7 +8852,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"I said ‘pick his brain,' not ‘tear off his head.'\"\n—Riptide Project researcher",
+      "flavor": "\"I said 'pick his brain,' not 'tear off his head.'\"\n—Riptide Project researcher",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -10000,7 +10008,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If an Equipment becomes a creature, it can no longer equip a creature. If it’s currently attached to a creature, it becomes unattached (but remains on the battlefield). You can activate the Equipment’s equip ability, but it won’t do anything."
+          "text": "If an Equipment becomes a creature, it can no longer equip a creature. If it's currently attached to a creature, it becomes unattached (but remains on the battlefield). You can activate the Equipment's equip ability, but it won't do anything."
         },
         {
           "date": "2004-12-01",
@@ -10008,11 +10016,11 @@
         },
         {
           "date": "2007-07-15",
-          "text": "If a noncreature artifact becomes an artifact creature this way and then another effect animates it, the new effect overrides March of the Machines’s effect. For example, Chimeric Staff is a 4/4 creature while March of the Machines is on the battlefield. If you activate Chimeric Staff’s ability and choose X = 5, Chimeric Staff will be a 5/5 artifact creature for the rest of the turn."
+          "text": "If a noncreature artifact becomes an artifact creature this way and then another effect animates it, the new effect overrides March of the Machines's effect. For example, Chimeric Staff is a 4/4 creature while March of the Machines is on the battlefield. If you activate Chimeric Staff's ability and choose X = 5, Chimeric Staff will be a 5/5 artifact creature for the rest of the turn."
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         }
       ],
       "text": "Each noncreature artifact is an artifact creature with power and toughness each equal to its converted mana cost. (Equipment that's a creature can't equip a creature.)",
@@ -10240,7 +10248,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -10252,11 +10260,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"islandwalk.\" This effect lasts indefinitely.)",
@@ -10681,11 +10689,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you target yourself, this spell has no useful effect. It will not cause an infinite loop since a replacement effect can’t modify the same event more than once. This effect will not modify the draw that it has you perform."
+          "text": "If you target yourself, this spell has no useful effect. It will not cause an infinite loop since a replacement effect can't modify the same event more than once. This effect will not modify the draw that it has you perform."
         },
         {
           "date": "2007-07-15",
-          "text": "You draw the card from your library as normal, not from your opponent’s library."
+          "text": "You draw the card from your library as normal, not from your opponent's library."
         },
         {
           "date": "2007-07-15",
@@ -10693,7 +10701,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "If you target a player whose library is empty, any effect or turn-based action that would cause that player to draw a card will cause you to draw a card instead. It doesn’t matter that the other player would be unable to draw."
+          "text": "If you target a player whose library is empty, any effect or turn-based action that would cause that player to draw a card will cause you to draw a card instead. It doesn't matter that the other player would be unable to draw."
         }
       ],
       "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
@@ -10915,7 +10923,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Target player shuffles his or her graveyard into his or her library.",
@@ -11026,7 +11034,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -11351,11 +11359,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A creature is “enchanted” if it has any Auras attached to it."
+          "text": "A creature is \"enchanted\" if it has any Auras attached to it."
         },
         {
           "date": "2007-07-15",
-          "text": "Unlike many similar creatures, Rootwater Matriarch untaps as normal during your untap step. Whether it’s tapped or untapped has no bearing on the control-change effect."
+          "text": "Unlike many similar creatures, Rootwater Matriarch untaps as normal during your untap step. Whether it's tapped or untapped has no bearing on the control-change effect."
         },
         {
           "date": "2009-02-01",
@@ -11577,7 +11585,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “repeat this process” means to repeat as often as it takes to not get a matching pair."
+          "text": "The \"repeat this process\" means to repeat as often as it takes to not get a matching pair."
         }
       ],
       "subtypes": [
@@ -11709,7 +11717,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"I leave words like ‘impossible' to the rabble. Whatever I imagine, I can create.\"\n—Ixidor, reality sculptor",
+      "flavor": "\"I leave words like 'impossible' to the rabble. Whatever I imagine, I can create.\"\n—Ixidor, reality sculptor",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -12226,7 +12234,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The spell’s controller gets the option to pay when this ability resolves."
+          "text": "The spell's controller gets the option to pay when this ability resolves."
         }
       ],
       "subtypes": [
@@ -12855,19 +12863,19 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Exiling a spell or ability prevents that spell or ability from resolving, but it doesn’t technically “counter” anything. This means that Time Stop can exile spells and abilities that “can’t be countered.”"
+          "text": "Exiling a spell or ability prevents that spell or ability from resolving, but it doesn't technically \"counter\" anything. This means that Time Stop can exile spells and abilities that \"can't be countered.\""
         },
         {
           "date": "2004-12-01",
-          "text": "Unless Time Stop is cast during the Ending phase, any “at the beginning of the end step”-triggered abilities don’t get the chance to trigger on the turn Time Stop is cast. These abilities will trigger at the beginning of the next end step."
+          "text": "Unless Time Stop is cast during the Ending phase, any \"at the beginning of the end step\"-triggered abilities don't get the chance to trigger on the turn Time Stop is cast. These abilities will trigger at the beginning of the next end step."
         },
         {
           "date": "2007-07-15",
-          "text": "Ending the turn this way means the following things happen in order: 1) All spells and abilities on the stack are exiled. This includes Time Stop, though it will continue to resolve. It also includes spells and abilities that can’t be countered. 2) All attacking and blocking creatures are removed from combat. 3) State-based actions are checked. No player gets priority, and no triggered abilities are put onto the stack. 4) The current phase and/or step ends. The game skips straight to the cleanup step. The cleanup step happens in its entirety."
+          "text": "Ending the turn this way means the following things happen in order: 1) All spells and abilities on the stack are exiled. This includes Time Stop, though it will continue to resolve. It also includes spells and abilities that can't be countered. 2) All attacking and blocking creatures are removed from combat. 3) State-based actions are checked. No player gets priority, and no triggered abilities are put onto the stack. 4) The current phase and/or step ends. The game skips straight to the cleanup step. The cleanup step happens in its entirety."
         },
         {
           "date": "2007-07-15",
-          "text": "If any triggered abilities do trigger during this process, they’re put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn finally ends."
+          "text": "If any triggered abilities do trigger during this process, they're put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn finally ends."
         }
       ],
       "text": "End the turn. (Exile all spells and abilities on the stack, including this card. The player whose turn it is discards down to his or her maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
@@ -12973,7 +12981,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Target player takes two extra turns after this one.",
@@ -13190,27 +13198,27 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs paid for the targeted spell are copied as though those same costs were paid for the copy too."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs paid for the targeted spell are copied as though those same costs were paid for the copy too."
         },
         {
           "date": "2005-06-01",
-          "text": "Twincast copies any text spliced onto the targeted spell, but you can’t splice additional text onto the copy."
+          "text": "Twincast copies any text spliced onto the targeted spell, but you can't splice additional text onto the copy."
         },
         {
           "date": "2009-10-01",
-          "text": "Twincast can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Twincast can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2009-10-01",
-          "text": "As Twincast resolves, it creates a copy of a spell. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "As Twincast resolves, it creates a copy of a spell. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2009-10-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell Twincast copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Twincast copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2009-10-01",
@@ -13218,7 +13226,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
@@ -13330,7 +13338,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If the targeted permanent is an illegal target by the time Twitch resolves, the entire spell is countered. You don’t draw a card."
+          "text": "If the targeted permanent is an illegal target by the time Twitch resolves, the entire spell is countered. You don't draw a card."
         }
       ],
       "text": "You may tap or untap target artifact, creature, or land.\nDraw a card.",
@@ -13400,6 +13408,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -14202,7 +14214,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Put target artifact or creature card from a graveyard onto the battlefield under your control. Shuffle Beacon of Unrest into its owner's library.",
@@ -14437,7 +14449,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
@@ -15515,7 +15527,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If the target creature or player is an illegal target when Essence Drain tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "If the target creature or player is an illegal target when Essence Drain tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "text": "Essence Drain deals 3 damage to target creature or player and you gain 3 life.",
@@ -16027,6 +16039,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -16040,6 +16056,10 @@
         },
         {
           "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -16085,7 +16105,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -16404,7 +16424,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -16633,7 +16653,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers even if the Specter’s damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
+          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
         }
       ],
       "subtypes": [
@@ -17632,11 +17652,11 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If you don’t have twenty or more creature cards in your graveyard by the time your upkeep starts, the ability won’t trigger that turn."
+          "text": "If you don't have twenty or more creature cards in your graveyard by the time your upkeep starts, the ability won't trigger that turn."
         },
         {
           "date": "2007-07-15",
-          "text": "Mortal Combat’s ability has an “intervening ‘if’ clause,” so the condition is checked again when the triggered ability resolves. If you don’t still have twenty creature cards in your graveyard, the ability does nothing."
+          "text": "Mortal Combat's ability has an \"intervening 'if' clause,\" so the condition is checked again when the triggered ability resolves. If you don't still have twenty creature cards in your graveyard, the ability does nothing."
         }
       ],
       "text": "At the beginning of your upkeep, if twenty or more creature cards are in your graveyard, you win the game.",
@@ -17972,7 +17992,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it’s a creature you control."
+          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it's a creature you control."
         }
       ],
       "subtypes": [
@@ -18101,19 +18121,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -18224,7 +18244,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "It doesn’t matter who controlled the creature cards when they were on the battlefield. As long as they were put into your graveyard, you get to put them into your hand."
+          "text": "It doesn't matter who controlled the creature cards when they were on the battlefield. As long as they were put into your graveyard, you get to put them into your hand."
         },
         {
           "date": "2007-07-15",
@@ -18335,7 +18355,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “cast from your hand” if you cast it as a spell from your hand. Putting it onto the battlefield from your hand using a spell or ability will cause you to lose the game."
+          "text": "It is only considered \"cast from your hand\" if you cast it as a spell from your hand. Putting it onto the battlefield from your hand using a spell or ability will cause you to lose the game."
         },
         {
           "date": "2013-07-01",
@@ -19106,11 +19126,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Yes, you’re allowed to have a deck consisting of sixty Relentless Rats and nothing else."
+          "text": "Yes, you're allowed to have a deck consisting of sixty Relentless Rats and nothing else."
         },
         {
           "date": "2004-12-01",
-          "text": "Relentless Rats’s last ability overrides the normal limit of four of an individual card in a Constructed deck."
+          "text": "Relentless Rats's last ability overrides the normal limit of four of an individual card in a Constructed deck."
         }
       ],
       "subtypes": [
@@ -19229,11 +19249,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -19481,15 +19501,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -19706,7 +19726,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card is a bit weird. When it enters the battlefield under your control, you give control of it to an opponent. After that it damages them each turn because the “you” on the card means its controller."
+          "text": "This card is a bit weird. When it enters the battlefield under your control, you give control of it to an opponent. After that it damages them each turn because the \"you\" on the card means its controller."
         }
       ],
       "subtypes": [
@@ -20892,7 +20912,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Beacon of Destruction deals 5 damage to target creature or player. Shuffle Beacon of Destruction into its owner's library.",
@@ -21120,7 +21140,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"There are only fifty words in the cyclops language, and ten of them mean ‘kill.'\"\n—Ertai",
+      "flavor": "\"There are only fifty words in the cyclops language, and ten of them mean 'kill.'\"\n—Ertai",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -21210,7 +21230,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "There is no penalty if it can’t attack."
+          "text": "There is no penalty if it can't attack."
         }
       ],
       "subtypes": [
@@ -21442,11 +21462,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of the three targets must be different. If there aren’t three different legal targets available, you can’t cast the spell."
+          "text": "Each of the three targets must be different. If there aren't three different legal targets available, you can't cast the spell."
         },
         {
           "date": "2014-07-18",
-          "text": "If one or two of Cone of Flame’s targets are illegal when it resolves, you can’t change how much damage will be dealt to the remaining legal targets."
+          "text": "If one or two of Cone of Flame's targets are illegal when it resolves, you can't change how much damage will be dealt to the remaining legal targets."
         }
       ],
       "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
@@ -22105,7 +22125,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -22533,7 +22553,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can’t normally end up with an odd amount of damage on something."
+          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can't normally end up with an odd amount of damage on something."
         },
         {
           "date": "2004-10-04",
@@ -22549,7 +22569,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn.” Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn.\" Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         }
       ],
       "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
@@ -23445,7 +23465,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Yes, I think ‘toast' is an appropriate description.\"\n—Jaya Ballard, task mage",
+      "flavor": "\"Yes, I think 'toast' is an appropriate description.\"\n—Jaya Ballard, task mage",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -23548,7 +23568,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Regeneration abilities that would affect that creature can still be activated; they just won’t do anything. The creature can’t be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
+          "text": "Regeneration abilities that would affect that creature can still be activated; they just won't do anything. The creature can't be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
         }
       ],
       "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
@@ -24129,7 +24149,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -24248,7 +24268,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it’s too late to activate its ability before it’s destroyed."
+          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it's too late to activate its ability before it's destroyed."
         }
       ],
       "subtypes": [
@@ -24938,7 +24958,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -25362,7 +25382,8 @@
         "3ED",
         "5ED",
         "6ED",
-        "10E"
+        "10E",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Destroy all artifacts. They can't be regenerated.",
@@ -25836,7 +25857,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -25856,11 +25877,11 @@
         },
         {
           "date": "2007-07-15",
-          "text": "If a spell targets multiple things, you can’t target it with Shunt, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Shunt, even if all but one of those targets has become illegal."
         },
         {
           "date": "2007-07-15",
-          "text": "If a spell targets the same player or object multiple times, you can’t target it with Shunt."
+          "text": "If a spell targets the same player or object multiple times, you can't target it with Shunt."
         }
       ],
       "text": "Change the target of target spell with a single target.",
@@ -25970,11 +25991,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander’s activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
+          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander's activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
         },
         {
           "date": "2016-06-08",
-          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -26504,7 +26525,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Squee’s ability triggers only if it’s in your graveyard as your upkeep begins."
+          "text": "Squee's ability triggers only if it's in your graveyard as your upkeep begins."
         }
       ],
       "subtypes": [
@@ -26623,11 +26644,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Must be used before blockers are declared in order to affect blocking decisions. You can’t wait to see what your opponent declares and then try to stop them."
+          "text": "Must be used before blockers are declared in order to affect blocking decisions. You can't wait to see what your opponent declares and then try to stop them."
         },
         {
           "date": "2004-10-04",
-          "text": "You can use it after combat or even on a creature which can’t possibly block this turn because it’s that player’s turn to attack, but it generally has no effect other than to let you draw a card."
+          "text": "You can use it after combat or even on a creature which can't possibly block this turn because it's that player's turn to attack, but it generally has no effect other than to let you draw a card."
         }
       ],
       "text": "Target creature can't block this turn.\nDraw a card.",
@@ -27257,7 +27278,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is returned to its owner’s hand at the end of turn only if it is on the battlefield."
+          "text": "It is returned to its owner's hand at the end of turn only if it is on the battlefield."
         }
       ],
       "subtypes": [
@@ -27489,7 +27510,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Tokens are permanents but not cards. They’ll count toward the number of permanents shuffled into your library, so you’ll get a card back for each token you owned. But the tokens themselves should be ignored while you’re revealing *cards* from your library. In practice, you shouldn’t actually shuffle them into your library since they’ll cease to exist as soon as Warp World finishes resolving. Note that a token’s owner is the player under whose control it first entered the battlefield."
+          "text": "Tokens are permanents but not cards. They'll count toward the number of permanents shuffled into your library, so you'll get a card back for each token you owned. But the tokens themselves should be ignored while you're revealing *cards* from your library. In practice, you shouldn't actually shuffle them into your library since they'll cease to exist as soon as Warp World finishes resolving. Note that a token's owner is the player under whose control it first entered the battlefield."
         }
       ],
       "text": "Each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, and land cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of his or her library.",
@@ -27603,11 +27624,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If no card of the chosen type is found before your library empties, you don’t get a card, but you do get to order all the cards in your library any way you choose."
+          "text": "If no card of the chosen type is found before your library empties, you don't get a card, but you do get to order all the cards in your library any way you choose."
         },
         {
           "date": "2007-07-15",
-          "text": "If your library is empty, Abundance can prevent you from losing the game for being unable to draw a card. If an effect or turn-based action would cause you to draw a card, you can replace that draw with Abundance’s replacement effect. (It doesn’t matter that you’d be unable to actually draw a card.) Since Abundance’s effect has you put a card into your hand instead of drawing a card, you’ll never be forced to draw a card with an empty library."
+          "text": "If your library is empty, Abundance can prevent you from losing the game for being unable to draw a card. If an effect or turn-based action would cause you to draw a card, you can replace that draw with Abundance's replacement effect. (It doesn't matter that you'd be unable to actually draw a card.) Since Abundance's effect has you put a card into your hand instead of drawing a card, you'll never be forced to draw a card with an empty library."
         }
       ],
       "text": "If you would draw a card, you may instead choose land or nonland and reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and put all other cards revealed this way on the bottom of your library in any order.",
@@ -28376,7 +28397,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If you don’t reveal a creature card, put all the revealed cards on the bottom of your library in any order."
+          "text": "If you don't reveal a creature card, put all the revealed cards on the bottom of your library in any order."
         }
       ],
       "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
@@ -28718,7 +28739,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -29064,7 +29085,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -29392,7 +29413,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability applies to your opponent’s spells as well as your own."
+          "text": "The ability applies to your opponent's spells as well as your own."
         }
       ],
       "subtypes": [
@@ -29602,6 +29623,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -29611,6 +29636,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -30556,11 +30585,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2007-07-15",
-          "text": "Llanowar Sentinels can “chain”: If you put a second Llanowar Sentinel onto the battlefield as a result of this ability, that creature’s enters-the-battlefield ability triggers and allows you to search for yet another Llanowar Sentinel."
+          "text": "Llanowar Sentinels can \"chain\": If you put a second Llanowar Sentinel onto the battlefield as a result of this ability, that creature's enters-the-battlefield ability triggers and allows you to search for yet another Llanowar Sentinel."
         }
       ],
       "subtypes": [
@@ -31608,7 +31637,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -31922,11 +31951,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Quirion Dryad’s ability will trigger only once per spell you cast, as long as that spell is at least one of the listed colors."
+          "text": "Quirion Dryad's ability will trigger only once per spell you cast, as long as that spell is at least one of the listed colors."
         },
         {
           "date": "2012-07-01",
-          "text": "Quirion Dryad’s ability will trigger if you cast a spell that’s green and at least one of the listed colors."
+          "text": "Quirion Dryad's ability will trigger if you cast a spell that's green and at least one of the listed colors."
         }
       ],
       "subtypes": [
@@ -32060,7 +32089,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -32390,11 +32419,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -32402,7 +32431,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -32618,7 +32647,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -32942,11 +32971,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Other effects can prevent a permanent from untapping during an untap step. You do need to look carefully, however, as many effects say that the permanent does not untap during its controller’s untap step, and this card’s ability occurs during other players’ untap steps. If a card does say this, then Seedborn Muse can untap it. But some other abilities are not written this way and can still prevent a card from untapping."
+          "text": "Other effects can prevent a permanent from untapping during an untap step. You do need to look carefully, however, as many effects say that the permanent does not untap during its controller's untap step, and this card's ability occurs during other players' untap steps. If a card does say this, then Seedborn Muse can untap it. But some other abilities are not written this way and can still prevent a card from untapping."
         },
         {
           "date": "2007-07-15",
-          "text": "All your permanents untap during each other player’s untap step. You have no choice about what untaps."
+          "text": "All your permanents untap during each other player's untap step. You have no choice about what untaps."
         }
       ],
       "subtypes": [
@@ -33391,7 +33420,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability that returns a creature doesn’t target anything. You can return a creature with shroud or protection from green, for example. You don’t decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
+          "text": "The ability that returns a creature doesn't target anything. You can return a creature with shroud or protection from green, for example. You don't decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
         },
         {
           "date": "2004-10-04",
@@ -33823,7 +33852,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block a creature enchanted with this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block a creature enchanted with this."
         }
       ],
       "subtypes": [
@@ -34155,7 +34184,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Verdant Force’s controller gets the tokens. That is the controller at the beginning of upkeep."
+          "text": "Verdant Force's controller gets the tokens. That is the controller at the beginning of upkeep."
         },
         {
           "date": "2005-08-01",
@@ -34603,7 +34632,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a white spell, Angel’s Feather’s ability triggers and is put on the stack on top of that spell. Angel’s Feather’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a white spell, Angel's Feather's ability triggers and is put on the stack on top of that spell. Angel's Feather's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a white spell, you may gain 1 life.",
@@ -34814,11 +34843,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "If Chimeric Staff is already an artifact creature when you activate its ability, Chimeric Staff stays an artifact creature but the ability resets its creature types. You always apply the effect from this card before counters or other effects that modify power and toughness. For example, if you pay {3} to make it a 3/3, then someone gives it -1/-1, it will be a 2/2. If you then activate the ability with {4}, you will apply the “4/4” effect before the -1/-1 effect, so the end result will be a 3/3. Damage that was dealt to the creature stays on it."
+          "text": "If Chimeric Staff is already an artifact creature when you activate its ability, Chimeric Staff stays an artifact creature but the ability resets its creature types. You always apply the effect from this card before counters or other effects that modify power and toughness. For example, if you pay {3} to make it a 3/3, then someone gives it -1/-1, it will be a 2/2. If you then activate the ability with {4}, you will apply the \"4/4\" effect before the -1/-1 effect, so the end result will be a 3/3. Damage that was dealt to the creature stays on it."
         }
       ],
       "text": "{X}: Chimeric Staff becomes an X/X Construct artifact creature until end of turn.",
@@ -35131,7 +35160,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Coat of Arms counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Coat of Arms counts creatures, not creature types."
         }
       ],
       "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
@@ -35449,11 +35478,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Crucible of Worlds doesn’t change the times when you can play those land cards. You can still play only one land per turn, and only during your main phase when you have priority and the stack is empty."
+          "text": "Crucible of Worlds doesn't change the times when you can play those land cards. You can still play only one land per turn, and only during your main phase when you have priority and the stack is empty."
         },
         {
           "date": "2004-12-01",
-          "text": "Crucible of Worlds doesn’t allow you to activate activated abilities (such as cycling) of land cards in your graveyard."
+          "text": "Crucible of Worlds doesn't allow you to activate activated abilities (such as cycling) of land cards in your graveyard."
         }
       ],
       "text": "You may play land cards from your graveyard.",
@@ -35564,7 +35593,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a black spell, Demon’s Horn’s ability triggers and is put on the stack on top of that spell. Demon’s Horn’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a black spell, Demon's Horn's ability triggers and is put on the stack on top of that spell. Demon's Horn's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a black spell, you may gain 1 life.",
@@ -35664,15 +35693,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Doubling Cube’s ability is a mana ability."
+          "text": "Doubling Cube's ability is a mana ability."
         },
         {
           "date": "2004-12-01",
-          "text": "The “type” of mana is its color, or lack thereof (if the mana is colorless)."
+          "text": "The \"type\" of mana is its color, or lack thereof (if the mana is colorless)."
         },
         {
           "date": "2004-12-01",
-          "text": "Any restrictions on the mana in your mana pool aren’t copied. For example, if you have {C}{W}{W}{B} with no restrictions on it in your mana pool and {U}{U}{U} that can be used only to cast artifact spells, you’ll end up with {C}{C}{W}{W}{W}{W}{B}{B}, {U}{U}{U} that can be used only to cast artifact spells, and {U}{U}{U} that can be used for anything."
+          "text": "Any restrictions on the mana in your mana pool aren't copied. For example, if you have {C}{W}{W}{B} with no restrictions on it in your mana pool and {U}{U}{U} that can be used only to cast artifact spells, you'll end up with {C}{C}{W}{W}{W}{W}{B}{B}, {U}{U}{U} that can be used only to cast artifact spells, and {U}{U}{U} that can be used for anything."
         }
       ],
       "text": "{3}, {T}: Double the amount of each type of mana in your mana pool.",
@@ -35782,7 +35811,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a red spell, Dragon’s Claw’s ability triggers and is put on the stack on top of that spell. Dragon’s Claw’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a red spell, Dragon's Claw's ability triggers and is put on the stack on top of that spell. Dragon's Claw's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a red spell, you may gain 1 life.",
@@ -36210,19 +36239,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player’s pool."
+          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player's pool."
         },
         {
           "date": "2004-10-04",
-          "text": "Icy Manipulator can’t be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
+          "text": "Icy Manipulator can't be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger “if the card becomes tapped” effects."
+          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger \"if the card becomes tapped\" effects."
         },
         {
           "date": "2004-10-04",
-          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use the Icy Manipulator."
+          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use the Icy Manipulator."
         },
         {
           "date": "2004-10-04",
@@ -36443,11 +36472,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -36561,7 +36590,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a blue spell, Kraken’s Eye’s ability triggers and is put on the stack on top of that spell. Kraken’s Eye’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a blue spell, Kraken's Eye's ability triggers and is put on the stack on top of that spell. Kraken's Eye's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a blue spell, you may gain 1 life.",
@@ -37497,15 +37526,15 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Pithing Needle affects cards regardless of what zone they’re in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can’t cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
+          "text": "Pithing Needle affects cards regardless of what zone they're in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can't cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
         },
         {
           "date": "2005-06-01",
-          "text": "You can name any card, even if that card doesn’t normally have an activated ability. You can’t name a token unless that token has the same name as a card."
+          "text": "You can name any card, even if that card doesn't normally have an activated ability. You can't name a token unless that token has the same name as a card."
         },
         {
           "date": "2005-06-01",
-          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can’t be activated."
+          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -37513,7 +37542,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” Triggered abilities and static abilities of the named card work normally."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" Triggered abilities and static abilities of the named card work normally."
         }
       ],
       "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
@@ -37619,23 +37648,23 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They’ll still work."
+          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They'll still work."
         },
         {
           "date": "2004-12-01",
-          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can’t prevent you from losing the game)."
+          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can't prevent you from losing the game)."
         },
         {
           "date": "2009-10-01",
-          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn’t matter whether you have 0 or less life, you’re forced to draw a card while your library is empty, you have ten or more poison counters, you’re dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
+          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn't matter whether you have 0 or less life, you're forced to draw a card while your library is empty, you have ten or more poison counters, you're dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
         },
         {
           "date": "2009-10-01",
-          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you’re penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
+          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you're penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
         },
         {
           "date": "2009-10-01",
-          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can’t lose the game and the opposing team can’t win the game."
+          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can't lose the game and the opposing team can't win the game."
         }
       ],
       "subtypes": [
@@ -37947,11 +37976,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Any enters-the-battlefield abilities of the copied artifact will trigger when Sculpting Steel enters the battlefield. Any “as enters the battlefield” or “enters the battlefield with” abilities of the chosen artifact will also work. For example, if Sculpting Steel copies an artifact creature with sunburst, the copy will get +1/+1 counters based on the number of different colors of mana used to pay Sculpting Steel’s total cost. If Sculpting Steel copies a noncreature artifact with sunburst, the copy will get charge counters based on the number of different colors of mana used to pay Sculpting Steel’s total cost."
+          "text": "Any enters-the-battlefield abilities of the copied artifact will trigger when Sculpting Steel enters the battlefield. Any \"as enters the battlefield\" or \"enters the battlefield with\" abilities of the chosen artifact will also work. For example, if Sculpting Steel copies an artifact creature with sunburst, the copy will get +1/+1 counters based on the number of different colors of mana used to pay Sculpting Steel's total cost. If Sculpting Steel copies a noncreature artifact with sunburst, the copy will get charge counters based on the number of different colors of mana used to pay Sculpting Steel's total cost."
         },
         {
           "date": "2007-07-15",
-          "text": "Sculpting Steel doesn’t copy whether the original artifact is tapped or untapped. It also doesn’t copy any counters on that artifact, any Auras or Equipment attached to that artifact, or any effects that are currently affecting that artifact — you get exactly what’s printed on the chosen card and nothing more. So if you copy an animated Chimeric Staff, for example, you get a normal, nonanimated Chimeric Staff."
+          "text": "Sculpting Steel doesn't copy whether the original artifact is tapped or untapped. It also doesn't copy any counters on that artifact, any Auras or Equipment attached to that artifact, or any effects that are currently affecting that artifact — you get exactly what's printed on the chosen card and nothing more. So if you copy an animated Chimeric Staff, for example, you get a normal, nonanimated Chimeric Staff."
         },
         {
           "date": "2007-07-15",
@@ -37963,7 +37992,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "You can choose not to copy anything. In that case, Sculpting Steel stays on the battlefield as an artifact that doesn’t do much of anything."
+          "text": "You can choose not to copy anything. In that case, Sculpting Steel stays on the battlefield as an artifact that doesn't do much of anything."
         }
       ],
       "text": "You may have Sculpting Steel enter the battlefield as a copy of any artifact on the battlefield.",
@@ -38067,7 +38096,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.",
@@ -38176,7 +38205,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -38393,7 +38422,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a green spell, Wurm’s Tooth’s ability triggers and is put on the stack on top of that spell. Wurm’s Tooth’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a green spell, Wurm's Tooth's ability triggers and is put on the stack on top of that spell. Wurm's Tooth's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a green spell, you may gain 1 life.",
@@ -38596,7 +38625,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -38806,7 +38835,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -38913,11 +38942,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Faerie Conclave enters the battlefield tapped.\n{T}: Add {U} to your mana pool.\n{1}{U}: Faerie Conclave becomes a 2/1 blue Faerie creature with flying until end of turn. It's still a land.",
@@ -39017,11 +39046,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Forbidding Watchtower enters the battlefield tapped.\n{T}: Add {W} to your mana pool.\n{1}{W}: Forbidding Watchtower becomes a 1/5 white Soldier creature until end of turn. It's still a land.",
@@ -39123,11 +39152,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Ghitu Encampment enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\n{1}{R}: Ghitu Encampment becomes a 2/1 red Warrior creature with first strike until end of turn. It's still a land. (It deals combat damage before creatures without first strike.)",
@@ -39332,7 +39361,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -39538,7 +39567,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -39642,11 +39671,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Spawning Pool enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\n{1}{B}: Spawning Pool becomes a 1/1 black Skeleton creature with \"{B}: Regenerate this creature\" until end of turn. It's still a land. (If it regenerates, the next time it would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
@@ -39961,11 +39990,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
@@ -40170,7 +40199,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",

--- a/json/2ED.json
+++ b/json/2ED.json
@@ -194,11 +194,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that’s already a creature, it won’t change its power and toughness."
+          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that's already a creature, it won't change its power and toughness."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -264,7 +264,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -272,11 +272,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -395,7 +395,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -454,7 +454,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -626,7 +627,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land type changing effects that change a dual land’s land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
+          "text": "Land type changing effects that change a dual land's land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
         },
         {
           "date": "2004-10-04",
@@ -638,7 +639,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -705,7 +706,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Balance doesn’t have targets, so permanents that can’t be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
+          "text": "Balance doesn't have targets, so permanents that can't be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
         },
         {
           "date": "2016-06-08",
@@ -817,7 +818,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -879,7 +880,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1187,7 +1188,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "text": "As Black Vise enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, Black Vise deals X damage to that player, where X is the number of cards in his or her hand minus 4.",
@@ -1296,7 +1297,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Blaze of Glory only during combat before blockers are declared.\nTarget creature defending player controls can block any number of creatures this turn. It blocks each attacking creature this turn if able.",
@@ -1408,7 +1409,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         }
       ],
       "text": "Choose one —\n• Counter target red spell.\n• Destroy target red permanent.",
@@ -1825,7 +1826,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life you don’t have. In other words, you can’t Channel yourself below zero life."
+          "text": "You can't pay life you don't have. In other words, you can't Channel yourself below zero life."
         }
       ],
       "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
@@ -1872,15 +1873,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Chaos Orb can only affect permanents. Cards that are in the game but not on the battlefield, such as those in the Library and Graveyard, can’t be affected."
+          "text": "Chaos Orb can only affect permanents. Cards that are in the game but not on the battlefield, such as those in the Library and Graveyard, can't be affected."
         },
         {
           "date": "2004-10-04",
-          "text": "You can arrange your cards any time before the Orb is put onto the battlefield, but not after. In general, you should not stack cards or put them in places where your opponent can’t read the names of all of them or count them. This is recommended good gaming practice."
+          "text": "You can arrange your cards any time before the Orb is put onto the battlefield, but not after. In general, you should not stack cards or put them in places where your opponent can't read the names of all of them or count them. This is recommended good gaming practice."
         },
         {
           "date": "2004-10-04",
-          "text": "It must flip 360 degrees (that’s what “flip” means). And this flip must be in the air and not in your hand."
+          "text": "It must flip 360 degrees (that's what \"flip\" means). And this flip must be in the air and not in your hand."
         },
         {
           "date": "2004-10-04",
@@ -1892,7 +1893,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t interfere in any physical way with the casting of this card."
+          "text": "You can't interfere in any physical way with the casting of this card."
         }
       ],
       "text": "{1}, {T}: If Chaos Orb is on the battlefield, flip Chaos Orb onto the battlefield from a height of at least one foot. If Chaos Orb turns over completely at least once during the flip, destroy all nontoken permanents it touches. Then destroy Chaos Orb.",
@@ -2014,7 +2015,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2090,7 +2091,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2166,7 +2167,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2246,7 +2247,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2322,7 +2323,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2396,7 +2397,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Clockwork Beast’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "Clockwork Beast's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         }
       ],
       "subtypes": [
@@ -2479,7 +2480,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -2487,11 +2488,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -2499,7 +2500,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -2637,11 +2638,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Consecrate Land enters the battlefield attached to a land that’s enchanted by other Auras, those Auras are put into their owners’ graveyards."
+          "text": "If Consecrate Land enters the battlefield attached to a land that's enchanted by other Auras, those Auras are put into their owners' graveyards."
         },
         {
           "date": "2013-07-01",
-          "text": "A permanent with indestructible can’t be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
+          "text": "A permanent with indestructible can't be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
         }
       ],
       "subtypes": [
@@ -2795,7 +2796,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -3363,7 +3364,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "After leaving the battlefield, the ability triggers during each of your upkeeps for the rest of the game. As it resolves, you must remove a mire counter from a land that had a mire counter put on it by that instance of Cyclopean Tomb, but it doesn’t matter where the mire counter you remove came from. For instance, you could remove mire counters that were put on the land by Gilder Bairn."
+          "text": "After leaving the battlefield, the ability triggers during each of your upkeeps for the rest of the game. As it resolves, you must remove a mire counter from a land that had a mire counter put on it by that instance of Cyclopean Tomb, but it doesn't matter where the mire counter you remove came from. For instance, you could remove mire counters that were put on the land by Gilder Bairn."
         },
         {
           "date": "2008-08-01",
@@ -3823,7 +3824,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t reveal the card to your opponent."
+          "text": "You don't reveal the card to your opponent."
         },
         {
           "date": "2004-10-04",
@@ -4045,7 +4046,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “can’t regenerate” is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
+          "text": "The \"can't regenerate\" is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
         },
         {
           "date": "2004-10-04",
@@ -4177,11 +4178,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -4319,7 +4320,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "text": "Target player activates a mana ability of each land he or she controls. Then put all mana from that player's mana pool into yours.",
@@ -4501,11 +4502,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can’t be unblocked."
+          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can't be unblocked."
         },
         {
           "date": "2004-10-04",
-          "text": "If you increase the power of the targeted creature after the ability resolves, it still can’t be blocked that turn."
+          "text": "If you increase the power of the targeted creature after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -4817,7 +4818,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability “{T}: Add {B} to your mana pool.” Evil Presence doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability \"{T}: Add {B} to your mana pool.\" Evil Presence doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         }
       ],
       "subtypes": [
@@ -4979,11 +4980,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You take damage when you play a land using the “play a land” action. Such an action can be your regular “play a land”, one enabled by Fastbond, or ones enabled through other effects."
+          "text": "You take damage when you play a land using the \"play a land\" action. Such an action can be your regular \"play a land\", one enabled by Fastbond, or ones enabled through other effects."
         },
         {
           "date": "2004-10-04",
-          "text": "You do not take damage when you “put a land onto the battlefield” through the effect of a spell or ability."
+          "text": "You do not take damage when you \"put a land onto the battlefield\" through the effect of a spell or ability."
         }
       ],
       "text": "You may play any number of lands on each of your turns.\nWhenever you play a land, if it wasn't the first land you played this turn, Fastbond deals 1 damage to you.",
@@ -5243,7 +5244,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -5255,7 +5256,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -5329,7 +5330,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -5634,7 +5635,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This can’t be used to prevent damage caused by a blocked creature with Trample ability."
+          "text": "This can't be used to prevent damage caused by a blocked creature with Trample ability."
         }
       ],
       "text": "{1}: The next time an unblocked creature of your choice would deal combat damage to you this turn, prevent all but 1 of that damage.",
@@ -6448,7 +6449,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When a spell with additional costs is copied, you don’t have to pay those costs again."
+          "text": "When a spell with additional costs is copied, you don't have to pay those costs again."
         },
         {
           "date": "2004-10-04",
@@ -6476,7 +6477,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy’s target will be illegal when it resolves."
+          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy's target will be illegal when it resolves."
         },
         {
           "date": "2004-10-04",
@@ -6484,7 +6485,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The copy that is placed on the stack is not considered to have been “cast”."
+          "text": "The copy that is placed on the stack is not considered to have been \"cast\"."
         },
         {
           "date": "2004-10-04",
@@ -6690,11 +6691,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When being declared as an attacker, use the “not attacking” power and toughness. It only changes after declaration is complete."
+          "text": "When being declared as an attacker, use the \"not attacking\" power and toughness. It only changes after declaration is complete."
         },
         {
           "date": "2006-09-25",
-          "text": "The activated ability doesn’t affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability “{T}: Add {G} to your mana pool.”"
+          "text": "The activated ability doesn't affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability \"{T}: Add {G} to your mana pool.\""
         },
         {
           "date": "2006-10-15",
@@ -6864,6 +6865,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -6873,6 +6878,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -7033,7 +7042,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "White spells cost {3} more to cast.\nActivated abilities of white enchantments cost {3} more to activate.",
@@ -7101,7 +7110,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade’s ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
         }
       ],
       "subtypes": [
@@ -7569,7 +7578,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -8080,7 +8089,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers even if the Specter’s damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
+          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
         }
       ],
       "subtypes": [
@@ -8197,19 +8206,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player’s pool."
+          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player's pool."
         },
         {
           "date": "2004-10-04",
-          "text": "Icy Manipulator can’t be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
+          "text": "Icy Manipulator can't be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger “if the card becomes tapped” effects."
+          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger \"if the card becomes tapped\" effects."
         },
         {
           "date": "2004-10-04",
-          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use the Icy Manipulator."
+          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use the Icy Manipulator."
         },
         {
           "date": "2004-10-04",
@@ -8261,11 +8270,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature enters the battlefield face down, so none of its “enters the battlefield” abilities will trigger or have any effect. Also none of its “As this enters the battlefield” abilities apply."
+          "text": "The creature enters the battlefield face down, so none of its \"enters the battlefield\" abilities will trigger or have any effect. Also none of its \"As this enters the battlefield\" abilities apply."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature’s “enters the battlefield” abilities (and any other abilities relating to the creature entering the battlefield) do not trigger when it turns face up."
+          "text": "The creature's \"enters the battlefield\" abilities (and any other abilities relating to the creature entering the battlefield) do not trigger when it turns face up."
         },
         {
           "date": "2004-10-04",
@@ -8273,11 +8282,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the ability to cast a creature card face down, you must keep track of the amount and types of mana you spent on {X}. If that creature spell is moved from the stack to anywhere other than the battlefield, the resulting creature leaves the battlefield, or the game ends, the face-down card is revealed. If its mana cost couldn’t be paid by some amount of, or all of, the mana you spent on {X}, all applicable penalties for casting a card illegally are assessed."
+          "text": "If you use the ability to cast a creature card face down, you must keep track of the amount and types of mana you spent on {X}. If that creature spell is moved from the stack to anywhere other than the battlefield, the resulting creature leaves the battlefield, or the game ends, the face-down card is revealed. If its mana cost couldn't be paid by some amount of, or all of, the mana you spent on {X}, all applicable penalties for casting a card illegally are assessed."
         },
         {
           "date": "2009-10-01",
@@ -8285,19 +8294,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect that turns it face-up is a replacement effect. It doesn’t use the stack and can’t be responded to."
+          "text": "The effect that turns it face-up is a replacement effect. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2009-10-01",
-          "text": "You may not turn a face-down spell face up. You may not turn a face-down permanent face up unless it would have morph while face up or an effect specifically allows you to turn it face up. Illusionary Mask’s ability has you turn a face-down creature face up if it would assign damage, deal damage, be dealt damage, or become tapped, but not for any other reason. For example, if you use Illusionary Mask’s ability to cast a black creature face down, you can’t turn it face up just because it’s being targeted by Terror."
+          "text": "You may not turn a face-down spell face up. You may not turn a face-down permanent face up unless it would have morph while face up or an effect specifically allows you to turn it face up. Illusionary Mask's ability has you turn a face-down creature face up if it would assign damage, deal damage, be dealt damage, or become tapped, but not for any other reason. For example, if you use Illusionary Mask's ability to cast a black creature face down, you can't turn it face up just because it's being targeted by Terror."
         },
         {
           "date": "2009-10-01",
-          "text": "Both the amount and types of mana you spend on {X} are taken into account while you’re choosing a creature card from your hand. For example, if you spent {U}{U} on {X}, you can choose a creature card with mana cost {U}{U}, {1}{U}, {2}, or {W/U}{W/U}, among other possibilities, but not one that costs {2}{U} or one that costs {G}."
+          "text": "Both the amount and types of mana you spend on {X} are taken into account while you're choosing a creature card from your hand. For example, if you spent {U}{U} on {X}, you can choose a creature card with mana cost {U}{U}, {1}{U}, {2}, or {W/U}{W/U}, among other possibilities, but not one that costs {2}{U} or one that costs {G}."
         },
         {
           "date": "2009-10-01",
-          "text": "While the creature card is face down, it’s a 2/2 creature with no name, mana cost, color, creature type, abilities, or expansion symbol. Since it has no mana cost, its converted mana cost is 0."
+          "text": "While the creature card is face down, it's a 2/2 creature with no name, mana cost, color, creature type, abilities, or expansion symbol. Since it has no mana cost, its converted mana cost is 0."
         },
         {
           "date": "2009-10-01",
@@ -8305,11 +8314,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You can turn a face-down permanent face up if it would have morph while face up. This applies to creatures you cast face down as a result of Illusionary Mask’s effect. The rest of Illusionary Mask’s effect applies to it as well."
+          "text": "You can turn a face-down permanent face up if it would have morph while face up. This applies to creatures you cast face down as a result of Illusionary Mask's effect. The rest of Illusionary Mask's effect applies to it as well."
         },
         {
           "date": "2009-10-01",
-          "text": "Illusionary Mask’s ability will continue to apply to creatures cast face down with it, even if Illusionary Mask has left the battlefield."
+          "text": "Illusionary Mask's ability will continue to apply to creatures cast face down with it, even if Illusionary Mask has left the battlefield."
         }
       ],
       "text": "{X}: You may choose a creature card in your hand whose mana cost could be paid by some amount of, or all of, the mana you spent on {X}. If you do, you may cast that card face down as a 2/2 creature spell without paying its mana cost. If the creature that spell becomes as it resolves has not been turned face up and would assign or deal damage, be dealt damage, or become tapped, instead it's turned face up and assigns or deals damage, is dealt damage, or becomes tapped. Activate this ability only any time you could cast a sorcery.",
@@ -8365,15 +8374,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If attached to an opponent’s creature, you can untap their creature during your turn."
+          "text": "If attached to an opponent's creature, you can untap their creature during your turn."
         },
         {
           "date": "2004-10-04",
-          "text": "Instill Energy’s untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
+          "text": "Instill Energy's untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
         },
         {
           "date": "2005-08-01",
-          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card’s ability to untap once during the turn."
+          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card's ability to untap once during the turn."
         }
       ],
       "subtypes": [
@@ -9402,7 +9411,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Since the draw is replaced, you can’t use the same draw to do other things."
+          "text": "Since the draw is replaced, you can't use the same draw to do other things."
         }
       ],
       "text": "If you would draw a card during your draw step, instead you may skip that draw. If you do, until your next turn, you can't be attacked except by creatures with flying and/or islandwalk.",
@@ -9553,19 +9562,19 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A delayed triggered ability that refers to Jade Statue still affects it even if it’s no longer a creature. For example, if Jade Statue blocks the Kashi-Tribe Warriors (“Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn’t untap during its controller’s next untap step.”), the Warriors’ effect stops Jade Statue from untapping."
+          "text": "A delayed triggered ability that refers to Jade Statue still affects it even if it's no longer a creature. For example, if Jade Statue blocks the Kashi-Tribe Warriors (\"Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.\"), the Warriors' effect stops Jade Statue from untapping."
         },
         {
           "date": "2005-08-01",
-          "text": "If Jade Statue’s ability has been activated, abilities that trigger “at end of combat” will see Jade Statue as an artifact creature."
+          "text": "If Jade Statue's ability has been activated, abilities that trigger \"at end of combat\" will see Jade Statue as an artifact creature."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-09-20",
-          "text": "If Jade Statue is animated by some other effect, you get an artifact creature with whatever power, toughness, and creature types (if any) are specified by that effect. If you subsequently use Jade Statue’s ability during combat, it will become 3/6 and gain the creature type Golem in addition to those creature types until end of combat."
+          "text": "If Jade Statue is animated by some other effect, you get an artifact creature with whatever power, toughness, and creature types (if any) are specified by that effect. If you subsequently use Jade Statue's ability during combat, it will become 3/6 and gain the creature type Golem in addition to those creature types until end of combat."
         }
       ],
       "text": "{2}: Jade Statue becomes a 3/6 Golem artifact creature until end of combat. Activate this ability only during combat.",
@@ -9686,11 +9695,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -9754,7 +9763,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         }
       ],
       "text": "Target creature gains flying until end of turn.",
@@ -9871,7 +9880,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never “locked in”."
+          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never \"locked in\"."
         }
       ],
       "subtypes": [
@@ -9933,7 +9942,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Swamps are 1/1 black creatures that are still lands.",
@@ -9988,7 +9997,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can move it to any other player’s land whenever you get to move it."
+          "text": "You can move it to any other player's land whenever you get to move it."
         },
         {
           "date": "2005-08-01",
@@ -10000,7 +10009,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Because the ability isn’t targeted, the controller of the destroyed land may attach it to a land that can’t be the target of abilities."
+          "text": "Because the ability isn't targeted, the controller of the destroyed land may attach it to a land that can't be the target of abilities."
         }
       ],
       "subtypes": [
@@ -10115,7 +10124,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can’t be used at times that only mana abilities can be used."
+          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can't be used at times that only mana abilities can be used."
         }
       ],
       "subtypes": [
@@ -10170,11 +10179,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not “discarded”."
+          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not \"discarded\"."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren’t effects."
+          "text": "You can't use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren't effects."
         },
         {
           "date": "2004-10-04",
@@ -10202,7 +10211,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\nIf an effect causes you to discard a card, discard it, but you may put it on top of your library instead of into your graveyard.",
@@ -10264,15 +10273,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life, just like any player at less than one life can’t pay life. You can pay zero life if you want."
+          "text": "You can't pay life, just like any player at less than one life can't pay life. You can pay zero life if you want."
         },
         {
           "date": "2004-10-04",
-          "text": "If an opponent steals control of Lich and no other effect prevents you from losing with a life total of zero, you will lose the game due to a zero life total as a State-Based Action before you can take any actions. The last sentence doesn’t apply in this case since the Lich didn’t leave the battlefield."
+          "text": "If an opponent steals control of Lich and no other effect prevents you from losing with a life total of zero, you will lose the game due to a zero life total as a State-Based Action before you can take any actions. The last sentence doesn't apply in this case since the Lich didn't leave the battlefield."
         },
         {
           "date": "2004-10-04",
-          "text": "If an opponent steals control of Lich, their life total does not change. The life total changes for a player only when it enters the battlefield under that player’s control."
+          "text": "If an opponent steals control of Lich, their life total does not change. The life total changes for a player only when it enters the battlefield under that player's control."
         },
         {
           "date": "2004-10-04",
@@ -10280,7 +10289,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich leaves the battlefield or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can’t lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
+          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich leaves the battlefield or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can't lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
         },
         {
           "date": "2010-08-15",
@@ -10288,7 +10297,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich is put into the graveyard or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can’t lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
+          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich is put into the graveyard or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can't lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
         }
       ],
       "text": "As Lich enters the battlefield, you lose life equal to your life total.\nYou don't lose the game for having 0 or less life.\nIf you would gain life, draw that many cards instead.\nWhenever you're dealt damage, sacrifice that many nontoken permanents. If you can't, you lose the game.\nWhen Lich is put into a graveyard from the battlefield, you lose the game.",
@@ -10562,7 +10571,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can cast it targeting your opponent’s artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
+          "text": "You can cast it targeting your opponent's artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
         },
         {
           "date": "2004-10-04",
@@ -10626,7 +10635,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Forests are 1/1 creatures that are still lands.",
@@ -11048,7 +11057,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -11060,7 +11069,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
@@ -11072,7 +11081,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target spell or permanent by replacing all instances of one basic land type with another. (For example, you may change \"swampwalk\" to \"plainswalk.\" This effect lasts indefinitely.)",
@@ -11195,7 +11204,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare’s ability."
+          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare's ability."
         },
         {
           "date": "2004-10-04",
@@ -11203,7 +11212,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can’t give a mana of a color that wasn’t produced."
+          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can't give a mana of a color that wasn't produced."
         },
         {
           "date": "2004-10-04",
@@ -11219,7 +11228,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Does not copy any restrictions on the mana, such as with Mishra’s Workshop or Pillar of the Paruns."
+          "text": "Does not copy any restrictions on the mana, such as with Mishra's Workshop or Pillar of the Paruns."
         },
         {
           "date": "2007-09-16",
@@ -11408,7 +11417,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -11583,7 +11592,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -12806,7 +12815,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can’t be countered with something that counters spells."
+          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can't be countered with something that counters spells."
         },
         {
           "date": "2004-10-04",
@@ -12814,7 +12823,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "A card is “above” another card in your graveyard if it was put into that graveyard later."
+          "text": "A card is \"above\" another card in your graveyard if it was put into that graveyard later."
         },
         {
           "date": "2008-10-01",
@@ -12826,11 +12835,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -12892,11 +12901,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can use this effect on a creature you know won’t be able to attack. For example, you can use it on a tapped creature."
+          "text": "You can use this effect on a creature you know won't be able to attack. For example, you can use it on a tapped creature."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2013-09-20",
@@ -12961,7 +12970,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -13037,19 +13046,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -13382,7 +13391,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' ‘Well, now that we have seen each other,' said the Unicorn, ‘if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
+      "flavor": "\"'Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' 'Well, now that we have seen each other,' said the Unicorn, 'if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
       "id": "781674682ab4e01e2d9467fa6a3da0b500b78e2c",
       "imageName": "pearled unicorn",
       "layout": "normal",
@@ -13480,7 +13489,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent’s Incarnation you can let it die to make them lose life."
+          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent's Incarnation you can let it die to make them lose life."
         },
         {
           "date": "2007-02-01",
@@ -13555,7 +13564,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -14667,7 +14676,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -14806,7 +14815,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -15235,7 +15244,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -15640,7 +15649,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -15763,7 +15772,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If damage that would be dealt to Rock Hydra can’t be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
+          "text": "If damage that would be dealt to Rock Hydra can't be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
         }
       ],
       "subtypes": [
@@ -15891,11 +15900,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -16085,7 +16094,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -16330,7 +16339,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -16587,15 +16596,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -16964,7 +16973,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t use Simulacrum on Loss of Life, just damage."
+          "text": "You can't use Simulacrum on Loss of Life, just damage."
         },
         {
           "date": "2004-10-04",
@@ -16972,7 +16981,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage’s source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
+          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage's source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
         }
       ],
       "text": "You gain life equal to the damage dealt to you this turn. Simulacrum deals damage to target creature you control equal to the damage dealt to you this turn.",
@@ -17075,15 +17084,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It will require creatures with Haste to attack since they are able, but it won’t destroy them if they don’t for some reason."
+          "text": "It will require creatures with Haste to attack since they are able, but it won't destroy them if they don't for some reason."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2009-02-01",
-          "text": "This will destroy creatures that weren’t able to attack because they had been previously tapped."
+          "text": "This will destroy creatures that weren't able to attack because they had been previously tapped."
         },
         {
           "date": "2013-09-20",
@@ -17147,7 +17156,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t Sleight proper nouns (i.e. card names). This means that you can’t affect a “Black Vise”."
+          "text": "You can't Sleight proper nouns (i.e. card names). This means that you can't affect a \"Black Vise\"."
         },
         {
           "date": "2004-10-04",
@@ -17155,7 +17164,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Can’t change a color word to the same color word. It must be a different word."
+          "text": "Can't change a color word to the same color word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -17167,7 +17176,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -17410,11 +17419,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -17470,7 +17479,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since there is no untap step, Phasing in/out won’t happen."
+          "text": "Since there is no untap step, Phasing in/out won't happen."
         },
         {
           "date": "2004-10-04",
@@ -17602,19 +17611,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the Giant’s power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
+          "text": "If the Giant's power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
         },
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stone Giant’s ability is activated during a turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. The targeted creature will be destroyed at that time."
+          "text": "If Stone Giant's ability is activated during a turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. The targeted creature will be destroyed at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it’s no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant’s power at that time."
+          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it's no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant's power at that time."
         }
       ],
       "subtypes": [
@@ -18643,7 +18652,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -18700,7 +18709,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18882,7 +18891,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Protection from Green does not stop the Basilisk’s ability because the ability is not targeted."
+          "text": "Protection from Green does not stop the Basilisk's ability because the ability is not targeted."
         },
         {
           "date": "2004-10-04",
@@ -19044,7 +19053,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -19109,7 +19118,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         },
         {
           "date": "2008-10-01",
@@ -19171,7 +19180,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one.",
@@ -19225,7 +19234,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. (Then put Timetwister into its owner's graveyard.)",
@@ -19350,7 +19359,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -19461,7 +19470,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -19690,7 +19699,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -20039,23 +20048,23 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
+          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
         },
         {
           "date": "2007-09-16",
-          "text": "When Vesuvan Doppelganger’s triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
+          "text": "When Vesuvan Doppelganger's triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger copies the mana cost of the creature it’s copying but doesn’t copy its color."
+          "text": "Vesuvan Doppelganger copies the mana cost of the creature it's copying but doesn't copy its color."
         },
         {
           "date": "2007-09-16",
-          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger’s color, and will gain Vesuvan Doppelganger’s triggered ability."
+          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger's color, and will gain Vesuvan Doppelganger's triggered ability."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger’s triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller’s upkeep. They’ll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger’s characteristics for the rest of the turn."
+          "text": "Vesuvan Doppelganger's triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller's upkeep. They'll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger's characteristics for the rest of the turn."
         },
         {
           "date": "2007-09-16",
@@ -20063,7 +20072,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Although Vesuvan Doppelganger’s triggered ability is targeted, its “as enters the battlefield” ability is not."
+          "text": "Although Vesuvan Doppelganger's triggered ability is targeted, its \"as enters the battlefield\" ability is not."
         }
       ],
       "subtypes": [
@@ -20124,7 +20133,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can’t be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
+          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can't be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
         },
         {
           "date": "2004-10-04",
@@ -20246,7 +20255,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -20268,7 +20277,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"This ‘standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
+      "flavor": "\"This 'standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
       "id": "14f4e474893c02ee4f7d798dac47623b86758085",
       "imageName": "wall of air",
       "layout": "normal",
@@ -20397,7 +20406,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"What else, when chaos draws all forces inward to shape a single leaf.\"\n —Conrad Aiken",
+      "flavor": "\"What else, when chaos draws all forces inward to shape a single leaf.\"\n—Conrad Aiken",
       "id": "9514046d50921f0e7ce0739271ac7f059db2ca02",
       "imageName": "wall of brambles",
       "layout": "normal",
@@ -21476,11 +21485,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All permanents untap during a player’s untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
+          "text": "All permanents untap during a player's untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
+          "text": "You can't tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
         }
       ],
       "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",
@@ -21584,7 +21593,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2009-10-01",
@@ -21592,15 +21601,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Word of Command can’t be used to force a player to play a card that isn’t in his or her hand."
+          "text": "Word of Command can't be used to force a player to play a card that isn't in his or her hand."
         },
         {
           "date": "2011-01-01",
-          "text": "You control the player while this spell is resolving, which means you get to see anything he or she can see. If that player is required to search his or her library as part of playing the card or as part of its resolution if it’s cast as a spell, then you can see the cards in that player’s library as well."
+          "text": "You control the player while this spell is resolving, which means you get to see anything he or she can see. If that player is required to search his or her library as part of playing the card or as part of its resolution if it's cast as a spell, then you can see the cards in that player's library as well."
         },
         {
           "date": "2011-01-01",
-          "text": "Your opponent can’t counter the Word of Command after letting you look at his or her hand, but they can attempt to counter the spell you force them to cast."
+          "text": "Your opponent can't counter the Word of Command after letting you look at his or her hand, but they can attempt to counter the spell you force them to cast."
         },
         {
           "date": "2011-01-01",
@@ -21616,7 +21625,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Since this spell is an instant, your opponent gets a chance to respond to it as normal. Once this spell resolves, you look at your opponent’s hand and choose a card. Note that it is common practice to respond to Word of Command by using up any spells or mana you have prior to letting it resolve."
+          "text": "Since this spell is an instant, your opponent gets a chance to respond to it as normal. Once this spell resolves, you look at your opponent's hand and choose a card. Note that it is common practice to respond to Word of Command by using up any spells or mana you have prior to letting it resolve."
         },
         {
           "date": "2011-01-01",
@@ -21624,11 +21633,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "text": "Look at target opponent's hand and choose a card from it. You control that player until Word of Command finishes resolving. The player plays that card if able. While doing so, the player can activate mana abilities only if they're from lands he or she controls and only if mana they produce is spent to activate other mana abilities of lands he or she controls and/or play that card. If the chosen card is cast as a spell, you control the player while that spell is resolving.",

--- a/json/3ED.json
+++ b/json/3ED.json
@@ -243,11 +243,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that’s already a creature, it won’t change its power and toughness."
+          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that's already a creature, it won't change its power and toughness."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -313,7 +313,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -321,11 +321,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -444,7 +444,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -503,7 +503,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -780,7 +781,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land type changing effects that change a dual land’s land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
+          "text": "Land type changing effects that change a dual land's land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
         },
         {
           "date": "2004-10-04",
@@ -792,7 +793,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -859,7 +860,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Balance doesn’t have targets, so permanents that can’t be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
+          "text": "Balance doesn't have targets, so permanents that can't be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
         },
         {
           "date": "2016-06-08",
@@ -971,7 +972,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -1033,7 +1034,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1243,7 +1244,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "text": "As Black Vise enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, Black Vise deals X damage to that player, where X is the number of cards in his or her hand minus 4.",
@@ -1406,7 +1407,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         }
       ],
       "text": "Choose one —\n• Counter target red spell.\n• Destroy target red permanent.",
@@ -1875,7 +1876,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life you don’t have. In other words, you can’t Channel yourself below zero life."
+          "text": "You can't pay life you don't have. In other words, you can't Channel yourself below zero life."
         }
       ],
       "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
@@ -1997,7 +1998,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2073,7 +2074,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2149,7 +2150,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2229,7 +2230,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2305,7 +2306,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2379,7 +2380,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Clockwork Beast’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "Clockwork Beast's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         }
       ],
       "subtypes": [
@@ -2462,7 +2463,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -2470,11 +2471,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -2482,7 +2483,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -2706,7 +2707,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -3742,7 +3743,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t reveal the card to your opponent."
+          "text": "You don't reveal the card to your opponent."
         },
         {
           "date": "2004-10-04",
@@ -4019,7 +4020,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “can’t regenerate” is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
+          "text": "The \"can't regenerate\" is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
         },
         {
           "date": "2004-10-04",
@@ -4200,11 +4201,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -4342,7 +4343,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "text": "Target player activates a mana ability of each land he or she controls. Then put all mana from that player's mana pool into yours.",
@@ -4467,11 +4468,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can’t be unblocked."
+          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can't be unblocked."
         },
         {
           "date": "2004-10-04",
-          "text": "If you increase the power of the targeted creature after the ability resolves, it still can’t be blocked that turn."
+          "text": "If you increase the power of the targeted creature after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -5027,7 +5028,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability “{T}: Add {B} to your mana pool.” Evil Presence doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability \"{T}: Add {B} to your mana pool.\" Evil Presence doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         }
       ],
       "subtypes": [
@@ -5193,11 +5194,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You take damage when you play a land using the “play a land” action. Such an action can be your regular “play a land”, one enabled by Fastbond, or ones enabled through other effects."
+          "text": "You take damage when you play a land using the \"play a land\" action. Such an action can be your regular \"play a land\", one enabled by Fastbond, or ones enabled through other effects."
         },
         {
           "date": "2004-10-04",
-          "text": "You do not take damage when you “put a land onto the battlefield” through the effect of a spell or ability."
+          "text": "You do not take damage when you \"put a land onto the battlefield\" through the effect of a spell or ability."
         }
       ],
       "text": "You may play any number of lands on each of your turns.\nWhenever you play a land, if it wasn't the first land you played this turn, Fastbond deals 1 damage to you.",
@@ -5457,7 +5458,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -5469,7 +5470,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -5543,7 +5544,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -6661,7 +6662,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When a spell with additional costs is copied, you don’t have to pay those costs again."
+          "text": "When a spell with additional costs is copied, you don't have to pay those costs again."
         },
         {
           "date": "2004-10-04",
@@ -6689,7 +6690,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy’s target will be illegal when it resolves."
+          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy's target will be illegal when it resolves."
         },
         {
           "date": "2004-10-04",
@@ -6697,7 +6698,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The copy that is placed on the stack is not considered to have been “cast”."
+          "text": "The copy that is placed on the stack is not considered to have been \"cast\"."
         },
         {
           "date": "2004-10-04",
@@ -6903,11 +6904,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When being declared as an attacker, use the “not attacking” power and toughness. It only changes after declaration is complete."
+          "text": "When being declared as an attacker, use the \"not attacking\" power and toughness. It only changes after declaration is complete."
         },
         {
           "date": "2006-09-25",
-          "text": "The activated ability doesn’t affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability “{T}: Add {G} to your mana pool.”"
+          "text": "The activated ability doesn't affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability \"{T}: Add {G} to your mana pool.\""
         },
         {
           "date": "2006-10-15",
@@ -7026,6 +7027,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -7035,6 +7040,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -7195,7 +7204,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "White spells cost {3} more to cast.\nActivated abilities of white enchantments cost {3} more to activate.",
@@ -7263,7 +7272,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade’s ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
         }
       ],
       "subtypes": [
@@ -7731,7 +7740,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -8304,7 +8313,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers even if the Specter’s damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
+          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
         }
       ],
       "subtypes": [
@@ -8364,15 +8373,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If attached to an opponent’s creature, you can untap their creature during your turn."
+          "text": "If attached to an opponent's creature, you can untap their creature during your turn."
         },
         {
           "date": "2004-10-04",
-          "text": "Instill Energy’s untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
+          "text": "Instill Energy's untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
         },
         {
           "date": "2005-08-01",
-          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card’s ability to untap once during the turn."
+          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card's ability to untap once during the turn."
         }
       ],
       "subtypes": [
@@ -9344,7 +9353,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Since the draw is replaced, you can’t use the same draw to do other things."
+          "text": "Since the draw is replaced, you can't use the same draw to do other things."
         }
       ],
       "text": "If you would draw a card during your draw step, instead you may skip that draw. If you do, until your next turn, you can't be attacked except by creatures with flying and/or islandwalk.",
@@ -9442,7 +9451,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have four or fewer cards in your hand when Ivory Tower’s ability resolves, the ability has no effect."
+          "text": "If you have four or fewer cards in your hand when Ivory Tower's ability resolves, the ability has no effect."
         }
       ],
       "text": "At the beginning of your upkeep, you gain X life, where X is the number of cards in your hand minus 4.",
@@ -9530,7 +9539,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you do not have the card still in your hand, you can’t pay the cost. There is currently no way to prove that it was the card you drew except to get a judge or 3rd party involved, or to put cards you draw aside until you decide whether or not to use this."
+          "text": "If you do not have the card still in your hand, you can't pay the cost. There is currently no way to prove that it was the card you drew except to get a judge or 3rd party involved, or to put cards you draw aside until you decide whether or not to use this."
         },
         {
           "date": "2004-10-04",
@@ -9696,11 +9705,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -9764,7 +9773,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         }
       ],
       "text": "Target creature gains flying until end of turn.",
@@ -9881,7 +9890,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never “locked in”."
+          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never \"locked in\"."
         }
       ],
       "subtypes": [
@@ -10001,7 +10010,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Swamps are 1/1 black creatures that are still lands.",
@@ -10056,7 +10065,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can move it to any other player’s land whenever you get to move it."
+          "text": "You can move it to any other player's land whenever you get to move it."
         },
         {
           "date": "2005-08-01",
@@ -10068,7 +10077,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Because the ability isn’t targeted, the controller of the destroyed land may attach it to a land that can’t be the target of abilities."
+          "text": "Because the ability isn't targeted, the controller of the destroyed land may attach it to a land that can't be the target of abilities."
         }
       ],
       "subtypes": [
@@ -10183,7 +10192,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can’t be used at times that only mana abilities can be used."
+          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can't be used at times that only mana abilities can be used."
         }
       ],
       "subtypes": [
@@ -10238,11 +10247,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not “discarded”."
+          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not \"discarded\"."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren’t effects."
+          "text": "You can't use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren't effects."
         },
         {
           "date": "2004-10-04",
@@ -10270,7 +10279,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\nIf an effect causes you to discard a card, discard it, but you may put it on top of your library instead of into your graveyard.",
@@ -10544,7 +10553,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can cast it targeting your opponent’s artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
+          "text": "You can cast it targeting your opponent's artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
         },
         {
           "date": "2004-10-04",
@@ -10608,7 +10617,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Forests are 1/1 creatures that are still lands.",
@@ -11030,7 +11039,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -11042,7 +11051,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
@@ -11054,7 +11063,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target spell or permanent by replacing all instances of one basic land type with another. (For example, you may change \"swampwalk\" to \"plainswalk.\" This effect lasts indefinitely.)",
@@ -11221,7 +11230,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare’s ability."
+          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare's ability."
         },
         {
           "date": "2004-10-04",
@@ -11229,7 +11238,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can’t give a mana of a color that wasn’t produced."
+          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can't give a mana of a color that wasn't produced."
         },
         {
           "date": "2004-10-04",
@@ -11245,7 +11254,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Does not copy any restrictions on the mana, such as with Mishra’s Workshop or Pillar of the Paruns."
+          "text": "Does not copy any restrictions on the mana, such as with Mishra's Workshop or Pillar of the Paruns."
         },
         {
           "date": "2007-09-16",
@@ -11434,7 +11443,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -11609,7 +11618,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -11847,11 +11856,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You may choose to take damage or to discard. You can’t avoid taking damage if you have no cards to discard."
+          "text": "You may choose to take damage or to discard. You can't avoid taking damage if you have no cards to discard."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -12747,7 +12756,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can’t be countered with something that counters spells."
+          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can't be countered with something that counters spells."
         },
         {
           "date": "2004-10-04",
@@ -12755,7 +12764,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "A card is “above” another card in your graveyard if it was put into that graveyard later."
+          "text": "A card is \"above\" another card in your graveyard if it was put into that graveyard later."
         },
         {
           "date": "2008-10-01",
@@ -12767,11 +12776,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -12833,11 +12842,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can use this effect on a creature you know won’t be able to attack. For example, you can use it on a tapped creature."
+          "text": "You can use this effect on a creature you know won't be able to attack. For example, you can use it on a tapped creature."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2013-09-20",
@@ -12902,7 +12911,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -12978,19 +12987,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -13441,7 +13450,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' ‘Well, now that we have seen each other,' said the Unicorn, ‘if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
+      "flavor": "\"'Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' 'Well, now that we have seen each other,' said the Unicorn, 'if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
       "id": "2dbc0b0a8f6b3bafc6d86d9bce5af537f756c705",
       "imageName": "pearled unicorn",
       "layout": "normal",
@@ -13539,7 +13548,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent’s Incarnation you can let it die to make them lose life."
+          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent's Incarnation you can let it die to make them lose life."
         },
         {
           "date": "2007-02-01",
@@ -13614,7 +13623,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -14726,7 +14735,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -14865,7 +14874,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -14980,11 +14989,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         },
         {
           "date": "2012-07-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -15247,7 +15256,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -15740,7 +15749,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -15863,7 +15872,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If damage that would be dealt to Rock Hydra can’t be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
+          "text": "If damage that would be dealt to Rock Hydra can't be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
         }
       ],
       "subtypes": [
@@ -16043,11 +16052,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -16237,7 +16246,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -16482,7 +16491,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -16739,15 +16748,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -17087,7 +17096,8 @@
         "3ED",
         "5ED",
         "6ED",
-        "10E"
+        "10E",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Destroy all artifacts. They can't be regenerated.",
@@ -17219,7 +17229,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t use Simulacrum on Loss of Life, just damage."
+          "text": "You can't use Simulacrum on Loss of Life, just damage."
         },
         {
           "date": "2004-10-04",
@@ -17227,7 +17237,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage’s source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
+          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage's source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
         }
       ],
       "text": "You gain life equal to the damage dealt to you this turn. Simulacrum deals damage to target creature you control equal to the damage dealt to you this turn.",
@@ -17281,15 +17291,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It will require creatures with Haste to attack since they are able, but it won’t destroy them if they don’t for some reason."
+          "text": "It will require creatures with Haste to attack since they are able, but it won't destroy them if they don't for some reason."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2009-02-01",
-          "text": "This will destroy creatures that weren’t able to attack because they had been previously tapped."
+          "text": "This will destroy creatures that weren't able to attack because they had been previously tapped."
         },
         {
           "date": "2013-09-20",
@@ -17353,7 +17363,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t Sleight proper nouns (i.e. card names). This means that you can’t affect a “Black Vise”."
+          "text": "You can't Sleight proper nouns (i.e. card names). This means that you can't affect a \"Black Vise\"."
         },
         {
           "date": "2004-10-04",
@@ -17361,7 +17371,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Can’t change a color word to the same color word. It must be a different word."
+          "text": "Can't change a color word to the same color word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -17373,7 +17383,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -17669,11 +17679,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -17729,7 +17739,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since there is no untap step, Phasing in/out won’t happen."
+          "text": "Since there is no untap step, Phasing in/out won't happen."
         },
         {
           "date": "2004-10-04",
@@ -17861,19 +17871,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the Giant’s power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
+          "text": "If the Giant's power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
         },
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stone Giant’s ability is activated during a turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. The targeted creature will be destroyed at that time."
+          "text": "If Stone Giant's ability is activated during a turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. The targeted creature will be destroyed at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it’s no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant’s power at that time."
+          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it's no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant's power at that time."
         }
       ],
       "subtypes": [
@@ -18902,7 +18912,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -18959,7 +18969,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -19196,7 +19206,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Protection from Green does not stop the Basilisk’s ability because the ability is not targeted."
+          "text": "Protection from Green does not stop the Basilisk's ability because the ability is not targeted."
         },
         {
           "date": "2004-10-04",
@@ -19358,7 +19368,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -19426,7 +19436,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Each noncreature artifact loses all abilities and becomes an artifact creature with power and toughness each equal to its converted mana cost. If Titania's Song leaves the battlefield, this effect continues until end of turn.",
@@ -19551,7 +19561,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -19662,7 +19672,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -19771,7 +19781,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -20183,23 +20193,23 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
+          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
         },
         {
           "date": "2007-09-16",
-          "text": "When Vesuvan Doppelganger’s triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
+          "text": "When Vesuvan Doppelganger's triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger copies the mana cost of the creature it’s copying but doesn’t copy its color."
+          "text": "Vesuvan Doppelganger copies the mana cost of the creature it's copying but doesn't copy its color."
         },
         {
           "date": "2007-09-16",
-          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger’s color, and will gain Vesuvan Doppelganger’s triggered ability."
+          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger's color, and will gain Vesuvan Doppelganger's triggered ability."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger’s triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller’s upkeep. They’ll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger’s characteristics for the rest of the turn."
+          "text": "Vesuvan Doppelganger's triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller's upkeep. They'll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger's characteristics for the rest of the turn."
         },
         {
           "date": "2007-09-16",
@@ -20207,7 +20217,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Although Vesuvan Doppelganger’s triggered ability is targeted, its “as enters the battlefield” ability is not."
+          "text": "Although Vesuvan Doppelganger's triggered ability is targeted, its \"as enters the battlefield\" ability is not."
         }
       ],
       "subtypes": [
@@ -20268,7 +20278,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can’t be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
+          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can't be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
         },
         {
           "date": "2004-10-04",
@@ -20390,7 +20400,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -20412,7 +20422,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"This ‘standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
+      "flavor": "\"This 'standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
       "id": "ab3d2c77ed400d7d58e295c3827bff97f6cd4b14",
       "imageName": "wall of air",
       "layout": "normal",
@@ -21620,11 +21630,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All permanents untap during a player’s untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
+          "text": "All permanents untap during a player's untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
+          "text": "You can't tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
         }
       ],
       "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",

--- a/json/4ED.json
+++ b/json/4ED.json
@@ -311,7 +311,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"When he reached the entrance of the cavern, he pronounced the words, ‘Open, Sesame!'\"\n—The Arabian Nights, Junior Classics trans.",
+      "flavor": "\"When he reached the entrance of the cavern, he pronounced the words, 'Open, Sesame!'\"\n—The Arabian Nights, Junior Classics trans.",
       "id": "2f8320f6a6bb185e3e11b85ebb344f1ea976f269",
       "imageName": "ali baba",
       "layout": "normal",
@@ -344,11 +344,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This ability may be used to tap more than one Wall per turn if you have enough mana, since tapping isn’t part of the activation cost."
+          "text": "This ability may be used to tap more than one Wall per turn if you have enough mana, since tapping isn't part of the activation cost."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability may tap walls even when Ali Baba is tapped or just entered the battlefield, since the activation cost doesn’t include {T}."
+          "text": "The ability may tap walls even when Ali Baba is tapped or just entered the battlefield, since the activation cost doesn't include {T}."
         }
       ],
       "subtypes": [
@@ -405,7 +405,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A creature with power 3 or greater can’t be declared as a blocker for Amrou Kithkin. If the power of a creature that’s already blocking Amrou Kithkin is increased to 3 or greater, it will continue to block Amrou Kithkin."
+          "text": "A creature with power 3 or greater can't be declared as a blocker for Amrou Kithkin. If the power of a creature that's already blocking Amrou Kithkin is increased to 3 or greater, it will continue to block Amrou Kithkin."
         }
       ],
       "subtypes": [
@@ -554,11 +554,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that’s already a creature, it won’t change its power and toughness."
+          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that's already a creature, it won't change its power and toughness."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -624,7 +624,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -632,11 +632,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -755,7 +755,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -864,7 +864,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -965,7 +966,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If both of the targeted creatures are illegal targets by the time Ashes to Ashes resolves, it’s countered. It doesn’t deal 5 damage to you."
+          "text": "If both of the targeted creatures are illegal targets by the time Ashes to Ashes resolves, it's countered. It doesn't deal 5 damage to you."
         }
       ],
       "text": "Exile two target nonartifact creatures. Ashes to Ashes deals 5 damage to you.",
@@ -1231,7 +1232,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Balance doesn’t have targets, so permanents that can’t be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
+          "text": "Balance doesn't have targets, so permanents that can't be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
         },
         {
           "date": "2016-06-08",
@@ -1347,7 +1348,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1422,7 +1423,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1730,7 +1731,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "text": "As Black Vise enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, Black Vise deals X damage to that player, where X is the number of cards in his or her hand minus 4.",
@@ -1993,7 +1994,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         }
       ],
       "text": "Choose one —\n• Counter target red spell.\n• Destroy target red permanent.",
@@ -2429,11 +2430,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t choose to pay 10 life if you have less than 10 life, but you may choose to give up the game immediately. This has roughly the same effect."
+          "text": "You can't choose to pay 10 life if you have less than 10 life, but you may choose to give up the game immediately. This has roughly the same effect."
         },
         {
           "date": "2004-10-04",
-          "text": "You can take control of your opponent’s Tablet and in the trade you only have to give them back their Tablet."
+          "text": "You can take control of your opponent's Tablet and in the trade you only have to give them back their Tablet."
         },
         {
           "date": "2004-10-04",
@@ -2846,7 +2847,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life you don’t have. In other words, you can’t Channel yourself below zero life."
+          "text": "You can't pay life you don't have. In other words, you can't Channel yourself below zero life."
         }
       ],
       "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
@@ -3021,7 +3022,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3097,7 +3098,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3173,7 +3174,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3253,7 +3254,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3329,7 +3330,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3508,7 +3509,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Clockwork Beast’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "Clockwork Beast's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         }
       ],
       "subtypes": [
@@ -3742,7 +3743,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -3895,7 +3896,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you choose not to pay Cosmic Horror’s upkeep cost, it deals 7 damage to you only if it’s actually destroyed. If it regenerates or an effect has given it indestructible, it deals no damage."
+          "text": "If you choose not to pay Cosmic Horror's upkeep cost, it deals 7 damage to you only if it's actually destroyed. If it regenerates or an effect has given it indestructible, it deals no damage."
         }
       ],
       "subtypes": [
@@ -5142,7 +5143,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “can’t regenerate” is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
+          "text": "The \"can't regenerate\" is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
         },
         {
           "date": "2004-10-04",
@@ -5373,11 +5374,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -5515,7 +5516,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "text": "Target player activates a mana ability of each land he or she controls. Then put all mana from that player's mana pool into yours.",
@@ -5692,11 +5693,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can’t be unblocked."
+          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can't be unblocked."
         },
         {
           "date": "2004-10-04",
-          "text": "If you increase the power of the targeted creature after the ability resolves, it still can’t be blocked that turn."
+          "text": "If you increase the power of the targeted creature after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -6039,7 +6040,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -6410,7 +6411,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability “{T}: Add {B} to your mana pool.” Evil Presence doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability \"{T}: Add {B} to your mana pool.\" Evil Presence doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         }
       ],
       "subtypes": [
@@ -6647,7 +6648,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This works even if the opponent’s lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
+          "text": "This works even if the opponent's lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
         },
         {
           "date": "2004-10-04",
@@ -6655,19 +6656,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, take into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, take into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Fellwar Stone doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -6807,7 +6808,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -6819,7 +6820,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -6893,7 +6894,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -8276,11 +8277,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When being declared as an attacker, use the “not attacking” power and toughness. It only changes after declaration is complete."
+          "text": "When being declared as an attacker, use the \"not attacking\" power and toughness. It only changes after declaration is complete."
         },
         {
           "date": "2006-09-25",
-          "text": "The activated ability doesn’t affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability “{T}: Add {G} to your mana pool.”"
+          "text": "The activated ability doesn't affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability \"{T}: Add {G} to your mana pool.\""
         },
         {
           "date": "2006-10-15",
@@ -8520,6 +8521,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -8529,6 +8534,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -8795,7 +8804,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "White spells cost {3} more to cast.\nActivated abilities of white enchantments cost {3} more to activate.",
@@ -8863,7 +8872,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade’s ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
         }
       ],
       "subtypes": [
@@ -9417,7 +9426,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -10038,7 +10047,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers even if the Specter’s damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
+          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
         }
       ],
       "subtypes": [
@@ -10197,15 +10206,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If attached to an opponent’s creature, you can untap their creature during your turn."
+          "text": "If attached to an opponent's creature, you can untap their creature during your turn."
         },
         {
           "date": "2004-10-04",
-          "text": "Instill Energy’s untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
+          "text": "Instill Energy's untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
         },
         {
           "date": "2005-08-01",
-          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card’s ability to untap once during the turn."
+          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card's ability to untap once during the turn."
         }
       ],
       "subtypes": [
@@ -11234,7 +11243,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Since the draw is replaced, you can’t use the same draw to do other things."
+          "text": "Since the draw is replaced, you can't use the same draw to do other things."
         }
       ],
       "text": "If you would draw a card during your draw step, instead you may skip that draw. If you do, until your next turn, you can't be attacked except by creatures with flying and/or islandwalk.",
@@ -11332,7 +11341,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have four or fewer cards in your hand when Ivory Tower’s ability resolves, the ability has no effect."
+          "text": "If you have four or fewer cards in your hand when Ivory Tower's ability resolves, the ability has no effect."
         }
       ],
       "text": "At the beginning of your upkeep, you gain X life, where X is the number of cards in your hand minus 4.",
@@ -11532,7 +11541,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         }
       ],
       "text": "Target creature gains flying until end of turn.",
@@ -11698,7 +11707,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never “locked in”."
+          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never \"locked in\"."
         }
       ],
       "subtypes": [
@@ -11817,7 +11826,7 @@
           "text": "Does not affect cards that phase in."
         }
       ],
-      "text": "Artifacts, creatures, and lands played by your opponents enter the battlefield tapped.",
+      "text": "Artifacts, creatures, and lands your opponents control enter the battlefield tapped.",
       "type": "Enchantment",
       "types": [
         "Enchantment"
@@ -11871,7 +11880,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Swamps are 1/1 black creatures that are still lands.",
@@ -11972,15 +11981,15 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "You can fetch any of the “Snow-Covered” lands, since they all also have the supertype basic."
+          "text": "You can fetch any of the \"Snow-Covered\" lands, since they all also have the supertype basic."
         },
         {
           "date": "2009-10-01",
-          "text": "This ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
+          "text": "This ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "You shuffle your library if you search, even if you don’t put any basic land cards into your hand."
+          "text": "You shuffle your library if you search, even if you don't put any basic land cards into your hand."
         }
       ],
       "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, and put them into your hand. If you do, shuffle your library.",
@@ -12041,7 +12050,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
+          "text": "You don't have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
         }
       ],
       "subtypes": [
@@ -12107,7 +12116,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can’t be used at times that only mana abilities can be used."
+          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can't be used at times that only mana abilities can be used."
         }
       ],
       "subtypes": [
@@ -12162,11 +12171,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not “discarded”."
+          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not \"discarded\"."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren’t effects."
+          "text": "You can't use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren't effects."
         },
         {
           "date": "2004-10-04",
@@ -12194,7 +12203,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\nIf an effect causes you to discard a card, discard it, but you may put it on top of your library instead of into your graveyard.",
@@ -12468,7 +12477,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can cast it targeting your opponent’s artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
+          "text": "You can cast it targeting your opponent's artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
         },
         {
           "date": "2004-10-04",
@@ -12532,7 +12541,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Forests are 1/1 creatures that are still lands.",
@@ -12959,7 +12968,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -12971,7 +12980,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
@@ -12983,7 +12992,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target spell or permanent by replacing all instances of one basic land type with another. (For example, you may change \"swampwalk\" to \"plainswalk.\" This effect lasts indefinitely.)",
@@ -13159,7 +13168,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This card’s coin flip has no winner or loser."
+          "text": "This card's coin flip has no winner or loser."
         }
       ],
       "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
@@ -13215,7 +13224,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare’s ability."
+          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare's ability."
         },
         {
           "date": "2004-10-04",
@@ -13223,7 +13232,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can’t give a mana of a color that wasn’t produced."
+          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can't give a mana of a color that wasn't produced."
         },
         {
           "date": "2004-10-04",
@@ -13239,7 +13248,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Does not copy any restrictions on the mana, such as with Mishra’s Workshop or Pillar of the Paruns."
+          "text": "Does not copy any restrictions on the mana, such as with Mishra's Workshop or Pillar of the Paruns."
         },
         {
           "date": "2007-09-16",
@@ -13428,7 +13437,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -13697,7 +13706,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -13920,19 +13929,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Once turned into a creature, Mishra’s Factory’s last ability can target itself. If it’s already blocking, this won’t remove it from combat."
+          "text": "Once turned into a creature, Mishra's Factory's last ability can target itself. If it's already blocking, this won't remove it from combat."
         },
         {
           "date": "2016-06-08",
-          "text": "If you turn Mishra’s Factory into a creature but haven’t controlled it continuously since your most recent turn began, you won’t be able to activate its first or last ability."
+          "text": "If you turn Mishra's Factory into a creature but haven't controlled it continuously since your most recent turn began, you won't be able to activate its first or last ability."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
@@ -13977,11 +13986,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You may choose to take damage or to discard. You can’t avoid taking damage if you have no cards to discard."
+          "text": "You may choose to take damage or to discard. You can't avoid taking damage if you have no cards to discard."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -14918,7 +14927,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -14976,7 +14985,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The player can pay the {1} mana at any time after damage is done before the draw step of that player’s turn. People commonly pay during upkeep."
+          "text": "The player can pay the {1} mana at any time after damage is done before the draw step of that player's turn. People commonly pay during upkeep."
         },
         {
           "date": "2004-10-04",
@@ -15045,7 +15054,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can’t be countered with something that counters spells."
+          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can't be countered with something that counters spells."
         },
         {
           "date": "2004-10-04",
@@ -15053,7 +15062,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "A card is “above” another card in your graveyard if it was put into that graveyard later."
+          "text": "A card is \"above\" another card in your graveyard if it was put into that graveyard later."
         },
         {
           "date": "2008-10-01",
@@ -15065,11 +15074,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -15130,7 +15139,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -15206,19 +15215,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -15760,7 +15769,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' ‘Well, now that we have seen each other,' said the Unicorn, ‘if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
+      "flavor": "\"'Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' 'Well, now that we have seen each other,' said the Unicorn, 'if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
       "id": "2e22cdb1b867544326c648018835ee84dc39c8ae",
       "imageName": "pearled unicorn",
       "layout": "normal",
@@ -15858,7 +15867,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent’s Incarnation you can let it die to make them lose life."
+          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent's Incarnation you can let it die to make them lose life."
         },
         {
           "date": "2007-02-01",
@@ -15933,7 +15942,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -16178,7 +16187,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"As the cavalry bore down, we faced them with swords drawn and pikes hidden in the grass at our feet. ‘Don't lift your pikes 'til I give the word,' I said.\"\n—Maeveen O'Donagh, Memoirs of a Soldier",
+      "flavor": "\"As the cavalry bore down, we faced them with swords drawn and pikes hidden in the grass at our feet. 'Don't lift your pikes 'til I give the word,' I said.\"\n—Maeveen O'Donagh, Memoirs of a Soldier",
       "id": "b2944198817ddd24b9d9f85c256a97420d5685c7",
       "imageName": "pikemen",
       "layout": "normal",
@@ -16212,7 +16221,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -17286,7 +17295,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -17452,11 +17461,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         },
         {
           "date": "2012-07-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -17767,15 +17776,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If some but not all of Pyrotechnics’s targets become illegal, you can’t change the division of damage. Damage that would have been dealt to illegal targets simply isn’t dealt."
+          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can’t deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
         },
         {
           "date": "2014-11-24",
-          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can’t be changed. The effect that creates the copy may allow you to change the targets, however."
+          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
         }
       ],
       "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
@@ -17963,7 +17972,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -18395,7 +18404,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -18519,11 +18528,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -19124,15 +19133,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -19556,7 +19565,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t use Simulacrum on Loss of Life, just damage."
+          "text": "You can't use Simulacrum on Loss of Life, just damage."
         },
         {
           "date": "2004-10-04",
@@ -19564,7 +19573,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage’s source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
+          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage's source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
         }
       ],
       "text": "You gain life equal to the damage dealt to you this turn. Simulacrum deals damage to target creature you control equal to the damage dealt to you this turn.",
@@ -19623,7 +19632,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If the draw is replaced by another effect, none of the rest of Sindbad’s ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
+          "text": "If the draw is replaced by another effect, none of the rest of Sindbad's ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
         },
         {
           "date": "2006-09-25",
@@ -19685,15 +19694,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It will require creatures with Haste to attack since they are able, but it won’t destroy them if they don’t for some reason."
+          "text": "It will require creatures with Haste to attack since they are able, but it won't destroy them if they don't for some reason."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2009-02-01",
-          "text": "This will destroy creatures that weren’t able to attack because they had been previously tapped."
+          "text": "This will destroy creatures that weren't able to attack because they had been previously tapped."
         },
         {
           "date": "2013-09-20",
@@ -19807,7 +19816,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t Sleight proper nouns (i.e. card names). This means that you can’t affect a “Black Vise”."
+          "text": "You can't Sleight proper nouns (i.e. card names). This means that you can't affect a \"Black Vise\"."
         },
         {
           "date": "2004-10-04",
@@ -19815,7 +19824,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Can’t change a color word to the same color word. It must be a different word."
+          "text": "Can't change a color word to the same color word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -19827,7 +19836,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -20071,11 +20080,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -20195,7 +20204,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Spirit Shackle’s ability triggers only when the enchanted creature changes from untapped to tapped. If Spirit Shackle enters the battlefield attached to an already tapped creature, it won’t do anything (until that creature untaps and becomes tapped again, that is)."
+          "text": "Spirit Shackle's ability triggers only when the enchanted creature changes from untapped to tapped. If Spirit Shackle enters the battlefield attached to an already tapped creature, it won't do anything (until that creature untaps and becomes tapped again, that is)."
         }
       ],
       "subtypes": [
@@ -20254,7 +20263,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since there is no untap step, Phasing in/out won’t happen."
+          "text": "Since there is no untap step, Phasing in/out won't happen."
         },
         {
           "date": "2004-10-04",
@@ -20385,19 +20394,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the Giant’s power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
+          "text": "If the Giant's power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
         },
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stone Giant’s ability is activated during a turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. The targeted creature will be destroyed at that time."
+          "text": "If Stone Giant's ability is activated during a turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. The targeted creature will be destroyed at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it’s no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant’s power at that time."
+          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it's no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant's power at that time."
         }
       ],
       "subtypes": [
@@ -21511,7 +21520,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -21565,19 +21574,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player’s draw step."
+          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player's draw step."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library’s ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
+          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library's ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
         },
         {
           "date": "2016-06-08",
-          "text": "Any cards drawn prior to Sylvan Library’s ability resolving, including in your upkeep or in response to Sylvan Library’s triggered ability, can be chosen to be put back using this effect. Sylvan Library’s controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
+          "text": "Any cards drawn prior to Sylvan Library's ability resolving, including in your upkeep or in response to Sylvan Library's triggered ability, can be chosen to be put back using this effect. Sylvan Library's controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don’t get to draw all the cards at once and then put them all back at once."
+          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don't get to draw all the cards at once and then put them all back at once."
         },
         {
           "date": "2016-06-08",
@@ -21585,11 +21594,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library’s ability still happens. If you’ve actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven’t actually drawn any cards that turn, the rest of the ability has no effect."
+          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library's ability still happens. If you've actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven't actually drawn any cards that turn, the rest of the ability has no effect."
         },
         {
           "date": "2016-06-08",
-          "text": "It’s not possible to take any actions between drawing the cards and choosing two cards. You can’t cast the cards you drew to avoid having two cards to choose."
+          "text": "It's not possible to take any actions between drawing the cards and choosing two cards. You can't cast the cards you drew to avoid having two cards to choose."
         }
       ],
       "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
@@ -21838,7 +21847,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Only Tetravites from this specific Tetravus may be used for the ability. Ones from a different Tetravus can’t."
+          "text": "Only Tetravites from this specific Tetravus may be used for the ability. Ones from a different Tetravus can't."
         },
         {
           "date": "2008-08-01",
@@ -22058,7 +22067,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Protection from Green does not stop the Basilisk’s ability because the ability is not targeted."
+          "text": "Protection from Green does not stop the Basilisk's ability because the ability is not targeted."
         },
         {
           "date": "2004-10-04",
@@ -22220,7 +22229,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -22292,11 +22301,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A “permanent that isn’t enchanted” is a permanent with no Auras on it."
+          "text": "A \"permanent that isn't enchanted\" is a permanent with no Auras on it."
         },
         {
           "date": "2007-09-16",
-          "text": "If Time Elemental attacks or blocks, but you no longer control it at end of combat, you can’t sacrifice it. However, it will still deal 5 damage to you."
+          "text": "If Time Elemental attacks or blocks, but you no longer control it at end of combat, you can't sacrifice it. However, it will still deal 5 damage to you."
         }
       ],
       "subtypes": [
@@ -22352,7 +22361,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Each noncreature artifact loses all abilities and becomes an artifact creature with power and toughness each equal to its converted mana cost. If Titania's Song leaves the battlefield, this effect continues until end of turn.",
@@ -22476,11 +22485,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it’ll be destroyed before you get a chance to activate its ability."
+          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it'll be destroyed before you get a chance to activate its ability."
         },
         {
           "date": "2010-08-15",
-          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won’t be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
+          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won't be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
         }
       ],
       "subtypes": [
@@ -23030,7 +23039,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2006-10-15",
@@ -23377,7 +23386,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t rearrange the cards. You put them back in the same order or have the whole library shuffled."
+          "text": "You can't rearrange the cards. You put them back in the same order or have the whole library shuffled."
         },
         {
           "date": "2004-10-04",
@@ -23457,7 +23466,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"This ‘standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
+      "flavor": "\"This 'standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
       "id": "42520cc70941e4072793a947e0a6d7cb0580e8b6",
       "imageName": "wall of air",
       "layout": "normal",
@@ -24889,7 +24898,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Checks if the creatures are Flying on resolution and not on announcement. It’s not a targeting restriction."
+          "text": "Checks if the creatures are Flying on resolution and not on announcement. It's not a targeting restriction."
         }
       ],
       "text": "Tap X target creatures. Winter Blast deals 2 damage to each of those creatures with flying.",
@@ -24940,11 +24949,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All permanents untap during a player’s untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
+          "text": "All permanents untap during a player's untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
+          "text": "You can't tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
         }
       ],
       "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",
@@ -25159,7 +25168,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [

--- a/json/5DN.json
+++ b/json/5DN.json
@@ -601,11 +601,11 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Beacon of Immortality’s effect counts as life gain (or life loss, if the life total was negative) for effects that trigger on or replace life gain (or life loss)."
+          "text": "Beacon of Immortality's effect counts as life gain (or life loss, if the life total was negative) for effects that trigger on or replace life gain (or life loss)."
         },
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Double target player's life total. Shuffle Beacon of Immortality into its owner's library.",
@@ -1175,7 +1175,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Raksha Golden Cub is a Cat, so it also gets +2/+2 and double strike if it’s equipped."
+          "text": "Raksha Golden Cub is a Cat, so it also gets +2/+2 and double strike if it's equipped."
         }
       ],
       "subtypes": [
@@ -1740,7 +1740,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -2289,7 +2289,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Target player takes an extra turn after this one. Shuffle Beacon of Tomorrows into its owner's library.",
@@ -2670,7 +2670,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Mana cost includes any requirements for colored mana, although most artifacts don’t have any color requirements."
+          "text": "Mana cost includes any requirements for colored mana, although most artifacts don't have any color requirements."
         },
         {
           "date": "2004-12-01",
@@ -2860,7 +2860,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You do the scrying at the end of the ability’s resolution (assuming you pay {1})."
+          "text": "You do the scrying at the end of the ability's resolution (assuming you pay {1})."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell, you may pay {1}. If you do, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -2954,7 +2954,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If the spell isn’t countered (because it’s a spell that can’t be countered, for example), nothing happens."
+          "text": "If the spell isn't countered (because it's a spell that can't be countered, for example), nothing happens."
         },
         {
           "date": "2004-12-01",
@@ -3519,7 +3519,7 @@
       "rulings": [
         {
           "date": "2005-04-01",
-          "text": "Because of updated targeting rulings, it’s possible to target the same spell or permanent with both abilities when cast with Entwine."
+          "text": "Because of updated targeting rulings, it's possible to target the same spell or permanent with both abilities when cast with Entwine."
         }
       ],
       "text": "Choose one —\n• Change the text of target spell or permanent by replacing all instances of one basic land type with another. (This effect lasts indefinitely.)\n• Change the text of target spell or permanent by replacing all instances of one color word with another. (This effect lasts indefinitely.)\nEntwine {2} (Choose both if you pay the entwine cost.)",
@@ -3917,7 +3917,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Put target artifact or creature card from a graveyard onto the battlefield under your control. Shuffle Beacon of Unrest into its owner's library.",
@@ -4013,7 +4013,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "This ability triggers off anyone casting a spell, including you, not just Blind Creeper’s controller or an opponent."
+          "text": "This ability triggers off anyone casting a spell, including you, not just Blind Creeper's controller or an opponent."
         }
       ],
       "subtypes": [
@@ -4307,11 +4307,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "This ability triggers off anyone casting a spell, including you, not just Desecration Elemental’s controller or an opponent."
+          "text": "This ability triggers off anyone casting a spell, including you, not just Desecration Elemental's controller or an opponent."
         },
         {
           "date": "2004-12-01",
-          "text": "If Desecration Elemental is the only creature you control when its triggered ability resolves, you’ll have to sacrifice it."
+          "text": "If Desecration Elemental is the only creature you control when its triggered ability resolves, you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -4594,7 +4594,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "This ability triggers off anyone casting a spell, including you, not just Ebon Drake’s controller or an opponent."
+          "text": "This ability triggers off anyone casting a spell, including you, not just Ebon Drake's controller or an opponent."
         }
       ],
       "subtypes": [
@@ -4693,7 +4693,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The creatures have the triggered ability, so each creature’s controller chooses one of his or her opponents to target."
+          "text": "The creatures have the triggered ability, so each creature's controller chooses one of his or her opponents to target."
         }
       ],
       "text": "Each creature has \"When this creature dies, choose target opponent. That player puts this card from its owner's graveyard onto the battlefield under his or her control at the beginning of the next end step.\"",
@@ -5540,11 +5540,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Yes, you’re allowed to have a deck consisting of sixty Relentless Rats and nothing else."
+          "text": "Yes, you're allowed to have a deck consisting of sixty Relentless Rats and nothing else."
         },
         {
           "date": "2004-12-01",
-          "text": "Relentless Rats’s last ability overrides the normal limit of four of an individual card in a Constructed deck."
+          "text": "Relentless Rats's last ability overrides the normal limit of four of an individual card in a Constructed deck."
         }
       ],
       "subtypes": [
@@ -5822,7 +5822,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Beacon of Destruction deals 5 damage to target creature or player. Shuffle Beacon of Destruction into its owner's library.",
@@ -6975,11 +6975,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Magma Jet deals 2 damage to target creature or player. Scry 2.",
@@ -7348,15 +7348,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Reversal of Fortune creates a copy of the card in the other player’s hand, then allows you to cast the copy from that player’s hand without paying its mana cost."
+          "text": "Reversal of Fortune creates a copy of the card in the other player's hand, then allows you to cast the copy from that player's hand without paying its mana cost."
         },
         {
           "date": "2004-12-01",
-          "text": "You cast the copy while this ability is resolving and still on the stack. Normally, you’re not allowed to cast spells or activate abilities at this time. Reversal of Fortune provides an exception."
+          "text": "You cast the copy while this ability is resolving and still on the stack. Normally, you're not allowed to cast spells or activate abilities at this time. Reversal of Fortune provides an exception."
         },
         {
           "date": "2004-12-01",
-          "text": "You don’t pay the spell’s mana cost. If the spell has X in its mana cost, X is 0. You do pay any additional costs for that spell. You can’t use any alternative costs."
+          "text": "You don't pay the spell's mana cost. If the spell has X in its mana cost, X is 0. You do pay any additional costs for that spell. You can't use any alternative costs."
         },
         {
           "date": "2004-12-01",
@@ -7364,19 +7364,19 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t cast the copy if an effect prevents you from casting instants or sorceries, or from casting that particular instant or sorcery. It doesn’t matter whether your opponent can cast the card at this time; the only thing that matters is whether you can cast it."
+          "text": "You can't cast the copy if an effect prevents you from casting instants or sorceries, or from casting that particular instant or sorcery. It doesn't matter whether your opponent can cast the card at this time; the only thing that matters is whether you can cast it."
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t cast the copy unless all of its targets, if any, can be chosen."
+          "text": "You can't cast the copy unless all of its targets, if any, can be chosen."
         },
         {
           "date": "2004-12-01",
-          "text": "If you don’t want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
+          "text": "If you don't want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
         },
         {
           "date": "2004-12-01",
-          "text": "The spell is cast from your opponent’s hand, not yours, which can be important for some cards."
+          "text": "The spell is cast from your opponent's hand, not yours, which can be important for some cards."
         },
         {
           "date": "2005-03-01",
@@ -7757,7 +7757,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "All Suns’ Dawn can have from zero to five targets, one for each color."
+          "text": "All Suns' Dawn can have from zero to five targets, one for each color."
         },
         {
           "date": "2004-12-01",
@@ -7765,7 +7765,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You choose the color each target must be when you choose it as a target, so if the card you targeted as a blue card is red when All Suns’ Dawn resolves, the card is an illegal target, even if the spell doesn’t target another red card."
+          "text": "You choose the color each target must be when you choose it as a target, so if the card you targeted as a blue card is red when All Suns' Dawn resolves, the card is an illegal target, even if the spell doesn't target another red card."
         }
       ],
       "text": "For each color, return up to one target card of that color from your graveyard to your hand. Exile All Suns' Dawn.",
@@ -7860,7 +7860,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Create a 1/1 green Insect creature token for each Forest you control. Shuffle Beacon of Creation into its owner's library.",
@@ -8633,11 +8633,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The ability targets an ability on the stack, not the artifact, so it can destroy an artifact with protection from green or one that can’t be targeted by spells and abilities."
+          "text": "The ability targets an ability on the stack, not the artifact, so it can destroy an artifact with protection from green or one that can't be targeted by spells and abilities."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -8741,7 +8741,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The creature doesn’t get a counter if all the damage that would be dealt to it is prevented."
+          "text": "The creature doesn't get a counter if all the damage that would be dealt to it is prevented."
         }
       ],
       "text": "Whenever a creature you control is dealt damage, put a +1/+1 counter on it. (The damage is dealt before the counter is put on.)",
@@ -8838,11 +8838,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-06-07",
-          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won’t be affected."
+          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won't be affected."
         }
       ],
       "text": "Choose one —\n• Untap all lands you control.\n• Until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
@@ -9313,11 +9313,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -9325,7 +9325,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -9886,11 +9886,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "For the leaves-the-battlefield ability, the number of counters on Arcbound Wanderer at the time it left the battlefield is what’s relevant; the number of colors of mana used to pay its cost doesn’t matter anymore."
+          "text": "For the leaves-the-battlefield ability, the number of counters on Arcbound Wanderer at the time it left the battlefield is what's relevant; the number of colors of mana used to pay its cost doesn't matter anymore."
         },
         {
           "date": "2004-12-01",
-          "text": "When the Wanderer leaves the battlefield, you may put the counters onto a single target artifact creature. You can’t split them among two or more artifact creatures."
+          "text": "When the Wanderer leaves the battlefield, you may put the counters onto a single target artifact creature. You can't split them among two or more artifact creatures."
         },
         {
           "date": "2006-09-25",
@@ -9988,7 +9988,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "It is possible to activate this ability in response to itself and generate some odd combinations. For example, if you control this card and another permanent, you can use this card’s ability and target the permanent you control. You can then use this card’s ability again and target a permanent your opponent controls. The second usage resolves first and you get your opponent’s permanent in exchange for this one. The first usage then resolves and swaps your other permanent for the Totem so you get it back. The net effect is that you can swap any non-land permanent you have for any of theirs if you can activate this ability twice. Note that your opponent does get the chance to use the Totem in between the resolutions of your two usages if they have the mana."
+          "text": "It is possible to activate this ability in response to itself and generate some odd combinations. For example, if you control this card and another permanent, you can use this card's ability and target the permanent you control. You can then use this card's ability again and target a permanent your opponent controls. The second usage resolves first and you get your opponent's permanent in exchange for this one. The first usage then resolves and swaps your other permanent for the Totem so you get it back. The net effect is that you can swap any non-land permanent you have for any of theirs if you can activate this ability twice. Note that your opponent does get the chance to use the Totem in between the resolutions of your two usages if they have the mana."
         }
       ],
       "text": "{5}: Exchange control of Avarice Totem and target nonland permanent.",
@@ -10330,11 +10330,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If X is 0, Chimeric Coils becomes a 0/0 creature and is put into its owner’s graveyard."
+          "text": "If X is 0, Chimeric Coils becomes a 0/0 creature and is put into its owner's graveyard."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{X}{1}: Chimeric Coils becomes an X/X Construct artifact creature. Sacrifice it at the beginning of the next end step.",
@@ -10867,11 +10867,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Crucible of Worlds doesn’t change the times when you can play those land cards. You can still play only one land per turn, and only during your main phase when you have priority and the stack is empty."
+          "text": "Crucible of Worlds doesn't change the times when you can play those land cards. You can still play only one land per turn, and only during your main phase when you have priority and the stack is empty."
         },
         {
           "date": "2004-12-01",
-          "text": "Crucible of Worlds doesn’t allow you to activate activated abilities (such as cycling) of land cards in your graveyard."
+          "text": "Crucible of Worlds doesn't allow you to activate activated abilities (such as cycling) of land cards in your graveyard."
         }
       ],
       "text": "You may play land cards from your graveyard.",
@@ -11053,15 +11053,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Doubling Cube’s ability is a mana ability."
+          "text": "Doubling Cube's ability is a mana ability."
         },
         {
           "date": "2004-12-01",
-          "text": "The “type” of mana is its color, or lack thereof (if the mana is colorless)."
+          "text": "The \"type\" of mana is its color, or lack thereof (if the mana is colorless)."
         },
         {
           "date": "2004-12-01",
-          "text": "Any restrictions on the mana in your mana pool aren’t copied. For example, if you have {C}{W}{W}{B} with no restrictions on it in your mana pool and {U}{U}{U} that can be used only to cast artifact spells, you’ll end up with {C}{C}{W}{W}{W}{W}{B}{B}, {U}{U}{U} that can be used only to cast artifact spells, and {U}{U}{U} that can be used for anything."
+          "text": "Any restrictions on the mana in your mana pool aren't copied. For example, if you have {C}{W}{W}{B} with no restrictions on it in your mana pool and {U}{U}{U} that can be used only to cast artifact spells, you'll end up with {C}{C}{W}{W}{W}{W}{B}{B}, {U}{U}{U} that can be used only to cast artifact spells, and {U}{U}{U} that can be used for anything."
         }
       ],
       "text": "{3}, {T}: Double the amount of each type of mana in your mana pool.",
@@ -11234,7 +11234,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If Engineered Explosives had no charge counters on it when you sacrificed it, it won’t destroy an animated land, because that permanent is a land in addition to being a creature."
+          "text": "If Engineered Explosives had no charge counters on it when you sacrificed it, it won't destroy an animated land, because that permanent is a land in addition to being a creature."
         }
       ],
       "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
@@ -11322,7 +11322,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -11418,7 +11418,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Upkeep-triggered abilities don’t trigger, and “activate this ability only during your upkeep” abilities can’t be activated."
+          "text": "Upkeep-triggered abilities don't trigger, and \"activate this ability only during your upkeep\" abilities can't be activated."
         },
         {
           "date": "2004-12-01",
@@ -11603,11 +11603,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Any permanent is a legal target for Ferropede’s last ability, not just one with a counter on it."
+          "text": "Any permanent is a legal target for Ferropede's last ability, not just one with a counter on it."
         },
         {
           "date": "2004-12-01",
-          "text": "If there’s more than one type of counter on the targeted permanent, Ferropede’s controller chooses which counter to remove from it."
+          "text": "If there's more than one type of counter on the targeted permanent, Ferropede's controller chooses which counter to remove from it."
         }
       ],
       "subtypes": [
@@ -11712,7 +11712,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t pay more than one alternative cost for a spell. For example, you can’t cast a spell using its flashback ability by paying {W}{U}{B}{R}{G}. Likewise, you can’t pay {W}{U}{B}{R}{G} to cast a creature with morph face down."
+          "text": "You can't pay more than one alternative cost for a spell. For example, you can't cast a spell using its flashback ability by paying {W}{U}{B}{R}{G}. Likewise, you can't pay {W}{U}{B}{R}{G} to cast a creature with morph face down."
         },
         {
           "date": "2004-12-01",
@@ -11892,7 +11892,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You can activate Goblin Cannon’s ability multiple times in response to the first activation. Goblin Cannon will be sacrificed the first time the ability resolves, but each activation still deals damage when it resolves."
+          "text": "You can activate Goblin Cannon's ability multiple times in response to the first activation. Goblin Cannon will be sacrificed the first time the ability resolves, but each activation still deals damage when it resolves."
         }
       ],
       "text": "{2}: Goblin Cannon deals 1 damage to target creature or player. Sacrifice Goblin Cannon.",
@@ -11980,19 +11980,19 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The “becomes unattached” ability triggers if (a) Grafted Wargear leaves the battlefield, (b) the equip ability moves it onto another creature, (c) another effect moves it onto another creature, (d) an effect causes it to become unattached, or (e) the creature leaves the battlefield."
+          "text": "The \"becomes unattached\" ability triggers if (a) Grafted Wargear leaves the battlefield, (b) the equip ability moves it onto another creature, (c) another effect moves it onto another creature, (d) an effect causes it to become unattached, or (e) the creature leaves the battlefield."
         },
         {
           "date": "2004-12-01",
-          "text": "Note that if (e) happens, the creature won’t be on the battlefield to be sacrificed. In all cases, it’s the creature that was equipped when the ability triggered that will be sacrificed."
+          "text": "Note that if (e) happens, the creature won't be on the battlefield to be sacrificed. In all cases, it's the creature that was equipped when the ability triggered that will be sacrificed."
         },
         {
           "date": "2004-12-01",
-          "text": "If your Grafted Wargear somehow ends up on an opponent’s creature and it then becomes unattached from that creature, you won’t be able to sacrifice that creature because you don’t control it."
+          "text": "If your Grafted Wargear somehow ends up on an opponent's creature and it then becomes unattached from that creature, you won't be able to sacrifice that creature because you don't control it."
         },
         {
           "date": "2013-04-15",
-          "text": "You may activate this card’s equip ability targeting the creature that it is currently attached to, even if it’s the only creature you control. Since the equip ability costs zero, you can do this as many times as you like during your main phases, though it generally won’t do anything."
+          "text": "You may activate this card's equip ability targeting the creature that it is currently attached to, even if it's the only creature you control. Since the equip ability costs zero, you can do this as many times as you like during your main phases, though it generally won't do anything."
         }
       ],
       "subtypes": [
@@ -12165,7 +12165,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Guardian Idol enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{2}: Guardian Idol becomes a 2/2 Golem artifact creature until end of turn.",
@@ -12424,7 +12424,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The token isn’t put onto the battlefield unless you control all three Equipment when the ability resolves."
+          "text": "The token isn't put onto the battlefield unless you control all three Equipment when the ability resolves."
         },
         {
           "date": "2004-12-01",
@@ -12780,11 +12780,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -12971,15 +12971,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The spells gain affinity for artifacts as they’re put onto the stack. They don’t have the ability while they’re cards in your hand."
+          "text": "The spells gain affinity for artifacts as they're put onto the stack. They don't have the ability while they're cards in your hand."
         },
         {
           "date": "2004-12-01",
-          "text": "If Mycosynth Golem is sacrificed as part of the cost to cast a spell, the cost reduction will already be locked in, and the cost won’t be increased."
+          "text": "If Mycosynth Golem is sacrificed as part of the cost to cast a spell, the cost reduction will already be locked in, and the cost won't be increased."
         },
         {
           "date": "2004-12-01",
-          "text": "Two or more instances of the affinity ability are cumulative, even if they’re both affinity for the same thing."
+          "text": "Two or more instances of the affinity ability are cumulative, even if they're both affinity for the same thing."
         }
       ],
       "subtypes": [
@@ -13078,7 +13078,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -13173,7 +13173,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The Myr Servitor that’s the source of the ability must be on the battlefield when the ability resolves. If it is, all other Myr Servitor cards are returned from all graveyards to the battlefield under their owner’s control. If it’s not, no Myr Servitors are returned to the battlefield."
+          "text": "The Myr Servitor that's the source of the ability must be on the battlefield when the ability resolves. If it is, all other Myr Servitor cards are returned from all graveyards to the battlefield under their owner's control. If it's not, no Myr Servitors are returned to the battlefield."
         }
       ],
       "subtypes": [
@@ -14221,11 +14221,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Skullcage’s ability deals damage if the player has zero, one, two, five, or more than five cards in hand when its ability resolves."
+          "text": "Skullcage's ability deals damage if the player has zero, one, two, five, or more than five cards in hand when its ability resolves."
         },
         {
           "date": "2004-12-01",
-          "text": "Skullcage doesn’t check hand size when it triggers, only when it resolves."
+          "text": "Skullcage doesn't check hand size when it triggers, only when it resolves."
         }
       ],
       "text": "At the beginning of each opponent's upkeep, Skullcage deals 2 damage to that player unless he or she has exactly three or exactly four cards in hand.",
@@ -14405,7 +14405,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "“Double” has its normal English meaning. If Solarion had three +1/+1 counters on it, it would end up with six +1/+1 counters on it."
+          "text": "\"Double\" has its normal English meaning. If Solarion had three +1/+1 counters on it, it would end up with six +1/+1 counters on it."
         }
       ],
       "subtypes": [
@@ -14587,7 +14587,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Yes, this card’s base power/toughness is -1/-1. If it has five +1/+1 counters on it, it’s a 4/4 creature."
+          "text": "Yes, this card's base power/toughness is -1/-1. If it has five +1/+1 counters on it, it's a 4/4 creature."
         },
         {
           "date": "2004-12-01",
@@ -14595,7 +14595,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Any permanent is a legal target for Spinal Parasite’s ability, not just one with a counter on it. The player who controls Spinal Parasite chooses which counter to remove from the targeted permanent."
+          "text": "Any permanent is a legal target for Spinal Parasite's ability, not just one with a counter on it. The player who controls Spinal Parasite chooses which counter to remove from the targeted permanent."
         }
       ],
       "subtypes": [
@@ -14772,15 +14772,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The card is imprinted face down. This means that other players don’t know what the card is and you can’t look at the card once it’s imprinted (until it’s turned face up, of course). Note that effects that exile cards, including all previous imprint cards, exile those cards face up unless the effect says otherwise."
+          "text": "The card is imprinted face down. This means that other players don't know what the card is and you can't look at the card once it's imprinted (until it's turned face up, of course). Note that effects that exile cards, including all previous imprint cards, exile those cards face up unless the effect says otherwise."
         },
         {
           "date": "2004-12-01",
-          "text": "If the card is not a creature card when it’s turned face up, it remains exiled face up."
+          "text": "If the card is not a creature card when it's turned face up, it remains exiled face up."
         },
         {
           "date": "2004-12-01",
-          "text": "Any “When this creature is turned face up” abilities that the exiled card may have don’t trigger because the card isn’t being turned face up while it’s on the battlefield."
+          "text": "Any \"When this creature is turned face up\" abilities that the exiled card may have don't trigger because the card isn't being turned face up while it's on the battlefield."
         }
       ],
       "subtypes": [
@@ -15315,11 +15315,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The controller of Vedalken Orrery can cast nonland artifact, creature, enchantment, and sorcery cards any time he or she could cast an instant. This includes on other players’ turns and during the upkeep step, draw step, combat phase, and end step."
+          "text": "The controller of Vedalken Orrery can cast nonland artifact, creature, enchantment, and sorcery cards any time he or she could cast an instant. This includes on other players' turns and during the upkeep step, draw step, combat phase, and end step."
         },
         {
           "date": "2010-06-15",
-          "text": "This applies only to casting spells. It does not, for example, change when you may activate abilities that can only be activated “any time you could cast a sorcery”."
+          "text": "This applies only to casting spells. It does not, for example, change when you may activate abilities that can only be activated \"any time you could cast a sorcery\"."
         }
       ],
       "text": "You may cast spells as though they had flash.",
@@ -15409,15 +15409,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The creature’s power and the number of Islands you control matter only when the ability is activated and when it resolves. After that, only the fact that Vedalken Shackles remains tapped matters. If the creature stops being a creature, you’ll keep control of it."
+          "text": "The creature's power and the number of Islands you control matter only when the ability is activated and when it resolves. After that, only the fact that Vedalken Shackles remains tapped matters. If the creature stops being a creature, you'll keep control of it."
         },
         {
           "date": "2004-12-01",
-          "text": "If Vedalken Shackles becomes untapped before its ability resolves, you won’t gain control of the creature."
+          "text": "If Vedalken Shackles becomes untapped before its ability resolves, you won't gain control of the creature."
         },
         {
           "date": "2004-12-01",
-          "text": "If Vedalken Shackles leaves the battlefield, it’s no longer tapped, so the control-changing effect ends."
+          "text": "If Vedalken Shackles leaves the battlefield, it's no longer tapped, so the control-changing effect ends."
         }
       ],
       "text": "You may choose not to untap Vedalken Shackles during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control for as long as Vedalken Shackles remains tapped.",

--- a/json/5ED.json
+++ b/json/5ED.json
@@ -245,7 +245,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Affects any spell with the type creature, including those with other types such as artifact or enchantment. This includes older cards with “summon” on their type line."
+          "text": "Affects any spell with the type creature, including those with other types such as artifact or enchantment. This includes older cards with \"summon\" on their type line."
         }
       ],
       "text": "Creature spells can't be cast.\nPay 4 life: Destroy Aether Storm. It can't be regenerated. Any player may activate this ability.",
@@ -725,7 +725,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -733,11 +733,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -858,7 +858,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -1012,7 +1012,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -1120,7 +1121,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If both of the targeted creatures are illegal targets by the time Ashes to Ashes resolves, it’s countered. It doesn’t deal 5 damage to you."
+          "text": "If both of the targeted creatures are illegal targets by the time Ashes to Ashes resolves, it's countered. It doesn't deal 5 damage to you."
         }
       ],
       "text": "Exile two target nonartifact creatures. Ashes to Ashes deals 5 damage to you.",
@@ -1208,7 +1209,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "It’s the ability, not the counter that makes the creature an artifact. The creature remains an artifact even if the +1/+1 counter is removed."
+          "text": "It's the ability, not the counter that makes the creature an artifact. The creature remains an artifact even if the +1/+1 counter is removed."
         }
       ],
       "text": "{T}, Sacrifice Ashnod's Transmogrant: Put a +1/+1 counter on target nonartifact creature. That creature becomes an artifact in addition to its other types.",
@@ -1720,19 +1721,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Does not prevent a creature from untapping at other times. It just stops the “normal” untap during the untap step."
+          "text": "Does not prevent a creature from untapping at other times. It just stops the \"normal\" untap during the untap step."
         },
         {
           "date": "2009-10-01",
-          "text": "You may target any creature with this ability. It doesn’t have to be tapped."
+          "text": "You may target any creature with this ability. It doesn't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when the targeted creature is tapped."
+          "text": "If the targeted creature is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when the targeted creature is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Barl’s Cage doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Barl's Cage doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "text": "{3}: Target creature doesn't untap during its controller's next untap step.",
@@ -1780,7 +1781,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1855,7 +1856,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -2658,7 +2659,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -3117,7 +3118,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won’t be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
+          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won't be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
         }
       ],
       "subtypes": [
@@ -3246,7 +3247,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"Hang out our banners on the outward walls; / The cry is still, ‘They come'; our castle's strength / Will laugh a siege to scorn.\"\n—William Shakespeare, Macbeth",
+      "flavor": "\"Hang out our banners on the outward walls; / The cry is still, 'They come'; our castle's strength / Will laugh a siege to scorn.\"\n—William Shakespeare, Macbeth",
       "id": "74a78f871a4d209f12b71ce08c4e4bdf0b45bf6d",
       "imageName": "castle",
       "layout": "normal",
@@ -3562,7 +3563,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3638,7 +3639,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3714,7 +3715,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3794,7 +3795,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3870,7 +3871,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3931,7 +3932,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass’s triggered ability is put on the stack on top of it. City of Brass’s ability will resolve first."
+          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass's triggered ability is put on the stack on top of it. City of Brass's ability will resolve first."
         },
         {
           "date": "2004-10-04",
@@ -4035,7 +4036,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -4108,7 +4109,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Clockwork Beast’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "Clockwork Beast's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         }
       ],
       "subtypes": [
@@ -4166,7 +4167,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "When Clockwork Steed’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "When Clockwork Steed's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         },
         {
           "date": "2008-10-01",
@@ -4692,7 +4693,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This only targets the Aura and not either creature. This means it can move Auras onto a creature which can’t normally be targeted by spells and abilities if the Aura is legal on that creature."
+          "text": "This only targets the Aura and not either creature. This means it can move Auras onto a creature which can't normally be targeted by spells and abilities if the Aura is legal on that creature."
         }
       ],
       "text": "{4}, {T}: Attach target Aura attached to a creature to another creature.",
@@ -5027,7 +5028,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Dance of Many leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and put a token onto the battlefield. That token won’t have any connection to a Dance of Many permanent, so it won’t be exiled when a Dance of Many leaves the battlefield."
+          "text": "If Dance of Many leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and put a token onto the battlefield. That token won't have any connection to a Dance of Many permanent, so it won't be exiled when a Dance of Many leaves the battlefield."
         }
       ],
       "text": "When Dance of Many enters the battlefield, create a token that's a copy of target nontoken creature.\nWhen Dance of Many leaves the battlefield, exile the token.\nWhen the token leaves the battlefield, sacrifice Dance of Many.\nAt the beginning of your upkeep, sacrifice Dance of Many unless you pay {U}{U}.",
@@ -5507,7 +5508,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -5527,11 +5528,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Deflection, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Deflection, even if all but one of those targets has become illegal."
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets the same player or object multiple times, you can’t target it with Deflection."
+          "text": "If a spell targets the same player or object multiple times, you can't target it with Deflection."
         }
       ],
       "text": "Change the target of target spell with a single target.",
@@ -5963,7 +5964,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “can’t regenerate” is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
+          "text": "The \"can't regenerate\" is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
         },
         {
           "date": "2004-10-04",
@@ -6094,7 +6095,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you’ll still gain the life."
+          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you'll still gain the life."
         }
       ],
       "text": "Destroy target artifact. You gain life equal to its converted mana cost.",
@@ -6327,7 +6328,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "text": "Target player activates a mana ability of each land he or she controls. Then put all mana from that player's mana pool into yours.",
@@ -6603,7 +6604,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -6767,11 +6768,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can’t be unblocked."
+          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can't be unblocked."
         },
         {
           "date": "2004-10-04",
-          "text": "If you increase the power of the targeted creature after the ability resolves, it still can’t be blocked that turn."
+          "text": "If you increase the power of the targeted creature after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -7001,15 +7002,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the Bottle leaves the battlefield or your control, the cards remain waiting until played or until the beginning of your next upkeep. The card is in the “Exile” zone."
+          "text": "If the Bottle leaves the battlefield or your control, the cards remain waiting until played or until the beginning of your next upkeep. The card is in the \"Exile\" zone."
         },
         {
           "date": "2004-10-04",
-          "text": "The card is not part of your hand in any way. You can’t be forced to discard it due to a discard from hand effect, and you can’t discard it to pay a cost."
+          "text": "The card is not part of your hand in any way. You can't be forced to discard it due to a discard from hand effect, and you can't discard it to pay a cost."
         },
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2008-08-01",
@@ -7017,7 +7018,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The exiled card is played using the normal timing rules for its card type, as well as any other applicable restrictions such as “Cast [this card] only during combat.” For example, you can’t play the card during an opponent’s turn unless it’s an instant or has flash. Similarly, if the exiled card is a land, you can’t play it if you’ve already played a land that turn. If it’s a nonland card, you’ll have to pay its mana cost. The only thing that’s different is you’re playing it from the Exile zone."
+          "text": "The exiled card is played using the normal timing rules for its card type, as well as any other applicable restrictions such as \"Cast [this card] only during combat.\" For example, you can't play the card during an opponent's turn unless it's an instant or has flash. Similarly, if the exiled card is a land, you can't play it if you've already played a land that turn. If it's a nonland card, you'll have to pay its mana cost. The only thing that's different is you're playing it from the Exile zone."
         }
       ],
       "text": "{3}, {T}: Exile the top card of your library. Until the beginning of your next upkeep, you may play that card.",
@@ -7083,7 +7084,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -7357,11 +7358,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Can only attack alone” means the enchanted creature can’t be declared as an attacker during the declare attackers step unless no other creatures are declared as attackers at that time (either by you or your Two-Headed Giant teammate)."
+          "text": "\"Can only attack alone\" means the enchanted creature can't be declared as an attacker during the declare attackers step unless no other creatures are declared as attackers at that time (either by you or your Two-Headed Giant teammate)."
         },
         {
           "date": "2008-10-01",
-          "text": "If the enchanted creature attacks alone, then a spell or ability causes another creature to be put onto the battlefield attacking, that’s fine."
+          "text": "If the enchanted creature attacks alone, then a spell or ability causes another creature to be put onto the battlefield attacking, that's fine."
         }
       ],
       "subtypes": [
@@ -7536,7 +7537,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability “{T}: Add {B} to your mana pool.” Evil Presence doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability \"{T}: Add {B} to your mana pool.\" Evil Presence doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         }
       ],
       "subtypes": [
@@ -7889,7 +7890,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This works even if the opponent’s lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
+          "text": "This works even if the opponent's lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
         },
         {
           "date": "2004-10-04",
@@ -7897,19 +7898,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, take into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, take into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Fellwar Stone doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -7954,7 +7955,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Creature spells cost {2} more to cast.",
@@ -8085,7 +8086,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -8097,7 +8098,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -8171,7 +8172,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -10123,7 +10124,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "To “double the life stakes” means to double the amount of life lost or gained."
+          "text": "To \"double the life stakes\" means to double the amount of life lost or gained."
         }
       ],
       "text": "Flip a coin. If you win the flip, you gain 1 life and target opponent loses 1 life, and you decide whether to flip again. If you lose the flip, you lose 1 life and that opponent gains 1 life, and that player decides whether to flip again. Double the life stakes with each flip.",
@@ -10231,11 +10232,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As you activate the ability, the targets you choose must be two artifacts, two creatures, or two lands. As the ability resolves, both targets will be legal only if they are two artifacts, two creatures, or two lands at that time as well, though they may be a different type than they were at the time the ability was activated. For example, if the targets were a creature and an artifact creature when the ability was activated, but the first target became a noncreature artifact by the time the ability resolves, both targets will still be legal (since they’re both artifacts)."
+          "text": "As you activate the ability, the targets you choose must be two artifacts, two creatures, or two lands. As the ability resolves, both targets will be legal only if they are two artifacts, two creatures, or two lands at that time as well, though they may be a different type than they were at the time the ability was activated. For example, if the targets were a creature and an artifact creature when the ability was activated, but the first target became a noncreature artifact by the time the ability resolves, both targets will still be legal (since they're both artifacts)."
         },
         {
           "date": "2009-10-01",
-          "text": "If one of the targets is illegal by the time the ability resolves (because the wrong player controls it, or it’s the wrong card type, or for any other reason), the exchange doesn’t happen. The target that’s still legal will remain under its controller’s control. Since the exchange doesn’t happen, no Auras are destroyed. (If both targets are illegal, the ability is countered.)"
+          "text": "If one of the targets is illegal by the time the ability resolves (because the wrong player controls it, or it's the wrong card type, or for any other reason), the exchange doesn't happen. The target that's still legal will remain under its controller's control. Since the exchange doesn't happen, no Auras are destroyed. (If both targets are illegal, the ability is countered.)"
         }
       ],
       "text": "{5}, Sacrifice Gauntlets of Chaos: Exchange control of target artifact, creature, or land you control and target permanent an opponent controls that shares one of those types with it. If those permanents are exchanged this way, destroy all Auras attached to them.",
@@ -10397,6 +10398,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -10406,6 +10411,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -10676,7 +10685,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "White spells cost {3} more to cast.\nActivated abilities of white enchantments cost {3} more to activate.",
@@ -10902,7 +10911,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When combined with an effect that reads “Each creature you control can’t be blocked by more than one creature,” none of your creatures can be blocked."
+          "text": "When combined with an effect that reads \"Each creature you control can't be blocked by more than one creature,\" none of your creatures can be blocked."
         },
         {
           "date": "2004-10-04",
@@ -11263,7 +11272,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You draw a card at the beginning of the next turn’s upkeep after Heal resolves, regardless of whether 1 damage was actually prevented."
+          "text": "You draw a card at the beginning of the next turn's upkeep after Heal resolves, regardless of whether 1 damage was actually prevented."
         }
       ],
       "text": "Prevent the next 1 damage that would be dealt to target creature or player this turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -11448,7 +11457,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -11622,7 +11631,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -12184,7 +12193,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         },
         {
           "date": "2016-06-08",
@@ -12240,7 +12249,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -12353,7 +12362,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -12461,7 +12470,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target a tapped creature with Ice Floe’s activated ability."
+          "text": "You may target a tapped creature with Ice Floe's activated ability."
         },
         {
           "date": "2008-10-01",
@@ -12469,19 +12478,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the ability resolves, then the creature gains flying later, Ice Floe’s effect will not end. (The ability checks whether the creature has flying only at the time you activate it and the time it resolves.)"
+          "text": "If the ability resolves, then the creature gains flying later, Ice Floe's effect will not end. (The ability checks whether the creature has flying only at the time you activate it and the time it resolves.)"
         },
         {
           "date": "2008-10-01",
-          "text": "If the affected creature is untapped by some other spell or ability, Ice Floe’s effect will not end. If you keep Ice Floe tapped, and that creature becomes tapped again, Ice Floe will continue to prevent it from being untapped during its controller’s untap step."
+          "text": "If the affected creature is untapped by some other spell or ability, Ice Floe's effect will not end. If you keep Ice Floe tapped, and that creature becomes tapped again, Ice Floe will continue to prevent it from being untapped during its controller's untap step."
         },
         {
           "date": "2008-10-01",
-          "text": "Ice Floe doesn’t track the creature’s controller. If the affected creature changes controllers, Ice Floe will prevent it from being untapped during its new controller’s untap step."
+          "text": "Ice Floe doesn't track the creature's controller. If the affected creature changes controllers, Ice Floe will prevent it from being untapped during its new controller's untap step."
         },
         {
           "date": "2008-10-01",
-          "text": "If Ice Floe untaps or leaves the battlefield, its effect will end. This has no immediate visible affect on the creature. (It doesn’t untap immediately, for example.) The creature will just untap as normal during its controller’s next untap step."
+          "text": "If Ice Floe untaps or leaves the battlefield, its effect will end. This has no immediate visible affect on the creature. (It doesn't untap immediately, for example.) The creature will just untap as normal during its controller's next untap step."
         }
       ],
       "text": "You may choose not to untap Ice Floe during your untap step.\n{T}: Tap target creature without flying that's attacking you. It doesn't untap during its controller's untap step for as long as Ice Floe remains tapped.",
@@ -12550,7 +12559,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Yes, I think ‘toast' is an appropriate description.\"\n—Jaya Ballard, task mage",
+      "flavor": "\"Yes, I think 'toast' is an appropriate description.\"\n—Jaya Ballard, task mage",
       "id": "131b5d3e3dadddfc14c9126a82d8d8e4f918b3cc",
       "imageName": "incinerate",
       "layout": "normal",
@@ -12605,7 +12614,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Regeneration abilities that would affect that creature can still be activated; they just won’t do anything. The creature can’t be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
+          "text": "Regeneration abilities that would affect that creature can still be activated; they just won't do anything. The creature can't be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
         }
       ],
       "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
@@ -12749,7 +12758,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Mana which “changes color” as it goes through the Hand forgets its original source because the old mana gets used up and new mana gets generated."
+          "text": "Mana which \"changes color\" as it goes through the Hand forgets its original source because the old mana gets used up and new mana gets generated."
         }
       ],
       "subtypes": [
@@ -12809,15 +12818,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If attached to an opponent’s creature, you can untap their creature during your turn."
+          "text": "If attached to an opponent's creature, you can untap their creature during your turn."
         },
         {
           "date": "2004-10-04",
-          "text": "Instill Energy’s untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
+          "text": "Instill Energy's untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
         },
         {
           "date": "2005-08-01",
-          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card’s ability to untap once during the turn."
+          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card's ability to untap once during the turn."
         }
       ],
       "subtypes": [
@@ -12991,7 +13000,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"‘I'll show you how to handle the treefolk!' the giant bragged, and he strode off into the forest. Two days later he returned, his face masked in sap and a nest behind his ear. None dared ask who won.\"\n—Azeworai, \"The Treeling\"",
+      "flavor": "\"'I'll show you how to handle the treefolk!' the giant bragged, and he strode off into the forest. Two days later he returned, his face masked in sap and a nest behind his ear. None dared ask who won.\"\n—Azeworai, \"The Treeling\"",
       "id": "6c667814573037df56a947f72791880f6a507eaf",
       "imageName": "ironroot treefolk",
       "layout": "normal",
@@ -14090,7 +14099,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Since the draw is replaced, you can’t use the same draw to do other things."
+          "text": "Since the draw is replaced, you can't use the same draw to do other things."
         }
       ],
       "text": "If you would draw a card during your draw step, instead you may skip that draw. If you do, until your next turn, you can't be attacked except by creatures with flying and/or islandwalk.",
@@ -14640,7 +14649,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a single source does damage to multiple targets at once, Justice will add up all the damage done and deal damage to the source’s controller at one time (not multiple separate damagings)."
+          "text": "If a single source does damage to multiple targets at once, Justice will add up all the damage done and deal damage to the source's controller at one time (not multiple separate damagings)."
         },
         {
           "date": "2004-10-04",
@@ -14696,7 +14705,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "First creatures are exchanged, then artifacts are exchanged. It’s possible that the same artifact creature may be involved in both exchanges."
+          "text": "First creatures are exchanged, then artifacts are exchanged. It's possible that the same artifact creature may be involved in both exchanges."
         },
         {
           "date": "2007-09-16",
@@ -14704,7 +14713,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If one of the players doesn’t control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn’t control an artifact at the time the exchange would be made, that part of the effect does nothing."
+          "text": "If one of the players doesn't control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn't control an artifact at the time the exchange would be made, that part of the effect does nothing."
         }
       ],
       "text": "You and target player exchange control of the creature you each control with the highest converted mana cost. Then exchange control of artifacts the same way. If two or more permanents a player controls are tied for highest cost, their controller chooses one of them.",
@@ -14875,7 +14884,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never “locked in”."
+          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never \"locked in\"."
         }
       ],
       "subtypes": [
@@ -14995,7 +15004,7 @@
           "text": "Does not affect cards that phase in."
         }
       ],
-      "text": "Artifacts, creatures, and lands played by your opponents enter the battlefield tapped.",
+      "text": "Artifacts, creatures, and lands your opponents control enter the battlefield tapped.",
       "type": "Enchantment",
       "types": [
         "Enchantment"
@@ -15054,7 +15063,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "When Kjeldoran Dead’s enters-the-battlefield ability resolves, if you don’t control any other creatures, you must sacrifice Kjeldoran Dead itself."
+          "text": "When Kjeldoran Dead's enters-the-battlefield ability resolves, if you don't control any other creatures, you must sacrifice Kjeldoran Dead itself."
         }
       ],
       "subtypes": [
@@ -15120,7 +15129,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won’t be redirected. It will be dealt to you as normal."
+          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won't be redirected. It will be dealt to you as normal."
         }
       ],
       "subtypes": [
@@ -15181,7 +15190,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -15423,11 +15432,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the creature Labyrinth Minotaur blocked is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when that creature is tapped."
+          "text": "If the creature Labyrinth Minotaur blocked is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Labyrinth Minotaur doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Labyrinth Minotaur doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -15545,7 +15554,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
+          "text": "You don't have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
         }
       ],
       "subtypes": [
@@ -15611,7 +15620,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can’t be used at times that only mana abilities can be used."
+          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can't be used at times that only mana abilities can be used."
         }
       ],
       "subtypes": [
@@ -15679,7 +15688,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -15733,11 +15742,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not “discarded”."
+          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not \"discarded\"."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren’t effects."
+          "text": "You can't use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren't effects."
         },
         {
           "date": "2004-10-04",
@@ -15765,7 +15774,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\nIf an effect causes you to discard a card, discard it, but you may put it on top of your library instead of into your graveyard.",
@@ -15931,7 +15940,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can cast it targeting your opponent’s artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
+          "text": "You can cast it targeting your opponent's artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
         },
         {
           "date": "2004-10-04",
@@ -15995,7 +16004,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Forests are 1/1 creatures that are still lands.",
@@ -16091,7 +16100,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"‘We have no legs,' the warrior spat, ‘for we have finished running.'\"\n—Vodalian folktale",
+      "flavor": "\"'We have no legs,' the warrior spat, 'for we have finished running.'\"\n—Vodalian folktale",
       "id": "11db03f20826e3e65be6ba2bf7b90255ef035057",
       "imageName": "lord of atlantis",
       "layout": "normal",
@@ -16423,7 +16432,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -16435,7 +16444,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
@@ -16447,7 +16456,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target spell or permanent by replacing all instances of one basic land type with another. (For example, you may change \"swampwalk\" to \"plainswalk.\" This effect lasts indefinitely.)",
@@ -16510,11 +16519,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the artifact when you lose control of it for any reason — because Magus of the Unseen’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the artifact when you lose control of it for any reason — because Magus of the Unseen's effect ends, or because a spell or ability causes another player to gain control of it."
         },
         {
           "date": "2008-10-01",
-          "text": "The artifact will gain haste whether or not it’s a creature. Of course, if it’s not a creature, haste will have no particular effect."
+          "text": "The artifact will gain haste whether or not it's a creature. Of course, if it's not a creature, haste will have no particular effect."
         }
       ],
       "subtypes": [
@@ -16584,7 +16593,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This card’s coin flip has no winner or loser."
+          "text": "This card's coin flip has no winner or loser."
         }
       ],
       "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
@@ -16640,7 +16649,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare’s ability."
+          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare's ability."
         },
         {
           "date": "2004-10-04",
@@ -16648,7 +16657,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can’t give a mana of a color that wasn’t produced."
+          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can't give a mana of a color that wasn't produced."
         },
         {
           "date": "2004-10-04",
@@ -16664,7 +16673,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Does not copy any restrictions on the mana, such as with Mishra’s Workshop or Pillar of the Paruns."
+          "text": "Does not copy any restrictions on the mana, such as with Mishra's Workshop or Pillar of the Paruns."
         },
         {
           "date": "2007-09-16",
@@ -16789,7 +16798,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -16950,7 +16959,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell’s destination from its owner’s library to exile."
+          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell's destination from its owner's library to exile."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
@@ -17125,7 +17134,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -17414,7 +17423,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -18660,7 +18669,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -18725,7 +18734,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -18781,7 +18790,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -18843,11 +18852,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Necropotence’s last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
+          "text": "Necropotence's last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
         },
         {
           "date": "2016-06-08",
-          "text": "If the discarded card isn’t put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won’t be exiled."
+          "text": "If the discarded card isn't put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won't be exiled."
         }
       ],
       "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
@@ -18904,7 +18913,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can’t be countered with something that counters spells."
+          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can't be countered with something that counters spells."
         },
         {
           "date": "2004-10-04",
@@ -18912,7 +18921,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "A card is “above” another card in your graveyard if it was put into that graveyard later."
+          "text": "A card is \"above\" another card in your graveyard if it was put into that graveyard later."
         },
         {
           "date": "2008-10-01",
@@ -18924,11 +18933,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -18989,7 +18998,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -19065,19 +19074,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -19247,7 +19256,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You choose the target when you activate the ability. You don’t flip a coin until the ability resolves."
+          "text": "You choose the target when you activate the ability. You don't flip a coin until the ability resolves."
         }
       ],
       "subtypes": [
@@ -19361,7 +19370,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This ability changes the targeted land’s land types. It doesn’t affect its name, its supertypes (such as whether or not it’s legendary, snow, or basic), or its other types (if it’s also a creature, for example). The ability will cause the land to lose all of its printed abilities and gain the ability “{T}: Add {B} to your mana pool.”"
+          "text": "This ability changes the targeted land's land types. It doesn't affect its name, its supertypes (such as whether or not it's legendary, snow, or basic), or its other types (if it's also a creature, for example). The ability will cause the land to lose all of its printed abilities and gain the ability \"{T}: Add {B} to your mana pool.\""
         }
       ],
       "subtypes": [
@@ -19479,11 +19488,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you lose control of Orcish Squatters before its ability resolves, you won’t gain control of the targeted land at all."
+          "text": "If you lose control of Orcish Squatters before its ability resolves, you won't gain control of the targeted land at all."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -19788,7 +19797,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Panic only during combat before blockers are declared.\nTarget creature can't block this turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -19882,7 +19891,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' ‘Well, now that we have seen each other,' said the Unicorn, ‘if you'll believe in me, I'll believe in you.'\"\n—Lewis Carroll, Through the Looking-Glass",
+      "flavor": "\"'Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' 'Well, now that we have seen each other,' said the Unicorn, 'if you'll believe in me, I'll believe in you.'\"\n—Lewis Carroll, Through the Looking-Glass",
       "id": "c4b630e614ff4643f8536723691cd8171e9369f8",
       "imageName": "pearled unicorn",
       "layout": "normal",
@@ -20024,7 +20033,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent’s Incarnation you can let it die to make them lose life."
+          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent's Incarnation you can let it die to make them lose life."
         },
         {
           "date": "2007-02-01",
@@ -20099,7 +20108,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -20300,7 +20309,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"As the cavalry bore down, we faced them with swords drawn and pikes hidden in the grass at our feet. ‘Don't lift your pikes 'til I give the word,' I said.\"\n—Maeveen O'Donagh,\nMemoirs of a Soldier",
+      "flavor": "\"As the cavalry bore down, we faced them with swords drawn and pikes hidden in the grass at our feet. 'Don't lift your pikes 'til I give the word,' I said.\"\n—Maeveen O'Donagh,\nMemoirs of a Soldier",
       "id": "bfb6f68bcc987cc20a436edf025e2f5ffcf3e661",
       "imageName": "pikemen",
       "layout": "normal",
@@ -20334,7 +20343,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -21667,7 +21676,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -21725,15 +21734,15 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "The losses, discards, and sacrifices are rounded up. For example, if you have 5 life, you’ll lose 2 life, leaving you at 3 life. (Five divided by three is one and two-thirds. Rounding that up to the nearest whole number gives you two.)"
+          "text": "The losses, discards, and sacrifices are rounded up. For example, if you have 5 life, you'll lose 2 life, leaving you at 3 life. (Five divided by three is one and two-thirds. Rounding that up to the nearest whole number gives you two.)"
         },
         {
           "date": "2007-09-16",
-          "text": "Each part of Pox’s effect is processed separately. For each part, first the player whose turn it is makes all necessary choices (such as which cards to discard), then each other player in turn order chooses, then the actions happen at the same time. Then Pox’s effect moves to the next stage."
+          "text": "Each part of Pox's effect is processed separately. For each part, first the player whose turn it is makes all necessary choices (such as which cards to discard), then each other player in turn order chooses, then the actions happen at the same time. Then Pox's effect moves to the next stage."
         },
         {
           "date": "2007-09-16",
-          "text": "The number you need to lose, discard, or sacrifice isn’t calculated until it’s time to perform that part of the effect. For example, if your opponent casts Pox and you discard Dodecapod as part of Pox’s discard effect, Dodecapod will be put onto the battlefield instead of into your graveyard. Then, when determining how many creatures you need to sacrifice, the Dodecapod is taken into account."
+          "text": "The number you need to lose, discard, or sacrifice isn't calculated until it's time to perform that part of the effect. For example, if your opponent casts Pox and you discard Dodecapod as part of Pox's discard effect, Dodecapod will be put onto the battlefield instead of into your graveyard. Then, when determining how many creatures you need to sacrifice, the Dodecapod is taken into account."
         }
       ],
       "text": "Each player loses a third of his or her life, then discards a third of the cards in his or her hand, then sacrifices a third of the creatures he or she controls, then sacrifices a third of the lands he or she controls. Round up each time.",
@@ -21842,11 +21851,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         },
         {
           "date": "2012-07-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -22189,7 +22198,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         },
         {
           "date": "2016-06-08",
@@ -22264,15 +22273,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If some but not all of Pyrotechnics’s targets become illegal, you can’t change the division of damage. Damage that would have been dealt to illegal targets simply isn’t dealt."
+          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can’t deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
         },
         {
           "date": "2014-11-24",
-          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can’t be changed. The effect that creates the copy may allow you to change the targets, however."
+          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
         }
       ],
       "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
@@ -22517,7 +22526,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -22583,11 +22592,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The creature returns to the opponent when the “until end of turn” effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
+          "text": "The creature returns to the opponent when the \"until end of turn\" effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command's effect ends, or because a spell or ability causes another player to gain control of it."
         }
       ],
       "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature gains haste until end of turn. When you lose control of the creature, tap it.",
@@ -22639,11 +22648,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t discard cards until Recall resolves. If you don’t have X cards in your hand at that time, you discard all the cards in your hand."
+          "text": "You don't discard cards until Recall resolves. If you don't have X cards in your hand at that time, you discard all the cards in your hand."
         },
         {
           "date": "2009-10-01",
-          "text": "You don’t choose which cards in your graveyard you’ll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
+          "text": "You don't choose which cards in your graveyard you'll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
         }
       ],
       "text": "Discard X cards, then return a card from your graveyard to your hand for each card discarded this way. Exile Recall.",
@@ -22827,7 +22836,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -23004,7 +23013,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -23321,7 +23330,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -23791,11 +23800,11 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If a creature’s controller doesn’t control an Island, that creature is an illegal target. Whether that player controls an Island is checked both when Seasinger’s ability is activated and when it resolves. However, targeting restrictions aren’t checked continually while a spell or ability is on the stack."
+          "text": "If a creature's controller doesn't control an Island, that creature is an illegal target. Whether that player controls an Island is checked both when Seasinger's ability is activated and when it resolves. However, targeting restrictions aren't checked continually while a spell or ability is on the stack."
         },
         {
           "date": "2007-09-16",
-          "text": "Whether you control Seasinger is checked continually, starting when the ability is activated. If, before the ability resolves, there’s any point at which you don’t control Seasinger, the ability has no effect — even if you control Seasinger again by the time the ability resolves. The same is true regarding whether Seasinger remains tapped."
+          "text": "Whether you control Seasinger is checked continually, starting when the ability is activated. If, before the ability resolves, there's any point at which you don't control Seasinger, the ability has no effect — even if you control Seasinger again by the time the ability resolves. The same is true regarding whether Seasinger remains tapped."
         }
       ],
       "subtypes": [
@@ -23912,7 +23921,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sengir Autocrat’s last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
+          "text": "Sengir Autocrat's last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
         },
         {
           "date": "2016-06-08",
@@ -23979,19 +23988,19 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If Seraph isn’t on the battlefield at the time the other creature is put into a graveyard, the ability won’t trigger. However, the ability does trigger if Seraph and the other creature are put into the graveyard at the same time."
+          "text": "If Seraph isn't on the battlefield at the time the other creature is put into a graveyard, the ability won't trigger. However, the ability does trigger if Seraph and the other creature are put into the graveyard at the same time."
         },
         {
           "date": "2007-09-16",
-          "text": "If the other creature is a token, it will cease to exist after being exiled. It won’t be returned to the battlefield."
+          "text": "If the other creature is a token, it will cease to exist after being exiled. It won't be returned to the battlefield."
         },
         {
           "date": "2007-09-16",
-          "text": "If the other creature ceases to be a creature card after it leaves the battlefield (it’s an animated Mishra’s Factory, for example), it will be returned to the battlefield by this ability and you will have to sacrifice it when you lose control of Seraph."
+          "text": "If the other creature ceases to be a creature card after it leaves the battlefield (it's an animated Mishra's Factory, for example), it will be returned to the battlefield by this ability and you will have to sacrifice it when you lose control of Seraph."
         },
         {
           "date": "2007-09-16",
-          "text": "Once the ability triggers, you’ll return the card to the battlefield under your control at the end of the turn even if you no longer control Seraph at that time. In fact, if Seraph leaves the battlefield before the card is returned to the battlefield, you’ll never have to sacrifice it as a result of this ability. If Seraph remains on the battlefield but changes controllers before the card is returned, you’ll still get the returned card. However, in that scenario, you’ll still have to sacrifice it if you later regain control Seraph and then lose control of it once more."
+          "text": "Once the ability triggers, you'll return the card to the battlefield under your control at the end of the turn even if you no longer control Seraph at that time. In fact, if Seraph leaves the battlefield before the card is returned to the battlefield, you'll never have to sacrifice it as a result of this ability. If Seraph remains on the battlefield but changes controllers before the card is returned, you'll still get the returned card. However, in that scenario, you'll still have to sacrifice it if you later regain control Seraph and then lose control of it once more."
         }
       ],
       "subtypes": [
@@ -24088,7 +24097,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -24396,7 +24405,8 @@
         "3ED",
         "5ED",
         "6ED",
-        "10E"
+        "10E",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Destroy all artifacts. They can't be regenerated.",
@@ -24452,7 +24462,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -24695,7 +24705,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Your opponent does not have to draw a card if they don’t want to."
+          "text": "Your opponent does not have to draw a card if they don't want to."
         }
       ],
       "subtypes": [
@@ -24804,7 +24814,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t Sleight proper nouns (i.e. card names). This means that you can’t affect a “Black Vise”."
+          "text": "You can't Sleight proper nouns (i.e. card names). This means that you can't affect a \"Black Vise\"."
         },
         {
           "date": "2004-10-04",
@@ -24812,7 +24822,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Can’t change a color word to the same color word. It must be a different word."
+          "text": "Can't change a color word to the same color word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -24824,7 +24834,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -25004,7 +25014,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Whenever an opponent casts a creature spell, Soul Barrier deals 2 damage to that player unless he or she pays {2}.",
@@ -25123,11 +25133,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -25303,7 +25313,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since there is no untap step, Phasing in/out won’t happen."
+          "text": "Since there is no untap step, Phasing in/out won't happen."
         },
         {
           "date": "2004-10-04",
@@ -25434,19 +25444,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the Giant’s power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
+          "text": "If the Giant's power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
         },
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stone Giant’s ability is activated during a turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. The targeted creature will be destroyed at that time."
+          "text": "If Stone Giant's ability is activated during a turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. The targeted creature will be destroyed at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it’s no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant’s power at that time."
+          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it's no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant's power at that time."
         }
       ],
       "subtypes": [
@@ -25594,7 +25604,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don’t actually have Flying."
+          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don't actually have Flying."
         }
       ],
       "subtypes": [
@@ -26879,19 +26889,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player’s draw step."
+          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player's draw step."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library’s ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
+          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library's ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
         },
         {
           "date": "2016-06-08",
-          "text": "Any cards drawn prior to Sylvan Library’s ability resolving, including in your upkeep or in response to Sylvan Library’s triggered ability, can be chosen to be put back using this effect. Sylvan Library’s controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
+          "text": "Any cards drawn prior to Sylvan Library's ability resolving, including in your upkeep or in response to Sylvan Library's triggered ability, can be chosen to be put back using this effect. Sylvan Library's controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don’t get to draw all the cards at once and then put them all back at once."
+          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don't get to draw all the cards at once and then put them all back at once."
         },
         {
           "date": "2016-06-08",
@@ -26899,11 +26909,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library’s ability still happens. If you’ve actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven’t actually drawn any cards that turn, the rest of the ability has no effect."
+          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library's ability still happens. If you've actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven't actually drawn any cards that turn, the rest of the ability has no effect."
         },
         {
           "date": "2016-06-08",
-          "text": "It’s not possible to take any actions between drawing the cards and choosing two cards. You can’t cast the cards you drew to avoid having two cards to choose."
+          "text": "It's not possible to take any actions between drawing the cards and choosing two cards. You can't cast the cards you drew to avoid having two cards to choose."
         }
       ],
       "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
@@ -27221,15 +27231,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Any blocking creatures that regenerated during combat will have been removed from combat. Since such creatures are no longer in combat, they cannot be blocking The Wretched, which means you won’t be able to gain control of them."
+          "text": "Any blocking creatures that regenerated during combat will have been removed from combat. Since such creatures are no longer in combat, they cannot be blocking The Wretched, which means you won't be able to gain control of them."
         },
         {
           "date": "2009-05-01",
-          "text": "If The Wretched itself regenerated during combat, then it will have been removed from combat. Since it is no longer in combat, there cannot be any creatures blocking it, which means you won’t be able to gain control of any creatures."
+          "text": "If The Wretched itself regenerated during combat, then it will have been removed from combat. Since it is no longer in combat, there cannot be any creatures blocking it, which means you won't be able to gain control of any creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "The Wretched’s ability triggers only if it’s still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it’s blocked by a 7/7 creature and is destroyed, its ability won’t trigger at all."
+          "text": "The Wretched's ability triggers only if it's still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it's blocked by a 7/7 creature and is destroyed, its ability won't trigger at all."
         },
         {
           "date": "2009-10-01",
@@ -27237,11 +27247,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you lose control of The Wretched before its ability resolves, you won’t gain control of the creatures blocking it at all."
+          "text": "If you lose control of The Wretched before its ability resolves, you won't gain control of the creatures blocking it at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the permanents you gained control of remain creatures, only that they remain on the battlefield."
+          "text": "Once the ability resolves, it doesn't care whether the permanents you gained control of remain creatures, only that they remain on the battlefield."
         }
       ],
       "subtypes": [
@@ -27304,7 +27314,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Protection from Green does not stop the Basilisk’s ability because the ability is not targeted."
+          "text": "Protection from Green does not stop the Basilisk's ability because the ability is not targeted."
         },
         {
           "date": "2004-10-04",
@@ -27413,7 +27423,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won’t be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
+          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won't be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
         }
       ],
       "subtypes": [
@@ -27514,11 +27524,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A “permanent that isn’t enchanted” is a permanent with no Auras on it."
+          "text": "A \"permanent that isn't enchanted\" is a permanent with no Auras on it."
         },
         {
           "date": "2007-09-16",
-          "text": "If Time Elemental attacks or blocks, but you no longer control it at end of combat, you can’t sacrifice it. However, it will still deal 5 damage to you."
+          "text": "If Time Elemental attacks or blocks, but you no longer control it at end of combat, you can't sacrifice it. However, it will still deal 5 damage to you."
         }
       ],
       "subtypes": [
@@ -27574,7 +27584,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Each noncreature artifact loses all abilities and becomes an artifact creature with power and toughness each equal to its converted mana cost. If Titania's Song leaves the battlefield, this effect continues until end of turn.",
@@ -28282,7 +28292,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2006-10-15",
@@ -28477,7 +28487,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -28531,7 +28541,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -29835,7 +29845,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Checks if the creatures are Flying on resolution and not on announcement. It’s not a targeting restriction."
+          "text": "Checks if the creatures are Flying on resolution and not on announcement. It's not a targeting restriction."
         }
       ],
       "text": "Tap X target creatures. Winter Blast deals 2 damage to each of those creatures with flying.",
@@ -29887,11 +29897,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All permanents untap during a player’s untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
+          "text": "All permanents untap during a player's untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
+          "text": "You can't tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
         }
       ],
       "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",
@@ -30215,7 +30225,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -30400,7 +30410,7 @@
         },
         {
           "date": "2006-04-01",
-          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur’s Weirding’s replacement. If the latter, you first resolve Zur’s Weirding’s ability, then if you’re going to draw the card, decide whether or not to replace that draw with Dredge."
+          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur's Weirding's replacement. If the latter, you first resolve Zur's Weirding's ability, then if you're going to draw the card, decide whether or not to replace that draw with Dredge."
         }
       ],
       "text": "Players play with their hands revealed.\nIf a player would draw a card, he or she reveals it instead. Then any other player may pay 2 life. If a player does, put that card into its owner's graveyard. Otherwise, that player draws a card.",

--- a/json/6ED.json
+++ b/json/6ED.json
@@ -276,7 +276,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -354,7 +355,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"Hang out our banners on the outward walls; / The cry is still, ‘They come'; our castle's strength / Will laugh a siege to scorn.\"\n—William Shakespeare, Macbeth",
+      "flavor": "\"Hang out our banners on the outward walls; / The cry is still, 'They come'; our castle's strength / Will laugh a siege to scorn.\"\n—William Shakespeare, Macbeth",
       "id": "9ebf04e29c943fe997e00e30787c5661927ce4f5",
       "imageName": "castle",
       "layout": "normal",
@@ -452,7 +453,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The effect to turn all your non-land cards (including artifacts) white is the effect of a static ability. Thus, a color change on a permanent prior to Celestial Dawn entering the battlefield will be overridden by Celestial Dawn’s effect."
+          "text": "The effect to turn all your non-land cards (including artifacts) white is the effect of a static ability. Thus, a color change on a permanent prior to Celestial Dawn entering the battlefield will be overridden by Celestial Dawn's effect."
         },
         {
           "date": "2004-10-04",
@@ -476,11 +477,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Mana produced by spells you control and nonland permanents you control isn’t affected by Celestial Dawn. Llanowar Elves will produce {G}, for example. However, any colored mana may be spent only on the colorless part of costs."
+          "text": "Mana produced by spells you control and nonland permanents you control isn't affected by Celestial Dawn. Llanowar Elves will produce {G}, for example. However, any colored mana may be spent only on the colorless part of costs."
         },
         {
           "date": "2006-09-25",
-          "text": "Land cards you own that aren’t on the battlefield aren’t changed to Plains."
+          "text": "Land cards you own that aren't on the battlefield aren't changed to Plains."
         },
         {
           "date": "2006-09-25",
@@ -488,15 +489,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "“Enters the battlefield” triggered abilities of lands you play won’t trigger since the lands will enter the battlefield as Plains. Effects that modify how those lands enter the battlefield, however, will still work. For example, if you play a Dimir Aqueduct, it will enter the battlefield tapped as a Plains, but you won’t return a land to your hand."
+          "text": "\"Enters the battlefield\" triggered abilities of lands you play won't trigger since the lands will enter the battlefield as Plains. Effects that modify how those lands enter the battlefield, however, will still work. For example, if you play a Dimir Aqueduct, it will enter the battlefield tapped as a Plains, but you won't return a land to your hand."
         },
         {
           "date": "2006-09-25",
-          "text": "If you use a text-changing effect such as Mind Bend on Celestial Dawn to change the word “Plains” to a different land type, your lands are all of that new land type, and they will produce mana of the appropriate color for that type."
+          "text": "If you use a text-changing effect such as Mind Bend on Celestial Dawn to change the word \"Plains\" to a different land type, your lands are all of that new land type, and they will produce mana of the appropriate color for that type."
         },
         {
           "date": "2006-09-25",
-          "text": "If a permanent enters the battlefield while Celestial Dawn is on the battlefield, and then Celestial Dawn leaves the battlefield, the permanent’s color will revert to the colors in its mana cost."
+          "text": "If a permanent enters the battlefield while Celestial Dawn is on the battlefield, and then Celestial Dawn leaves the battlefield, the permanent's color will revert to the colors in its mana cost."
         }
       ],
       "text": "Lands you control are Plains.\nNonland cards you own that aren't on the battlefield, spells you control, and nonland permanents you control are white.\nYou may spend white mana as though it were mana of any color. You may spend other mana only as though it were colorless mana.",
@@ -571,7 +572,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -648,7 +649,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -725,7 +726,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -806,7 +807,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -883,7 +884,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -1014,7 +1015,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"And the flamingos said, ‘Get out of our nest—we can't be seen with the likes of you!' So, the griffin ate them.\"\n—Azeworai, \"The Ugly Bird\"",
+      "flavor": "\"And the flamingos said, 'Get out of our nest—we can't be seen with the likes of you!' So, the griffin ate them.\"\n—Azeworai, \"The Ugly Bird\"",
       "id": "1f317ada9fb39283dfdfb3e075c62ce6a46879f0",
       "imageName": "daraja griffin",
       "layout": "normal",
@@ -1315,7 +1316,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for an artifact or enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -1714,7 +1715,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         }
       ],
       "subtypes": [
@@ -1784,7 +1785,7 @@
           "text": "Does not affect cards that phase in."
         }
       ],
-      "text": "Artifacts, creatures, and lands played by your opponents enter the battlefield tapped.",
+      "text": "Artifacts, creatures, and lands your opponents control enter the battlefield tapped.",
       "type": "Enchantment",
       "types": [
         "Enchantment"
@@ -1844,7 +1845,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won’t be redirected. It will be dealt to you as normal."
+          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won't be redirected. It will be dealt to you as normal."
         }
       ],
       "subtypes": [
@@ -2322,7 +2323,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t choose zero targets. You must choose at least one target."
+          "text": "You can't choose zero targets. You must choose at least one target."
         }
       ],
       "text": "Prevent the next 5 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.",
@@ -2625,7 +2626,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Serenity’s triggered ability destroys itself too."
+          "text": "Serenity's triggered ability destroys itself too."
         }
       ],
       "text": "At the beginning of your upkeep, destroy all artifacts and enchantments. They can't be regenerated.",
@@ -3003,11 +3004,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "First the active player identifies the creature he or she controls with the highest mana cost (and chooses one if there’s a tie) and chooses whether to sacrifice it or pay mana. Then each other player in turn order does the same. All creatures sacrificed this way are sacrificed at the same time."
+          "text": "First the active player identifies the creature he or she controls with the highest mana cost (and chooses one if there's a tie) and chooses whether to sacrifice it or pay mana. Then each other player in turn order does the same. All creatures sacrificed this way are sacrificed at the same time."
         },
         {
           "date": "2008-04-01",
-          "text": "Although Tariff checks the converted mana cost of the creatures on the battlefield, you need to pay the creature’s actual mana cost (including color) to keep it on the battlefield."
+          "text": "Although Tariff checks the converted mana cost of the creatures on the battlefield, you need to pay the creature's actual mana cost (including color) to keep it on the battlefield."
         }
       ],
       "text": "Each player sacrifices the creature he or she controls with the highest converted mana cost unless he or she pays that creature's mana cost. If two or more creatures a player controls are tied for highest cost, that player chooses one.",
@@ -3370,7 +3371,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Warrior’s Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won’t get the bonus."
+          "text": "Warrior's Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won't get the bonus."
         }
       ],
       "text": "Creatures you control get +1/+1 until end of turn.",
@@ -4010,7 +4011,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -4030,11 +4031,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Deflection, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Deflection, even if all but one of those targets has become illegal."
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets the same player or object multiple times, you can’t target it with Deflection."
+          "text": "If a spell targets the same player or object multiple times, you can't target it with Deflection."
         }
       ],
       "text": "Change the target of target spell with a single target.",
@@ -4091,7 +4092,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The card is put onto the battlefield, but any effects that check if the original card was “cast from your hand” will not trigger or otherwise consider the card to have been cast from your hand. The card was put onto the battlefield by the effect of Desertion instead."
+          "text": "The card is put onto the battlefield, but any effects that check if the original card was \"cast from your hand\" will not trigger or otherwise consider the card to have been cast from your hand. The card was put onto the battlefield by the effect of Desertion instead."
         },
         {
           "date": "2004-10-04",
@@ -4099,7 +4100,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then this card’s ability does not put the card onto the battlefield. The spell continues to resolve as normal."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then this card's ability does not put the card onto the battlefield. The spell continues to resolve as normal."
         }
       ],
       "text": "Counter target spell. If an artifact or creature spell is countered this way, put that card onto the battlefield under your control instead of into its owner's graveyard.",
@@ -4159,11 +4160,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Diminishing Returns won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "Diminishing Returns won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         },
         {
           "date": "2016-06-08",
-          "text": "The exiled cards are exiled face up. You’ll see them before you choose how many cards to draw."
+          "text": "The exiled cards are exiled face up. You'll see them before you choose how many cards to draw."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library. You exile the top ten cards of your library. Then each player draws up to seven cards.",
@@ -4271,7 +4272,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Any X in the creature’s mana cost is zero."
+          "text": "Any X in the creature's mana cost is zero."
         },
         {
           "date": "2004-10-04",
@@ -4851,7 +4852,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "First creatures are exchanged, then artifacts are exchanged. It’s possible that the same artifact creature may be involved in both exchanges."
+          "text": "First creatures are exchanged, then artifacts are exchanged. It's possible that the same artifact creature may be involved in both exchanges."
         },
         {
           "date": "2007-09-16",
@@ -4859,7 +4860,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If one of the players doesn’t control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn’t control an artifact at the time the exchange would be made, that part of the effect does nothing."
+          "text": "If one of the players doesn't control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn't control an artifact at the time the exchange would be made, that part of the effect does nothing."
         }
       ],
       "text": "You and target player exchange control of the creature you each control with the highest converted mana cost. Then exchange control of artifacts the same way. If two or more permanents a player controls are tied for highest cost, their controller chooses one of them.",
@@ -5101,7 +5102,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell’s destination from its owner’s library to exile."
+          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell's destination from its owner's library to exile."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
@@ -5185,7 +5186,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"To the tutors, a ‘poem of sand' was of little account, a ‘poem of ivory,' priceless.\"\n—Afari, Tales",
+      "flavor": "\"To the tutors, a 'poem of sand' was of little account, a 'poem of ivory,' priceless.\"\n—Afari, Tales",
       "id": "d7b822ab692e005d3abe2d95ff433df3a16592fa",
       "imageName": "mystical tutor",
       "layout": "normal",
@@ -5224,7 +5225,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for an instant or sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -5419,7 +5420,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If there are no creatures in the player’s library, then the target creature is still destroyed, you see all the cards in that player’s library, and then they shuffle and continue play."
+          "text": "If there are no creatures in the player's library, then the target creature is still destroyed, you see all the cards in that player's library, and then they shuffle and continue play."
         },
         {
           "date": "2009-10-01",
@@ -5427,15 +5428,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If there are no creature cards in the player’s library, all the cards in that library are revealed, then the library is shuffled. (The targeted creature remains destroyed.)"
+          "text": "If there are no creature cards in the player's library, all the cards in that library are revealed, then the library is shuffled. (The targeted creature remains destroyed.)"
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2013-07-01",
-          "text": "If the targeted creature has indestructible, it’s still a legal target — it just isn’t destroyed. The rest of Polymorph’s effect happens as normal."
+          "text": "If the targeted creature has indestructible, it's still a legal target — it just isn't destroyed. The rest of Polymorph's effect happens as normal."
         }
       ],
       "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card onto the battlefield, then shuffles all other cards revealed this way into his or her library.",
@@ -5520,7 +5521,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -5714,7 +5715,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says that a player can’t lose life, that player can’t exchange life totals with a player who has a lower life total; in that case, the exchange won’t happen."
+          "text": "If an effect says that a player can't lose life, that player can't exchange life totals with a player who has a lower life total; in that case, the exchange won't happen."
         }
       ],
       "text": "If the difference between your life total and target player's life total is 5 or less, exchange life totals with that player.",
@@ -5828,11 +5829,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t discard cards until Recall resolves. If you don’t have X cards in your hand at that time, you discard all the cards in your hand."
+          "text": "You don't discard cards until Recall resolves. If you don't have X cards in your hand at that time, you discard all the cards in your hand."
         },
         {
           "date": "2009-10-01",
-          "text": "You don’t choose which cards in your graveyard you’ll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
+          "text": "You don't choose which cards in your graveyard you'll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
         }
       ],
       "text": "Discard X cards, then return a card from your graveyard to your hand for each card discarded this way. Exile Recall.",
@@ -5946,7 +5947,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -6181,7 +6182,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Your opponent does not have to draw a card if they don’t want to."
+          "text": "Your opponent does not have to draw a card if they don't want to."
         }
       ],
       "subtypes": [
@@ -6309,11 +6310,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -6450,6 +6451,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -6829,7 +6834,7 @@
         },
         {
           "date": "2006-04-01",
-          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur’s Weirding’s replacement. If the latter, you first resolve Zur’s Weirding’s ability, then if you’re going to draw the card, decide whether or not to replace that draw with Dredge."
+          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur's Weirding's replacement. If the latter, you first resolve Zur's Weirding's ability, then if you're going to draw the card, decide whether or not to replace that draw with Dredge."
         }
       ],
       "text": "Players play with their hands revealed.\nIf a player would draw a card, he or she reveals it instead. Then any other player may pay 2 life. If a player does, put that card into its owner's graveyard. Otherwise, that player draws a card.",
@@ -7578,7 +7583,8 @@
       "originalType": "Sorcery",
       "printings": [
         "WTH",
-        "6ED"
+        "6ED",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -7588,7 +7594,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If your graveyard and library combined contain five or more cards, you must choose five cards from among them. You can’t choose to find fewer than that."
+          "text": "If your graveyard and library combined contain five or more cards, you must choose five cards from among them. You can't choose to find fewer than that."
         },
         {
           "date": "2008-04-01",
@@ -8004,7 +8010,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Fatal Blow can’t target a creature that hasn’t been dealt damage this turn."
+          "text": "Fatal Blow can't target a creature that hasn't been dealt damage this turn."
         },
         {
           "date": "2008-04-01",
@@ -8244,7 +8250,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The “if you can’t” in the first ability refers to putting the card in your hand, as well as being unable to choose a card. Thus, if you can’t choose a card during resolution, you lose the game."
+          "text": "The \"if you can't\" in the first ability refers to putting the card in your hand, as well as being unable to choose a card. Thus, if you can't choose a card during resolution, you lose the game."
         },
         {
           "date": "2004-10-04",
@@ -8325,6 +8331,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -8338,6 +8348,10 @@
         },
         {
           "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -8383,7 +8397,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -8561,7 +8575,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -8746,7 +8760,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "When Kjeldoran Dead’s enters-the-battlefield ability resolves, if you don’t control any other creatures, you must sacrifice Kjeldoran Dead itself."
+          "text": "When Kjeldoran Dead's enters-the-battlefield ability resolves, if you don't control any other creatures, you must sacrifice Kjeldoran Dead itself."
         }
       ],
       "subtypes": [
@@ -9108,19 +9122,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -9290,7 +9304,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -9482,7 +9496,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -9670,7 +9684,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sengir Autocrat’s last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
+          "text": "Sengir Autocrat's last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
         },
         {
           "date": "2016-06-08",
@@ -10025,7 +10039,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
@@ -10138,7 +10152,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This is not a targeted ability, so it deals damage to creatures that can’t be targeted by spells and abilities."
+          "text": "This is not a targeted ability, so it deals damage to creatures that can't be targeted by spells and abilities."
         }
       ],
       "text": "Whenever a creature enters the battlefield, Aether Flash deals 2 damage to it.",
@@ -10268,7 +10282,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Barbarian raids were a concern to those living in the northwest provinces, but the skyknights never dealt with the problem in a systematic way. They thought of the Balduvians as an ‘amusing model' of their forebears' culture.\"\n—Kjeldor: Ice Civilization",
+      "flavor": "\"Barbarian raids were a concern to those living in the northwest provinces, but the skyknights never dealt with the problem in a systematic way. They thought of the Balduvians as an 'amusing model' of their forebears' culture.\"\n—Kjeldor: Ice Civilization",
       "id": "c12ac349e2cb14a2bbfc597ab8f24e5493587a7e",
       "imageName": "balduvian barbarians",
       "layout": "normal",
@@ -10486,7 +10500,8 @@
         "TMP",
         "6ED",
         "7ED",
-        "8ED"
+        "8ED",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Destroy all Islands.",
@@ -10777,7 +10792,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If an attacking creature loses haste, perhaps because Fervor leaves the battlefield after attackers have been declared, it won’t be removed from combat."
+          "text": "If an attacking creature loses haste, perhaps because Fervor leaves the battlefield after attackers have been declared, it won't be removed from combat."
         }
       ],
       "text": "Creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
@@ -10837,7 +10852,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
@@ -10969,7 +10984,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -11499,7 +11514,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type “Summon Goblin” and “Summon Goblins” also count. You can’t search for cards that have Goblin in the name but don’t have the creature type Goblin."
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
         }
       ],
       "subtypes": [
@@ -11964,7 +11979,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -12279,15 +12294,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If some but not all of Pyrotechnics’s targets become illegal, you can’t change the division of damage. Damage that would have been dealt to illegal targets simply isn’t dealt."
+          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can’t deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
         },
         {
           "date": "2014-11-24",
-          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can’t be changed. The effect that creates the copy may allow you to change the targets, however."
+          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
         }
       ],
       "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
@@ -12482,7 +12497,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -12699,7 +12714,8 @@
         "3ED",
         "5ED",
         "6ED",
-        "10E"
+        "10E",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all artifacts. They can't be regenerated.",
@@ -13924,7 +13940,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -13946,7 +13962,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"I tell you, there was so many arrows flying about you couldn't hardly see the sun. So I says to young Angus, ‘Well, at least now we're fighting in the shade!'\"",
+      "flavor": "\"I tell you, there was so many arrows flying about you couldn't hardly see the sun. So I says to young Angus, 'Well, at least now we're fighting in the shade!'\"",
       "id": "2b72b279245a69ddbde09f82b2eaaf654e085d86",
       "imageName": "elvish archers",
       "layout": "normal",
@@ -14094,7 +14110,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When combined with an effect that reads “Each creature you control can’t be blocked except by two or more creatures,” none of your creatures can be blocked."
+          "text": "When combined with an effect that reads \"Each creature you control can't be blocked except by two or more creatures,\" none of your creatures can be blocked."
         }
       ],
       "text": "Each creature you control can't be blocked by more than one creature.",
@@ -14453,6 +14469,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -14462,6 +14482,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -14762,7 +14786,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Forests are 1/1 creatures that are still lands.",
@@ -14996,7 +15020,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro’s toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won’t be put into your graveyard when state-based actions are checked."
+          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro's toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won't be put into your graveyard when state-based actions are checked."
         }
       ],
       "subtypes": [
@@ -15298,7 +15322,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -15909,7 +15933,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Protection from Green does not stop the Basilisk’s ability because the ability is not targeted."
+          "text": "Protection from Green does not stop the Basilisk's ability because the ability is not targeted."
         },
         {
           "date": "2004-10-04",
@@ -16316,7 +16340,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2006-10-15",
@@ -16659,7 +16683,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a creature card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -16860,7 +16884,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -17106,7 +17130,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Activated abilities of creatures can't be activated.",
@@ -17607,15 +17631,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You may choose to find any kind of card, including a land. You must exile a card (unless the opponent’s library is empty); you can’t fail to find anything."
+          "text": "You may choose to find any kind of card, including a land. You must exile a card (unless the opponent's library is empty); you can't fail to find anything."
         },
         {
           "date": "2006-09-25",
-          "text": "“Until the beginning of your next upkeep” means the effect wears off as soon as your next upkeep starts. Your last chance to play the card is usually the End step of the player who immediately precedes you."
+          "text": "\"Until the beginning of your next upkeep\" means the effect wears off as soon as your next upkeep starts. Your last chance to play the card is usually the End step of the player who immediately precedes you."
         },
         {
           "date": "2006-09-25",
-          "text": "The exiled card is played using the normal rules for timing and priority for its card type, as well as any other applicable restrictions. You’ll have to pay its mana cost. The only thing that’s different is you’re casting it from the Exile zone."
+          "text": "The exiled card is played using the normal rules for timing and priority for its card type, as well as any other applicable restrictions. You'll have to pay its mana cost. The only thing that's different is you're casting it from the Exile zone."
         }
       ],
       "text": "{2}, {T}, Sacrifice Grinning Totem: Search target opponent's library for a card and exile it. Then that player shuffles his or her library. Until the beginning of your next upkeep, you may play that card. At the beginning of your next upkeep, if you haven't played it, put it into its owner's graveyard.",
@@ -18611,11 +18635,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         },
         {
           "date": "2012-07-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -18922,11 +18946,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a land is tapped for mana and sacrificed all in one action, it goes to the graveyard before the Cauldron can return it to the player’s hand."
+          "text": "If a land is tapped for mana and sacrificed all in one action, it goes to the graveyard before the Cauldron can return it to the player's hand."
         },
         {
           "date": "2004-10-04",
-          "text": "If a land is tapped for mana, it is returned to its owner’s hand as a triggered ability."
+          "text": "If a land is tapped for mana, it is returned to its owner's hand as a triggered ability."
         },
         {
           "date": "2004-10-04",
@@ -19348,7 +19372,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass’s triggered ability is put on the stack on top of it. City of Brass’s ability will resolve first."
+          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass's triggered ability is put on the stack on top of it. City of Brass's ability will resolve first."
         },
         {
           "date": "2004-10-04",

--- a/json/7ED.json
+++ b/json/7ED.json
@@ -490,7 +490,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -584,7 +584,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -678,7 +678,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -776,7 +776,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -870,7 +870,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -1172,7 +1172,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"Training? Seeing my crops burnt to cinders was all the ‘training' I needed.\"",
+      "flavor": "\"Training? Seeing my crops burnt to cinders was all the 'training' I needed.\"",
       "foreignNames": [
         {
           "language": "French",
@@ -1847,7 +1847,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The power of the creature is checked on activation and on resolution. If the targeted creature’s power is not 4 or greater on resolution, the ability is countered."
+          "text": "The power of the creature is checked on activation and on resolution. If the targeted creature's power is not 4 or greater on resolution, the ability is countered."
         }
       ],
       "subtypes": [
@@ -1932,7 +1932,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won’t be redirected. It will be dealt to you as normal."
+          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won't be redirected. It will be dealt to you as normal."
         }
       ],
       "subtypes": [
@@ -2490,7 +2490,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can attach this to an opponent’s creature, and all damage done to you is instead done to their creature."
+          "text": "You can attach this to an opponent's creature, and all damage done to you is instead done to their creature."
         },
         {
           "date": "2004-10-04",
@@ -3175,7 +3175,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Gaining life is optional. If you forget, you can’t go back later even if it is something you usually do."
+          "text": "Gaining life is optional. If you forget, you can't go back later even if it is something you usually do."
         }
       ],
       "text": "Whenever an opponent taps a Mountain for mana, you may gain 1 life.",
@@ -5573,7 +5573,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -5593,11 +5593,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Deflection, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Deflection, even if all but one of those targets has become illegal."
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets the same player or object multiple times, you can’t target it with Deflection."
+          "text": "If a spell targets the same player or object multiple times, you can't target it with Deflection."
         }
       ],
       "text": "Change the target of target spell with a single target.",
@@ -5735,11 +5735,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         },
         {
           "date": "2008-08-01",
-          "text": "The ability is put on the stack immediately after you cast a creature spell, which means the creature that spell will become won’t be a legal target."
+          "text": "The ability is put on the stack immediately after you cast a creature spell, which means the creature that spell will become won't be a legal target."
         },
         {
           "date": "2008-08-01",
@@ -6814,7 +6814,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability itself is controlled by Mana Breach’s controller."
+          "text": "The ability itself is controlled by Mana Breach's controller."
         },
         {
           "date": "2004-10-04",
@@ -7051,7 +7051,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell’s destination from its owner’s library to exile."
+          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell's destination from its owner's library to exile."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
@@ -7356,7 +7356,8 @@
       "originalType": "Enchantment",
       "printings": [
         "UDS",
-        "7ED"
+        "7ED",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
@@ -7611,7 +7612,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -8578,6 +8579,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -9896,7 +9901,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -10057,7 +10062,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"Hence ‘banishèd' is banished from the world, / And the world's exile is death.\"\n—William Shakespeare,\nRomeo and Juliet",
+      "flavor": "\"Hence 'banishèd' is banished from the world, / And the world's exile is death.\"\n—William Shakespeare,\nRomeo and Juliet",
       "foreignNames": [
         {
           "language": "French",
@@ -11029,6 +11034,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -11042,6 +11051,10 @@
         },
         {
           "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -11087,7 +11100,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -11109,7 +11122,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "An advisor once asked the Western Paladin how much gold would be enough. \"I have no need of fools who can imagine ‘enough,'\" he told the advisor's corpse.",
+      "flavor": "An advisor once asked the Western Paladin how much gold would be enough. \"I have no need of fools who can imagine 'enough,'\" he told the advisor's corpse.",
       "foreignNames": [
         {
           "language": "French",
@@ -11958,19 +11971,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -12185,7 +12198,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose a creature card from it. That player discards that card.",
@@ -12509,7 +12522,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -12738,7 +12751,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The ability that defines Revenant’s power and toughness applies in all zones, not just the battlefield. If Revenant is in your graveyard, its ability will count itself."
+          "text": "The ability that defines Revenant's power and toughness applies in all zones, not just the battlefield. If Revenant is in your graveyard, its ability will count itself."
         }
       ],
       "subtypes": [
@@ -13289,7 +13302,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Tainted Aether’s controller is the one that controls its triggered ability, but the controller of the creature that entered the battlefield chooses what creature they sacrifice during resolution."
+          "text": "Tainted Aether's controller is the one that controls its triggered ability, but the controller of the creature that entered the battlefield chooses what creature they sacrifice during resolution."
         }
       ],
       "text": "Whenever a creature enters the battlefield, its controller sacrifices a creature or land.",
@@ -13673,7 +13686,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This is not a targeted ability, so it deals damage to creatures that can’t be targeted by spells and abilities."
+          "text": "This is not a targeted ability, so it deals damage to creatures that can't be targeted by spells and abilities."
         }
       ],
       "text": "Whenever a creature enters the battlefield, Aether Flash deals 2 damage to it.",
@@ -14039,7 +14052,8 @@
         "TMP",
         "6ED",
         "7ED",
-        "8ED"
+        "8ED",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Destroy all Islands.",
@@ -14346,7 +14360,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If an attacking creature loses haste, perhaps because Fervor leaves the battlefield after attackers have been declared, it won’t be removed from combat."
+          "text": "If an attacking creature loses haste, perhaps because Fervor leaves the battlefield after attackers have been declared, it won't be removed from combat."
         }
       ],
       "text": "Creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
@@ -14423,7 +14437,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
@@ -15112,11 +15126,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type “Summon Goblin” and “Summon Goblins” also count. You can’t search for cards that have Goblin in the name but don’t have the creature type Goblin."
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
         }
       ],
       "subtypes": [
@@ -15349,7 +15363,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When combined with an effect that reads “Each creature you control can’t be blocked by more than one creature,” none of your creatures can be blocked."
+          "text": "When combined with an effect that reads \"Each creature you control can't be blocked by more than one creature,\" none of your creatures can be blocked."
         },
         {
           "date": "2004-10-04",
@@ -15969,7 +15983,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This card’s coin flip has no winner or loser."
+          "text": "This card's coin flip has no winner or loser."
         }
       ],
       "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
@@ -16600,15 +16614,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If some but not all of Pyrotechnics’s targets become illegal, you can’t change the division of damage. Damage that would have been dealt to illegal targets simply isn’t dealt."
+          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can’t deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
         },
         {
           "date": "2014-11-24",
-          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can’t be changed. The effect that creates the copy may allow you to change the targets, however."
+          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
         }
       ],
       "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
@@ -16929,7 +16943,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -19219,7 +19233,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -19297,7 +19311,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When combined with an effect that reads “Each creature you control can’t be blocked except by two or more creatures,” none of your creatures can be blocked."
+          "text": "When combined with an effect that reads \"Each creature you control can't be blocked except by two or more creatures,\" none of your creatures can be blocked."
         }
       ],
       "text": "Each creature you control can't be blocked by more than one creature.",
@@ -19765,6 +19779,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -19774,6 +19792,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -20244,11 +20266,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -20256,7 +20278,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -20449,7 +20471,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro’s toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won’t be put into your graveyard when state-based actions are checked."
+          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro's toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won't be put into your graveyard when state-based actions are checked."
         }
       ],
       "subtypes": [
@@ -20736,7 +20758,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All lands are 2/2 creatures that are still lands.",
@@ -20806,11 +20828,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -20818,7 +20840,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -20922,7 +20944,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -21758,11 +21780,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -21770,7 +21792,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -22228,7 +22250,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2006-10-15",
@@ -22636,7 +22658,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -23069,7 +23091,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Coat of Arms counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Coat of Arms counts creatures, not creature types."
         }
       ],
       "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
@@ -23421,7 +23443,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Creature spells cost {2} more to cast.",
@@ -25008,7 +25030,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.",
@@ -25141,11 +25163,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a land is tapped for mana and sacrificed all in one action, it goes to the graveyard before the Cauldron can return it to the player’s hand."
+          "text": "If a land is tapped for mana and sacrificed all in one action, it goes to the graveyard before the Cauldron can return it to the player's hand."
         },
         {
           "date": "2004-10-04",
-          "text": "If a land is tapped for mana, it is returned to its owner’s hand as a triggered ability."
+          "text": "If a land is tapped for mana, it is returned to its owner's hand as a triggered ability."
         },
         {
           "date": "2004-10-04",
@@ -25647,7 +25669,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass’s triggered ability is put on the stack on top of it. City of Brass’s ability will resolve first."
+          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass's triggered ability is put on the stack on top of it. City of Brass's ability will resolve first."
         },
         {
           "date": "2004-10-04",

--- a/json/8ED.json
+++ b/json/8ED.json
@@ -923,7 +923,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -1027,7 +1027,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -1131,7 +1131,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -1239,7 +1239,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -1343,7 +1343,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2409,7 +2409,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The power of the creature is checked on activation and on resolution. If the targeted creature’s power is not 4 or greater on resolution, the ability is countered."
+          "text": "The power of the creature is checked on activation and on resolution. If the targeted creature's power is not 4 or greater on resolution, the ability is countered."
         }
       ],
       "subtypes": [
@@ -3552,7 +3552,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"Over the silver mountains,\nWhere spring the nectar fountains,\n     There will I kiss\n     The bowl of bliss;\nAnd drink my everlasting fill. . . .\"\n—Sir Walter Raleigh, \"The Pilgrimage\"",
+      "flavor": "\"Over the silver mountains,\nWhere spring the nectar fountains,\nThere will I kiss\nThe bowl of bliss;\nAnd drink my everlasting fill. . . .\"\n—Sir Walter Raleigh, \"The Pilgrimage\"",
       "foreignNames": [
         {
           "language": "French",
@@ -3795,7 +3795,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Gaining life is optional. If you forget, you can’t go back later even if it is something you usually do."
+          "text": "Gaining life is optional. If you forget, you can't go back later even if it is something you usually do."
         }
       ],
       "text": "Whenever an opponent taps a Mountain for mana, you may gain 1 life.",
@@ -5791,11 +5791,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You put the creature onto the battlefield, so you control it and any “enters the battlefield” abilities it has."
+          "text": "You put the creature onto the battlefield, so you control it and any \"enters the battlefield\" abilities it has."
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles his or her library.",
@@ -6487,7 +6487,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If put on your opponent’s creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
+          "text": "If put on your opponent's creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
         },
         {
           "date": "2007-02-01",
@@ -6495,7 +6495,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "“You” refers to the controller of Curiosity, which may be different from the controller of the enchanted creature. “An opponent” refers to an opponent of Curiosity’s controller."
+          "text": "\"You\" refers to the controller of Curiosity, which may be different from the controller of the enchanted creature. \"An opponent\" refers to an opponent of Curiosity's controller."
         },
         {
           "date": "2011-09-22",
@@ -6503,7 +6503,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Curiosity doesn’t trigger if the enchanted creature deals damage to a planeswalker controlled by an opponent."
+          "text": "Curiosity doesn't trigger if the enchanted creature deals damage to a planeswalker controlled by an opponent."
         }
       ],
       "subtypes": [
@@ -6696,7 +6696,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -6716,11 +6716,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Deflection, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Deflection, even if all but one of those targets has become illegal."
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets the same player or object multiple times, you can’t target it with Deflection."
+          "text": "If a spell targets the same player or object multiple times, you can't target it with Deflection."
         }
       ],
       "text": "Change the target of target spell with a single target.",
@@ -7744,7 +7744,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple creatures enter the battlefield at one time, this ability triggers once for each creature. This doesn’t matter much, but it can in some cases."
+          "text": "If multiple creatures enter the battlefield at one time, this ability triggers once for each creature. This doesn't matter much, but it can in some cases."
         }
       ],
       "text": "Creatures don't untap during their controllers' untap steps.\nWhenever a creature enters the battlefield, untap all creatures.",
@@ -8180,7 +8180,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a blue instant card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -8275,7 +8275,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -8287,11 +8287,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"islandwalk.\" This effect lasts indefinitely.)",
@@ -8570,7 +8570,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -8660,19 +8660,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Rewind targets only a spell. It doesn’t target any lands. The lands are chosen as Rewind resolves."
+          "text": "Rewind targets only a spell. It doesn't target any lands. The lands are chosen as Rewind resolves."
         },
         {
           "date": "2017-03-14",
-          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can’t choose one land and have it untap four times, for example."
+          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can't choose one land and have it untap four times, for example."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won’t untap any lands."
+          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won't untap any lands."
         },
         {
           "date": "2017-03-14",
-          "text": "If Rewind resolves but the target spell can’t be countered, you’ll still untap lands."
+          "text": "If Rewind resolves but the target spell can't be countered, you'll still untap lands."
         }
       ],
       "text": "Counter target spell. Untap up to four lands.",
@@ -9186,7 +9186,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The spell’s controller gets the option to pay when this ability resolves."
+          "text": "The spell's controller gets the option to pay when this ability resolves."
         }
       ],
       "subtypes": [
@@ -10027,6 +10027,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -10459,7 +10463,7 @@
         },
         {
           "date": "2006-04-01",
-          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur’s Weirding’s replacement. If the latter, you first resolve Zur’s Weirding’s ability, then if you’re going to draw the card, decide whether or not to replace that draw with Dredge."
+          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur's Weirding's replacement. If the latter, you first resolve Zur's Weirding's ability, then if you're going to draw the card, decide whether or not to replace that draw with Dredge."
         }
       ],
       "text": "Players play with their hands revealed.\nIf a player would draw a card, he or she reveals it instead. Then any other player may pay 2 life. If a player does, put that card into its owner's graveyard. Otherwise, that player draws a card.",
@@ -11016,7 +11020,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"Ha, banishment? Be merciful, say ‘death,'\nFor exile hath more terror in his look,\nMuch more than death.\"\n—William Shakespeare, Romeo and Juliet",
+      "flavor": "\"Ha, banishment? Be merciful, say 'death,'\nFor exile hath more terror in his look,\nMuch more than death.\"\n—William Shakespeare, Romeo and Juliet",
       "foreignNames": [
         {
           "language": "French",
@@ -12384,6 +12388,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -12397,6 +12405,10 @@
         },
         {
           "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -12442,7 +12454,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -13418,7 +13430,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it’s a creature you control."
+          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it's a creature you control."
         }
       ],
       "subtypes": [
@@ -13527,19 +13539,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -14168,7 +14180,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -14362,11 +14374,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -14816,7 +14828,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t draw a card if this spell is countered."
+          "text": "You don't draw a card if this spell is countered."
         }
       ],
       "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
@@ -15505,7 +15517,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card can trigger on itself being returned to a player’s hand."
+          "text": "This card can trigger on itself being returned to a player's hand."
         }
       ],
       "text": "Whenever a permanent is returned to a player's hand, that player discards a card.",
@@ -16010,25 +16022,26 @@
         "8ED",
         "9ED",
         "MMA",
-        "MM3"
+        "MM3",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability “{T}: Add {R} to your mana pool.”"
+          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability \"{T}: Add {R} to your mana pool.\""
         },
         {
           "date": "2017-03-14",
-          "text": "Blood Moon’s effect doesn’t affect names or supertypes. It won’t turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won’t be named “Mountain.”"
+          "text": "Blood Moon's effect doesn't affect names or supertypes. It won't turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won't be named \"Mountain.\""
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply “as” a land enters the battlefield, such as the first ability of Cavern of Souls."
+          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply \"as\" a land enters the battlefield, such as the first ability of Cavern of Souls."
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that triggers “when” it enters the battlefield, it will lose that ability before it triggers."
+          "text": "If a nonbasic land has an ability that triggers \"when\" it enters the battlefield, it will lose that ability before it triggers."
         }
       ],
       "text": "Nonbasic lands are Mountains.",
@@ -16197,7 +16210,8 @@
         "TMP",
         "6ED",
         "7ED",
-        "8ED"
+        "8ED",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Destroy all Islands.",
@@ -16823,7 +16837,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can’t normally end up with an odd amount of damage on something."
+          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can't normally end up with an odd amount of damage on something."
         },
         {
           "date": "2004-10-04",
@@ -16839,7 +16853,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn.” Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn.\" Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         }
       ],
       "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
@@ -18164,7 +18178,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This card’s coin flip has no winner or loser."
+          "text": "This card's coin flip has no winner or loser."
         }
       ],
       "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
@@ -18338,7 +18352,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Counterspells can be cast that target it, but when they resolve they simply don’t counter it since it can’t be countered."
+          "text": "Counterspells can be cast that target it, but when they resolve they simply don't counter it since it can't be countered."
         }
       ],
       "text": "Obliterate can't be countered.\nDestroy all artifacts, creatures, and lands. They can't be regenerated.",
@@ -18967,15 +18981,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If some but not all of Pyrotechnics’s targets become illegal, you can’t change the division of damage. Damage that would have been dealt to illegal targets simply isn’t dealt."
+          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can’t deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
         },
         {
           "date": "2014-11-24",
-          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can’t be changed. The effect that creates the copy may allow you to change the targets, however."
+          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
         }
       ],
       "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
@@ -19253,7 +19267,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -20494,7 +20508,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t pick a card that can’t legally be returned to the battlefield. If there are no cards that can be legally returned, then you can’t pick one."
+          "text": "You can't pick a card that can't legally be returned to the battlefield. If there are no cards that can be legally returned, then you can't pick one."
         },
         {
           "date": "2005-08-01",
@@ -20763,7 +20777,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is returned to its owner’s hand at the end of any turn in which it is on the battlefield."
+          "text": "It is returned to its owner's hand at the end of any turn in which it is on the battlefield."
         }
       ],
       "subtypes": [
@@ -21380,7 +21394,8 @@
       "originalType": "Enchantment",
       "printings": [
         "TMP",
-        "8ED"
+        "8ED",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Islands don't untap during their controllers' untap steps.",
@@ -22019,7 +22034,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -22198,7 +22213,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Emperor Crocodile’s ability will trigger if you don’t control another creature, even if it’s only for a brief moment during the resolution of another spell or ability (such as that of Brago, King Eternal)."
+          "text": "Emperor Crocodile's ability will trigger if you don't control another creature, even if it's only for a brief moment during the resolution of another spell or ability (such as that of Brago, King Eternal)."
         },
         {
           "date": "2016-06-08",
@@ -22742,7 +22757,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability applies to your opponent’s spells as well as your own."
+          "text": "The ability applies to your opponent's spells as well as your own."
         }
       ],
       "subtypes": [
@@ -22993,6 +23008,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -23002,6 +23021,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -23405,7 +23428,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -23503,7 +23526,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -23594,7 +23617,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Since the activated ability doesn’t have a tap symbol in its cost, you can tap a creature (including Llanowar Behemoth itself) that hasn’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the activated ability doesn't have a tap symbol in its cost, you can tap a creature (including Llanowar Behemoth itself) that hasn't been under your control since your most recent turn began to pay the cost."
         }
       ],
       "subtypes": [
@@ -23689,11 +23712,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -23701,7 +23724,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -23914,7 +23937,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro’s toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won’t be put into your graveyard when state-based actions are checked."
+          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro's toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won't be put into your graveyard when state-based actions are checked."
         }
       ],
       "subtypes": [
@@ -24334,7 +24357,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All lands become 2/2 creatures until end of turn. They're still lands.",
@@ -24808,7 +24831,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -25078,11 +25101,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -25090,7 +25113,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -25442,7 +25465,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "This card now has Enchant Swamp, which works exactly like any other Enchant ability. This means it can only be cast targeting a Swamp, and it will be put into its owner’s graveyard if the permanent it’s attached to ever stops being a Swamp."
+          "text": "This card now has Enchant Swamp, which works exactly like any other Enchant ability. This means it can only be cast targeting a Swamp, and it will be put into its owner's graveyard if the permanent it's attached to ever stops being a Swamp."
         }
       ],
       "subtypes": [
@@ -25619,11 +25642,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -25631,7 +25654,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -26170,7 +26193,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -26605,7 +26628,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Coat of Arms counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Coat of Arms counts creatures, not creature types."
         }
       ],
       "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
@@ -26770,7 +26793,7 @@
         },
         {
           "date": "2006-05-01",
-          "text": "In Two-Headed Giant, spells don’t cost extra on your own turn."
+          "text": "In Two-Headed Giant, spells don't cost extra on your own turn."
         }
       ],
       "text": "Each spell costs {3} more to cast except during its controller's turn.",
@@ -28252,7 +28275,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.",
@@ -28902,7 +28925,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass’s triggered ability is put on the stack on top of it. City of Brass’s ability will resolve first."
+          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass's triggered ability is put on the stack on top of it. City of Brass's ability will resolve first."
         },
         {
           "date": "2004-10-04",
@@ -29366,7 +29389,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -29447,7 +29470,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -36692,7 +36715,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"Training? Seeing my crops burnt to cinders was all the ‘training' I needed.\"",
+      "flavor": "\"Training? Seeing my crops burnt to cinders was all the 'training' I needed.\"",
       "foreignNames": [
         {
           "language": "French",

--- a/json/9ED.json
+++ b/json/9ED.json
@@ -1074,7 +1074,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -1197,7 +1197,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2246,7 +2246,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         }
       ],
       "subtypes": [
@@ -3825,7 +3825,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -3940,7 +3940,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"Over the silver mountains,\nWhere spring the nectar fountains,\n     There will I kiss\n     The bowl of bliss;\nAnd drink my everlasting fill. . . .\"\n—Sir Walter Raleigh, \"The Pilgrimage\"",
+      "flavor": "\"Over the silver mountains,\nWhere spring the nectar fountains,\nThere will I kiss\nThe bowl of bliss;\nAnd drink my everlasting fill. . . .\"\n—Sir Walter Raleigh, \"The Pilgrimage\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -4891,7 +4891,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other’s ability to trigger."
+          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other's ability to trigger."
         },
         {
           "date": "2005-08-01",
@@ -5631,7 +5631,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Warrior’s Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won’t get the bonus."
+          "text": "Warrior's Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won't get the bonus."
         }
       ],
       "text": "Creatures you control get +1/+1 until end of turn.",
@@ -6877,7 +6877,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Battle of Wits has an “intervening ‘if’ clause.” This means that if you don’t have 200 or more cards in your library at the beginning of your upkeep, the ability won’t trigger. If the ability does trigger, but you have fewer than 200 cards in your library when the ability resolves, the ability will do nothing."
+          "text": "Battle of Wits has an \"intervening 'if' clause.\" This means that if you don't have 200 or more cards in your library at the beginning of your upkeep, the ability won't trigger. If the ability does trigger, but you have fewer than 200 cards in your library when the ability resolves, the ability will do nothing."
         },
         {
           "date": "2012-07-01",
@@ -7107,7 +7107,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -7115,11 +7115,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -7127,7 +7127,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -7541,7 +7541,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you increase the power of the targeted creature after the ability resolves, it still can’t be blocked that turn."
+          "text": "If you increase the power of the targeted creature after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -8055,7 +8055,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures and lands are only prevented from untapping during the targeted player’s next untap step. They can still can untap during other player’s untap steps."
+          "text": "The creatures and lands are only prevented from untapping during the targeted player's next untap step. They can still can untap during other player's untap steps."
         },
         {
           "date": "2009-10-01",
@@ -8678,7 +8678,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "Imaginary Pet’s ability triggers only if you have cards in your hand as your upkeep begins, and the ability checks again as it resolves. If your hand is empty at both those times, Imaginary Pet stays on the battlefield."
+          "text": "Imaginary Pet's ability triggers only if you have cards in your hand as your upkeep begins, and the ability checks again as it resolves. If your hand is empty at both those times, Imaginary Pet stays on the battlefield."
         }
       ],
       "subtypes": [
@@ -9224,7 +9224,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -9236,11 +9236,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"islandwalk.\" This effect lasts indefinitely.)",
@@ -9452,11 +9452,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you target yourself, this spell has no useful effect. It will not cause an infinite loop since a replacement effect can’t modify the same event more than once. This effect will not modify the draw that it has you perform."
+          "text": "If you target yourself, this spell has no useful effect. It will not cause an infinite loop since a replacement effect can't modify the same event more than once. This effect will not modify the draw that it has you perform."
         },
         {
           "date": "2007-07-15",
-          "text": "You draw the card from your library as normal, not from your opponent’s library."
+          "text": "You draw the card from your library as normal, not from your opponent's library."
         },
         {
           "date": "2007-07-15",
@@ -9464,7 +9464,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "If you target a player whose library is empty, any effect or turn-based action that would cause that player to draw a card will cause you to draw a card instead. It doesn’t matter that the other player would be unable to draw."
+          "text": "If you target a player whose library is empty, any effect or turn-based action that would cause that player to draw a card will cause you to draw a card instead. It doesn't matter that the other player would be unable to draw."
         }
       ],
       "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
@@ -9566,7 +9566,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If there are no creatures in the player’s library, then the target creature is still destroyed, you see all the cards in that player’s library, and then they shuffle and continue play."
+          "text": "If there are no creatures in the player's library, then the target creature is still destroyed, you see all the cards in that player's library, and then they shuffle and continue play."
         },
         {
           "date": "2009-10-01",
@@ -9574,15 +9574,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If there are no creature cards in the player’s library, all the cards in that library are revealed, then the library is shuffled. (The targeted creature remains destroyed.)"
+          "text": "If there are no creature cards in the player's library, all the cards in that library are revealed, then the library is shuffled. (The targeted creature remains destroyed.)"
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2013-07-01",
-          "text": "If the targeted creature has indestructible, it’s still a legal target — it just isn’t destroyed. The rest of Polymorph’s effect happens as normal."
+          "text": "If the targeted creature has indestructible, it's still a legal target — it just isn't destroyed. The rest of Polymorph's effect happens as normal."
         }
       ],
       "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card onto the battlefield, then shuffles all other cards revealed this way into his or her library.",
@@ -9794,7 +9794,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Target player shuffles his or her graveyard into his or her library.",
@@ -9910,7 +9910,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -10015,19 +10015,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Rewind targets only a spell. It doesn’t target any lands. The lands are chosen as Rewind resolves."
+          "text": "Rewind targets only a spell. It doesn't target any lands. The lands are chosen as Rewind resolves."
         },
         {
           "date": "2017-03-14",
-          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can’t choose one land and have it untap four times, for example."
+          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can't choose one land and have it untap four times, for example."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won’t untap any lands."
+          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won't untap any lands."
         },
         {
           "date": "2017-03-14",
-          "text": "If Rewind resolves but the target spell can’t be countered, you’ll still untap lands."
+          "text": "If Rewind resolves but the target spell can't be countered, you'll still untap lands."
         }
       ],
       "text": "Counter target spell. Untap up to four lands.",
@@ -12093,7 +12093,7 @@
         },
         {
           "date": "2006-04-01",
-          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur’s Weirding’s replacement. If the latter, you first resolve Zur’s Weirding’s ability, then if you’re going to draw the card, decide whether or not to replace that draw with Dredge."
+          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur's Weirding's replacement. If the latter, you first resolve Zur's Weirding's ability, then if you're going to draw the card, decide whether or not to replace that draw with Dredge."
         }
       ],
       "text": "Players play with their hands revealed.\nIf a player would draw a card, he or she reveals it instead. Then any other player may pay 2 life. If a player does, put that card into its owner's graveyard. Otherwise, that player draws a card.",
@@ -12643,7 +12643,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
@@ -12854,7 +12854,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"Ha, banishment? Be merciful, say ‘death,'\nFor exile hath more terror in his look,\nMuch more than death.\"\n—William Shakespeare, Romeo and Juliet",
+      "flavor": "\"Ha, banishment? Be merciful, say 'death,'\nFor exile hath more terror in his look,\nMuch more than death.\"\n—William Shakespeare, Romeo and Juliet",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -14390,6 +14390,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -14403,6 +14407,10 @@
         },
         {
           "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -14448,7 +14456,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -14562,7 +14570,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -14976,7 +14984,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers even if the Specter’s damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
+          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
         }
       ],
       "subtypes": [
@@ -15855,7 +15863,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it’s a creature you control."
+          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it's a creature you control."
         }
       ],
       "subtypes": [
@@ -15979,19 +15987,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -16625,7 +16633,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -16951,11 +16959,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -17203,15 +17211,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -17430,7 +17438,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t draw a card if this spell is countered."
+          "text": "You don't draw a card if this spell is countered."
         }
       ],
       "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
@@ -18759,25 +18767,26 @@
         "8ED",
         "9ED",
         "MMA",
-        "MM3"
+        "MM3",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability “{T}: Add {R} to your mana pool.”"
+          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability \"{T}: Add {R} to your mana pool.\""
         },
         {
           "date": "2017-03-14",
-          "text": "Blood Moon’s effect doesn’t affect names or supertypes. It won’t turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won’t be named “Mountain.”"
+          "text": "Blood Moon's effect doesn't affect names or supertypes. It won't turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won't be named \"Mountain.\""
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply “as” a land enters the battlefield, such as the first ability of Cavern of Souls."
+          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply \"as\" a land enters the battlefield, such as the first ability of Cavern of Souls."
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that triggers “when” it enters the battlefield, it will lose that ability before it triggers."
+          "text": "If a nonbasic land has an ability that triggers \"when\" it enters the battlefield, it will lose that ability before it triggers."
         }
       ],
       "text": "Nonbasic lands are Mountains.",
@@ -19313,7 +19322,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -19619,7 +19628,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "Flowstone Crusher’s ability can be activated multiple times, but Flowstone Crusher is put into the graveyard after an effect resolves that makes its toughness 0."
+          "text": "Flowstone Crusher's ability can be activated multiple times, but Flowstone Crusher is put into the graveyard after an effect resolves that makes its toughness 0."
         }
       ],
       "subtypes": [
@@ -19924,11 +19933,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It sets your life total at the beginning of the end step of every player’s turn, not just your own."
+          "text": "It sets your life total at the beginning of the end step of every player's turn, not just your own."
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "At the beginning of your upkeep, Form of the Dragon deals 5 damage to target creature or player.\nAt the beginning of each end step, your life total becomes 5.\nCreatures without flying can't attack you.",
@@ -20033,7 +20042,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can’t normally end up with an odd amount of damage on something."
+          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can't normally end up with an odd amount of damage on something."
         },
         {
           "date": "2004-10-04",
@@ -20049,7 +20058,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn.” Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn.\" Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         }
       ],
       "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
@@ -20160,7 +20169,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade’s ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
         }
       ],
       "subtypes": [
@@ -21668,7 +21677,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This card’s coin flip has no winner or loser."
+          "text": "This card's coin flip has no winner or loser."
         }
       ],
       "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
@@ -22625,7 +22634,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -24090,7 +24099,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is returned to its owner’s hand at the end of any turn in which it is on the battlefield."
+          "text": "It is returned to its owner's hand at the end of any turn in which it is on the battlefield."
         }
       ],
       "subtypes": [
@@ -25563,7 +25572,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -25779,7 +25788,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Emperor Crocodile’s ability will trigger if you don’t control another creature, even if it’s only for a brief moment during the resolution of another spell or ability (such as that of Brago, King Eternal)."
+          "text": "Emperor Crocodile's ability will trigger if you don't control another creature, even if it's only for a brief moment during the resolution of another spell or ability (such as that of Brago, King Eternal)."
         },
         {
           "date": "2016-06-08",
@@ -26088,6 +26097,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -26097,6 +26110,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -26249,7 +26266,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "You draw cards equal to the creature’s power when you sacrificed it. This includes any bonuses from effects like Giant Growth."
+          "text": "You draw cards equal to the creature's power when you sacrificed it. This includes any bonuses from effects like Giant Growth."
         }
       ],
       "text": "Sacrifice a creature: Draw cards equal to the sacrificed creature's power, then discard three cards.",
@@ -26893,7 +26910,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can’t be used at times that only mana abilities can be used."
+          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can't be used at times that only mana abilities can be used."
         }
       ],
       "subtypes": [
@@ -27001,7 +27018,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Since the activated ability doesn’t have a tap symbol in its cost, you can tap a creature (including Llanowar Behemoth itself) that hasn’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the activated ability doesn't have a tap symbol in its cost, you can tap a creature (including Llanowar Behemoth itself) that hasn't been under your control since your most recent turn began to pay the cost."
         }
       ],
       "subtypes": [
@@ -27241,7 +27258,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro’s toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won’t be put into your graveyard when state-based actions are checked."
+          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro's toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won't be put into your graveyard when state-based actions are checked."
         }
       ],
       "subtypes": [
@@ -27446,7 +27463,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All lands become 2/2 creatures until end of turn. They're still lands.",
@@ -28228,7 +28245,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -28742,7 +28759,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -28952,11 +28969,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Other effects can prevent a permanent from untapping during an untap step. You do need to look carefully, however, as many effects say that the permanent does not untap during its controller’s untap step, and this card’s ability occurs during other players’ untap steps. If a card does say this, then Seedborn Muse can untap it. But some other abilities are not written this way and can still prevent a card from untapping."
+          "text": "Other effects can prevent a permanent from untapping during an untap step. You do need to look carefully, however, as many effects say that the permanent does not untap during its controller's untap step, and this card's ability occurs during other players' untap steps. If a card does say this, then Seedborn Muse can untap it. But some other abilities are not written this way and can still prevent a card from untapping."
         },
         {
           "date": "2007-07-15",
-          "text": "All your permanents untap during each other player’s untap step. You have no choice about what untaps."
+          "text": "All your permanents untap during each other player's untap step. You have no choice about what untaps."
         }
       ],
       "subtypes": [
@@ -29579,7 +29596,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block a creature enchanted with this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block a creature enchanted with this."
         }
       ],
       "subtypes": [
@@ -29790,7 +29807,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Verdant Force’s controller gets the tokens. That is the controller at the beginning of upkeep."
+          "text": "Verdant Force's controller gets the tokens. That is the controller at the beginning of upkeep."
         },
         {
           "date": "2005-08-01",
@@ -30319,7 +30336,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -30721,7 +30738,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a white spell, Angel’s Feather’s ability triggers and is put on the stack on top of that spell. Angel’s Feather’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a white spell, Angel's Feather's ability triggers and is put on the stack on top of that spell. Angel's Feather's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a white spell, you may gain 1 life.",
@@ -30913,23 +30930,23 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “if you do” part is only done if you successfully sacrifice this card. In other words, it has to be on the battlefield when the trigger resolves or it does not deal damage."
+          "text": "The \"if you do\" part is only done if you successfully sacrifice this card. In other words, it has to be on the battlefield when the trigger resolves or it does not deal damage."
         },
         {
           "date": "2005-08-01",
-          "text": "The choice of which card to name is part of the resolution of the spell or ability which puts Booby Trap onto the battlefield. It can’t be countered."
+          "text": "The choice of which card to name is part of the resolution of the spell or ability which puts Booby Trap onto the battlefield. It can't be countered."
         },
         {
           "date": "2005-08-01",
-          "text": "If an effect causes the player to draw multiple cards, each card is revealed as it’s drawn. If Booby Trap’s ability triggers, it will go on the stack once the card-drawing effect has concluded."
+          "text": "If an effect causes the player to draw multiple cards, each card is revealed as it's drawn. If Booby Trap's ability triggers, it will go on the stack once the card-drawing effect has concluded."
         },
         {
           "date": "2005-08-01",
-          "text": "If a single Booby Trap’s ability triggers multiple times, then only the first ability to resolve causes Booby Trap to be sacrificed and damage to be dealt."
+          "text": "If a single Booby Trap's ability triggers multiple times, then only the first ability to resolve causes Booby Trap to be sacrificed and damage to be dealt."
         },
         {
           "date": "2005-08-01",
-          "text": "If Booby Trap’s last ability is countered, Booby Trap remains on the battlefield (and no damage is dealt)."
+          "text": "If Booby Trap's last ability is countered, Booby Trap remains on the battlefield (and no damage is dealt)."
         }
       ],
       "text": "As Booby Trap enters the battlefield, choose an opponent and a card name other than a basic land card name.\nThe chosen player reveals each card he or she draws.\nWhen the chosen player draws a card with the chosen name, sacrifice Booby Trap. If you do, Booby Trap deals 10 damage to that player.",
@@ -31156,7 +31173,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Coat of Arms counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Coat of Arms counts creatures, not creature types."
         }
       ],
       "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
@@ -31352,7 +31369,7 @@
         },
         {
           "date": "2006-05-01",
-          "text": "In Two-Headed Giant, spells don’t cost extra on your own turn."
+          "text": "In Two-Headed Giant, spells don't cost extra on your own turn."
         }
       ],
       "text": "Each spell costs {3} more to cast except during its controller's turn.",
@@ -31458,7 +31475,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a black spell, Demon’s Horn’s ability triggers and is put on the stack on top of that spell. Demon’s Horn’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a black spell, Demon's Horn's ability triggers and is put on the stack on top of that spell. Demon's Horn's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a black spell, you may gain 1 life.",
@@ -31664,7 +31681,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a red spell, Dragon’s Claw’s ability triggers and is put on the stack on top of that spell. Dragon’s Claw’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a red spell, Dragon's Claw's ability triggers and is put on the stack on top of that spell. Dragon's Claw's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a red spell, you may gain 1 life.",
@@ -31765,7 +31782,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This works even if the opponent’s lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
+          "text": "This works even if the opponent's lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
         },
         {
           "date": "2004-10-04",
@@ -31773,19 +31790,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, take into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, take into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Fellwar Stone doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -32012,19 +32029,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player’s pool."
+          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player's pool."
         },
         {
           "date": "2004-10-04",
-          "text": "Icy Manipulator can’t be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
+          "text": "Icy Manipulator can't be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger “if the card becomes tapped” effects."
+          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger \"if the card becomes tapped\" effects."
         },
         {
           "date": "2004-10-04",
-          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use the Icy Manipulator."
+          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use the Icy Manipulator."
         },
         {
           "date": "2004-10-04",
@@ -32127,19 +32144,19 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A delayed triggered ability that refers to Jade Statue still affects it even if it’s no longer a creature. For example, if Jade Statue blocks the Kashi-Tribe Warriors (“Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn’t untap during its controller’s next untap step.”), the Warriors’ effect stops Jade Statue from untapping."
+          "text": "A delayed triggered ability that refers to Jade Statue still affects it even if it's no longer a creature. For example, if Jade Statue blocks the Kashi-Tribe Warriors (\"Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.\"), the Warriors' effect stops Jade Statue from untapping."
         },
         {
           "date": "2005-08-01",
-          "text": "If Jade Statue’s ability has been activated, abilities that trigger “at end of combat” will see Jade Statue as an artifact creature."
+          "text": "If Jade Statue's ability has been activated, abilities that trigger \"at end of combat\" will see Jade Statue as an artifact creature."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-09-20",
-          "text": "If Jade Statue is animated by some other effect, you get an artifact creature with whatever power, toughness, and creature types (if any) are specified by that effect. If you subsequently use Jade Statue’s ability during combat, it will become 3/6 and gain the creature type Golem in addition to those creature types until end of combat."
+          "text": "If Jade Statue is animated by some other effect, you get an artifact creature with whatever power, toughness, and creature types (if any) are specified by that effect. If you subsequently use Jade Statue's ability during combat, it will become 3/6 and gain the creature type Golem in addition to those creature types until end of combat."
         }
       ],
       "text": "{2}: Jade Statue becomes a 3/6 Golem artifact creature until end of combat. Activate this ability only during combat.",
@@ -32340,7 +32357,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a blue spell, Kraken’s Eye’s ability triggers and is put on the stack on top of that spell. Kraken’s Eye’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a blue spell, Kraken's Eye's ability triggers and is put on the stack on top of that spell. Kraken's Eye's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a blue spell, you may gain 1 life.",
@@ -33063,7 +33080,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.",
@@ -33157,7 +33174,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card’s ability does not override effects which prevent a permanent from untapping."
+          "text": "This card's ability does not override effects which prevent a permanent from untapping."
         },
         {
           "date": "2005-08-01",
@@ -33165,7 +33182,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "If another effect limits the number of permanents that untap, that number combines with Storage Matrix’s effect. For example, Imi Statue says “players can’t untap more than one artifact during their untap steps.” If both Imi Statue and an untapped Storage Matrix are on the battlefield, and you choose “artifact,” only one artifact untaps."
+          "text": "If another effect limits the number of permanents that untap, that number combines with Storage Matrix's effect. For example, Imi Statue says \"players can't untap more than one artifact during their untap steps.\" If both Imi Statue and an untapped Storage Matrix are on the battlefield, and you choose \"artifact,\" only one artifact untaps."
         }
       ],
       "text": "As long as Storage Matrix is untapped, each player chooses artifact, creature, or land during his or her untap step. That player can untap only permanents of the chosen type this step.",
@@ -33739,7 +33756,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a green spell, Wurm’s Tooth’s ability triggers and is put on the stack on top of that spell. Wurm’s Tooth’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a green spell, Wurm's Tooth's ability triggers and is put on the stack on top of that spell. Wurm's Tooth's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a green spell, you may gain 1 life.",
@@ -33932,7 +33949,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -34132,7 +34149,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -34331,7 +34348,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -34527,7 +34544,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -34814,7 +34831,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -34910,7 +34927,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -35103,7 +35120,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -42773,7 +42790,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"Training? Seeing my crops burnt to cinders was all the ‘training' I needed.\"",
+      "flavor": "\"Training? Seeing my crops burnt to cinders was all the 'training' I needed.\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",

--- a/json/AER.json
+++ b/json/AER.json
@@ -130,7 +130,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If Aerial Modification becomes unattached from a Vehicle that’s attacking or blocking, that Vehicle will be removed from combat unless another effect (such as its crew ability) is also making it a creature."
+          "text": "If Aerial Modification becomes unattached from a Vehicle that's attacking or blocking, that Vehicle will be removed from combat unless another effect (such as its crew ability) is also making it a creature."
         }
       ],
       "subtypes": [
@@ -363,7 +363,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -375,15 +375,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -502,7 +502,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "After Aethergeode Miner returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won’t be in combat or have any additional abilities it may have had when it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
+          "text": "After Aethergeode Miner returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won't be in combat or have any additional abilities it may have had when it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
         },
         {
           "date": "2017-02-09",
@@ -510,7 +510,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -522,11 +522,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -645,11 +645,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -657,11 +657,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "subtypes": [
@@ -1110,11 +1110,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -1122,11 +1122,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "text": "Revolt — At the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a unity counter on Call for Unity.\nCreatures you control get +1/+1 for each unity counter on Call for Unity.",
@@ -1239,7 +1239,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "After the enchanted creature is exiled, Caught in the Brights is put into its owner’s graveyard."
+          "text": "After the enchanted creature is exiled, Caught in the Brights is put into its owner's graveyard."
         },
         {
           "date": "2017-02-09",
@@ -1363,11 +1363,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Auras attached to the exiled artifacts will be put into their owners’ graveyards. Any counters on the exiled artifacts will cease to exist."
+          "text": "Auras attached to the exiled artifacts will be put into their owners' graveyards. Any counters on the exiled artifacts will cease to exist."
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If an artifact token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2017-02-09",
@@ -1375,11 +1375,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "In a multiplayer game, if Consulate Crackdown’s owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Consulate Crackdown's owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "When Consulate Crackdown enters the battlefield, exile all artifacts your opponents control until Consulate Crackdown leaves the battlefield.",
@@ -1499,7 +1499,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Players don’t have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Conviction to its owner’s hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get +1/+3)."
+          "text": "Players don't have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Conviction to its owner's hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get +1/+3)."
         }
       ],
       "subtypes": [
@@ -1616,11 +1616,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -1628,11 +1628,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "subtypes": [
@@ -1751,11 +1751,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The set of creatures affected by Dawnfeather Eagle’s triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn and permanents you control that become creatures later in the turn won’t get +1/+1 or gain vigilance."
+          "text": "The set of creatures affected by Dawnfeather Eagle's triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn and permanents you control that become creatures later in the turn won't get +1/+1 or gain vigilance."
         },
         {
           "date": "2017-02-09",
-          "text": "Dawnfeather Eagle’s triggered ability affects itself."
+          "text": "Dawnfeather Eagle's triggered ability affects itself."
         }
       ],
       "subtypes": [
@@ -1873,11 +1873,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -1885,11 +1885,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "subtypes": [
@@ -2007,19 +2007,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If Decommission destroys a permanent you control, it will enable its own revolt ability and you’ll gain 3 life."
+          "text": "If Decommission destroys a permanent you control, it will enable its own revolt ability and you'll gain 3 life."
         },
         {
           "date": "2017-02-09",
-          "text": "If the target artifact or enchantment becomes an illegal target, Decommission is countered and none of its effects happen. You won’t gain life."
+          "text": "If the target artifact or enchantment becomes an illegal target, Decommission is countered and none of its effects happen. You won't gain life."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -2027,7 +2027,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         }
       ],
       "text": "Destroy target artifact or enchantment.\nRevolt — If a permanent you controlled left the battlefield this turn, you gain 3 life.",
@@ -2258,35 +2258,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If Exquisite Archangel is dealt lethal damage at the same time that you’re dealt damage that brings your life total to 0 or less, its effect applies and your life total becomes equal to your starting life total. You choose whether Exquisite Archangel is moved to exile or to your graveyard."
+          "text": "If Exquisite Archangel is dealt lethal damage at the same time that you're dealt damage that brings your life total to 0 or less, its effect applies and your life total becomes equal to your starting life total. You choose whether Exquisite Archangel is moved to exile or to your graveyard."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect says that you can’t lose the game, Exquisite Archangel’s effect doesn’t apply."
+          "text": "If an effect says that you can't lose the game, Exquisite Archangel's effect doesn't apply."
         },
         {
           "date": "2017-02-09",
-          "text": "If you control two Exquisite Archangels, you choose which one’s effect applies. The other’s effect won’t be applicable after that until the next time you would lose the game."
+          "text": "If you control two Exquisite Archangels, you choose which one's effect applies. The other's effect won't be applicable after that until the next time you would lose the game."
         },
         {
           "date": "2017-02-09",
-          "text": "Exquisite Archangel’s effect applies any time you would lose the game, even if you’re not losing due to your life total being 0 or less. If you would have lost the game because you tried to draw from an empty library, you won’t lose again until you try to draw again and still can’t do so."
+          "text": "Exquisite Archangel's effect applies any time you would lose the game, even if you're not losing due to your life total being 0 or less. If you would have lost the game because you tried to draw from an empty library, you won't lose again until you try to draw again and still can't do so."
         },
         {
           "date": "2017-02-09",
-          "text": "Exquisite Archangel’s effect does nothing if you concede the game. A player who concedes leaves the game."
+          "text": "Exquisite Archangel's effect does nothing if you concede the game. A player who concedes leaves the game."
         },
         {
           "date": "2017-02-09",
-          "text": "For your life total to become your starting life total (normally 20), you gain or lose the appropriate amount of life. For example, if your life total is -4 when Exquisite Archangel’s ability applies, it will cause you to gain 24 life; alternatively, if your life total is 40 when it applies, it will cause you to lose 20 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For your life total to become your starting life total (normally 20), you gain or lose the appropriate amount of life. For example, if your life total is -4 when Exquisite Archangel's ability applies, it will cause you to gain 24 life; alternatively, if your life total is 40 when it applies, it will cause you to lose 20 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect states that an opponent wins the game, Exquisite Archangel’s ability doesn’t apply."
+          "text": "If an effect states that an opponent wins the game, Exquisite Archangel's ability doesn't apply."
         },
         {
           "date": "2017-02-09",
-          "text": "In a Two-Headed Giant game, Exquisite Archangel’s ability causes the team’s life total to become the team’s starting life total (normally 30), but only you actually gain or lose life."
+          "text": "In a Two-Headed Giant game, Exquisite Archangel's ability causes the team's life total to become the team's starting life total (normally 30), but only you actually gain or lose life."
         }
       ],
       "subtypes": [
@@ -2408,7 +2408,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "After the permanent returns to the battlefield, it will be a new object with no connection to the permanent that was exiled. It won’t have any additional abilities it may have had when it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
+          "text": "After the permanent returns to the battlefield, it will be a new object with no connection to the permanent that was exiled. It won't have any additional abilities it may have had when it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
         }
       ],
       "subtypes": [
@@ -2639,7 +2639,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You can activate Restoration Specialist’s ability choosing no targets at all if you wish."
+          "text": "You can activate Restoration Specialist's ability choosing no targets at all if you wish."
         }
       ],
       "subtypes": [
@@ -2758,11 +2758,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -2770,11 +2770,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "subtypes": [
@@ -2893,7 +2893,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Sram’s triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Sram's triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         }
       ],
       "subtypes": [
@@ -3014,7 +3014,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "A card’s converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
+          "text": "A card's converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
         },
         {
           "date": "2017-02-09",
@@ -3022,19 +3022,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Effects that allow you to “cast” a card don’t allow you to play a land card."
+          "text": "Effects that allow you to \"cast\" a card don't allow you to play a land card."
         },
         {
           "date": "2017-02-09",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
         },
         {
           "date": "2017-02-09",
-          "text": "While you’re casting your free spell, the Expertise spell is still on the stack. It will be put into its owner’s graveyard after the free spell is cast. The free spell can’t target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
+          "text": "While you're casting your free spell, the Expertise spell is still on the stack. It will be put into its owner's graveyard after the free spell is cast. The free spell can't target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
         },
         {
           "date": "2017-02-09",
-          "text": "Any triggered abilities that trigger while performing the Expertise spell’s first effect won’t be put onto the stack until after you’re done casting your free spell. They’re put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
+          "text": "Any triggered abilities that trigger while performing the Expertise spell's first effect won't be put onto the stack until after you're done casting your free spell. They're put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
         },
         {
           "date": "2017-04-18",
@@ -3151,15 +3151,15 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If Thopter Arrest leaves the battlefield before its triggered ability resolves, the target permanent won’t be exiled."
+          "text": "If Thopter Arrest leaves the battlefield before its triggered ability resolves, the target permanent won't be exiled."
         },
         {
           "date": "2017-02-09",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         },
         {
           "date": "2017-02-09",
-          "text": "If a token is exiled this way, it will cease to exist and won’t return to the battlefield."
+          "text": "If a token is exiled this way, it will cease to exist and won't return to the battlefield."
         },
         {
           "date": "2017-02-09",
@@ -3167,7 +3167,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "In a multiplayer game, if Thopter Arrest’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Thopter Arrest's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "When Thopter Arrest enters the battlefield, exile target artifact or creature an opponent controls until Thopter Arrest leaves the battlefield.",
@@ -3284,7 +3284,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -3296,15 +3296,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -3427,7 +3427,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -3439,11 +3439,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -3561,15 +3561,15 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Baral’s first ability doesn’t affect the colored mana requirements of instant and sorcery spells."
+          "text": "Baral's first ability doesn't affect the colored mana requirements of instant and sorcery spells."
         },
         {
           "date": "2017-02-09",
-          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as Thalia, Guardian of Thraben’s ability, for example), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as Thalia, Guardian of Thraben's ability, for example), apply those increases before applying cost reductions."
         },
         {
           "date": "2017-02-09",
-          "text": "A spell or ability counters a spell only if it specifically contains the word “counter” in its text. If a spell or ability you control causes all the targets of a spell to become illegal, that spell is considered to be countered by the game rules, not by the spell or ability you control, and Baral’s ability won’t trigger."
+          "text": "A spell or ability counters a spell only if it specifically contains the word \"counter\" in its text. If a spell or ability you control causes all the targets of a spell to become illegal, that spell is considered to be countered by the game rules, not by the spell or ability you control, and Baral's ability won't trigger."
         }
       ],
       "subtypes": [
@@ -3694,11 +3694,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If the Expertise spell you cast has any targets, and those targets become illegal before the spell resolves, the spell is countered and none of its effects happen. You won’t get to cast a free spell."
+          "text": "If the Expertise spell you cast has any targets, and those targets become illegal before the spell resolves, the spell is countered and none of its effects happen. You won't get to cast a free spell."
         },
         {
           "date": "2017-02-09",
-          "text": "A card’s converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
+          "text": "A card's converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
         },
         {
           "date": "2017-02-09",
@@ -3706,19 +3706,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Effects that allow you to “cast” a card don’t allow you to play a land card."
+          "text": "Effects that allow you to \"cast\" a card don't allow you to play a land card."
         },
         {
           "date": "2017-02-09",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
         },
         {
           "date": "2017-02-09",
-          "text": "While you’re casting your free spell, the Expertise spell is still on the stack. It will be put into its owner’s graveyard after the free spell is cast. The free spell can’t target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
+          "text": "While you're casting your free spell, the Expertise spell is still on the stack. It will be put into its owner's graveyard after the free spell is cast. The free spell can't target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
         },
         {
           "date": "2017-02-09",
-          "text": "Any triggered abilities that trigger while performing the Expertise spell’s first effect won’t be put onto the stack until after you’re done casting your free spell. They’re put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
+          "text": "Any triggered abilities that trigger while performing the Expertise spell's first effect won't be put onto the stack until after you're done casting your free spell. They're put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
         },
         {
           "date": "2017-04-18",
@@ -3836,35 +3836,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -3982,27 +3982,27 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Activated abilities are written in the form “Cost: Effect.” Some keyword abilities, such as equip and crew, are activated abilities and will have colons in their reminder texts."
+          "text": "Activated abilities are written in the form \"Cost: Effect.\" Some keyword abilities, such as equip and crew, are activated abilities and will have colons in their reminder texts."
         },
         {
           "date": "2017-02-09",
-          "text": "Triggered abilities use the word “when,” “whenever,” or “at.” They’re often written as “[Trigger condition], [effect].” Some keyword abilities, such as prowess and fabricate, are triggered abilities and will have “when,” “whenever,” or “at” in their reminder text."
+          "text": "Triggered abilities use the word \"when,\" \"whenever,\" or \"at.\" They're often written as \"[Trigger condition], [effect].\" Some keyword abilities, such as prowess and fabricate, are triggered abilities and will have \"when,\" \"whenever,\" or \"at\" in their reminder text."
         },
         {
           "date": "2017-02-09",
-          "text": "If you counter a delayed triggered ability that triggers at the beginning of the “next” occurrence of a specified step or phase, that ability won’t trigger again the following time that phase or step occurs."
+          "text": "If you counter a delayed triggered ability that triggers at the beginning of the \"next\" occurrence of a specified step or phase, that ability won't trigger again the following time that phase or step occurs."
         },
         {
           "date": "2017-02-09",
-          "text": "An activated mana ability is one that adds mana to a player’s mana pool as it resolves, doesn’t have a target, and isn’t a loyalty ability. A triggered mana ability is one that adds mana to a player’s mana pool and triggers on an activated mana ability."
+          "text": "An activated mana ability is one that adds mana to a player's mana pool as it resolves, doesn't have a target, and isn't a loyalty ability. A triggered mana ability is one that adds mana to a player's mana pool and triggers on an activated mana ability."
         },
         {
           "date": "2017-02-09",
-          "text": "Abilities that create replacement effects, such as a permanent entering the battlefield tapped or with counters on it, can’t be targeted. Abilities that apply “as [this creature] enters the battlefield” are also replacement effects and can’t be targeted."
+          "text": "Abilities that create replacement effects, such as a permanent entering the battlefield tapped or with counters on it, can't be targeted. Abilities that apply \"as [this creature] enters the battlefield\" are also replacement effects and can't be targeted."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Counter target spell, activated ability, or triggered ability. (Mana abilities can't be targeted.)",
@@ -4229,7 +4229,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Efficient Construction’s triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Efficient Construction's triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         }
       ],
       "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.",
@@ -4574,19 +4574,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Each card that returns to the battlefield will be a new object with no connection to the creature that was exiled. It won’t be in combat or have any additional abilities it may have had when it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
+          "text": "Each card that returns to the battlefield will be a new object with no connection to the creature that was exiled. It won't be in combat or have any additional abilities it may have had when it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
         },
         {
           "date": "2017-02-09",
-          "text": "If you choose two target creatures and one is an illegal target as Illusionist’s Stratagem resolves, you’ll exile the other, return it, and draw a card."
+          "text": "If you choose two target creatures and one is an illegal target as Illusionist's Stratagem resolves, you'll exile the other, return it, and draw a card."
         },
         {
           "date": "2017-02-09",
-          "text": "If each target creature is an illegal target as Illusionist’s Stratagem resolves, the spell is countered. You won’t draw a card."
+          "text": "If each target creature is an illegal target as Illusionist's Stratagem resolves, the spell is countered. You won't draw a card."
         },
         {
           "date": "2017-02-09",
-          "text": "You may cast Illusionist’s Stratagem without any targets if you wish to just draw a card."
+          "text": "You may cast Illusionist's Stratagem without any targets if you wish to just draw a card."
         }
       ],
       "text": "Exile up to two target creatures you control, then return those cards to the battlefield under their owner's control.\nDraw a card.",
@@ -4699,7 +4699,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If the target permanent becomes an illegal target, Leave in the Dust is countered and none of its effects happen. You won’t draw a card."
+          "text": "If the target permanent becomes an illegal target, Leave in the Dust is countered and none of its effects happen. You won't draw a card."
         }
       ],
       "text": "Return target nonland permanent to its owner's hand.\nDraw a card.",
@@ -4812,23 +4812,23 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Any abilities that trigger on the token being created won’t resolve until after Mechanized Production’s triggered ability has finished resolving entirely and performed its check for eight artifacts with the same name."
+          "text": "Any abilities that trigger on the token being created won't resolve until after Mechanized Production's triggered ability has finished resolving entirely and performed its check for eight artifacts with the same name."
         },
         {
           "date": "2017-02-09",
-          "text": "The eight artifacts with the same name don’t have to have the same name as the enchanted artifact. For example, you win the game if you control eight Thopter artifact creature tokens as Mechanized Production’s ability resolves, even if Mechanized Production isn’t attached to a Thopter."
+          "text": "The eight artifacts with the same name don't have to have the same name as the enchanted artifact. For example, you win the game if you control eight Thopter artifact creature tokens as Mechanized Production's ability resolves, even if Mechanized Production isn't attached to a Thopter."
         },
         {
           "date": "2017-02-09",
-          "text": "All eight of the permanents sharing a name must be artifacts. If you control only seven artifacts with the same name and a nonartifact permanent with that same name, you won’t win the game."
+          "text": "All eight of the permanents sharing a name must be artifacts. If you control only seven artifacts with the same name and a nonartifact permanent with that same name, you won't win the game."
         },
         {
           "date": "2017-02-09",
-          "text": "If you control eight or more artifacts that share a name while you control Mechanized Production, you won’t win the game yet. You’ll win the game while resolving its triggered ability during your upkeep."
+          "text": "If you control eight or more artifacts that share a name while you control Mechanized Production, you won't win the game yet. You'll win the game while resolving its triggered ability during your upkeep."
         },
         {
           "date": "2017-02-09",
-          "text": "The token copies exactly what was printed on the original artifact and nothing else (unless that artifact is copying something else or is a token; see below). It doesn’t copy whether that artifact is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its types, color, or so on."
+          "text": "The token copies exactly what was printed on the original artifact and nothing else (unless that artifact is copying something else or is a token; see below). It doesn't copy whether that artifact is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its types, color, or so on."
         },
         {
           "date": "2017-02-09",
@@ -4840,19 +4840,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If the copied artifact is a token, the token that’s created copies the original characteristics of that token as stated by the effect that created it."
+          "text": "If the copied artifact is a token, the token that's created copies the original characteristics of that token as stated by the effect that created it."
         },
         {
           "date": "2017-02-09",
-          "text": "Any enters-the-battlefield abilities of the copied artifact trigger when the artifact token enters the battlefield. The artifact token also has any “this enters the battlefield with” or “as this enters the battlefield” abilities that the copied artifact has."
+          "text": "Any enters-the-battlefield abilities of the copied artifact trigger when the artifact token enters the battlefield. The artifact token also has any \"this enters the battlefield with\" or \"as this enters the battlefield\" abilities that the copied artifact has."
         },
         {
           "date": "2017-02-09",
-          "text": "If Mechanized Production and the enchanted artifact leave the battlefield simultaneously in response to the triggered ability, then the effect creates a token that’s a copy of the artifact as it last existed on the battlefield."
+          "text": "If Mechanized Production and the enchanted artifact leave the battlefield simultaneously in response to the triggered ability, then the effect creates a token that's a copy of the artifact as it last existed on the battlefield."
         },
         {
           "date": "2017-02-09",
-          "text": "If the enchanted artifact leaves the battlefield in response to Mechanized Production’s triggered ability but Mechanized Production does not, Mechanized Production is put into its owner’s graveyard as a state-based action with no enchanted artifact. The triggered ability creates no token, but you can still win the game if you control enough artifacts with the same name."
+          "text": "If the enchanted artifact leaves the battlefield in response to Mechanized Production's triggered ability but Mechanized Production does not, Mechanized Production is put into its owner's graveyard as a state-based action with no enchanted artifact. The triggered ability creates no token, but you can still win the game if you control enough artifacts with the same name."
         }
       ],
       "subtypes": [
@@ -4968,35 +4968,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nCounter target spell unless its controller pays {3}.",
@@ -5134,7 +5134,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -5378,35 +5378,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nDraw three cards.",
@@ -5520,7 +5520,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If you control no artifacts, you won’t return anything to your hand. There’s no penalty for being unable to do so."
+          "text": "If you control no artifacts, you won't return anything to your hand. There's no penalty for being unable to do so."
         }
       ],
       "subtypes": [
@@ -5646,7 +5646,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -5658,11 +5658,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -5785,7 +5785,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -5797,11 +5797,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -5919,15 +5919,15 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Skyship Plunderer’s triggered ability can target any permanent or player, regardless of which player was dealt combat damage."
+          "text": "Skyship Plunderer's triggered ability can target any permanent or player, regardless of which player was dealt combat damage."
         },
         {
           "date": "2017-02-09",
-          "text": "Skyship Plunderer’s triggered ability gives only one counter of each kind. It doesn’t double the number of each kind of counter. For example, if a creature has two +1/+1 counters and a charge counter on it, it gets one +1/+1 counter and one charge counter."
+          "text": "Skyship Plunderer's triggered ability gives only one counter of each kind. It doesn't double the number of each kind of counter. For example, if a creature has two +1/+1 counters and a charge counter on it, it gets one +1/+1 counter and one charge counter."
         },
         {
           "date": "2017-02-09",
-          "text": "To give a counter is to put a counter on a permanent or to have a player get a counter. Effects that interact with a player getting counters or counters being placed on permanents interact with Skyship Plunderer’s triggered ability."
+          "text": "To give a counter is to put a counter on a permanent or to have a player get a counter. Effects that interact with a player getting counters or counters being placed on permanents interact with Skyship Plunderer's triggered ability."
         }
       ],
       "subtypes": [
@@ -6045,7 +6045,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Take into Custody can target a creature that’s already tapped. That creature won’t untap during its controller’s next untap step."
+          "text": "Take into Custody can target a creature that's already tapped. That creature won't untap during its controller's next untap step."
         }
       ],
       "text": "Tap target creature. It doesn't untap during its controller's next untap step.",
@@ -6159,7 +6159,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Trophy Mage’s ability finds an artifact card with converted mana cost exactly 3."
+          "text": "Trophy Mage's ability finds an artifact card with converted mana cost exactly 3."
         }
       ],
       "subtypes": [
@@ -6276,39 +6276,39 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         },
         {
           "date": "2017-02-09",
-          "text": "When using improvise to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap artifacts you control to help pay that cost. For example, if you cast Whir of Invention (a spell with improvise and mana cost {X}{U}{U}{U}) and choose X to be 3, the total cost is {3}{U}{U}{U}. If you tap two artifacts, you’ll have to pay {1}{U}{U}{U}."
+          "text": "When using improvise to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap artifacts you control to help pay that cost. For example, if you cast Whir of Invention (a spell with improvise and mana cost {X}{U}{U}{U}) and choose X to be 3, the total cost is {3}{U}{U}{U}. If you tap two artifacts, you'll have to pay {1}{U}{U}{U}."
         }
       ],
       "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nSearch your library for an artifact card with converted mana cost X or less, put it onto the battlefield, then shuffle your library.",
@@ -6422,35 +6422,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -6572,7 +6572,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -6584,15 +6584,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -6823,47 +6823,47 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If the target creature becomes an illegal target, Battle at the Bridge is countered and none of its effects happen. You won’t gain life."
+          "text": "If the target creature becomes an illegal target, Battle at the Bridge is countered and none of its effects happen. You won't gain life."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         },
         {
           "date": "2017-02-09",
-          "text": "When using improvise to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap artifacts you control to help pay that cost. For example, if you cast Whir of Invention (a spell with improvise and mana cost {X}{U}{U}{U}) and choose X to be 3, the total cost is {3}{U}{U}{U}. If you tap two artifacts, you’ll have to pay {1}{U}{U}{U}."
+          "text": "When using improvise to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap artifacts you control to help pay that cost. For example, if you cast Whir of Invention (a spell with improvise and mana cost {X}{U}{U}{U}) and choose X to be 3, the total cost is {3}{U}{U}{U}. If you tap two artifacts, you'll have to pay {1}{U}{U}{U}."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nTarget creature gets -X/-X until end of turn. You gain X life.",
@@ -6977,7 +6977,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If the target creature becomes an illegal target, Cruel Finality is countered and none of its effects happen. You won’t scry 1."
+          "text": "If the target creature becomes an illegal target, Cruel Finality is countered and none of its effects happen. You won't scry 1."
         }
       ],
       "text": "Target creature gets -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -7198,11 +7198,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You can sacrifice Defiant Salvager to activate its own ability. It won’t receive a counter, but it will enable your revolt abilities."
+          "text": "You can sacrifice Defiant Salvager to activate its own ability. It won't receive a counter, but it will enable your revolt abilities."
         },
         {
           "date": "2017-02-09",
-          "text": "If you sacrifice an artifact creature to activate Defiant Salvager’s ability, you put one +1/+1 counter on Defiant Salvager, not two."
+          "text": "If you sacrifice an artifact creature to activate Defiant Salvager's ability, you put one +1/+1 counter on Defiant Salvager, not two."
         }
       ],
       "subtypes": [
@@ -7319,7 +7319,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Fatal Push can target any creature, even one with converted mana cost 5 or greater. The creature’s converted mana cost is checked only as Fatal Push resolves."
+          "text": "Fatal Push can target any creature, even one with converted mana cost 5 or greater. The creature's converted mana cost is checked only as Fatal Push resolves."
         },
         {
           "date": "2017-02-09",
@@ -7327,11 +7327,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -7339,7 +7339,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         }
       ],
       "text": "Destroy target creature if it has converted mana cost 2 or less.\nRevolt — Destroy that creature if it has converted mana cost 4 or less instead if a permanent you controlled left the battlefield this turn.",
@@ -7453,35 +7453,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -7599,11 +7599,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The set of creatures affected by Foundry Hornet’s triggered ability is determined as the ability resolves. Creatures opponents begin to control later in the turn and permanents opponents control that become creatures later in the turn won’t get -1/-1. The effect continues until end of turn even if you stop controlling a creature with a +1/+1 counter on it."
+          "text": "The set of creatures affected by Foundry Hornet's triggered ability is determined as the ability resolves. Creatures opponents begin to control later in the turn and permanents opponents control that become creatures later in the turn won't get -1/-1. The effect continues until end of turn even if you stop controlling a creature with a +1/+1 counter on it."
         },
         {
           "date": "2017-02-09",
-          "text": "If you don’t control a creature with a +1/+1 counter as Foundry Hornet enters the battlefield, its ability doesn’t trigger, even if you can give a +1/+1 counter to a creature right away. If you control no creatures with a +1/+1 counter as the ability resolves, nothing happens."
+          "text": "If you don't control a creature with a +1/+1 counter as Foundry Hornet enters the battlefield, its ability doesn't trigger, even if you can give a +1/+1 counter to a creature right away. If you control no creatures with a +1/+1 counter as the ability resolves, nothing happens."
         },
         {
           "date": "2017-02-09",
@@ -7956,7 +7956,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The first triggered ability triggers both when Glint-Sleeve Siphoner enters the battlefield and whenever it attacks. You don’t have to choose only one."
+          "text": "The first triggered ability triggers both when Glint-Sleeve Siphoner enters the battlefield and whenever it attacks. You don't have to choose only one."
         },
         {
           "date": "2017-02-09",
@@ -7964,7 +7964,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -7976,15 +7976,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -8106,11 +8106,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "In a Two-Headed Giant game, damage and life loss happen to individual players, and the result affects the team’s life total. Combat damage is assigned and dealt to specific players. If your teammate is dealt damage or otherwise loses life, Gonti’s Machinations doesn’t trigger, even though your life total went down."
+          "text": "In a Two-Headed Giant game, damage and life loss happen to individual players, and the result affects the team's life total. Combat damage is assigned and dealt to specific players. If your teammate is dealt damage or otherwise loses life, Gonti's Machinations doesn't trigger, even though your life total went down."
         },
         {
           "date": "2017-02-09",
-          "text": "In a Two-Headed Giant game, Gonti’s Machinations’s second ability causes the opposing team to lose a total of 6 life."
+          "text": "In a Two-Headed Giant game, Gonti's Machinations's second ability causes the opposing team to lose a total of 6 life."
         },
         {
           "date": "2017-02-09",
@@ -8118,7 +8118,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -8130,11 +8130,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Whenever you lose life for the first time each turn, you get {E}. (You get an energy counter. Damage causes loss of life.)\nPay {E}{E}, Sacrifice Gonti's Machinations: Each opponent loses 3 life. You gain life equal to the life lost this way.",
@@ -8247,35 +8247,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -8393,15 +8393,15 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You choose whether to sacrifice an artifact or not as Ironclad Revolutionary’s ability resolves. No player may take actions between the time you choose whether to sacrifice an artifact and, if you do so, the time that counters are added and life is lost."
+          "text": "You choose whether to sacrifice an artifact or not as Ironclad Revolutionary's ability resolves. No player may take actions between the time you choose whether to sacrifice an artifact and, if you do so, the time that counters are added and life is lost."
         },
         {
           "date": "2017-02-09",
-          "text": "You can sacrifice an artifact only once when Ironclad Revolutionary’s triggered ability resolves. You can’t sacrifice more to get more counters or more life loss."
+          "text": "You can sacrifice an artifact only once when Ironclad Revolutionary's triggered ability resolves. You can't sacrifice more to get more counters or more life loss."
         },
         {
           "date": "2017-02-09",
-          "text": "In a Two-Headed Giant game, Ironclad Revolutionary’s ability causes the opposing team to lose a total of 4 life."
+          "text": "In a Two-Headed Giant game, Ironclad Revolutionary's ability causes the opposing team to lose a total of 4 life."
         }
       ],
       "subtypes": [
@@ -8519,7 +8519,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Midnight Entourage’s triggered ability is mandatory. You draw a card and lose 1 life even if you don’t want to."
+          "text": "Midnight Entourage's triggered ability is mandatory. You draw a card and lose 1 life even if you don't want to."
         },
         {
           "date": "2017-02-09",
@@ -8527,7 +8527,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If a creature has been dealt damage, that damage remains marked on it until the cleanup step. If Midnight Entourage leaves the battlefield and another Aetherborn creature you control has been dealt damage, that creature will be destroyed if the damage is now lethal. The same is true if an Aetherborn’s toughness becomes 0 this way."
+          "text": "If a creature has been dealt damage, that damage remains marked on it until the cleanup step. If Midnight Entourage leaves the battlefield and another Aetherborn creature you control has been dealt damage, that creature will be destroyed if the damage is now lethal. The same is true if an Aetherborn's toughness becomes 0 this way."
         }
       ],
       "subtypes": [
@@ -8646,11 +8646,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -8658,7 +8658,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         }
       ],
       "subtypes": [
@@ -8780,7 +8780,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If each creature an opponent controls is an artifact creature, that player sacrifices only one creature. Similarly, if each creature an opponent controls is a nonartifact creature, that player sacrifices only one creature. If an opponent controls no creatures, that player doesn’t sacrifice anything."
+          "text": "If each creature an opponent controls is an artifact creature, that player sacrifices only one creature. Similarly, if each creature an opponent controls is a nonartifact creature, that player sacrifices only one creature. If an opponent controls no creatures, that player doesn't sacrifice anything."
         }
       ],
       "text": "Each opponent sacrifices an artifact creature and a nonartifact creature.",
@@ -8893,11 +8893,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "There’s no way to have Renegade’s Getaway’s effect create a Servo token and give that token indestructible."
+          "text": "There's no way to have Renegade's Getaway's effect create a Servo token and give that token indestructible."
         },
         {
           "date": "2017-02-09",
-          "text": "If the target permanent becomes an illegal target, Renegade’s Getaway is countered and none of its effects happen. You won’t create a Servo token."
+          "text": "If the target permanent becomes an illegal target, Renegade's Getaway is countered and none of its effects happen. You won't create a Servo token."
         }
       ],
       "text": "Target permanent gains indestructible until end of turn. Create a 1/1 colorless Servo artifact creature token. (Effects that say \"destroy\" don't destroy a permanent with indestructible, and if it's a creature, it can't be destroyed by damage.)",
@@ -9010,7 +9010,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You can’t cast Resourceful Return without a target creature card in your graveyard."
+          "text": "You can't cast Resourceful Return without a target creature card in your graveyard."
         },
         {
           "date": "2017-02-09",
@@ -9238,35 +9238,35 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -9385,11 +9385,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -9397,11 +9397,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "subtypes": [
@@ -9520,7 +9520,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If Yahenni and a creature an opponent controls die simultaneously (perhaps because they fought or were in combat together), Yahenni won’t be on the battlefield as its triggered ability resolves. It can’t be saved by the +1/+1 counter that would have been put on it."
+          "text": "If Yahenni and a creature an opponent controls die simultaneously (perhaps because they fought or were in combat together), Yahenni won't be on the battlefield as its triggered ability resolves. It can't be saved by the +1/+1 counter that would have been put on it."
         }
       ],
       "subtypes": [
@@ -9641,11 +9641,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If a creature’s toughness is reduced to 0 or less by Yahenni’s Expertise, that creature is still on the battlefield as you cast your free spell. It can be the target of that spell, although it will become an illegal target before that spell resolves. If it has any abilities that trigger on the spell being cast, those abilities will trigger."
+          "text": "If a creature's toughness is reduced to 0 or less by Yahenni's Expertise, that creature is still on the battlefield as you cast your free spell. It can be the target of that spell, although it will become an illegal target before that spell resolves. If it has any abilities that trigger on the spell being cast, those abilities will trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "A card’s converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
+          "text": "A card's converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
         },
         {
           "date": "2017-02-09",
@@ -9653,19 +9653,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Effects that allow you to “cast” a card don’t allow you to play a land card."
+          "text": "Effects that allow you to \"cast\" a card don't allow you to play a land card."
         },
         {
           "date": "2017-02-09",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
         },
         {
           "date": "2017-02-09",
-          "text": "While you’re casting your free spell, the Expertise spell is still on the stack. It will be put into its owner’s graveyard after the free spell is cast. The free spell can’t target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
+          "text": "While you're casting your free spell, the Expertise spell is still on the stack. It will be put into its owner's graveyard after the free spell is cast. The free spell can't target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
         },
         {
           "date": "2017-02-09",
-          "text": "Any triggered abilities that trigger while performing the Expertise spell’s first effect won’t be put onto the stack until after you’re done casting your free spell. They’re put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
+          "text": "Any triggered abilities that trigger while performing the Expertise spell's first effect won't be put onto the stack until after you're done casting your free spell. They're put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
         },
         {
           "date": "2017-04-18",
@@ -9786,7 +9786,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -9798,15 +9798,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -9924,7 +9924,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Chandra’s Revolution can target a land that’s already tapped. That land won’t untap during its controller’s next untap step."
+          "text": "Chandra's Revolution can target a land that's already tapped. That land won't untap during its controller's next untap step."
         }
       ],
       "text": "Chandra's Revolution deals 4 damage to target creature. Tap target land. That land doesn't untap during its controller's next untap step.",
@@ -10037,11 +10037,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You choose which mode you’re using as you cast Destructive Tampering. Once this choice is made, it can’t be changed."
+          "text": "You choose which mode you're using as you cast Destructive Tampering. Once this choice is made, it can't be changed."
         },
         {
           "date": "2017-02-09",
-          "text": "Because the effect of Destructive Tampering’s second mode doesn’t change the characteristics of any permanents, the set of creatures affected by it is constantly updated. Creatures without flying that enter the battlefield later in the turn won’t be able to block."
+          "text": "Because the effect of Destructive Tampering's second mode doesn't change the characteristics of any permanents, the set of creatures affected by it is constantly updated. Creatures without flying that enter the battlefield later in the turn won't be able to block."
         }
       ],
       "text": "Choose one —\n• Destroy target artifact.\n• Creatures without flying can't block this turn.",
@@ -10155,7 +10155,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "In a Two-Headed Giant game, Embraal Gear-Smasher’s ability causes 4 damage total to be dealt to the opposing team."
+          "text": "In a Two-Headed Giant game, Embraal Gear-Smasher's ability causes 4 damage total to be dealt to the opposing team."
         }
       ],
       "subtypes": [
@@ -10274,35 +10274,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -10420,35 +10420,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -10566,7 +10566,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If, during your declare attackers step, Frontline Rebel is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having it attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Frontline Rebel is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having it attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -10683,7 +10683,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "When the enchanted artifact is put into a graveyard, Gremlin Infestation’s controller creates the Gremlin token."
+          "text": "When the enchanted artifact is put into a graveyard, Gremlin Infestation's controller creates the Gremlin token."
         }
       ],
       "subtypes": [
@@ -10799,7 +10799,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You can’t cast Hungry Flames unless you target both a creature and a player. If one target is illegal as Hungry Flames resolves, the spell deals damage to the remaining legal target."
+          "text": "You can't cast Hungry Flames unless you target both a creature and a player. If one target is illegal as Hungry Flames resolves, the spell deals damage to the remaining legal target."
         }
       ],
       "text": "Hungry Flames deals 3 damage to target creature and 2 damage to target player.",
@@ -10911,19 +10911,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If a player controls no permanents destroyed this way, that player reveals no cards from his or her library and doesn’t shuffle it."
+          "text": "If a player controls no permanents destroyed this way, that player reveals no cards from his or her library and doesn't shuffle it."
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact or creature is targeted but not destroyed (perhaps because it gained indestructible or became an illegal target), it doesn’t count as one of the artifacts or creatures destroyed this way. An artifact or creature that’s destroyed but put into a zone other than a graveyard (such as a player’s commander in the Commander variant) does count."
+          "text": "If an artifact or creature is targeted but not destroyed (perhaps because it gained indestructible or became an illegal target), it doesn't count as one of the artifacts or creatures destroyed this way. An artifact or creature that's destroyed but put into a zone other than a graveyard (such as a player's commander in the Commander variant) does count."
         },
         {
           "date": "2017-02-09",
-          "text": "While revealing cards, a player stops as soon as he or she reveals a card that’s an artifact or a creature (or both). That player doesn’t choose one type."
+          "text": "While revealing cards, a player stops as soon as he or she reveals a card that's an artifact or a creature (or both). That player doesn't choose one type."
         },
         {
           "date": "2017-02-09",
-          "text": "If a player’s library no longer contains an artifact or creature card when instructed to reveal cards, that player reveals the entire library, exiles no cards, and then shuffles it."
+          "text": "If a player's library no longer contains an artifact or creature card when instructed to reveal cards, that player reveals the entire library, exiles no cards, and then shuffles it."
         },
         {
           "date": "2017-02-09",
@@ -11040,7 +11040,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If you choose Invigorated Rampage’s second mode and one target becomes an illegal target, the remaining target gets +2/+0 and gains trample. It doesn’t get +4/+0."
+          "text": "If you choose Invigorated Rampage's second mode and one target becomes an illegal target, the remaining target gets +2/+0 and gains trample. It doesn't get +4/+0."
         }
       ],
       "text": "Choose one —\n• Target creature gets +4/+0 and gains trample until end of turn.\n• Two target creatures each get +2/+0 and gain trample until end of turn.",
@@ -11154,7 +11154,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You choose which opponent or opposing planeswalker Ragavan is attacking as you create the token. It doesn’t have to be the same player or planeswalker Kari Zev is attacking."
+          "text": "You choose which opponent or opposing planeswalker Ragavan is attacking as you create the token. It doesn't have to be the same player or planeswalker Kari Zev is attacking."
         },
         {
           "date": "2017-02-09",
@@ -11283,15 +11283,15 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Kari Zev’s Expertise can target any creature or Vehicle, even one that you already control or that is already untapped."
+          "text": "Kari Zev's Expertise can target any creature or Vehicle, even one that you already control or that is already untapped."
         },
         {
           "date": "2017-02-09",
-          "text": "If the Expertise spell you cast has any targets, and those targets become illegal before the spell resolves, the spell is countered and none of its effects happen. You won’t get to cast a free spell."
+          "text": "If the Expertise spell you cast has any targets, and those targets become illegal before the spell resolves, the spell is countered and none of its effects happen. You won't get to cast a free spell."
         },
         {
           "date": "2017-02-09",
-          "text": "A card’s converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
+          "text": "A card's converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
         },
         {
           "date": "2017-02-09",
@@ -11299,19 +11299,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Effects that allow you to “cast” a card don’t allow you to play a land card."
+          "text": "Effects that allow you to \"cast\" a card don't allow you to play a land card."
         },
         {
           "date": "2017-02-09",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
         },
         {
           "date": "2017-02-09",
-          "text": "While you’re casting your free spell, the Expertise spell is still on the stack. It will be put into its owner’s graveyard after the free spell is cast. The free spell can’t target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
+          "text": "While you're casting your free spell, the Expertise spell is still on the stack. It will be put into its owner's graveyard after the free spell is cast. The free spell can't target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
         },
         {
           "date": "2017-02-09",
-          "text": "Any triggered abilities that trigger while performing the Expertise spell’s first effect won’t be put onto the stack until after you’re done casting your free spell. They’re put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
+          "text": "Any triggered abilities that trigger while performing the Expertise spell's first effect won't be put onto the stack until after you're done casting your free spell. They're put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
         },
         {
           "date": "2017-04-18",
@@ -11539,7 +11539,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You untap all creatures you control, including ones that aren’t attacking."
+          "text": "You untap all creatures you control, including ones that aren't attacking."
         },
         {
           "date": "2017-02-09",
@@ -11547,7 +11547,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -11559,15 +11559,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -11685,23 +11685,23 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If a nontoken artifact is put into your graveyard at the same time as Pia’s Revolution, Pia’s Revolution’s ability triggers."
+          "text": "If a nontoken artifact is put into your graveyard at the same time as Pia's Revolution, Pia's Revolution's ability triggers."
         },
         {
           "date": "2017-02-09",
-          "text": "It doesn’t matter who controlled the artifact when it was put into your graveyard. Pia’s Revolution’s ability will trigger if you own that artifact."
+          "text": "It doesn't matter who controlled the artifact when it was put into your graveyard. Pia's Revolution's ability will trigger if you own that artifact."
         },
         {
           "date": "2017-02-09",
-          "text": "The target opponent chooses whether to have Pia’s Revolution deal 3 damage to him or her as its ability resolves. You won’t return the card to your hand if that player chooses to be dealt damage or if the card leaves the graveyard before the ability resolves."
+          "text": "The target opponent chooses whether to have Pia's Revolution deal 3 damage to him or her as its ability resolves. You won't return the card to your hand if that player chooses to be dealt damage or if the card leaves the graveyard before the ability resolves."
         },
         {
           "date": "2017-02-09",
-          "text": "If there are no legal targets for Pia’s Revolution’s ability (perhaps because each of your opponents has hexproof), it will be removed from the stack with no effect. No one may choose to be dealt damage and you won’t return the artifact card to your hand."
+          "text": "If there are no legal targets for Pia's Revolution's ability (perhaps because each of your opponents has hexproof), it will be removed from the stack with no effect. No one may choose to be dealt damage and you won't return the artifact card to your hand."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Whenever a nontoken artifact is put into your graveyard from the battlefield, return that card to your hand unless target opponent has Pia's Revolution deal 3 damage to him or her.",
@@ -12166,11 +12166,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "This is a triggered ability, not an activated ability. It doesn’t allow you to tap Reckless Racer whenever you want; rather, you need some other way of tapping it, such as by attacking or crewing a Vehicle."
+          "text": "This is a triggered ability, not an activated ability. It doesn't allow you to tap Reckless Racer whenever you want; rather, you need some other way of tapping it, such as by attacking or crewing a Vehicle."
         },
         {
           "date": "2017-02-09",
-          "text": "For the ability to trigger, Reckless Racer has to actually change from untapped to tapped. If an effect attempts to tap it, but it was already tapped at the time, this ability won’t trigger."
+          "text": "For the ability to trigger, Reckless Racer has to actually change from untapped to tapped. If an effect attempts to tap it, but it was already tapped at the time, this ability won't trigger."
         }
       ],
       "subtypes": [
@@ -12288,15 +12288,15 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The value of X is limited by the number of artifacts that you can target. You can’t target the same artifact more than once."
+          "text": "The value of X is limited by the number of artifacts that you can target. You can't target the same artifact more than once."
         },
         {
           "date": "2017-02-09",
-          "text": "You can target an artifact with indestructible. It won’t be destroyed, and you’ll still create X Gremlin tokens."
+          "text": "You can target an artifact with indestructible. It won't be destroyed, and you'll still create X Gremlin tokens."
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact becomes an illegal target for Release the Gremlins, it won’t change the number of tokens created. However, if every target artifact becomes an illegal target, Release the Gremlins is countered and no tokens are created."
+          "text": "If an artifact becomes an illegal target for Release the Gremlins, it won't change the number of tokens created. However, if every target artifact becomes an illegal target, Release the Gremlins is countered and no tokens are created."
         }
       ],
       "text": "Destroy X target artifacts. Create X 2/2 red Gremlin creature tokens.",
@@ -12413,7 +12413,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -12425,15 +12425,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -12680,7 +12680,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If Siege Modification becomes unattached from a Vehicle that’s attacking or blocking, that Vehicle will be removed from combat unless another effect (such as its crew ability) is also making it a creature."
+          "text": "If Siege Modification becomes unattached from a Vehicle that's attacking or blocking, that Vehicle will be removed from combat unless another effect (such as its crew ability) is also making it a creature."
         }
       ],
       "subtypes": [
@@ -12797,35 +12797,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -12947,7 +12947,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If the target creature’s power becomes 5 or greater as you gain control of it (perhaps because an enchantment gives creatures you control +1/+1), Wrangle will continue to resolve as normal. The creature will still be untapped and gain haste until end of turn, and you’ll still control it until end of turn."
+          "text": "If the target creature's power becomes 5 or greater as you gain control of it (perhaps because an enchantment gives creatures you control +1/+1), Wrangle will continue to resolve as normal. The creature will still be untapped and gain haste until end of turn, and you'll still control it until end of turn."
         }
       ],
       "text": "Gain control of target creature with power 4 or less until end of turn. Untap that creature. It gains haste until end of turn.",
@@ -13064,7 +13064,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -13076,15 +13076,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -13207,7 +13207,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -13219,15 +13219,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -13345,11 +13345,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The triggered ability triggers both when Aetherwind Basker enters the battlefield and whenever it attacks. You don’t have to choose only one."
+          "text": "The triggered ability triggers both when Aetherwind Basker enters the battlefield and whenever it attacks. You don't have to choose only one."
         },
         {
           "date": "2017-02-09",
-          "text": "Abilities that trigger “whenever you get one or more {E},” such as that of Fabrication Module from the Kaladesh set, trigger only once as Aetherwind Basker’s triggered ability resolves."
+          "text": "Abilities that trigger \"whenever you get one or more {E},\" such as that of Fabrication Module from the Kaladesh set, trigger only once as Aetherwind Basker's triggered ability resolves."
         },
         {
           "date": "2017-02-09",
@@ -13357,7 +13357,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -13369,11 +13369,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -13489,7 +13489,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If the revealed card is not a permanent card or if you choose not to put it onto the battlefield, you may put it on the bottom of your library. If you don’t, it remains on top of your library."
+          "text": "If the revealed card is not a permanent card or if you choose not to put it onto the battlefield, you may put it on the bottom of your library. If you don't, it remains on top of your library."
         },
         {
           "date": "2017-02-09",
@@ -13497,15 +13497,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent put onto the battlefield this way has an ability that triggers at the beginning of your end step, it won’t trigger during this end step."
+          "text": "If a permanent put onto the battlefield this way has an ability that triggers at the beginning of your end step, it won't trigger during this end step."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -13513,11 +13513,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "text": "Revolt — At the beginning of your end step, if a permanent you controlled left the battlefield this turn, reveal the top card of your library. If it's a permanent card, you may put it onto the battlefield. Otherwise, you may put it on the bottom of your library.",
@@ -13744,11 +13744,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If you have only one {E}, you can’t pay it even if you want to."
+          "text": "If you have only one {E}, you can't pay it even if you want to."
         },
         {
           "date": "2017-02-09",
-          "text": "If you have {E}{E}, you have to pay it, even if you don’t want to."
+          "text": "If you have {E}{E}, you have to pay it, even if you don't want to."
         },
         {
           "date": "2017-02-09",
@@ -13756,7 +13756,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -13768,11 +13768,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -13890,11 +13890,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -13902,7 +13902,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         }
       ],
       "subtypes": [
@@ -14020,7 +14020,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The set of permanents affected by Heroic Intervention is determined as the spell resolves. Permanents you begin to control later in the turn won’t gain hexproof and indestructible."
+          "text": "The set of permanents affected by Heroic Intervention is determined as the spell resolves. Permanents you begin to control later in the turn won't gain hexproof and indestructible."
         }
       ],
       "text": "Permanents you control gain hexproof and indestructible until end of turn.",
@@ -14134,11 +14134,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -14146,11 +14146,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "subtypes": [
@@ -14268,7 +14268,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If the target creature becomes an illegal target, the spell is countered and none of its effects happen. You won’t get {E}{E}."
+          "text": "If the target creature becomes an illegal target, the spell is countered and none of its effects happen. You won't get {E}{E}."
         },
         {
           "date": "2017-02-09",
@@ -14276,7 +14276,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -14288,11 +14288,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Target creature gets +3/+3 until end of turn. You get {E}{E} (two energy counters).",
@@ -14405,19 +14405,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You can cast Lifecraft Awakening declaring X as 0. If the artifact isn’t a creature or Vehicle, it’ll become a 0/0 creature and, unless another effect modifies its toughness, be put into your graveyard soon after."
+          "text": "You can cast Lifecraft Awakening declaring X as 0. If the artifact isn't a creature or Vehicle, it'll become a 0/0 creature and, unless another effect modifies its toughness, be put into your graveyard soon after."
         },
         {
           "date": "2017-02-09",
-          "text": "You can put +1/+1 counters on a noncreature Vehicle this way. They’ll be put there, apply if the Vehicle becomes a creature, and remain there when it stops being a creature."
+          "text": "You can put +1/+1 counters on a noncreature Vehicle this way. They'll be put there, apply if the Vehicle becomes a creature, and remain there when it stops being a creature."
         },
         {
           "date": "2017-02-09",
-          "text": "If the artifact isn’t a creature or Vehicle as Lifecraft Awakening resolves, the artifact becomes a creature indefinitely."
+          "text": "If the artifact isn't a creature or Vehicle as Lifecraft Awakening resolves, the artifact becomes a creature indefinitely."
         },
         {
           "date": "2017-02-09",
-          "text": "If an Equipment becomes a creature, it becomes unattached and it can’t be attached to a creature."
+          "text": "If an Equipment becomes a creature, it becomes unattached and it can't be attached to a creature."
         }
       ],
       "text": "Put X +1/+1 counters on target artifact you control. If it isn't a creature or Vehicle, it becomes a 0/0 Construct artifact creature.",
@@ -14531,11 +14531,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -14543,7 +14543,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         }
       ],
       "subtypes": [
@@ -14665,15 +14665,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If the target creature becomes an illegal target, Lifecrafter’s Gift is countered and none of its effects happen. You won’t put any counters on other creatures."
+          "text": "If the target creature becomes an illegal target, Lifecrafter's Gift is countered and none of its effects happen. You won't put any counters on other creatures."
         },
         {
           "date": "2017-02-09",
-          "text": "If there is a +/1+1 counter on a noncreature permanent you control, such as a Vehicle that isn’t crewed, it won’t get another one from Lifecrafter’s Gift."
+          "text": "If there is a +/1+1 counter on a noncreature permanent you control, such as a Vehicle that isn't crewed, it won't get another one from Lifecrafter's Gift."
         },
         {
           "date": "2017-04-18",
-          "text": "The state-based action that removes matching +1/+1 and -1/-1 counters won’t check until after Lifecrafter’s Gift finishes resolving. It’s possible put a +1/+1 counter on a creature with a -1/-1 counter on it and then give it a second +1/+1 counter."
+          "text": "The state-based action that removes matching +1/+1 and -1/-1 counters won't check until after Lifecrafter's Gift finishes resolving. It's possible put a +1/+1 counter on a creature with a -1/-1 counter on it and then give it a second +1/+1 counter."
         }
       ],
       "text": "Put a +1/+1 counter on target creature, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
@@ -14786,15 +14786,15 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The triggered ability triggers both when Maulfist Revolutionary enters the battlefield and when it dies. You don’t have to choose only one."
+          "text": "The triggered ability triggers both when Maulfist Revolutionary enters the battlefield and when it dies. You don't have to choose only one."
         },
         {
           "date": "2017-02-09",
-          "text": "Maulfist Revolutionary’s triggered ability gives only one counter of each kind. It doesn’t double the number of each kind of counter. For example, if a creature has two +1/+1 counters and a charge counter on it, it gets one +1/+1 counter and one charge counter."
+          "text": "Maulfist Revolutionary's triggered ability gives only one counter of each kind. It doesn't double the number of each kind of counter. For example, if a creature has two +1/+1 counters and a charge counter on it, it gets one +1/+1 counter and one charge counter."
         },
         {
           "date": "2017-02-09",
-          "text": "To give a counter is to put a counter on a permanent or to have a player get a counter. Effects that interact with a player getting counters or counters being placed on permanents interact with Maulfist Revolutionary’s triggered ability."
+          "text": "To give a counter is to put a counter on a permanent or to have a player get a counter. Effects that interact with a player getting counters or counters being placed on permanents interact with Maulfist Revolutionary's triggered ability."
         }
       ],
       "subtypes": [
@@ -14916,7 +14916,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "The value of X is determined at the time you divide damage. It won’t change later, even if the highest power among creatures you control changes."
+          "text": "The value of X is determined at the time you divide damage. It won't change later, even if the highest power among creatures you control changes."
         },
         {
           "date": "2017-02-09",
@@ -15038,11 +15038,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -15050,7 +15050,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         }
       ],
       "subtypes": [
@@ -15276,11 +15276,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The amount of {E} you get is determined as Peema Aether-Seer’s first ability resolves. If the greatest power among creatures you control is somehow negative, you don’t get or lose any {E}."
+          "text": "The amount of {E} you get is determined as Peema Aether-Seer's first ability resolves. If the greatest power among creatures you control is somehow negative, you don't get or lose any {E}."
         },
         {
           "date": "2017-02-09",
-          "text": "The target creature blocks only if it’s able to do so as the declare blockers step begins. If, at that time, the creature is tapped, it’s affected by a spell or ability that says it can’t block, or no creatures are attacking its controller or a planeswalker controlled by that player, then it doesn’t block. If there’s a cost associated with having the creature block, the player isn’t forced to pay that cost. If that cost isn’t paid, the creature won’t block."
+          "text": "The target creature blocks only if it's able to do so as the declare blockers step begins. If, at that time, the creature is tapped, it's affected by a spell or ability that says it can't block, or no creatures are attacking its controller or a planeswalker controlled by that player, then it doesn't block. If there's a cost associated with having the creature block, the player isn't forced to pay that cost. If that cost isn't paid, the creature won't block."
         },
         {
           "date": "2017-02-09",
@@ -15288,7 +15288,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If there are multiple combat phases in a turn, the target creature must block only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, the target creature must block only in the first one in which it's able to."
         },
         {
           "date": "2017-02-09",
@@ -15296,7 +15296,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -15308,11 +15308,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -15673,11 +15673,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t target the same creature twice to have one recipient get two +1/+1 counters."
+          "text": "You can't target the same creature twice to have one recipient get two +1/+1 counters."
         },
         {
           "date": "2017-02-09",
-          "text": "Each creature you control has Rishkar’s mana ability as long as that creature has any kind of counter on it. The effect isn’t limited to those with +1/+1 counters."
+          "text": "Each creature you control has Rishkar's mana ability as long as that creature has any kind of counter on it. The effect isn't limited to those with +1/+1 counters."
         }
       ],
       "subtypes": [
@@ -15798,19 +15798,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The greatest power among creatures you control is determined as Rishkar’s Expertise resolves."
+          "text": "The greatest power among creatures you control is determined as Rishkar's Expertise resolves."
         },
         {
           "date": "2017-02-09",
-          "text": "If you control no creatures with power greater than 0 as Rishkar’s Expertise resolves, you draw no cards, but you may cast a card with converted mana cost 5 or less from your hand without paying its mana cost."
+          "text": "If you control no creatures with power greater than 0 as Rishkar's Expertise resolves, you draw no cards, but you may cast a card with converted mana cost 5 or less from your hand without paying its mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "You may cast one of the cards drawn by Rishkar’s Expertise’s first effect while performing its second effect."
+          "text": "You may cast one of the cards drawn by Rishkar's Expertise's first effect while performing its second effect."
         },
         {
           "date": "2017-02-09",
-          "text": "A card’s converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
+          "text": "A card's converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
         },
         {
           "date": "2017-02-09",
@@ -15818,19 +15818,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Effects that allow you to “cast” a card don’t allow you to play a land card."
+          "text": "Effects that allow you to \"cast\" a card don't allow you to play a land card."
         },
         {
           "date": "2017-02-09",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, you must pay those to cast the card."
         },
         {
           "date": "2017-02-09",
-          "text": "While you’re casting your free spell, the Expertise spell is still on the stack. It will be put into its owner’s graveyard after the free spell is cast. The free spell can’t target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
+          "text": "While you're casting your free spell, the Expertise spell is still on the stack. It will be put into its owner's graveyard after the free spell is cast. The free spell can't target the Expertise card in your graveyard. It can target the Expertise spell on the stack, but the Expertise spell will become an illegal target before the free spell resolves."
         },
         {
           "date": "2017-02-09",
-          "text": "Any triggered abilities that trigger while performing the Expertise spell’s first effect won’t be put onto the stack until after you’re done casting your free spell. They’re put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
+          "text": "Any triggered abilities that trigger while performing the Expertise spell's first effect won't be put onto the stack until after you're done casting your free spell. They're put onto the stack at the same time as any abilities that triggered while casting that spell regardless of the order in which those abilities triggered."
         },
         {
           "date": "2017-04-18",
@@ -15948,7 +15948,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "You choose a target creature as Scrounging Bandar’s triggered ability is put onto the stack. You choose how many counters to move (if any) as that ability resolves. If that creature becomes an illegal target or if Scrounging Bandar has left the battlefield, you can’t move any counters."
+          "text": "You choose a target creature as Scrounging Bandar's triggered ability is put onto the stack. You choose how many counters to move (if any) as that ability resolves. If that creature becomes an illegal target or if Scrounging Bandar has left the battlefield, you can't move any counters."
         },
         {
           "date": "2017-02-09",
@@ -16071,11 +16071,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -16083,11 +16083,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "subtypes": [
@@ -16321,7 +16321,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "The amount of life gained from Ajani’s second ability is equal to power of the creature as it last existed on the battlefield."
+          "text": "The amount of life gained from Ajani's second ability is equal to power of the creature as it last existed on the battlefield."
         }
       ],
       "subtypes": [
@@ -16444,11 +16444,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Each opponent chooses a permanent to sacrifice from among the creatures and planeswalkers that player controls. You don’t choose which type of permanent the player has to sacrifice."
+          "text": "Each opponent chooses a permanent to sacrifice from among the creatures and planeswalkers that player controls. You don't choose which type of permanent the player has to sacrifice."
         },
         {
           "date": "2017-02-09",
-          "text": "If an opponent can’t sacrifice a creature or planeswalker, that player still discards a card if able. You still return a creature or planeswalker card to your hand if able, even if no opponent sacrifices a permanent and/or discards a card. You still draw a card even if you can’t return a card to your hand."
+          "text": "If an opponent can't sacrifice a creature or planeswalker, that player still discards a card if able. You still return a creature or planeswalker card to your hand if able, even if no opponent sacrifices a permanent and/or discards a card. You still draw a card even if you can't return a card to your hand."
         },
         {
           "date": "2017-02-09",
@@ -16456,15 +16456,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If two or more Dark Intimations are in your graveyard when you cast a Bolas planeswalker spell, you’ll exile each of them and that planeswalker will enter the battlefield with that many additional loyalty counters."
+          "text": "If two or more Dark Intimations are in your graveyard when you cast a Bolas planeswalker spell, you'll exile each of them and that planeswalker will enter the battlefield with that many additional loyalty counters."
         },
         {
           "date": "2017-02-09",
           "text": "The draconic Planeswalker Nicol Bolas is not featured in the Aether Revolt set. He must be up to something nefarious elsewhere."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Each opponent sacrifices a creature or planeswalker, then discards a card. You return a creature or planeswalker card from your graveyard to your hand, then draw a card.\nWhen you cast a Bolas planeswalker spell, exile Dark Intimations from your graveyard. That planeswalker enters the battlefield with an additional loyalty counter on it.",
@@ -16579,11 +16579,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -16591,11 +16591,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "text": "Revolt — At the beginning of your end step, if a permanent you controlled left the battlefield this turn, create a 1/1 colorless Servo artifact creature token.\n{1}, Sacrifice a creature: Scry 1.",
@@ -16937,7 +16937,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Once a creature with power 3 or greater has blocked Outland Boar, changing the power of the blocking creature won’t cause Outland Boar to become unblocked."
+          "text": "Once a creature with power 3 or greater has blocked Outland Boar, changing the power of the blocking creature won't cause Outland Boar to become unblocked."
         }
       ],
       "subtypes": [
@@ -17065,7 +17065,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         },
         {
           "date": "2017-02-09",
@@ -17077,11 +17077,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don’t apply multiple times if more than one permanent you controlled left the battlefield. They don’t check whether the permanent that left the battlefield is still in the zone it moved to."
+          "text": "Revolt abilities check only whether a permanent you controlled left the battlefield this turn or not. They don't apply multiple times if more than one permanent you controlled left the battlefield. They don't check whether the permanent that left the battlefield is still in the zone it moved to."
         },
         {
           "date": "2017-02-09",
-          "text": "Revolt abilities don’t care why the permanent left the battlefield, who caused it to move, or where it moved to. They’re equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
+          "text": "Revolt abilities don't care why the permanent left the battlefield, who caused it to move, or where it moved to. They're equally satisfied by an artifact you sacrificed to pay a cost, a creature you controlled that was destroyed by Murder, or an enchantment you returned to your hand with Leave in the Dust."
         },
         {
           "date": "2017-02-09",
@@ -17089,11 +17089,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t permanents. Paying {E} won’t satisfy a revolt ability."
+          "text": "Energy counters aren't permanents. Paying {E} won't satisfy a revolt ability."
         },
         {
           "date": "2017-02-09",
-          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening “if” clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there’s no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
+          "text": "All cards in the Aether Revolt set with triggered revolt abilities use an intervening \"if\" clause. A permanent you controlled must have left the battlefield earlier in the turn in order for these abilities to trigger; otherwise they do nothing. In other words, there's no way to have the ability trigger if no permanent you controlled has left the battlefield that turn, even if you intend to have one do so in response to the triggered ability."
         }
       ],
       "subtypes": [
@@ -17214,11 +17214,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "This is a triggered ability, not an activated ability. It doesn’t allow you to tap Renegade Wheelsmith whenever you want; rather, you need some other way of tapping it, such as by attacking or crewing a Vehicle."
+          "text": "This is a triggered ability, not an activated ability. It doesn't allow you to tap Renegade Wheelsmith whenever you want; rather, you need some other way of tapping it, such as by attacking or crewing a Vehicle."
         },
         {
           "date": "2017-02-09",
-          "text": "For the ability to trigger, Renegade Wheelsmith has to actually change from untapped to tapped. If an effect attempts to tap it, but it was already tapped at the time, this ability won’t trigger."
+          "text": "For the ability to trigger, Renegade Wheelsmith has to actually change from untapped to tapped. If an effect attempts to tap it, but it was already tapped at the time, this ability won't trigger."
         }
       ],
       "subtypes": [
@@ -17343,7 +17343,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -17355,11 +17355,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -17480,7 +17480,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Spire Patrol’s ability can target a creature that’s already tapped. That creature won’t untap during its controller’s next untap step."
+          "text": "Spire Patrol's ability can target a creature that's already tapped. That creature won't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -17600,27 +17600,27 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The value of X for Tezzeret’s second ability is determined only as the ability resolves. It won’t change later in the turn if the number of artifacts you control changes."
+          "text": "The value of X for Tezzeret's second ability is determined only as the ability resolves. It won't change later in the turn if the number of artifacts you control changes."
         },
         {
           "date": "2017-02-09",
-          "text": "The effect of the emblem’s triggered ability lasts indefinitely."
+          "text": "The effect of the emblem's triggered ability lasts indefinitely."
         },
         {
           "date": "2017-02-09",
-          "text": "An artifact that becomes a creature due to the emblem’s ability can’t attack unless you’ve controlled it continuously since your turn began. It doesn’t matter whether or not it was a creature at that time."
+          "text": "An artifact that becomes a creature due to the emblem's ability can't attack unless you've controlled it continuously since your turn began. It doesn't matter whether or not it was a creature at that time."
         },
         {
           "date": "2017-02-09",
-          "text": "An artifact creature targeted by the emblem’s ability becomes 5/5 instead of its normal power and toughness."
+          "text": "An artifact creature targeted by the emblem's ability becomes 5/5 instead of its normal power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "A Vehicle targeted by the emblem’s ability becomes a 5/5 creature. Crewing it won’t change its power and toughness."
+          "text": "A Vehicle targeted by the emblem's ability becomes a 5/5 creature. Crewing it won't change its power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an Equipment becomes a creature, it becomes unattached and it can’t be attached to a creature."
+          "text": "If an Equipment becomes a creature, it becomes unattached and it can't be attached to a creature."
         }
       ],
       "subtypes": [
@@ -17737,23 +17737,23 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "An artifact that becomes a creature due to Tezzeret’s Touch can’t attack unless you’ve controlled it continuously since your turn began. It doesn’t matter whether or not it was a creature at that time."
+          "text": "An artifact that becomes a creature due to Tezzeret's Touch can't attack unless you've controlled it continuously since your turn began. It doesn't matter whether or not it was a creature at that time."
         },
         {
           "date": "2017-02-09",
-          "text": "An artifact creature enchanted by Tezzeret’s Touch becomes 5/5 instead of its normal power and toughness."
+          "text": "An artifact creature enchanted by Tezzeret's Touch becomes 5/5 instead of its normal power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "A Vehicle enchanted by Tezzeret’s Touch becomes a 5/5 creature. Crewing it won’t change its power and toughness."
+          "text": "A Vehicle enchanted by Tezzeret's Touch becomes a 5/5 creature. Crewing it won't change its power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If the enchanted artifact is an Equipment, it becomes unattached and it can’t be attached to anything for as long as it remains a creature."
+          "text": "If the enchanted artifact is an Equipment, it becomes unattached and it can't be attached to anything for as long as it remains a creature."
         },
         {
           "date": "2017-02-09",
-          "text": "If Tezzeret’s Touch becomes unattached from an artifact that’s attacking or blocking, that artifact will be removed from combat unless it’s normally a creature or another effect such as a crew ability is also making it a creature."
+          "text": "If Tezzeret's Touch becomes unattached from an artifact that's attacking or blocking, that artifact will be removed from combat unless it's normally a creature or another effect such as a crew ability is also making it a creature."
         }
       ],
       "subtypes": [
@@ -17994,7 +17994,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect includes multiple instructions to put one or more counters on an artifact or creature, such as Lifecrafter’s Gift does, Winding Constrictor’s effect applies to each of those instructions."
+          "text": "If an effect includes multiple instructions to put one or more counters on an artifact or creature, such as Lifecrafter's Gift does, Winding Constrictor's effect applies to each of those instructions."
         },
         {
           "date": "2017-02-09",
@@ -18006,11 +18006,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Winding Constrictor’s effect can’t apply to itself as it’s entering the battlefield or to any other permanent entering the battlefield at the same time as it."
+          "text": "Winding Constrictor's effect can't apply to itself as it's entering the battlefield or to any other permanent entering the battlefield at the same time as it."
         },
         {
           "date": "2017-02-09",
-          "text": "If a nonartifact, noncreature permanent (such as a planeswalker) would enter the battlefield with counters on it and become an artifact or a creature on the battlefield due to another card’s effect (such as that of Mycosynth Lattice), Winding Constrictor’s effect doesn’t apply to that permanent."
+          "text": "If a nonartifact, noncreature permanent (such as a planeswalker) would enter the battlefield with counters on it and become an artifact or a creature on the battlefield due to another card's effect (such as that of Mycosynth Lattice), Winding Constrictor's effect doesn't apply to that permanent."
         }
       ],
       "subtypes": [
@@ -18231,7 +18231,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Multiple instances of lifelink are redundant."
+          "text": "multiple instances of lifelink on the same creature are redundant."
         },
         {
           "date": "2017-02-09",
@@ -18239,7 +18239,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -18251,27 +18251,27 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -18283,15 +18283,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -18299,11 +18299,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -18525,39 +18525,39 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If, during your declare attackers step, Barricade Breaker is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having it attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Barricade Breaker is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having it attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -18670,7 +18670,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The token copies exactly what was printed on the original artifact and nothing else (unless that artifact is copying something else or is a token; see below). It doesn’t copy whether that artifact is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "The token copies exactly what was printed on the original artifact and nothing else (unless that artifact is copying something else or is a token; see below). It doesn't copy whether that artifact is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2017-02-09",
@@ -18686,7 +18686,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Any enters-the-battlefield abilities of the copied artifact will trigger when the token enters the battlefield. Any “as [this artifact] enters the battlefield” or “[this artifact] enters the battlefield with” abilities of the chosen artifact will also work."
+          "text": "Any enters-the-battlefield abilities of the copied artifact will trigger when the token enters the battlefield. Any \"as [this artifact] enters the battlefield\" or \"[this artifact] enters the battlefield with\" abilities of the chosen artifact will also work."
         }
       ],
       "subtypes": [
@@ -18799,19 +18799,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -18823,15 +18823,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -18839,11 +18839,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -18958,7 +18958,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -18970,11 +18970,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "{T}: You get {E} (an energy counter).\n{T}, Pay {E}{E}{E}: Consulate Turret deals 2 damage to target player.",
@@ -19082,19 +19082,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Activated abilities are written in the form “Cost: Effect.” Some keyword abilities, such as equip and crew, are activated abilities and will have colons in their reminder texts."
+          "text": "Activated abilities are written in the form \"Cost: Effect.\" Some keyword abilities, such as equip and crew, are activated abilities and will have colons in their reminder texts."
         },
         {
           "date": "2017-02-09",
-          "text": "An activated mana ability is one that adds mana to a player’s mana pool as it resolves, doesn’t have a target, and isn’t a loyalty ability."
+          "text": "An activated mana ability is one that adds mana to a player's mana pool as it resolves, doesn't have a target, and isn't a loyalty ability."
         },
         {
           "date": "2017-02-09",
-          "text": "Crackdown Construct’s ability doesn’t trigger if you activate an ability of an artifact or creature card not on the battlefield."
+          "text": "Crackdown Construct's ability doesn't trigger if you activate an ability of an artifact or creature card not on the battlefield."
         },
         {
           "date": "2017-02-09",
-          "text": "An ability whose cost is simply {0} can be activated as many times as you’d like. Each activation causes Crackdown Construct’s ability to trigger."
+          "text": "An ability whose cost is simply {0} can be activated as many times as you'd like. Each activation causes Crackdown Construct's ability to trigger."
         }
       ],
       "subtypes": [
@@ -19206,35 +19206,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If Daredevil Dragster doesn’t survive the combat damage step, its ability won’t trigger."
+          "text": "If Daredevil Dragster doesn't survive the combat damage step, its ability won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a second velocity counter is put on Daredevil Dragster by something other than the resolution of its triggered ability, you won’t sacrifice it yet."
+          "text": "If a second velocity counter is put on Daredevil Dragster by something other than the resolution of its triggered ability, you won't sacrifice it yet."
         },
         {
           "date": "2017-02-09",
-          "text": "If Daredevil Dragster has one velocity counter on it and leaves the battlefield while its triggered ability is on the stack, it won’t get a second velocity counter and you won’t draw cards."
+          "text": "If Daredevil Dragster has one velocity counter on it and leaves the battlefield while its triggered ability is on the stack, it won't get a second velocity counter and you won't draw cards."
         },
         {
           "date": "2017-02-09",
-          "text": "If Daredevil Dragster somehow has two velocity counters on it and leaves the battlefield while its triggered ability is on the stack, you’ll draw two cards even though you can’t sacrifice it."
+          "text": "If Daredevil Dragster somehow has two velocity counters on it and leaves the battlefield while its triggered ability is on the stack, you'll draw two cards even though you can't sacrifice it."
         },
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -19246,15 +19246,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -19262,11 +19262,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -19485,35 +19485,35 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         }
       ],
       "subtypes": [
@@ -19629,7 +19629,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -19641,11 +19641,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "supertypes": [
@@ -19755,23 +19755,23 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Paying Heart of Kiran’s alternative crew cost isn’t a loyalty ability. It can be done even if you’ve already activated a loyalty ability of the planeswalker this turn, and it can be done any time you could activate Heart of Kiran’s crew ability."
+          "text": "Paying Heart of Kiran's alternative crew cost isn't a loyalty ability. It can be done even if you've already activated a loyalty ability of the planeswalker this turn, and it can be done any time you could activate Heart of Kiran's crew ability."
         },
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -19783,15 +19783,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -19799,11 +19799,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -19918,7 +19918,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The affected player won’t be able to cast any noncreature spells until after the time that your “beginning of upkeep” triggered abilities are put onto the stack on your next turn."
+          "text": "The affected player won't be able to cast any noncreature spells until after the time that your \"beginning of upkeep\" triggered abilities are put onto the stack on your next turn."
         },
         {
           "date": "2017-02-09",
@@ -19926,7 +19926,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "The target player (and any other player) may cast spells in response to the activated ability of Hope of Ghirapur. The ability won’t affect those spells and it won’t affect spells that the target player cast before you activated it. (In other words, the ability can’t be used to counter a spell.)"
+          "text": "The target player (and any other player) may cast spells in response to the activated ability of Hope of Ghirapur. The ability won't affect those spells and it won't affect spells that the target player cast before you activated it. (In other words, the ability can't be used to counter a spell.)"
         },
         {
           "date": "2017-02-09",
@@ -19934,7 +19934,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "subtypes": [
@@ -20052,11 +20052,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "An Implement’s last ability triggers no matter why it’s put into a graveyard from the battlefield. You don’t have to activate its first ability."
+          "text": "An Implement's last ability triggers no matter why it's put into a graveyard from the battlefield. You don't have to activate its first ability."
         },
         {
           "date": "2017-02-09",
-          "text": "If you activate an Implement’s first ability, you’ll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you’ll draw."
+          "text": "If you activate an Implement's first ability, you'll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you'll draw."
         }
       ],
       "text": "{R}, Sacrifice Implement of Combustion: It deals 1 damage to target player.\nWhen Implement of Combustion is put into a graveyard from the battlefield, draw a card.",
@@ -20166,11 +20166,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "An Implement’s last ability triggers no matter why it’s put into a graveyard from the battlefield. You don’t have to activate its first ability."
+          "text": "An Implement's last ability triggers no matter why it's put into a graveyard from the battlefield. You don't have to activate its first ability."
         },
         {
           "date": "2017-02-09",
-          "text": "If you activate an Implement’s first ability, you’ll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you’ll draw."
+          "text": "If you activate an Implement's first ability, you'll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you'll draw."
         }
       ],
       "text": "{U}, Sacrifice Implement of Examination: Draw a card.\nWhen Implement of Examination is put into a graveyard from the battlefield, draw a card.",
@@ -20279,11 +20279,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "An Implement’s last ability triggers no matter why it’s put into a graveyard from the battlefield. You don’t have to activate its first ability."
+          "text": "An Implement's last ability triggers no matter why it's put into a graveyard from the battlefield. You don't have to activate its first ability."
         },
         {
           "date": "2017-02-09",
-          "text": "If you activate an Implement’s first ability, you’ll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you’ll draw."
+          "text": "If you activate an Implement's first ability, you'll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you'll draw."
         }
       ],
       "text": "{G}, Sacrifice Implement of Ferocity: Put a +1/+1 counter on target creature. Activate this ability only any time you could cast a sorcery.\nWhen Implement of Ferocity is put into a graveyard from the battlefield, draw a card.",
@@ -20393,11 +20393,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "An Implement’s last ability triggers no matter why it’s put into a graveyard from the battlefield. You don’t have to activate its first ability."
+          "text": "An Implement's last ability triggers no matter why it's put into a graveyard from the battlefield. You don't have to activate its first ability."
         },
         {
           "date": "2017-02-09",
-          "text": "If you activate an Implement’s first ability, you’ll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you’ll draw."
+          "text": "If you activate an Implement's first ability, you'll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you'll draw."
         }
       ],
       "text": "{W}, Sacrifice Implement of Improvement: You gain 2 life.\nWhen Implement of Improvement is put into a graveyard from the battlefield, draw a card.",
@@ -20506,11 +20506,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "An Implement’s last ability triggers no matter why it’s put into a graveyard from the battlefield. You don’t have to activate its first ability."
+          "text": "An Implement's last ability triggers no matter why it's put into a graveyard from the battlefield. You don't have to activate its first ability."
         },
         {
           "date": "2017-02-09",
-          "text": "If you activate an Implement’s first ability, you’ll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you’ll draw."
+          "text": "If you activate an Implement's first ability, you'll draw a card from its second ability before the first ability resolves. If the first ability has a target, you need a legal target to activate that ability, and you choose that target before seeing what card you'll draw."
         }
       ],
       "text": "{B}, Sacrifice Implement of Malice: Target player discards a card. Activate this ability only any time you could cast a sorcery.\nWhen Implement of Malice is put into a graveyard from the battlefield, draw a card.",
@@ -20621,43 +20621,43 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If you cast a nonartifact spell that requires you to sacrifice a permanent as an additional cost, you may tap that permanent (if it’s an artifact) for the spell’s improvise ability before you sacrifice it to pay that cost."
+          "text": "If you cast a nonartifact spell that requires you to sacrifice a permanent as an additional cost, you may tap that permanent (if it's an artifact) for the spell's improvise ability before you sacrifice it to pay that cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Improvise doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2017-02-09",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Improvise applies after the total cost is calculated."
         },
         {
           "date": "2017-02-09",
-          "text": "Because improvise isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because improvise isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell’s total cost."
+          "text": "Improvise can't pay for {W}, {U}, {B}, {R}, {G}, or {C} mana symbols in a spell's total cost."
         },
         {
           "date": "2017-02-09",
-          "text": "Improvise can’t be used to pay for anything other than the cost of casting the spell. For example, it can’t be used during the resolution of an ability that says “Counter target spell unless its controller pays {3}.”"
+          "text": "Improvise can't be used to pay for anything other than the cost of casting the spell. For example, it can't be used during the resolution of an ability that says \"Counter target spell unless its controller pays {3}.\""
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell’s costs. You won’t be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for improvise."
+          "text": "If an artifact you control has a mana ability with {T} in the cost, activating that ability while casting a spell with improvise will result in the artifact being tapped when you pay the spell's costs. You won't be able to tap it again for improvise. Similarly, if you sacrifice an artifact to activate a mana ability while casting a spell with improvise, that artifact won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for improvise."
         },
         {
           "date": "2017-02-09",
-          "text": "Tapping an artifact won’t cause its abilities to stop applying unless those abilities say so."
+          "text": "Tapping an artifact won't cause its abilities to stop applying unless those abilities say so."
         },
         {
           "date": "2017-02-09",
-          "text": "Equipment attached to a creature doesn’t become tapped when that creature becomes tapped, and tapping that Equipment doesn’t cause the creature to become tapped."
+          "text": "Equipment attached to a creature doesn't become tapped when that creature becomes tapped, and tapping that Equipment doesn't cause the creature to become tapped."
         },
         {
           "date": "2017-02-09",
-          "text": "When using improvise to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap artifacts you control to help pay that cost. For example, if you cast Whir of Invention (a spell with improvise and mana cost {X}{U}{U}{U}) and choose X to be 3, the total cost is {3}{U}{U}{U}. If you tap two artifacts, you’ll have to pay {1}{U}{U}{U}."
+          "text": "When using improvise to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap artifacts you control to help pay that cost. For example, if you cast Whir of Invention (a spell with improvise and mana cost {X}{U}{U}{U}) and choose X to be 3, the total cost is {3}{U}{U}{U}. If you tap two artifacts, you'll have to pay {1}{U}{U}{U}."
         }
       ],
       "text": "Nonartifact spells you cast have improvise. (Your artifacts can help cast those spells. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
@@ -20765,19 +20765,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -20789,15 +20789,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -20805,11 +20805,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -20923,15 +20923,15 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The draw step is after the upkeep step, so you’ll scry 1 before you draw for the turn."
+          "text": "The draw step is after the upkeep step, so you'll scry 1 before you draw for the turn."
         },
         {
           "date": "2017-02-09",
-          "text": "Lifecrafter’s Bestiary’s second triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Lifecrafter's Bestiary's second triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         },
         {
           "date": "2017-02-09",
-          "text": "While resolving Lifecrafter’s Bestiary’s second triggered ability, you can’t pay {G} multiple times to draw multiple cards."
+          "text": "While resolving Lifecrafter's Bestiary's second triggered ability, you can't pay {G} multiple times to draw multiple cards."
         }
       ],
       "text": "At the beginning of your upkeep, scry 1.\nWhenever you cast a creature spell, you may pay {G}. If you do, draw a card.",
@@ -21042,7 +21042,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Merchant’s Dockhand is tapped to pay the {T} cost. It can’t also be one of the X untapped artifacts you tap."
+          "text": "Merchant's Dockhand is tapped to pay the {T} cost. It can't also be one of the X untapped artifacts you tap."
         },
         {
           "date": "2017-02-09",
@@ -21050,7 +21050,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "If the value of X is 0, you don’t look at or move any cards."
+          "text": "If the value of X is 0, you don't look at or move any cards."
         }
       ],
       "subtypes": [
@@ -21162,23 +21162,23 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The choice of creature type is made as Metallic Mimic enters the battlefield. Players can’t respond to this choice. Metallic Mimic’s second ability starts applying immediately."
+          "text": "The choice of creature type is made as Metallic Mimic enters the battlefield. Players can't respond to this choice. Metallic Mimic's second ability starts applying immediately."
         },
         {
           "date": "2017-02-09",
-          "text": "You must choose an existing creature type. “Artifact” and “Vehicle” aren’t creature types."
+          "text": "You must choose an existing creature type. \"Artifact\" and \"Vehicle\" aren't creature types."
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures of the chosen type that enter the battlefield at the same time as Metallic Mimic won’t enter with an additional +1/+1 counter."
+          "text": "Creatures of the chosen type that enter the battlefield at the same time as Metallic Mimic won't enter with an additional +1/+1 counter."
         },
         {
           "date": "2017-02-09",
-          "text": "If a creature entering the battlefield won’t have the chosen type until another card’s effect gives it that type after it has entered the battlefield, it won’t enter with a +1/+1 counter. Creatures that have the chosen type due to their own abilities, such as a second Metallic Mimic with the same creature type chosen, will enter with a +1/+1 counter."
+          "text": "If a creature entering the battlefield won't have the chosen type until another card's effect gives it that type after it has entered the battlefield, it won't enter with a +1/+1 counter. Creatures that have the chosen type due to their own abilities, such as a second Metallic Mimic with the same creature type chosen, will enter with a +1/+1 counter."
         },
         {
           "date": "2017-02-09",
-          "text": "Even though Metallic Mimic is a Shapeshifter, other Shapeshifter creatures you control won’t get a +1/+1 counter unless you chose Shapeshifter as Metallic Mimic entered the battlefield. If you do, that creature must be entering the battlefield as a Shapeshifter to get a +1/+1 counter. It won’t get a +1/+1 counter if it enters the battlefield as a copy of a non-Shapeshifter creature."
+          "text": "Even though Metallic Mimic is a Shapeshifter, other Shapeshifter creatures you control won't get a +1/+1 counter unless you chose Shapeshifter as Metallic Mimic entered the battlefield. If you do, that creature must be entering the battlefield as a Shapeshifter to get a +1/+1 counter. It won't get a +1/+1 counter if it enters the battlefield as a copy of a non-Shapeshifter creature."
         }
       ],
       "subtypes": [
@@ -21290,27 +21290,27 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "All attackers are chosen at once. You can’t attack with Mobile Garrison, untap a tapped creature, and then attack with that creature."
+          "text": "All attackers are chosen at once. You can't attack with Mobile Garrison, untap a tapped creature, and then attack with that creature."
         },
         {
           "date": "2017-02-09",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         },
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -21322,15 +21322,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -21338,11 +21338,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -21683,15 +21683,15 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Players may respond to Pacification Array’s ability by activating an ability of the target permanent if that ability’s timing permissions allow it. Players may also respond by activating abilities or casting spells whose costs include tapping the target permanent."
+          "text": "Players may respond to Pacification Array's ability by activating an ability of the target permanent if that ability's timing permissions allow it. Players may also respond by activating abilities or casting spells whose costs include tapping the target permanent."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player has activated an ability with {T} in its cost, Pacification Array can’t be used to undo or counter that ability."
+          "text": "Once a player has activated an ability with {T} in its cost, Pacification Array can't be used to undo or counter that ability."
         },
         {
           "date": "2017-02-09",
-          "text": "If you want to stop someone from attacking with a creature by using Pacification Array’s ability, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use your Pacification Array."
+          "text": "If you want to stop someone from attacking with a creature by using Pacification Array's ability, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use your Pacification Array."
         }
       ],
       "text": "{2}, {T}: Tap target artifact or creature.",
@@ -21799,7 +21799,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Paradox Engine’s triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Paradox Engine's triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         }
       ],
       "supertypes": [
@@ -21913,19 +21913,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -21937,15 +21937,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -21953,11 +21953,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -22390,7 +22390,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -22402,11 +22402,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -22518,19 +22518,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If Scrap Trawler and another artifact you control are put into a graveyard at the same time, Scrap Trawler’s ability triggers for each of them."
+          "text": "If Scrap Trawler and another artifact you control are put into a graveyard at the same time, Scrap Trawler's ability triggers for each of them."
         },
         {
           "date": "2017-02-09",
-          "text": "The target artifact card must have a lesser converted mana cost than the artifact that caused Scrap Trawler’s ability to trigger by being put into a graveyard. Use the artifact’s converted mana cost as it last existed on the battlefield to determine what may be returned."
+          "text": "The target artifact card must have a lesser converted mana cost than the artifact that caused Scrap Trawler's ability to trigger by being put into a graveyard. Use the artifact's converted mana cost as it last existed on the battlefield to determine what may be returned."
         },
         {
           "date": "2017-02-09",
-          "text": "While on the battlefield or in a graveyard, {X} in an object’s mana cost is 0."
+          "text": "While on the battlefield or in a graveyard, {X} in an object's mana cost is 0."
         },
         {
           "date": "2017-02-09",
-          "text": "If an artifact is a copy of another artifact with greater converted mana cost, such as Sculpting Steel copying an artifact with converted mana cost 4, Scrap Trawler’s ability can target that artifact card in your graveyard when that artifact is put into your graveyard."
+          "text": "If an artifact is a copy of another artifact with greater converted mana cost, such as Sculpting Steel copying an artifact with converted mana cost 4, Scrap Trawler's ability can target that artifact card in your graveyard when that artifact is put into your graveyard."
         }
       ],
       "subtypes": [
@@ -22642,7 +22642,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Servo Schematic’s ability doesn’t allow you to sacrifice it whenever you’d like. You must find another way to get Servo Schematic into the graveyard."
+          "text": "Servo Schematic's ability doesn't allow you to sacrifice it whenever you'd like. You must find another way to get Servo Schematic into the graveyard."
         }
       ],
       "text": "When Servo Schematic enters the battlefield or is put into a graveyard from the battlefield, create a 1/1 colorless Servo artifact creature token.",
@@ -22749,11 +22749,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If you don’t cast the nonland card with converted mana cost 3 or less, it’ll be put on the bottom of your library in a random order with the other cards."
+          "text": "If you don't cast the nonland card with converted mana cost 3 or less, it'll be put on the bottom of your library in a random order with the other cards."
         },
         {
           "date": "2017-02-09",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, those must be paid to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, those must be paid to cast the card."
         },
         {
           "date": "2017-02-09",
@@ -22975,19 +22975,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -22999,15 +22999,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -23015,11 +23015,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -23240,11 +23240,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The value of each X in Walking Ballista’s mana cost must be equal. For example, if X is 2, you’ll pay {4} to cast Walking Ballista and it will enter the battlefield with two +1/+1 counters on it."
+          "text": "The value of each X in Walking Ballista's mana cost must be equal. For example, if X is 2, you'll pay {4} to cast Walking Ballista and it will enter the battlefield with two +1/+1 counters on it."
         },
         {
           "date": "2017-02-09",
-          "text": "If Walking Ballista has been dealt damage or had its toughness reduced by an effect, this limits how many times you’ll be able to remove +1/+1 counters from it in a single turn. For example, if it has three +1/+1 counters on it and has been dealt 1 damage this turn, it will be destroyed immediately after you activate the ability a second time and you won’t be able to activate it a third time."
+          "text": "If Walking Ballista has been dealt damage or had its toughness reduced by an effect, this limits how many times you'll be able to remove +1/+1 counters from it in a single turn. For example, if it has three +1/+1 counters on it and has been dealt 1 damage this turn, it will be destroyed immediately after you activate the ability a second time and you won't be able to activate it a third time."
         }
       ],
       "subtypes": [
@@ -23360,7 +23360,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If you activate Watchful Automaton’s ability more than once, you’ll scry 1 each time. You won’t be able to look at multiple cards at once."
+          "text": "If you activate Watchful Automaton's ability more than once, you'll scry 1 each time. You won't be able to look at multiple cards at once."
         }
       ],
       "subtypes": [
@@ -23476,7 +23476,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "In a Two-Headed Giant game, Welder Automaton’s ability causes 2 damage total to be dealt to the opposing team."
+          "text": "In a Two-Headed Giant game, Welder Automaton's ability causes 2 damage total to be dealt to the opposing team."
         }
       ],
       "subtypes": [
@@ -23695,11 +23695,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If you don’t have a creature card in your library while resolving Ajani’s second ability, you’ll reveal your library and then randomize it."
+          "text": "If you don't have a creature card in your library while resolving Ajani's second ability, you'll reveal your library and then randomize it."
         },
         {
           "date": "2017-02-09",
-          "text": "The value of X for Ajani’s third ability is determined only as it resolves. The number of +1/+1 counters on the creature won’t change later if your life total changes."
+          "text": "The value of X for Ajani's third ability is determined only as it resolves. The number of +1/+1 counters on the creature won't change later if your life total changes."
         }
       ],
       "subtypes": [
@@ -24036,7 +24036,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "The last ability of Ajani’s Aid doesn’t target anything. You choose a source of damage as the ability resolves."
+          "text": "The last ability of Ajani's Aid doesn't target anything. You choose a source of damage as the ability resolves."
         },
         {
           "date": "2017-02-09",
@@ -24112,6 +24112,10 @@
       "imageName": "tranquil expanse",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Battle for Zendikar Block",
           "legality": "Legal"
@@ -24264,11 +24268,11 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If you don’t have an artifact card in your library while resolving Tezzeret’s first ability, you’ll reveal your library and then randomize it."
+          "text": "If you don't have an artifact card in your library while resolving Tezzeret's first ability, you'll reveal your library and then randomize it."
         },
         {
           "date": "2017-02-09",
-          "text": "The effect of Tezzeret’s third ability lasts indefinitely."
+          "text": "The effect of Tezzeret's third ability lasts indefinitely."
         }
       ],
       "subtypes": [
@@ -24386,7 +24390,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "If the target creature becomes an illegal target for Tezzeret’s Betrayal, the spell will be countered and none of its effects will happen. You won’t search for Tezzeret, Master of Metal."
+          "text": "If the target creature becomes an illegal target for Tezzeret's Betrayal, the spell will be countered and none of its effects will happen. You won't search for Tezzeret, Master of Metal."
         }
       ],
       "text": "Destroy target creature. You may search your library and/or graveyard for a card named Tezzeret, Master of Metal, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
@@ -24666,6 +24670,10 @@
       "imageName": "submerged boneyard",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Battle for Zendikar Block",
           "legality": "Legal"

--- a/json/AKH.json
+++ b/json/AKH.json
@@ -131,15 +131,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If Angel of Sanctions leaves the battlefield before its triggered ability resolves, the target permanent won’t be exiled."
+          "text": "If Angel of Sanctions leaves the battlefield before its triggered ability resolves, the target permanent won't be exiled."
         },
         {
           "date": "2017-04-18",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         },
         {
           "date": "2017-04-18",
-          "text": "If a token is exiled this way, it will cease to exist and won’t return to the battlefield."
+          "text": "If a token is exiled this way, it will cease to exist and won't return to the battlefield."
         },
         {
           "date": "2017-04-18",
@@ -147,7 +147,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "In a multiplayer game, if Angel of Sanctions’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Angel of Sanctions's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         },
         {
           "date": "2017-04-18",
@@ -155,7 +155,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -163,15 +163,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -288,15 +288,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "All of the tokens enter the battlefield simultaneously. They’ll be created with the same name, color, type and subtype, abilities, power, toughness, and so on."
+          "text": "All of the tokens enter the battlefield simultaneously. They'll be created with the same name, color, type and subtype, abilities, power, toughness, and so on."
         },
         {
           "date": "2017-04-18",
-          "text": "If the token you create has any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities, first determine how many tokens are being created, then apply those abilities individually for each one. For example, if a token with “You may have [this permanent] enter the battlefield as a copy of any creature on the battlefield” would be created (such as an embalmed Vizier of Many Faces), the resulting two tokens can each copy a different creature."
+          "text": "If the token you create has any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities, first determine how many tokens are being created, then apply those abilities individually for each one. For example, if a token with \"You may have [this permanent] enter the battlefield as a copy of any creature on the battlefield\" would be created (such as an embalmed Vizier of Many Faces), the resulting two tokens can each copy a different creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an effect creates more than one kind of token, it’ll create twice as many of each kind. For example, if you cast Bestial Menace while controlling Anointed Procession, you’ll create two Snake tokens, two Wolf tokens, and two Elephant tokens."
+          "text": "If an effect creates more than one kind of token, it'll create twice as many of each kind. For example, if you cast Bestial Menace while controlling Anointed Procession, you'll create two Snake tokens, two Wolf tokens, and two Elephant tokens."
         },
         {
           "date": "2017-04-18",
@@ -304,11 +304,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the effect creating the tokens instructs you to do something with those tokens at a later time, like exiling them at the end of combat, you’ll do that for all the tokens."
+          "text": "If the effect creating the tokens instructs you to do something with those tokens at a later time, like exiling them at the end of combat, you'll do that for all the tokens."
         },
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.",
@@ -422,7 +422,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If Anointer Priest is a token, most likely because it’s embalmed, it will cause its own ability to trigger when it enters the battlefield."
+          "text": "If Anointer Priest is a token, most likely because it's embalmed, it will cause its own ability to trigger when it enters the battlefield."
         },
         {
           "date": "2017-04-18",
@@ -434,7 +434,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -442,15 +442,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -567,11 +567,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "A card that changes zones is considered a new object, so casting the same Approach of the Second Sun card on a later turn is “another spell” named Approach of the Second Sun."
+          "text": "A card that changes zones is considered a new object, so casting the same Approach of the Second Sun card on a later turn is \"another spell\" named Approach of the Second Sun."
         },
         {
           "date": "2017-04-18",
-          "text": "If you have fewer than six cards in your library, you’ll put Approach of the Second Sun on the bottom of your library. Otherwise, you’ll lift up the top six cards without looking at them and place Approach of the Second Sun just under them."
+          "text": "If you have fewer than six cards in your library, you'll put Approach of the Second Sun on the bottom of your library. Otherwise, you'll lift up the top six cards without looking at them and place Approach of the Second Sun just under them."
         },
         {
           "date": "2017-04-18",
@@ -579,15 +579,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "A copy of a spell isn’t cast, so it won’t count as the first nor as the second Approach of the Second Sun."
+          "text": "A copy of a spell isn't cast, so it won't count as the first nor as the second Approach of the Second Sun."
         },
         {
           "date": "2017-04-18",
-          "text": "As your second Approach of the Second Sun resolves, it checks only whether the first one was cast, not whether the first one resolved. If your first Approach of the Second Sun was countered, you’ll still win the game as your second one resolves."
+          "text": "As your second Approach of the Second Sun resolves, it checks only whether the first one was cast, not whether the first one resolved. If your first Approach of the Second Sun was countered, you'll still win the game as your second one resolves."
         },
         {
           "date": "2017-06-27",
-          "text": "Approach of the Second Sun has no effect until it’s resolving. If the second one you cast is countered, you won’t win the game."
+          "text": "Approach of the Second Sun has no effect until it's resolving. If the second one you cast is countered, you won't win the game."
         }
       ],
       "text": "If Approach of the Second Sun was cast from your hand and you've cast another spell named Approach of the Second Sun this game, you win the game. Otherwise, put Approach of the Second Sun into its owner's library seventh from the top and you gain 7 life.",
@@ -707,7 +707,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Each search works exactly the same as normal except that the opponent doing the searching sees only the top four cards of that library. He or she can’t look at the other cards in that library at all. Cards not in the top four cards of the library can’t be found in the search, even if they’re identifiable in some manner."
+          "text": "Each search works exactly the same as normal except that the opponent doing the searching sees only the top four cards of that library. He or she can't look at the other cards in that library at all. Cards not in the top four cards of the library can't be found in the search, even if they're identifiable in some manner."
         },
         {
           "date": "2017-04-18",
@@ -715,7 +715,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If an effect uses the word “search” once but allows an opponent to search for multiple cards, the top four cards remain the same throughout the entire search. Finding one card won’t cause the fifth card to be included in the search."
+          "text": "If an effect uses the word \"search\" once but allows an opponent to search for multiple cards, the top four cards remain the same throughout the entire search. Finding one card won't cause the fifth card to be included in the search."
         },
         {
           "date": "2017-04-18",
@@ -952,11 +952,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn’t enter the battlefield."
+          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn't enter the battlefield."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Cartouche is an Aura with “Enchant creature you control.” If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner’s graveyard as a state-based action."
+          "text": "Each Cartouche is an Aura with \"Enchant creature you control.\" If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -1072,15 +1072,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If Cast Out leaves the battlefield before its triggered ability resolves, the target permanent won’t be exiled."
+          "text": "If Cast Out leaves the battlefield before its triggered ability resolves, the target permanent won't be exiled."
         },
         {
           "date": "2017-04-18",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         },
         {
           "date": "2017-04-18",
-          "text": "If a token is exiled this way, it will cease to exist and won’t return to the battlefield."
+          "text": "If a token is exiled this way, it will cease to exist and won't return to the battlefield."
         },
         {
           "date": "2017-04-18",
@@ -1088,7 +1088,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "In a multiplayer game, if Cast Out’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Cast Out's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "Flash\nWhen Cast Out enters the battlefield, exile target nonland permanent an opponent controls until Cast Out leaves the battlefield.\nCycling {W} ({W}, Discard this card: Draw a card.)",
@@ -1201,7 +1201,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Compulsory Rest grants the activated ability to the enchanted creature. That creature’s controller (not the controller of Compulsory Rest) may activate the ability and gain 2 life."
+          "text": "Compulsory Rest grants the activated ability to the enchanted creature. That creature's controller (not the controller of Compulsory Rest) may activate the ability and gain 2 life."
         }
       ],
       "subtypes": [
@@ -1325,31 +1325,31 @@
         },
         {
           "date": "2017-04-18",
-          "text": "All attackers are chosen at once. You can’t attack with Devoted Crop-Mate, return a creature card to the battlefield, and then attack with that creature."
+          "text": "All attackers are chosen at once. You can't attack with Devoted Crop-Mate, return a creature card to the battlefield, and then attack with that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If the creature returned to the battlefield has any abilities that trigger when creatures attack or when you exert creatures, those abilities won’t trigger."
+          "text": "If the creature returned to the battlefield has any abilities that trigger when creatures attack or when you exert creatures, those abilities won't trigger."
         },
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "If a creature has a targeted triggered ability that triggers when you exert it, you can exert it even if there isn’t a legal target for that triggered ability."
+          "text": "If a creature has a targeted triggered ability that triggers when you exert it, you can exert it even if there isn't a legal target for that triggered ability."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -1467,11 +1467,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         },
         {
           "date": "2017-04-18",
-          "text": "Djeru’s Resolve can target an untapped creature. Its prevention effect will still be applied."
+          "text": "Djeru's Resolve can target an untapped creature. Its prevention effect will still be applied."
         }
       ],
       "text": "Untap target creature. Prevent all damage that would be dealt to it this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
@@ -1803,39 +1803,39 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Gideon’s first ability will continue to prevent damage dealt by the target permanent even if Gideon leaves the battlefield before your next turn."
+          "text": "Gideon's first ability will continue to prevent damage dealt by the target permanent even if Gideon leaves the battlefield before your next turn."
         },
         {
           "date": "2017-04-18",
-          "text": "Gideon’s second ability doesn’t count as a creature entering the battlefield. Gideon was already on the battlefield; he only changed his types."
+          "text": "Gideon's second ability doesn't count as a creature entering the battlefield. Gideon was already on the battlefield; he only changed his types."
         },
         {
           "date": "2017-04-18",
-          "text": "If Gideon becomes a creature the same turn he enters the battlefield, you can’t attack with him or use any of his {T} abilities (if he gains any)."
+          "text": "If Gideon becomes a creature the same turn he enters the battlefield, you can't attack with him or use any of his {T} abilities (if he gains any)."
         },
         {
           "date": "2017-04-18",
-          "text": "Gideon’s second ability causes him to become a creature with the creature types Human and Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: planeswalker is only a type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
+          "text": "Gideon's second ability causes him to become a creature with the creature types Human and Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: planeswalker is only a type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
         },
         {
           "date": "2017-04-18",
-          "text": "If damage that can’t be prevented is dealt to Gideon after his second ability has resolved, that damage will have all applicable results: specifically, the damage is marked on Gideon (since he’s a creature) and that damage causes that many loyalty counters to be removed from him (since he’s a planeswalker). Even though he has indestructible, if Gideon has no loyalty counters on him, he’s put into his owner’s graveyard."
+          "text": "If damage that can't be prevented is dealt to Gideon after his second ability has resolved, that damage will have all applicable results: specifically, the damage is marked on Gideon (since he's a creature) and that damage causes that many loyalty counters to be removed from him (since he's a planeswalker). Even though he has indestructible, if Gideon has no loyalty counters on him, he's put into his owner's graveyard."
         },
         {
           "date": "2017-04-18",
-          "text": "If Gideon leaves the battlefield after giving you his emblem, you’ll keep the emblem. Its effect will apply again later if another Gideon comes under your control."
+          "text": "If Gideon leaves the battlefield after giving you his emblem, you'll keep the emblem. Its effect will apply again later if another Gideon comes under your control."
         },
         {
           "date": "2017-04-18",
-          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while Gideon’s emblem is in effect. It doesn’t matter whether you have 0 or less life, you’re forced to draw a card while your library is empty, you have ten or more poison counters, you’re at your Glorious End, your opponent casts a second Approach of the Second Sun, or so on. You keep playing."
+          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while Gideon's emblem is in effect. It doesn't matter whether you have 0 or less life, you're forced to draw a card while your library is empty, you have ten or more poison counters, you're at your Glorious End, your opponent casts a second Approach of the Second Sun, or so on. You keep playing."
         },
         {
           "date": "2017-04-18",
-          "text": "Other circumstances can still cause you to lose the game. You will lose a game if you concede, if you’re penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your Magic Online® game clock runs out of time."
+          "text": "Other circumstances can still cause you to lose the game. You will lose a game if you concede, if you're penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your Magic Online® game clock runs out of time."
         },
         {
           "date": "2017-04-18",
-          "text": "If you have Gideon’s emblem in a Two-Headed Giant game and control a Gideon planeswalker, your team can’t lose the game and the opposing team can’t win the game. If your teammate controls a Gideon planeswalker but you do not, your emblem’s effect doesn’t apply."
+          "text": "If you have Gideon's emblem in a Two-Headed Giant game and control a Gideon planeswalker, your team can't lose the game and the opposing team can't win the game. If your teammate controls a Gideon planeswalker but you do not, your emblem's effect doesn't apply."
         }
       ],
       "subtypes": [
@@ -1954,15 +1954,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If you choose the name of a split card, you choose one name, not both. For example, you could name Failure or Comply, but not Failure // Comply. Opponents are still allowed to cast the half you didn’t choose."
+          "text": "If you choose the name of a split card, you choose one name, not both. For example, you could name Failure or Comply, but not Failure // Comply. Opponents are still allowed to cast the half you didn't choose."
         },
         {
           "date": "2017-04-18",
-          "text": "You must choose the name of a card, not the name of a token. For example, you can’t choose “Zombie” or “Ragavan.” However, if a token happens to have the same name as a card (such as an embalmed creature token), you can choose it."
+          "text": "You must choose the name of a card, not the name of a token. For example, you can't choose \"Zombie\" or \"Ragavan.\" However, if a token happens to have the same name as a card (such as an embalmed creature token), you can choose it."
         },
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "As Gideon's Intervention enters the battlefield, choose a card name.\nYour opponents can't cast spells with the chosen name.\nPrevent all damage that would be dealt to you and permanents you control by sources with the chosen name.",
@@ -2077,19 +2077,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -2208,19 +2208,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -2450,7 +2450,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The set of creatures affected by In Oketra’s Name and how those creatures are affected is locked in as In Oketra’s Name resolves. Creatures you begin to control later in the turn won’t get any bonus, and creatures that start or stop being Zombies later in the turn won’t have their bonus changed."
+          "text": "The set of creatures affected by In Oketra's Name and how those creatures are affected is locked in as In Oketra's Name resolves. Creatures you begin to control later in the turn won't get any bonus, and creatures that start or stop being Zombies later in the turn won't have their bonus changed."
         }
       ],
       "text": "Zombies you control get +2/+1 until end of turn. Other creatures you control get +1/+1 until end of turn.",
@@ -2575,7 +2575,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
         }
       ],
       "text": "Target creature gets +2/+2 and gains flying until end of turn.",
@@ -2693,7 +2693,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "You don’t have to attack with three other creatures for Oketra to be able to attack. The same is true of blocking."
+          "text": "You don't have to attack with three other creatures for Oketra to be able to attack. The same is true of blocking."
         }
       ],
       "subtypes": [
@@ -2817,7 +2817,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -2825,11 +2825,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -2955,7 +2955,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If a prevention effect applies to noncombat damage that would be dealt to you while you control a planeswalker, you choose whether to apply that prevention effect before or after the planeswalker redirection effect. If you apply Protection of the Hekma’s prevention effect first, the planeswalker redirection effect still applies to the remaining damage. If you apply the planeswalker redirection effect and your opponent chooses to have the damage dealt to a planeswalker you control, none of that damage is prevented."
+          "text": "If a prevention effect applies to noncombat damage that would be dealt to you while you control a planeswalker, you choose whether to apply that prevention effect before or after the planeswalker redirection effect. If you apply Protection of the Hekma's prevention effect first, the planeswalker redirection effect still applies to the remaining damage. If you apply the planeswalker redirection effect and your opponent chooses to have the damage dealt to a planeswalker you control, none of that damage is prevented."
         }
       ],
       "text": "If a source an opponent controls would deal damage to you, prevent 1 of that damage.",
@@ -3073,7 +3073,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "All other Cats you control get +1/+1 and have lifelink, not just those created by Regal Caracal’s last ability."
+          "text": "All other Cats you control get +1/+1 and have lifelink, not just those created by Regal Caracal's last ability."
         }
       ],
       "subtypes": [
@@ -3204,7 +3204,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2017-04-18",
@@ -3212,15 +3212,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Triggered abilities from cycling a card and the cycling ability itself aren’t spells. Effects that interact with spells (such as that of Cancel) won’t affect them."
+          "text": "Triggered abilities from cycling a card and the cycling ability itself aren't spells. Effects that interact with spells (such as that of Cancel) won't affect them."
         },
         {
           "date": "2017-04-18",
-          "text": "You can cycle a card even if it has a triggered ability from cycling that won’t have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability’s targets have become illegal), the other ability will still resolve."
+          "text": "You can cycle a card even if it has a triggered ability from cycling that won't have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability's targets have become illegal), the other ability will still resolve."
         },
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
@@ -3335,19 +3335,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -3469,7 +3469,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -3477,11 +3477,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -3823,7 +3823,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If you don’t control a tapped creature as Supply Caravan enters the battlefield, its ability doesn’t trigger, even if you can tap a creature right away. If you control no tapped creatures as the ability resolves, nothing happens."
+          "text": "If you don't control a tapped creature as Supply Caravan enters the battlefield, its ability doesn't trigger, even if you can tap a creature right away. If you control no tapped creatures as the ability resolves, nothing happens."
         },
         {
           "date": "2017-04-18",
@@ -3944,19 +3944,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -4184,7 +4184,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Time to Reflect can target a creature that’s currently blocking or being blocked by a Zombie, or one that blocked or was blocked by a Zombie earlier in the turn."
+          "text": "Time to Reflect can target a creature that's currently blocking or being blocked by a Zombie, or one that blocked or was blocked by a Zombie earlier in the turn."
         },
         {
           "date": "2017-04-18",
@@ -4301,15 +4301,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Trial of Solidarity’s triggered ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Trial of Solidarity's triggered ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         },
         {
           "date": "2017-04-18",
-          "text": "If an effect allows you to exert a creature as it attacks, you may do so even if it has vigilance. It won’t be tapped."
+          "text": "If an effect allows you to exert a creature as it attacks, you may do so even if it has vigilance. It won't be tapped."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner’s hand only if it’s on the battlefield as the ability resolves."
+          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner's hand only if it's on the battlefield as the ability resolves."
         }
       ],
       "text": "When Trial of Solidarity enters the battlefield, creatures you control get +2/+1 and gain vigilance until end of turn.\nWhen a Cartouche enters the battlefield under your control, return Trial of Solidarity to its owner's hand.",
@@ -4426,7 +4426,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -4434,11 +4434,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -4560,7 +4560,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -4568,11 +4568,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -4690,15 +4690,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Vizier of Deferment’s triggered ability can target any creature, but it will affect a creature only if that creature was declared as an attacker or blocker this turn, whether you cast Vizier of Deferment during combat or later in the turn. Notably, the ability won’t affect a creature that entered the battlefield attacking or blocking."
+          "text": "Vizier of Deferment's triggered ability can target any creature, but it will affect a creature only if that creature was declared as an attacker or blocker this turn, whether you cast Vizier of Deferment during combat or later in the turn. Notably, the ability won't affect a creature that entered the battlefield attacking or blocking."
         },
         {
           "date": "2017-04-18",
-          "text": "After the target creature returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won’t be in combat or have any additional abilities it may have had when it was exiled. Any counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
+          "text": "After the target creature returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won't be in combat or have any additional abilities it may have had when it was exiled. Any counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
         },
         {
           "date": "2017-04-18",
-          "text": "A token creature exiled this way won’t return to the battlefield."
+          "text": "A token creature exiled this way won't return to the battlefield."
         }
       ],
       "subtypes": [
@@ -4817,19 +4817,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "“Put on a creature you control” includes that creature entering the battlefield with -1/-1 counters on it. If a creature would enter the battlefield under your control with a number of -1/-1 counters on it while you control Vizier of Remedies, it enters with that many counters minus one."
+          "text": "\"Put on a creature you control\" includes that creature entering the battlefield with -1/-1 counters on it. If a creature would enter the battlefield under your control with a number of -1/-1 counters on it while you control Vizier of Remedies, it enters with that many counters minus one."
         },
         {
           "date": "2017-04-18",
-          "text": "If an effect puts Vizier of Remedies onto the battlefield with one or more -1/-1 counters on it, its effect won’t apply. This is because you must control Vizier of Remedies before the creature begins to enter the battlefield for its effect to apply. The same is true of any creatures entering the battlefield with -1/-1 counters on them at the same time as Vizier of Remedies enters the battlefield."
+          "text": "If an effect puts Vizier of Remedies onto the battlefield with one or more -1/-1 counters on it, its effect won't apply. This is because you must control Vizier of Remedies before the creature begins to enter the battlefield for its effect to apply. The same is true of any creatures entering the battlefield with -1/-1 counters on them at the same time as Vizier of Remedies enters the battlefield."
         },
         {
           "date": "2017-04-18",
-          "text": "If a creature you control is dealt damage by a source with wither or infect, that much damage is dealt, but one fewer -1/-1 counter is put on your creature. For example, if a 2/2 creature with lifelink and infect is blocked by Vizier of Remedies, the first creature’s controller gains 2 life and puts one -1/-1 counter on Vizier of Remedies."
+          "text": "If a creature you control is dealt damage by a source with wither or infect, that much damage is dealt, but one fewer -1/-1 counter is put on your creature. For example, if a 2/2 creature with lifelink and infect is blocked by Vizier of Remedies, the first creature's controller gains 2 life and puts one -1/-1 counter on Vizier of Remedies."
         },
         {
           "date": "2017-04-18",
-          "text": "If multiple creatures with wither and/or infect deal damage to a creature at once, Vizier of Remedies causes only one counter fewer to be put on that creature. Its effect doesn’t apply separately for each creature dealing damage."
+          "text": "If multiple creatures with wither and/or infect deal damage to a creature at once, Vizier of Remedies causes only one counter fewer to be put on that creature. Its effect doesn't apply separately for each creature dealing damage."
         },
         {
           "date": "2017-04-18",
@@ -5289,23 +5289,23 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If you cast a card for an alternative cost of {0}, you can’t pay any other alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
+          "text": "If you cast a card for an alternative cost of {0}, you can't pay any other alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
         },
         {
           "date": "2017-04-18",
-          "text": "A card’s converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
+          "text": "A card's converted mana cost is determined solely by the mana symbols printed in its upper right corner. The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {1}{U}{U} has converted mana cost 3. Ignore any alternative costs, additional costs, cost increases, or cost reductions that could apply to it. A card with no mana cost has a converted mana cost of 0."
         },
         {
           "date": "2017-04-18",
-          "text": "If a spell has no mana cost, its converted mana cost is 0. You can cast it with As Foretold’s alternative cost."
+          "text": "If a spell has no mana cost, its converted mana cost is 0. You can cast it with As Foretold's alternative cost."
         },
         {
           "date": "2017-04-18",
-          "text": "If you’re casting a split card, only the converted mana cost of the half you’re casting is compared to the number of time counters on As Foretold. This is because only that half is on the stack at the time that you choose to apply the effect of As Foretold."
+          "text": "If you're casting a split card, only the converted mana cost of the half you're casting is compared to the number of time counters on As Foretold. This is because only that half is on the stack at the time that you choose to apply the effect of As Foretold."
         },
         {
           "date": "2017-04-18",
-          "text": "If the card has X in its mana cost, you must choose 0 as the value of X when casting it for another cost that doesn’t include X. For example, if there are five time counters on As Foretold and you choose to use its effect to cast Pull from Tomorrow, X must be 0. X can’t be 2, even though the spell’s converted mana cost would be 4."
+          "text": "If the card has X in its mana cost, you must choose 0 as the value of X when casting it for another cost that doesn't include X. For example, if there are five time counters on As Foretold and you choose to use its effect to cast Pull from Tomorrow, X must be 0. X can't be 2, even though the spell's converted mana cost would be 4."
         },
         {
           "date": "2017-04-18",
@@ -5430,7 +5430,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -5438,11 +5438,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -5706,11 +5706,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn’t enter the battlefield."
+          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn't enter the battlefield."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Cartouche is an Aura with “Enchant creature you control.” If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner’s graveyard as a state-based action."
+          "text": "Each Cartouche is an Aura with \"Enchant creature you control.\" If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -6042,15 +6042,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Cryptic Serpent’s ability doesn’t change its mana cost or converted mana cost. It just reduces the cost to cast the spell."
+          "text": "Cryptic Serpent's ability doesn't change its mana cost or converted mana cost. It just reduces the cost to cast the spell."
         },
         {
           "date": "2017-04-18",
-          "text": "A split card only counts once for Cryptic Serpent’s ability, even if it’s both an instant and a sorcery."
+          "text": "A split card only counts once for Cryptic Serpent's ability, even if it's both an instant and a sorcery."
         },
         {
           "date": "2017-04-18",
-          "text": "Cryptic Serpent’s ability can’t reduce its cost to less than {U}{U}."
+          "text": "Cryptic Serpent's ability can't reduce its cost to less than {U}{U}."
         }
       ],
       "subtypes": [
@@ -6172,11 +6172,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -6404,7 +6404,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "While resolving Drake Haven’s triggered ability, you can’t pay {1} multiple times to get multiple Drakes."
+          "text": "While resolving Drake Haven's triggered ability, you can't pay {1} multiple times to get multiple Drakes."
         },
         {
           "date": "2017-04-18",
@@ -6412,11 +6412,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -6537,7 +6537,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -6757,7 +6757,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If the target creature is an illegal target by the time Galestrike resolves, the entire spell is countered. You won’t draw a card."
+          "text": "If the target creature is an illegal target by the time Galestrike resolves, the entire spell is countered. You won't draw a card."
         }
       ],
       "text": "Return target tapped creature to its owner's hand.\nDraw a card.",
@@ -6874,7 +6874,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -6882,11 +6882,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -7008,11 +7008,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -7241,11 +7241,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Illusory Wrappings overwrites all previous effects that set the creature’s base power and toughness to specific values, including those that define a * such as that of Enigma Drake. Any power- or toughness-setting effects that start to apply to a creature after Illusory Wrappings becomes attached to it will overwrite this effect."
+          "text": "Illusory Wrappings overwrites all previous effects that set the creature's base power and toughness to specific values, including those that define a * such as that of Enigma Drake. Any power- or toughness-setting effects that start to apply to a creature after Illusory Wrappings becomes attached to it will overwrite this effect."
         },
         {
           "date": "2017-04-18",
-          "text": "Any power- or toughness-modifying effects (those that give +N/+N, for example) and counters will apply to the creature’s new base power and toughness, even if they started to apply before Illusory Wrappings became attached."
+          "text": "Any power- or toughness-modifying effects (those that give +N/+N, for example) and counters will apply to the creature's new base power and toughness, even if they started to apply before Illusory Wrappings became attached."
         }
       ],
       "subtypes": [
@@ -7366,7 +7366,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While resolving Kefnet’s activated ability, you don’t choose which land to return to its owner’s hand (or whether you’ll return one at all) until you see the card you draw."
+          "text": "While resolving Kefnet's activated ability, you don't choose which land to return to its owner's hand (or whether you'll return one at all) until you see the card you draw."
         }
       ],
       "subtypes": [
@@ -7486,7 +7486,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You’ll sacrifice Labyrinth Guardian even if you counter the spell that targets it. If that spell has no other targets, it’ll be countered when it tries to resolve."
+          "text": "You'll sacrifice Labyrinth Guardian even if you counter the spell that targets it. If that spell has no other targets, it'll be countered when it tries to resolve."
         },
         {
           "date": "2017-04-18",
@@ -7498,7 +7498,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -7506,11 +7506,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -7628,7 +7628,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it. They’ll remain attached, but an Aura’s effect that affects “you” still affects its controller rather than you, the controller of an Equipment can move it during his or her next main phase, and so on."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it. They'll remain attached, but an Aura's effect that affects \"you\" still affects its controller rather than you, the controller of an Equipment can move it during his or her next main phase, and so on."
         }
       ],
       "subtypes": [
@@ -7857,7 +7857,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If you choose to pay New Perspectives’s alternate activation cost, you still discard the card with cycling to activate the ability."
+          "text": "If you choose to pay New Perspectives's alternate activation cost, you still discard the card with cycling to activate the ability."
         },
         {
           "date": "2017-04-18",
@@ -8537,7 +8537,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "It doesn’t matter whether the noncreature spell has resolved or was countered, as long as it was cast. That spell may even still be on the stack when you activate Seeker of Insight’s ability."
+          "text": "It doesn't matter whether the noncreature spell has resolved or was countered, as long as it was cast. That spell may even still be on the stack when you activate Seeker of Insight's ability."
         }
       ],
       "subtypes": [
@@ -8885,7 +8885,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -8893,11 +8893,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -9014,7 +9014,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner’s hand only if it’s on the battlefield as the ability resolves."
+          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner's hand only if it's on the battlefield as the ability resolves."
         }
       ],
       "text": "When Trial of Knowledge enters the battlefield, draw three cards, then discard a card.\nWhen a Cartouche enters the battlefield under your control, return Trial of Knowledge to its owner's hand.",
@@ -9127,7 +9127,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Vizier of Many Faces copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Vizier of Many Faces copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2017-04-18",
@@ -9143,15 +9143,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the chosen creature is a token, Vizier of Many Faces copies the original characteristics of that token as stated by the effect that created the token. Vizier of Many Faces is not a token in this case unless it’s embalmed."
+          "text": "If the chosen creature is a token, Vizier of Many Faces copies the original characteristics of that token as stated by the effect that created the token. Vizier of Many Faces is not a token in this case unless it's embalmed."
         },
         {
           "date": "2017-04-18",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Vizier of Many Faces enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Vizier of Many Faces enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2017-04-18",
-          "text": "If Vizier of Many Faces somehow enters the battlefield at the same time as another creature, Vizier of Many Faces can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Vizier of Many Faces somehow enters the battlefield at the same time as another creature, Vizier of Many Faces can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2017-04-18",
@@ -9159,7 +9159,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -9167,15 +9167,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -9298,11 +9298,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Triggered abilities from cycling a card and the cycling ability itself aren’t spells. Effects that interact with spells (such as that of Cancel) won’t affect them."
+          "text": "Triggered abilities from cycling a card and the cycling ability itself aren't spells. Effects that interact with spells (such as that of Cancel) won't affect them."
         },
         {
           "date": "2017-04-18",
-          "text": "You can cycle a card even if it has a triggered ability from cycling that won’t have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability’s targets have become illegal), the other ability will still resolve."
+          "text": "You can cycle a card even if it has a triggered ability from cycling that won't have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability's targets have become illegal), the other ability will still resolve."
         }
       ],
       "subtypes": [
@@ -9534,7 +9534,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want the flying to affect what can block the creature, you must cycle or discard a card during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want the flying to affect what can block the creature, you must cycle or discard a card during the declare attackers step at the latest."
         },
         {
           "date": "2017-04-18",
@@ -9542,11 +9542,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -9672,11 +9672,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -10024,15 +10024,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The creature that died doesn’t have to still be in its owner’s graveyard as you cast Bone Picker for the first ability to apply."
+          "text": "The creature that died doesn't have to still be in its owner's graveyard as you cast Bone Picker for the first ability to apply."
         },
         {
           "date": "2017-04-18",
-          "text": "Creature tokens that die are put into your graveyard as normal (and cease to exist soon after). If one died this turn, Bone Picker’s first ability applies."
+          "text": "Creature tokens that die are put into your graveyard as normal (and cease to exist soon after). If one died this turn, Bone Picker's first ability applies."
         },
         {
           "date": "2017-04-18",
-          "text": "In a multiplayer game, a player may lose the game at the same time that his or her creatures die. If so, Bone Picker’s first ability applies."
+          "text": "In a multiplayer game, a player may lose the game at the same time that his or her creatures die. If so, Bone Picker's first ability applies."
         }
       ],
       "subtypes": [
@@ -10150,19 +10150,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The creature that died doesn’t have to still be in its owner’s graveyard to satisfy Bontu’s combat restriction."
+          "text": "The creature that died doesn't have to still be in its owner's graveyard to satisfy Bontu's combat restriction."
         },
         {
           "date": "2017-04-18",
-          "text": "Creature tokens that die are put into your graveyard as normal (and cease to exist soon after). If one died this turn, it satisfies Bontu’s combat restriction."
+          "text": "Creature tokens that die are put into your graveyard as normal (and cease to exist soon after). If one died this turn, it satisfies Bontu's combat restriction."
         },
         {
           "date": "2017-04-18",
-          "text": "All attackers are chosen at once. You can’t attack with one, sacrifice it to satisfy Bontu’s combat restriction, and then attack with Bontu."
+          "text": "All attackers are chosen at once. You can't attack with one, sacrifice it to satisfy Bontu's combat restriction, and then attack with Bontu."
         },
         {
           "date": "2017-04-18",
-          "text": "In a Two-Headed Giant game, Bontu’s activated ability causes the opposing team to lose 2 life and you gain 1 life."
+          "text": "In a Two-Headed Giant game, Bontu's activated ability causes the opposing team to lose 2 life and you gain 1 life."
         }
       ],
       "subtypes": [
@@ -10281,7 +10281,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The target creature for the triggered ability of Cartouche of Ambition doesn’t have to be the creature it enchants."
+          "text": "The target creature for the triggered ability of Cartouche of Ambition doesn't have to be the creature it enchants."
         },
         {
           "date": "2017-04-18",
@@ -10289,11 +10289,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn’t enter the battlefield."
+          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn't enter the battlefield."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Cartouche is an Aura with “Enchant creature you control.” If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner’s graveyard as a state-based action."
+          "text": "Each Cartouche is an Aura with \"Enchant creature you control.\" If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -10410,15 +10410,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The enchanted player chooses a permanent to sacrifice from among the creatures and planeswalkers that player controls. You don’t choose which type of permanent the player has to sacrifice."
+          "text": "The enchanted player chooses a permanent to sacrifice from among the creatures and planeswalkers that player controls. You don't choose which type of permanent the player has to sacrifice."
         },
         {
           "date": "2017-04-18",
-          "text": "The enchanted player can’t choose to lose 5 life if he or she has a creature or planeswalker that can be sacrificed."
+          "text": "The enchanted player can't choose to lose 5 life if he or she has a creature or planeswalker that can be sacrificed."
         },
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "subtypes": [
@@ -11089,7 +11089,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "While resolving the triggered ability of Faith of the Devoted, you can’t pay {1} multiple times to multiply the effect."
+          "text": "While resolving the triggered ability of Faith of the Devoted, you can't pay {1} multiple times to multiply the effect."
         },
         {
           "date": "2017-04-18",
@@ -11453,7 +11453,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -11575,7 +11575,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Because damage remains marked on a creature until it’s removed as the turn ends, the damage a Grim Strider takes during combat may become lethal if you draw cards later in the turn."
+          "text": "Because damage remains marked on a creature until it's removed as the turn ends, the damage a Grim Strider takes during combat may become lethal if you draw cards later in the turn."
         }
       ],
       "subtypes": [
@@ -11697,11 +11697,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -11929,7 +11929,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "A creature that is a Zombie and has other types, such as a Zombie Jackal, isn’t a non-Zombie creature."
+          "text": "A creature that is a Zombie and has other types, such as a Zombie Jackal, isn't a non-Zombie creature."
         }
       ],
       "subtypes": [
@@ -12265,7 +12265,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "When Miasmic Mummy’s triggered ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order chooses a card to discard, then all of those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
+          "text": "When Miasmic Mummy's triggered ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order chooses a card to discard, then all of those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
         }
       ],
       "subtypes": [
@@ -12383,7 +12383,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If an effect has you put more -1/-1 counters on a creature than it has toughness, you’ll put all of those counters on it and create that many Insects, even if that makes its toughness a negative number."
+          "text": "If an effect has you put more -1/-1 counters on a creature than it has toughness, you'll put all of those counters on it and create that many Insects, even if that makes its toughness a negative number."
         },
         {
           "date": "2017-04-18",
@@ -12611,11 +12611,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -12737,7 +12737,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If another Zombie you control dies at the same time as Plague Belcher, Plague Belcher’s last ability will trigger for that Zombie."
+          "text": "If another Zombie you control dies at the same time as Plague Belcher, Plague Belcher's last ability will trigger for that Zombie."
         },
         {
           "date": "2017-04-18",
@@ -12860,7 +12860,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "While resolving Ruthless Sniper’s triggered ability, you can’t pay {1} multiple times to put more counters on creatures."
+          "text": "While resolving Ruthless Sniper's triggered ability, you can't pay {1} multiple times to put more counters on creatures."
         },
         {
           "date": "2017-04-18",
@@ -12868,11 +12868,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -13101,11 +13101,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Shadow of the Grave returns to your hand all cards that you discarded for any reason—a card you cycled, cards you discarded to an opponent’s Unburden, and a card you discarded to cast Tormenting Voice all count."
+          "text": "Shadow of the Grave returns to your hand all cards that you discarded for any reason—a card you cycled, cards you discarded to an opponent's Unburden, and a card you discarded to cast Tormenting Voice all count."
         },
         {
           "date": "2017-04-18",
-          "text": "If you discard a card with madness but don’t cast it, Shadow of the Grave can find it in your graveyard. If you do cast that card, Shadow of the Grave can’t find it in your graveyard."
+          "text": "If you discard a card with madness but don't cast it, Shadow of the Grave can find it in your graveyard. If you do cast that card, Shadow of the Grave can't find it in your graveyard."
         }
       ],
       "text": "Return to your hand all cards in your graveyard that you cycled or discarded this turn.",
@@ -13218,7 +13218,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Soulstinger’s second ability targets one creature to get all the counters. You can’t distribute the counters among multiple creatures."
+          "text": "Soulstinger's second ability targets one creature to get all the counters. You can't distribute the counters among multiple creatures."
         }
       ],
       "subtypes": [
@@ -13340,7 +13340,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If one of two target creatures becomes an illegal target in response to Splendid Agony, the -1/-1 counter that would have been put on that creature is lost. It can’t be put on the legal target."
+          "text": "If one of two target creatures becomes an illegal target in response to Splendid Agony, the -1/-1 counter that would have been put on that creature is lost. It can't be put on the legal target."
         }
       ],
       "text": "Distribute two -1/-1 counters among one or two target creatures.",
@@ -13456,11 +13456,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Triggered abilities from cycling a card and the cycling ability itself aren’t spells. Effects that interact with spells (such as that of Cancel) won’t affect them."
+          "text": "Triggered abilities from cycling a card and the cycling ability itself aren't spells. Effects that interact with spells (such as that of Cancel) won't affect them."
         },
         {
           "date": "2017-04-18",
-          "text": "You can cycle a card even if it has a triggered ability from cycling that won’t have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability’s targets have become illegal), the other ability will still resolve."
+          "text": "You can cycle a card even if it has a triggered ability from cycling that won't have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability's targets have become illegal), the other ability will still resolve."
         }
       ],
       "text": "Create three 2/2 black Zombie creature tokens.\nCycling {3}{B} ({3}{B}, Discard this card: Draw a card.)\nWhen you cycle Stir the Sands, create a 2/2 black Zombie creature token.",
@@ -13573,7 +13573,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Supernatural Stamina’s effect works only once. If the targeted creature dies and is then returned to the battlefield, it’s considered to be a new creature. If that new creature dies, it won’t come back a second time."
+          "text": "Supernatural Stamina's effect works only once. If the targeted creature dies and is then returned to the battlefield, it's considered to be a new creature. If that new creature dies, it won't come back a second time."
         }
       ],
       "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
@@ -13686,7 +13686,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If a creature enters the battlefield under enchanted player’s control and causes an ability controlled by that player to trigger, the triggered ability of Trespasser’s Curse resolves first if it’s that player’s turn, and resolves last if it’s your turn."
+          "text": "If a creature enters the battlefield under enchanted player's control and causes an ability controlled by that player to trigger, the triggered ability of Trespasser's Curse resolves first if it's that player's turn, and resolves last if it's your turn."
         }
       ],
       "subtypes": [
@@ -13802,7 +13802,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner’s hand only if it’s on the battlefield as the ability resolves."
+          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner's hand only if it's on the battlefield as the ability resolves."
         }
       ],
       "text": "When Trial of Ambition enters the battlefield, target opponent sacrifices a creature.\nWhen a Cartouche enters the battlefield under your control, return Trial of Ambition to its owner's hand.",
@@ -14253,23 +14253,23 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "If a creature has a targeted triggered ability that triggers when you exert it, you can exert it even if there isn’t a legal target for that triggered ability."
+          "text": "If a creature has a targeted triggered ability that triggers when you exert it, you can exert it even if there isn't a legal target for that triggered ability."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -14387,15 +14387,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
@@ -14403,7 +14403,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -14972,7 +14972,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Destroy X target artifacts.",
@@ -15090,11 +15090,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn’t enter the battlefield."
+          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn't enter the battlefield."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Cartouche is an Aura with “Enchant creature you control.” If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner’s graveyard as a state-based action."
+          "text": "Each Cartouche is an Aura with \"Enchant creature you control.\" If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -15211,39 +15211,39 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Combat Celebrant’s ability untaps all of your creatures, not just the ones that are attacking."
+          "text": "Combat Celebrant's ability untaps all of your creatures, not just the ones that are attacking."
         },
         {
           "date": "2017-04-18",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         },
         {
           "date": "2017-04-18",
-          "text": "There’s no main phase between your combat phases, so you’ll have no opportunity to cast spells or activate abilities that could only be cast any time you could cast a sorcery. For example, you won’t be able to cast another creature or equip Equipment between combats."
+          "text": "There's no main phase between your combat phases, so you'll have no opportunity to cast spells or activate abilities that could only be cast any time you could cast a sorcery. For example, you won't be able to cast another creature or equip Equipment between combats."
         },
         {
           "date": "2017-04-18",
-          "text": "If you exert Combat Celebrant, you get an additional combat phase even if Combat Celebrant doesn’t survive the first combat phase."
+          "text": "If you exert Combat Celebrant, you get an additional combat phase even if Combat Celebrant doesn't survive the first combat phase."
         },
         {
           "date": "2017-04-18",
-          "text": "If you exert multiple Combat Celebrants in one combat phase, you’ll have that many additional combat phases, but all of your creatures are untapped only during the current combat phase. You’ll need to exert the Combat Celebrants one at a time, in multiple combat phases, to untap your attacking creatures and attack with them in each combat step."
+          "text": "If you exert multiple Combat Celebrants in one combat phase, you'll have that many additional combat phases, but all of your creatures are untapped only during the current combat phase. You'll need to exert the Combat Celebrants one at a time, in multiple combat phases, to untap your attacking creatures and attack with them in each combat step."
         },
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -15484,11 +15484,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Triggered abilities from cycling a card and the cycling ability itself aren’t spells. Effects that interact with spells (such as that of Cancel) won’t affect them."
+          "text": "Triggered abilities from cycling a card and the cycling ability itself aren't spells. Effects that interact with spells (such as that of Cancel) won't affect them."
         },
         {
           "date": "2017-04-18",
-          "text": "You can cycle a card even if it has a triggered ability from cycling that won’t have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability’s targets have become illegal), the other ability will still resolve."
+          "text": "You can cycle a card even if it has a triggered ability from cycling that won't have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability's targets have become illegal), the other ability will still resolve."
         }
       ],
       "text": "Deem Worthy deals 7 damage to target creature.\nCycling {3}{R} ({3}{R}, Discard this card: Draw a card.)\nWhen you cycle Deem Worthy, you may have it deal 2 damage to target creature.",
@@ -15821,19 +15821,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -15956,11 +15956,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -16098,11 +16098,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its power."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         },
         {
           "date": "2013-04-15",
@@ -16222,23 +16222,23 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Ending the turn this way means the following things happen in order: 1) All spells and abilities on the stack are exiled. This includes spells and abilities that can’t be countered. 2) If there are any attacking and blocking creatures, they’re removed from combat. 3) State-based actions are checked. No player gets priority, and no triggered abilities are put onto the stack. 4) The current phase and/or step ends. The game skips straight to the cleanup step. 5) The cleanup step happens in its entirety."
+          "text": "Ending the turn this way means the following things happen in order: 1) All spells and abilities on the stack are exiled. This includes spells and abilities that can't be countered. 2) If there are any attacking and blocking creatures, they're removed from combat. 3) State-based actions are checked. No player gets priority, and no triggered abilities are put onto the stack. 4) The current phase and/or step ends. The game skips straight to the cleanup step. 5) The cleanup step happens in its entirety."
         },
         {
           "date": "2017-04-18",
-          "text": "If any triggered abilities do trigger during this process, they’re put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn is over."
+          "text": "If any triggered abilities do trigger during this process, they're put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn is over."
         },
         {
           "date": "2017-04-18",
-          "text": "Though other spells and abilities that are exiled won’t get a chance to resolve, they don’t count as being countered."
+          "text": "Though other spells and abilities that are exiled won't get a chance to resolve, they don't count as being countered."
         },
         {
           "date": "2017-04-18",
-          "text": "Any “at the beginning of the next end step” triggered abilities won’t get the chance to trigger that turn because the end step is skipped. Those abilities will trigger at the beginning of the end step of the next turn."
+          "text": "Any \"at the beginning of the next end step\" triggered abilities won't get the chance to trigger that turn because the end step is skipped. Those abilities will trigger at the beginning of the end step of the next turn."
         },
         {
           "date": "2017-04-18",
-          "text": "If Glorious End’s delayed triggered ability is countered, it won’t trigger again. The same is true if it’s removed from the stack in any other way (such as by a second even more Glorious End) or if it resolves and you don’t lose the game (perhaps because of the emblem of Gideon of the Trials)."
+          "text": "If Glorious End's delayed triggered ability is countered, it won't trigger again. The same is true if it's removed from the stack in any other way (such as by a second even more Glorious End) or if it resolves and you don't lose the game (perhaps because of the emblem of Gideon of the Trials)."
         }
       ],
       "text": "End the turn. (Exile all spells and abilities on the stack, including this card. The player whose turn it is discards down to his or her maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)\nAt the beginning of your next end step, you lose the game.",
@@ -16352,23 +16352,23 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "If a creature has a targeted triggered ability that triggers when you exert it, you can exert it even if there isn’t a legal target for that triggered ability."
+          "text": "If a creature has a targeted triggered ability that triggers when you exert it, you can exert it even if there isn't a legal target for that triggered ability."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -16486,15 +16486,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keyword abilities (such as equip) are activated abilities and will have colons in their reminder text. An activated mana ability is one that produces mana as it resolves, not one that costs mana to activate. Notably, exerting a creature isn’t an activated ability."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keyword abilities (such as equip) are activated abilities and will have colons in their reminder text. An activated mana ability is one that produces mana as it resolves, not one that costs mana to activate. Notably, exerting a creature isn't an activated ability."
         },
         {
           "date": "2017-04-18",
-          "text": "Harsh Mentor’s ability doesn’t trigger when an opponent activates an ability of a card in hand (such as cycling) or a card in a graveyard (such as embalm), even if that causes a card to be put onto the battlefield."
+          "text": "Harsh Mentor's ability doesn't trigger when an opponent activates an ability of a card in hand (such as cycling) or a card in a graveyard (such as embalm), even if that causes a card to be put onto the battlefield."
         },
         {
           "date": "2017-04-18",
-          "text": "Harsh Mentor’s ability resolves before the ability that caused it to trigger."
+          "text": "Harsh Mentor's ability resolves before the ability that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -16617,7 +16617,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "In a Two-Headed Giant game, Hazoret’s activated ability causes 2 damage to be dealt to each opponent, which is 4 damage to the opposing team."
+          "text": "In a Two-Headed Giant game, Hazoret's activated ability causes 2 damage to be dealt to each opponent, which is 4 damage to the opposing team."
         }
       ],
       "subtypes": [
@@ -16844,19 +16844,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its power."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2017-04-18",
-          "text": "You can’t sacrifice multiple creatures to deal damage multiple times."
+          "text": "You can't sacrifice multiple creatures to deal damage multiple times."
         },
         {
           "date": "2017-04-18",
-          "text": "Heart-Piercer Manticore features a new style of triggered ability. When it enters the battlefield, its triggered ability goes on the stack without a target. While that ability is resolving, you may sacrifice a creature. If you do, a second ability triggers and you pick a target creature or player that will be dealt damage. This is different from other abilities that say “If you do . . .” in that players may cast spells and activate abilities before a creature is sacrificed and then again after the creature is sacrificed but before damage is dealt."
+          "text": "Heart-Piercer Manticore features a new style of triggered ability. When it enters the battlefield, its triggered ability goes on the stack without a target. While that ability is resolving, you may sacrifice a creature. If you do, a second ability triggers and you pick a target creature or player that will be dealt damage. This is different from other abilities that say \"If you do . . .\" in that players may cast spells and activate abilities before a creature is sacrificed and then again after the creature is sacrificed but before damage is dealt."
         },
         {
           "date": "2017-04-18",
-          "text": "Heart-Piercer Manticore’s damage-dealing ability triggers only when you sacrifice a creature as a result of the instruction of its triggered ability. It won’t trigger if you sacrifice a creature for any other reason."
+          "text": "Heart-Piercer Manticore's damage-dealing ability triggers only when you sacrifice a creature as a result of the instruction of its triggered ability. It won't trigger if you sacrifice a creature for any other reason."
         },
         {
           "date": "2017-04-18",
@@ -16864,7 +16864,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -16872,15 +16872,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -17226,7 +17226,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Magma Spray’s replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Magma Spray deals no damage to it (due to a prevention effect) or Magma Spray deals damage to a different creature (due to a redirection effect)."
+          "text": "Magma Spray's replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Magma Spray deals no damage to it (due to a prevention effect) or Magma Spray deals damage to a different creature (due to a redirection effect)."
         }
       ],
       "text": "Magma Spray deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
@@ -17340,11 +17340,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If you can’t choose a target opponent when you put Manticore of the Gauntlet’s triggered ability on the stack (most likely because your opponents have hexproof), the ability is removed from the stack and you won’t put a -1/-1 counter on any creature."
+          "text": "If you can't choose a target opponent when you put Manticore of the Gauntlet's triggered ability on the stack (most likely because your opponents have hexproof), the ability is removed from the stack and you won't put a -1/-1 counter on any creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If either target becomes illegal after Manticore of the Gauntlet’s triggered ability is put onto the stack but before it resolves, the other is still affected as appropriate."
+          "text": "If either target becomes illegal after Manticore of the Gauntlet's triggered ability is put onto the stack but before it resolves, the other is still affected as appropriate."
         }
       ],
       "subtypes": [
@@ -17575,19 +17575,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -17819,7 +17819,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If the creature’s power is greater than 2 as the activated ability tries to resolve, the ability will be countered and none of its effects will happen. However, if instead the creature’s power is raised above 2 after the ability resolves, it still can’t be blocked that turn."
+          "text": "If the creature's power is greater than 2 as the activated ability tries to resolve, the ability will be countered and none of its effects will happen. However, if instead the creature's power is raised above 2 after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -18044,7 +18044,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If an effect causes a creature you control to fight a creature an opponent controls, the damage is dealt simultaneously. For instance, if your 2/2 creature fights an opponent’s 4/4 creature, your creature will be dealt 4 damage and your opponent’s creature will have two -1/-1 counters put on it."
+          "text": "If an effect causes a creature you control to fight a creature an opponent controls, the damage is dealt simultaneously. For instance, if your 2/2 creature fights an opponent's 4/4 creature, your creature will be dealt 4 damage and your opponent's creature will have two -1/-1 counters put on it."
         },
         {
           "date": "2017-04-18",
@@ -18052,11 +18052,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Soul-Scar Mage’s effect isn’t a prevention effect. Damage that can’t be prevented will be replaced with -1/-1 counters."
+          "text": "Soul-Scar Mage's effect isn't a prevention effect. Damage that can't be prevented will be replaced with -1/-1 counters."
         },
         {
           "date": "2017-04-18",
-          "text": "If multiple prevention and/or replacement effects are trying to apply to the same damage, the controller of the creature that would be dealt damage chooses the order in which to apply them. As examples, an opponent could choose to apply the effect of Djeru’s Resolve and prevent the damage rather than put -1/-1 counters on it; or an opponent could choose to convert the damage to -1/-1 counters before Insult could double it, and then Insult’s effect won’t apply anymore."
+          "text": "If multiple prevention and/or replacement effects are trying to apply to the same damage, the controller of the creature that would be dealt damage chooses the order in which to apply them. As examples, an opponent could choose to apply the effect of Djeru's Resolve and prevent the damage rather than put -1/-1 counters on it; or an opponent could choose to convert the damage to -1/-1 counters before Insult could double it, and then Insult's effect won't apply anymore."
         }
       ],
       "subtypes": [
@@ -18282,7 +18282,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If a creature has been dealt damage, that damage remains marked on it until the cleanup step. If Thresher Lizard has been dealt 2 or 3 damage while you have zero or one card in hand, and later in the turn two cards are in your hand after a spell or ability has finished resolving, Thresher Lizard will be destroyed. Similarly, if that causes it to have 0 toughness, it’s put into its owner’s graveyard."
+          "text": "If a creature has been dealt damage, that damage remains marked on it until the cleanup step. If Thresher Lizard has been dealt 2 or 3 damage while you have zero or one card in hand, and later in the turn two cards are in your hand after a spell or ability has finished resolving, Thresher Lizard will be destroyed. Similarly, if that causes it to have 0 toughness, it's put into its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -18411,7 +18411,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Because discarding a card is an additional cost, you can’t cast Tormenting Voice if you have no other cards in hand."
+          "text": "Because discarding a card is an additional cost, you can't cast Tormenting Voice if you have no other cards in hand."
         }
       ],
       "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
@@ -18524,7 +18524,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner’s hand only if it’s on the battlefield as the ability resolves."
+          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner's hand only if it's on the battlefield as the ability resolves."
         }
       ],
       "text": "When Trial of Zeal enters the battlefield, it deals 3 damage to target creature or player.\nWhen a Cartouche enters the battlefield under your control, return Trial of Zeal to its owner's hand.",
@@ -18638,15 +18638,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
@@ -18654,7 +18654,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -18880,7 +18880,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "A split card only counts once for Warfire Javelineer’s ability, even if it’s both an instant and a sorcery."
+          "text": "A split card only counts once for Warfire Javelineer's ability, even if it's both an instant and a sorcery."
         }
       ],
       "subtypes": [
@@ -19112,19 +19112,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -19241,15 +19241,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If the triggered ability’s target is illegal when it tries to resolve, or if the enchanted creature has left the battlefield, no creature will deal or be dealt damage."
+          "text": "If the triggered ability's target is illegal when it tries to resolve, or if the enchanted creature has left the battlefield, no creature will deal or be dealt damage."
         },
         {
           "date": "2017-04-18",
-          "text": "The enchanted creature has +1/+1 and trample while it’s fighting. However, trample doesn’t apply during a fight."
+          "text": "The enchanted creature has +1/+1 and trample while it's fighting. However, trample doesn't apply during a fight."
         },
         {
           "date": "2017-04-18",
-          "text": "If Cartouche of Strength leaves the battlefield before its triggered ability resolves, the creature it last enchanted will fight the target creature if it’s still on the battlefield at that time. However, it won’t have +1/+1 from Cartouche of Strength anymore."
+          "text": "If Cartouche of Strength leaves the battlefield before its triggered ability resolves, the creature it last enchanted will fight the target creature if it's still on the battlefield at that time. However, it won't have +1/+1 from Cartouche of Strength anymore."
         },
         {
           "date": "2017-04-18",
@@ -19257,11 +19257,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn’t enter the battlefield."
+          "text": "If the target creature becomes an illegal target before a Cartouche spell resolves, the spell is countered. It doesn't enter the battlefield."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Cartouche is an Aura with “Enchant creature you control.” If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner’s graveyard as a state-based action."
+          "text": "Each Cartouche is an Aura with \"Enchant creature you control.\" If another player gains control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -19379,27 +19379,27 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "All attackers are chosen at once. You can’t attack with Champion of Rhonas, put a creature card onto the battlefield, and then attack with that creature."
+          "text": "All attackers are chosen at once. You can't attack with Champion of Rhonas, put a creature card onto the battlefield, and then attack with that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If the creature put onto the battlefield has any abilities that trigger when creatures attack or when you exert creatures, those abilities won’t trigger."
+          "text": "If the creature put onto the battlefield has any abilities that trigger when creatures attack or when you exert creatures, those abilities won't trigger."
         },
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -20080,7 +20080,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If Exemplar of Strength leaves the battlefield in response to its second triggered ability, you won’t be able to remove a counter from it, and you won’t gain 1 life."
+          "text": "If Exemplar of Strength leaves the battlefield in response to its second triggered ability, you won't be able to remove a counter from it, and you won't gain 1 life."
         }
       ],
       "subtypes": [
@@ -20446,7 +20446,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Once a creature with power 3 or greater has blocked Greater Sandwurm, changing the power of the blocking creature won’t cause Greater Sandwurm to become unblocked."
+          "text": "Once a creature with power 3 or greater has blocked Greater Sandwurm, changing the power of the blocking creature won't cause Greater Sandwurm to become unblocked."
         }
       ],
       "subtypes": [
@@ -20895,7 +20895,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -20903,11 +20903,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -21026,19 +21026,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -21269,7 +21269,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If an artifact enters the battlefield under an opponent’s control at the same time that Manglehorn enters the battlefield under your control, that artifact won’t enter tapped."
+          "text": "If an artifact enters the battlefield under an opponent's control at the same time that Manglehorn enters the battlefield under your control, that artifact won't enter tapped."
         }
       ],
       "subtypes": [
@@ -21391,15 +21391,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Any change to a land’s type or abilities gained by a land can affect the types of mana a land can produce."
+          "text": "Any change to a land's type or abilities gained by a land can affect the types of mana a land can produce."
         },
         {
           "date": "2017-04-18",
-          "text": "Naga Vitalist checks the effects of all mana-producing abilities of lands you control, but it doesn’t check their costs or legality. For example, Spire of Industry says “{T}, Pay 1 life: Add one mana of any color to your mana pool. Activate this ability only if you control an artifact.” If you control Spire of Industry and Naga Vitalist, you can tap Naga Vitalist for any color of mana. It doesn’t matter whether you control an artifact, whether you can pay 1 life, or whether Spire of Industry is untapped."
+          "text": "Naga Vitalist checks the effects of all mana-producing abilities of lands you control, but it doesn't check their costs or legality. For example, Spire of Industry says \"{T}, Pay 1 life: Add one mana of any color to your mana pool. Activate this ability only if you control an artifact.\" If you control Spire of Industry and Naga Vitalist, you can tap Naga Vitalist for any color of mana. It doesn't matter whether you control an artifact, whether you can pay 1 life, or whether Spire of Industry is untapped."
         },
         {
           "date": "2017-04-18",
-          "text": "Naga Vitalist doesn’t care about any restrictions or riders your lands put on the mana they produce, such as the one Cavern of Souls has. It just cares about types of mana."
+          "text": "Naga Vitalist doesn't care about any restrictions or riders your lands put on the mana they produce, such as the one Cavern of Souls has. It just cares about types of mana."
         }
       ],
       "subtypes": [
@@ -21855,7 +21855,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "A spell or ability that counters spells can still target a creature spell you control. When that spell or ability resolves, the creature spell won’t be countered, but any additional effects of that spell or ability will still happen."
+          "text": "A spell or ability that counters spells can still target a creature spell you control. When that spell or ability resolves, the creature spell won't be countered, but any additional effects of that spell or ability will still happen."
         }
       ],
       "subtypes": [
@@ -21974,7 +21974,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You don’t have to make the same choice for each kind of counter. For example, if a Gideon planeswalker has two loyalty counters and three -1/-1 counters on it, you can put another loyalty counter on it and remove a -1/-1 counter from it."
+          "text": "You don't have to make the same choice for each kind of counter. For example, if a Gideon planeswalker has two loyalty counters and three -1/-1 counters on it, you can put another loyalty counter on it and remove a -1/-1 counter from it."
         }
       ],
       "subtypes": [
@@ -22096,7 +22096,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "You don’t have to attack with another creature with power 4 or greater for Rhonas to be able to attack. The same is true of blocking."
+          "text": "You don't have to attack with another creature with power 4 or greater for Rhonas to be able to attack. The same is true of blocking."
         }
       ],
       "subtypes": [
@@ -22216,7 +22216,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Once a creature has attacked you or a planeswalker you control, it will remain in combat even if it gains flying. Similarly, if a creature with flying enters the battlefield attacking, Sandwurm Convergence’s first ability can’t undo that attack."
+          "text": "Once a creature has attacked you or a planeswalker you control, it will remain in combat even if it gains flying. Similarly, if a creature with flying enters the battlefield attacking, Sandwurm Convergence's first ability can't undo that attack."
         }
       ],
       "text": "Creatures with flying can't attack you or planeswalkers you control.\nAt the beginning of your end step, create a 5/5 green Wurm creature token.",
@@ -22552,11 +22552,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Triggered abilities from cycling a card and the cycling ability itself aren’t spells. Effects that interact with spells (such as that of Cancel) won’t affect them."
+          "text": "Triggered abilities from cycling a card and the cycling ability itself aren't spells. Effects that interact with spells (such as that of Cancel) won't affect them."
         },
         {
           "date": "2017-04-18",
-          "text": "You can cycle a card even if it has a triggered ability from cycling that won’t have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability’s targets have become illegal), the other ability will still resolve."
+          "text": "You can cycle a card even if it has a triggered ability from cycling that won't have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability's targets have become illegal), the other ability will still resolve."
         }
       ],
       "subtypes": [
@@ -22788,7 +22788,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Spidery Grasp can target a creature that’s already untapped. It will still get +2/+4 and gain reach."
+          "text": "Spidery Grasp can target a creature that's already untapped. It will still get +2/+4 and gain reach."
         }
       ],
       "text": "Untap target creature. It gets +2/+4 and gains reach until end of turn. (It can block creatures with flying.)",
@@ -23020,7 +23020,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "You can’t target the same creature twice to have it get +4/+4."
+          "text": "You can't target the same creature twice to have it get +4/+4."
         }
       ],
       "text": "Untap up to two target creatures. They each get +2/+2 until end of turn.",
@@ -23133,7 +23133,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner’s hand only if it’s on the battlefield as the ability resolves."
+          "text": "Each Trial has an ability to return to your hand when a Cartouche enters the battlefield under your control. The Trial is returned to its owner's hand only if it's on the battlefield as the ability resolves."
         }
       ],
       "text": "When Trial of Strength enters the battlefield, create a 4/2 green Beast creature token.\nWhen a Cartouche enters the battlefield under your control, return Trial of Strength to its owner's hand.",
@@ -23246,15 +23246,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Vizier of the Menagerie lets you look at the top card of your library whenever you want (with one restriction—see below), even if you don’t have priority. This action doesn’t use the stack. Knowing what that card is becomes part of the information you have access to, just like you can look at the cards in your hand."
+          "text": "Vizier of the Menagerie lets you look at the top card of your library whenever you want (with one restriction—see below), even if you don't have priority. This action doesn't use the stack. Knowing what that card is becomes part of the information you have access to, just like you can look at the cards in your hand."
         },
         {
           "date": "2017-04-18",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, you can’t look at the new top card until you finish casting that spell or activating that ability. This means that if you cast the top card of your library, you can’t look at the next one until you’re done paying for that spell."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, you can't look at the new top card until you finish casting that spell or activating that ability. This means that if you cast the top card of your library, you can't look at the next one until you're done paying for that spell."
         },
         {
           "date": "2017-04-18",
-          "text": "Normally, Vizier of the Menagerie allows you to cast the top card of your library if it’s a creature card, it’s your main phase, and the stack is empty. If that creature card has flash, you’ll be able to cast it any time you could cast an instant, even on an opponent’s turn."
+          "text": "Normally, Vizier of the Menagerie allows you to cast the top card of your library if it's a creature card, it's your main phase, and the stack is empty. If that creature card has flash, you'll be able to cast it any time you could cast an instant, even on an opponent's turn."
         },
         {
           "date": "2017-04-18",
@@ -23262,11 +23262,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "You’ll still pay all costs for that spell, including additional costs. You may also pay alternative costs such as emerge or that of As Foretold."
+          "text": "You'll still pay all costs for that spell, including additional costs. You may also pay alternative costs such as emerge or that of As Foretold."
         },
         {
           "date": "2017-04-18",
-          "text": "The top card of your library isn’t in your hand, so you can’t cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't cycle it, discard it, or activate any of its activated abilities."
         }
       ],
       "subtypes": [
@@ -23385,19 +23385,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -23518,11 +23518,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "All attackers are chosen at once. You can’t attack with Ahn-Crop Champion, untap a tapped creature, and then attack with that creature."
+          "text": "All attackers are chosen at once. You can't attack with Ahn-Crop Champion, untap a tapped creature, and then attack with that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         },
         {
           "date": "2017-04-18",
@@ -23530,19 +23530,19 @@
         },
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -23666,7 +23666,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -23674,11 +23674,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -23797,11 +23797,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If Bounty of the Luxa somehow has multiple flood counters on it, you’ll still get only {C}{G}{U} when you remove them all."
+          "text": "If Bounty of the Luxa somehow has multiple flood counters on it, you'll still get only {C}{G}{U} when you remove them all."
         },
         {
           "date": "2017-04-18",
-          "text": "If Bounty of the Luxa leaves the battlefield while its triggered ability is on the stack, you can’t remove any flood counters from it, even if it had one before it left the battlefield. You won’t put one on it as the ability resolves, but you will draw a card."
+          "text": "If Bounty of the Luxa leaves the battlefield while its triggered ability is on the stack, you can't remove any flood counters from it, even if it had one before it left the battlefield. You won't put one on it as the ability resolves, but you will draw a card."
         }
       ],
       "text": "At the beginning of your precombat main phase, remove all flood counters from Bounty of the Luxa. If no counters were removed this way, put a flood counter on Bounty of the Luxa and draw a card. Otherwise, add {C}{G}{U} to your mana pool.",
@@ -23916,11 +23916,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Decimator Beetle’s second ability can target any creature you control, not just one with a -1/-1 counter on it. It’ll put a -1/-1 counter on the opponent’s creature even if there isn’t one to remove from your creature."
+          "text": "Decimator Beetle's second ability can target any creature you control, not just one with a -1/-1 counter on it. It'll put a -1/-1 counter on the opponent's creature even if there isn't one to remove from your creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If one target of Decimator Beetle’s second ability becomes illegal, the other will still be affected."
+          "text": "If one target of Decimator Beetle's second ability becomes illegal, the other will still be affected."
         }
       ],
       "subtypes": [
@@ -24040,11 +24040,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "A split card only counts once for Enigma Drake’s ability, even if it’s both an instant and a sorcery."
+          "text": "A split card only counts once for Enigma Drake's ability, even if it's both an instant and a sorcery."
         },
         {
           "date": "2017-04-18",
-          "text": "The ability that defines Enigma Drake’s power works in all zones."
+          "text": "The ability that defines Enigma Drake's power works in all zones."
         }
       ],
       "subtypes": [
@@ -24164,7 +24164,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If you put any number of -1/-1 counters on more than one creature at once, Hapatra’s last ability triggers once for each of those creatures."
+          "text": "If you put any number of -1/-1 counters on more than one creature at once, Hapatra's last ability triggers once for each of those creatures."
         },
         {
           "date": "2017-04-18",
@@ -24526,11 +24526,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Once a creature has blocked, Merciless Javelineer’s ability can’t undo that block."
+          "text": "Once a creature has blocked, Merciless Javelineer's ability can't undo that block."
         },
         {
           "date": "2017-04-18",
-          "text": "The target creature won’t be able to block even if the -1/-1 counter is removed from it or if the -1/-1 counter can’t be put on it."
+          "text": "The target creature won't be able to block even if the -1/-1 counter is removed from it or if the -1/-1 counter can't be put on it."
         }
       ],
       "subtypes": [
@@ -24654,7 +24654,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "When Neheb’s triggered ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order chooses a card to discard, then all of those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
+          "text": "When Neheb's triggered ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order chooses a card to discard, then all of those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
         }
       ],
       "subtypes": [
@@ -24777,15 +24777,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If X is 0, Nissa enters the battlefield with no loyalty and is put into her owner’s graveyard before you can activate her abilities."
+          "text": "If X is 0, Nissa enters the battlefield with no loyalty and is put into her owner's graveyard before you can activate her abilities."
         },
         {
           "date": "2017-04-18",
-          "text": "While resolving Nissa’s second ability, if you can’t or don’t put the card onto the battlefield, it remains on top of your library."
+          "text": "While resolving Nissa's second ability, if you can't or don't put the card onto the battlefield, it remains on top of your library."
         },
         {
           "date": "2017-04-18",
-          "text": "Once Nissa’s second ability begins to resolve, no player may take actions until it’s done. Notably, players can’t try to change Nissa’s loyalty once you look at the card or choose to put it onto the battlefield."
+          "text": "Once Nissa's second ability begins to resolve, no player may take actions until it's done. Notably, players can't try to change Nissa's loyalty once you look at the card or choose to put it onto the battlefield."
         },
         {
           "date": "2017-04-18",
@@ -24793,7 +24793,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Nissa’s last ability sets the base power and toughness of the lands to 5/5. Any +1/+1 or -1/-1 counters that were on those lands will apply to those values."
+          "text": "Nissa's last ability sets the base power and toughness of the lands to 5/5. Any +1/+1 or -1/-1 counters that were on those lands will apply to those values."
         }
       ],
       "subtypes": [
@@ -25035,11 +25035,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -25167,7 +25167,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-04-18",
@@ -25175,11 +25175,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you’ll have priority immediately after that spell or ability resolves. You can activate the creature card’s embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a spell or ability puts a creature card with embalm into your graveyard during your main phase, you'll have priority immediately after that spell or ability resolves. You can activate the creature card's embalm ability before any player can exile it with an effect, such as that of Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an embalm ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
+          "text": "Once you've activated an embalm ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnatnion."
         }
       ],
       "subtypes": [
@@ -25542,15 +25542,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -25558,23 +25558,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Destroy all creatures with power 3 or greater.",
@@ -25690,7 +25690,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nReturn all creature cards with power 2 or less from your graveyard to your hand.",
@@ -25806,27 +25806,27 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If the target’s owner’s library contains no cards, the target spell or permanent will be put into that player’s library as the only card."
+          "text": "If the target's owner's library contains no cards, the target spell or permanent will be put into that player's library as the only card."
         },
         {
           "date": "2017-04-18",
-          "text": "If a spell is put into its owner’s library, it’s removed from the stack and thus will not resolve. The spell isn’t countered; it just no longer exists. This works against a spell that can’t be countered."
+          "text": "If a spell is put into its owner's library, it's removed from the stack and thus will not resolve. The spell isn't countered; it just no longer exists. This works against a spell that can't be countered."
         },
         {
           "date": "2017-04-18",
-          "text": "If a copy of a spell or a token is put into its owner’s library, it’s moved there, then it will cease to exist as a state-based action."
+          "text": "If a copy of a spell or a token is put into its owner's library, it's moved there, then it will cease to exist as a state-based action."
         },
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -25834,23 +25834,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Put target spell or nonland permanent into its owner's library second from the top.",
@@ -25966,7 +25966,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach player shuffles his or her hand and graveyard into his or her library, then draws seven cards.",
@@ -26082,15 +26082,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -26098,23 +26098,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Destroy target creature or planeswalker.",
@@ -26230,7 +26230,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nExile target card from a graveyard. Create a 2/2 black Zombie creature token.",
@@ -26350,7 +26350,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If an effect such as that of Chandra’s Pyrohelix asks you to divide damage among targets, you must divide the unmodified damage before doubling it."
+          "text": "If an effect such as that of Chandra's Pyrohelix asks you to divide damage among targets, you must divide the unmodified damage before doubling it."
         },
         {
           "date": "2017-04-18",
@@ -26358,15 +26358,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -26374,23 +26374,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Damage can't be prevented this turn. If a source you control would deal damage this turn, it deals double that damage instead.",
@@ -26506,11 +26506,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t cast Injury unless you target both a creature and a player. If one target is illegal as Injury resolves, the spell deals damage to the remaining legal target."
+          "text": "You can't cast Injury unless you target both a creature and a player. If one target is illegal as Injury resolves, the spell deals damage to the remaining legal target."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nInjury deals 2 damage to target creature and 2 damage to target player.",
@@ -26626,15 +26626,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -26642,23 +26642,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Create a 3/3 green Hippo creature token.",
@@ -26774,7 +26774,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw a card for each creature you control with power 3 or greater.",
@@ -26890,15 +26890,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -26906,23 +26906,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Create two 1/1 white Warrior creature tokens with vigilance.",
@@ -27038,7 +27038,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nAs an additional cost to cast Finish, sacrifice a creature.\nDestroy target creature.",
@@ -27154,15 +27154,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -27170,23 +27170,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Counter target spell unless its controller pays {3}.",
@@ -27302,7 +27302,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nUp to three target lands don't untap during their controller's next untap step.",
@@ -27418,15 +27418,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -27434,23 +27434,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Target creature gets +1/+0 and gains indestructible until end of turn.",
@@ -27566,19 +27566,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Lead doesn’t give any creatures the ability to block the target creature. It just forces those creatures that are already able to block the creature to do so."
+          "text": "Lead doesn't give any creatures the ability to block the target creature. It just forces those creatures that are already able to block the creature to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "As blockers are declared, any creature that’s tapped or affected by a spell or ability that says it can’t block doesn’t block. If there’s a cost associated with having the creature block, no player is forced to pay that cost, so it doesn’t block if that cost isn’t paid."
+          "text": "As blockers are declared, any creature that's tapped or affected by a spell or ability that says it can't block doesn't block. If there's a cost associated with having the creature block, no player is forced to pay that cost, so it doesn't block if that cost isn't paid."
         },
         {
           "date": "2017-04-18",
-          "text": "If there are multiple combat phases, creatures that blocked the creature targeted by Lead in the first combat aren’t required to block it again in subsequent combats. This is because Lead’s effect looks at this turn, not at each combat."
+          "text": "If there are multiple combat phases, creatures that blocked the creature targeted by Lead in the first combat aren't required to block it again in subsequent combats. This is because Lead's effect looks at this turn, not at each combat."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nAll creatures able to block target creature this turn do so.",
@@ -27694,19 +27694,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The value of X is determined only as Onward resolves. It won’t change later in the turn if other effects modify the creature’s power."
+          "text": "The value of X is determined only as Onward resolves. It won't change later in the turn if other effects modify the creature's power."
         },
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -27714,23 +27714,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Target creature gets +X/+0 until end of turn, where X is its power.",
@@ -27846,7 +27846,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature gains double strike until end of turn.",
@@ -27962,15 +27962,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -27978,23 +27978,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
@@ -28110,7 +28110,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw two cards.",
@@ -28226,7 +28226,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         },
         {
           "date": "2017-04-18",
@@ -28238,15 +28238,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -28254,23 +28254,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Untap target creature. It gets +2/+2 and gains lifelink until end of turn.",
@@ -28390,7 +28390,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature you control fights target creature an opponent controls.",
@@ -28506,23 +28506,23 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "If a spell is returned to its owner’s hand, it’s removed from the stack and thus will not resolve. The spell isn’t countered; it just no longer exists. This works against a spell that can’t be countered."
+          "text": "If a spell is returned to its owner's hand, it's removed from the stack and thus will not resolve. The spell isn't countered; it just no longer exists. This works against a spell that can't be countered."
         },
         {
           "date": "2017-04-18",
-          "text": "If a copy of a spell is returned to its owner’s hand, it’s moved there, then it will cease to exist as a state-based action."
+          "text": "If a copy of a spell is returned to its owner's hand, it's moved there, then it will cease to exist as a state-based action."
         },
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -28530,23 +28530,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Return target spell to its owner's hand.",
@@ -28662,7 +28662,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You choose a card name as Comply resolves, not as you cast it. Opponents can’t cast spells with that name after you’ve chosen it."
+          "text": "You choose a card name as Comply resolves, not as you cast it. Opponents can't cast spells with that name after you've chosen it."
         },
         {
           "date": "2017-04-18",
@@ -28670,11 +28670,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If you choose the name of a split card, you choose one name, not both. For example, you could name Failure or Comply, but not Failure // Comply. Opponents are still allowed to cast the half you didn’t choose."
+          "text": "If you choose the name of a split card, you choose one name, not both. For example, you could name Failure or Comply, but not Failure // Comply. Opponents are still allowed to cast the half you didn't choose."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nChoose a card name. Until your next turn, your opponents can't cast spells with the chosen name.",
@@ -28790,19 +28790,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Rags affects only creatures on the battlefield at the time it resolves. It won’t affect creatures that enter the battlefield or noncreature permanents that become creatures later in the turn."
+          "text": "Rags affects only creatures on the battlefield at the time it resolves. It won't affect creatures that enter the battlefield or noncreature permanents that become creatures later in the turn."
         },
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -28810,23 +28810,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "All creatures get -2/-2 until end of turn.",
@@ -28942,15 +28942,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Riches’s effect doesn’t target. Creatures with hexproof may be lured away this way."
+          "text": "Riches's effect doesn't target. Creatures with hexproof may be lured away this way."
         },
         {
           "date": "2017-04-18",
-          "text": "Riches’s effect lasts indefinitely. It doesn’t wear off during the cleanup step."
+          "text": "Riches's effect lasts indefinitely. It doesn't wear off during the cleanup step."
         },
         {
           "date": "2017-04-18",
-          "text": "Once Riches begins to resolve, no player may take other actions until it’s done. Notably, opponents can’t try to remove a creature after choosing it but before you gain control of it."
+          "text": "Once Riches begins to resolve, no player may take other actions until it's done. Notably, opponents can't try to remove a creature after choosing it but before you gain control of it."
         },
         {
           "date": "2017-04-18",
@@ -28962,7 +28962,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach opponent chooses a creature he or she controls. You gain control of those creatures.",
@@ -29078,15 +29078,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -29094,23 +29094,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Cut deals 4 damage to target creature.",
@@ -29230,7 +29230,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach opponent loses X life.",
@@ -29346,15 +29346,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -29362,23 +29362,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Heaven deals X damage to each creature with flying.",
@@ -29494,11 +29494,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You don’t have to choose the same value for X while casting Earth as you did while casting Heaven."
+          "text": "You don't have to choose the same value for X while casting Earth as you did while casting Heaven."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEarth deals X damage to each creature without flying.",
@@ -29605,7 +29605,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "In a Two-Headed Giant game, the triggered ability of Bontu’s Monument causes the opposing team to lose 2 life and you gain 1 life."
+          "text": "In a Two-Headed Giant game, the triggered ability of Bontu's Monument causes the opposing team to lose 2 life and you gain 1 life."
         },
         {
           "date": "2017-04-18",
@@ -29613,15 +29613,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "A creature spell that’s multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra’s Monument or Rhonas’s Monument—or both at once."
+          "text": "A creature spell that's multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra's Monument or Rhonas's Monument—or both at once."
         },
         {
           "date": "2017-04-18",
-          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you’re paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
+          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Monument’s triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
+          "text": "Each Monument's triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
         }
       ],
       "supertypes": [
@@ -29730,15 +29730,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Edifice of Authority can’t be used to undo an attack or block once it has been declared. Its abilities must be activated no later than the beginning of combat step to stop a creature from attacking, and no later than the declare attackers step to stop a creature from blocking."
+          "text": "Edifice of Authority can't be used to undo an attack or block once it has been declared. Its abilities must be activated no later than the beginning of combat step to stop a creature from attacking, and no later than the declare attackers step to stop a creature from blocking."
         },
         {
           "date": "2017-04-18",
-          "text": "Once a player has announced that he or she is activating the ability of a creature, Edifice of Authority can’t be used to undo it. Its last ability must be activated before the player activates that creature’s ability. The player may respond to Edifice of Authority’s ability with the target creature’s ability if able."
+          "text": "Once a player has announced that he or she is activating the ability of a creature, Edifice of Authority can't be used to undo it. Its last ability must be activated before the player activates that creature's ability. The player may respond to Edifice of Authority's ability with the target creature's ability if able."
         },
         {
           "date": "2017-04-18",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keyword abilities are activated abilities and will have colons in their reminder text. Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected by the last ability of Edifice of Authority. Notably, exerting a creature isn’t an activated ability."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keyword abilities are activated abilities and will have colons in their reminder text. Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected by the last ability of Edifice of Authority. Notably, exerting a creature isn't an activated ability."
         }
       ],
       "text": "{1}, {T}: Target creature can't attack this turn. Put a brick counter on Edifice of Authority.\n{1}, {T}: Until your next turn, target creature can't attack or block and its activated abilities can't be activated. Activate this ability only if there are three or more brick counters on Edifice of Authority.",
@@ -29845,15 +29845,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keyword abilities (such as embalm) are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keyword abilities (such as embalm) are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2017-04-18",
-          "text": "You can’t normally activate abilities of cards in graveyards. Those that you can activate are those that instruct you to move the card out of a graveyard, or those that specifically say that you can activate them if the card is in your graveyard."
+          "text": "You can't normally activate abilities of cards in graveyards. Those that you can activate are those that instruct you to move the card out of a graveyard, or those that specifically say that you can activate them if the card is in your graveyard."
         },
         {
           "date": "2017-04-18",
-          "text": "Any untapped Zombie you control can be tapped to pay the second ability’s activation cost, even one that just came under your control."
+          "text": "Any untapped Zombie you control can be tapped to pay the second ability's activation cost, even one that just came under your control."
         }
       ],
       "text": "Activated abilities of creature cards in your graveyard cost {1} less to activate.\nTap an untapped Zombie you control: Target player puts the top card of his or her library into his or her graveyard.",
@@ -29963,7 +29963,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "There is no card named God-Pharaoh’s Gift in this set. During the upcoming Hour of Devastation set, you may prove worthy of receiving it."
+          "text": "There is no card named God-Pharaoh's Gift in this set. During the upcoming Hour of Devastation set, you may prove worthy of receiving it."
         }
       ],
       "text": "Whenever a nontoken creature you control dies, you gain 1 life. Then you may draw a card. If you do, discard a card.\n{2}, {T}, Sacrifice Gate to the Afterlife: Search your graveyard, hand, and/or library for a card named God-Pharaoh's Gift and put it onto the battlefield. If you search your library this way, shuffle it. Activate this ability only if there are six or more creature cards in your graveyard.",
@@ -30074,15 +30074,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "A creature spell that’s multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra’s Monument or Rhonas’s Monument—or both at once."
+          "text": "A creature spell that's multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra's Monument or Rhonas's Monument—or both at once."
         },
         {
           "date": "2017-04-18",
-          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you’re paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
+          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Monument’s triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
+          "text": "Each Monument's triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
         }
       ],
       "supertypes": [
@@ -30296,7 +30296,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The triggered ability of Kefnet’s Monument doesn’t tap the creature. It can target any creature, tapped or untapped. If that creature is already untapped at the beginning of its controller’s next untap step, the effect won’t do anything."
+          "text": "The triggered ability of Kefnet's Monument doesn't tap the creature. It can target any creature, tapped or untapped. If that creature is already untapped at the beginning of its controller's next untap step, the effect won't do anything."
         },
         {
           "date": "2017-04-18",
@@ -30304,15 +30304,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "A creature spell that’s multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra’s Monument or Rhonas’s Monument—or both at once."
+          "text": "A creature spell that's multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra's Monument or Rhonas's Monument—or both at once."
         },
         {
           "date": "2017-04-18",
-          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you’re paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
+          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Monument’s triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
+          "text": "Each Monument's triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
         }
       ],
       "supertypes": [
@@ -30527,15 +30527,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "A creature spell that’s multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra’s Monument or Rhonas’s Monument—or both at once."
+          "text": "A creature spell that's multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra's Monument or Rhonas's Monument—or both at once."
         },
         {
           "date": "2017-04-18",
-          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you’re paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
+          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Monument’s triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
+          "text": "Each Monument's triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
         }
       ],
       "supertypes": [
@@ -30644,15 +30644,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The cards exiled by Oracle’s Vault are exiled face up."
+          "text": "The cards exiled by Oracle's Vault are exiled face up."
         },
         {
           "date": "2017-04-18",
-          "text": "You may play the exiled card this turn even if Oracle’s Vault is no longer on the battlefield or under your control."
+          "text": "You may play the exiled card this turn even if Oracle's Vault is no longer on the battlefield or under your control."
         },
         {
           "date": "2017-04-18",
-          "text": "Playing a card exiled with Oracle’s Vault follows the normal timing rules for playing that card. For example, if the card is a creature card, you can cast that card only during your main phase while the stack is empty."
+          "text": "Playing a card exiled with Oracle's Vault follows the normal timing rules for playing that card. For example, if the card is a creature card, you can cast that card only during your main phase while the stack is empty."
         },
         {
           "date": "2017-04-18",
@@ -30660,15 +30660,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If you don’t play the card, it will remain exiled."
+          "text": "If you don't play the card, it will remain exiled."
         },
         {
           "date": "2017-04-18",
-          "text": "The first ability of Oracle’s Vault puts a brick counter on it even if you can’t or don’t play the card."
+          "text": "The first ability of Oracle's Vault puts a brick counter on it even if you can't or don't play the card."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, those must be paid to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, those must be paid to cast the card."
         },
         {
           "date": "2017-04-18",
@@ -30880,7 +30880,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "The triggered ability of Rhonas’s Monument can’t target the creature spell that caused it to trigger."
+          "text": "The triggered ability of Rhonas's Monument can't target the creature spell that caused it to trigger."
         },
         {
           "date": "2017-04-18",
@@ -30888,15 +30888,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "A creature spell that’s multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra’s Monument or Rhonas’s Monument—or both at once."
+          "text": "A creature spell that's multiple colors is each of those colors. For example, Ahn-Crop Champion is a white creature and a green creature, so it can benefit from either Oketra's Monument or Rhonas's Monument—or both at once."
         },
         {
           "date": "2017-04-18",
-          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you’re paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
+          "text": "To determine the total cost of a creature spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
         },
         {
           "date": "2017-04-18",
-          "text": "Each Monument’s triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
+          "text": "Each Monument's triggered ability triggers as the creature spell is cast and resolves before that creature spell resolves. The ability will resolve even if that creature spell is countered."
         }
       ],
       "supertypes": [
@@ -31006,7 +31006,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Throne of the God-Pharaoh’s ability triggers at the beginning of each of your end steps, even if you control no tapped creatures. The number of tapped creatures you control is checked as the ability resolves."
+          "text": "Throne of the God-Pharaoh's ability triggers at the beginning of each of your end steps, even if you control no tapped creatures. The number of tapped creatures you control is checked as the ability resolves."
         },
         {
           "date": "2017-04-18",
@@ -31014,7 +31014,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "In a Two-Headed Giant game, the triggered ability of Throne of the God-Pharaoh causes the opposing team to lose life equal to twice the number of tapped creatures you control. Tapped creatures your teammate controls aren’t counted."
+          "text": "In a Two-Headed Giant game, the triggered ability of Throne of the God-Pharaoh causes the opposing team to lose life equal to twice the number of tapped creatures you control. Tapped creatures your teammate controls aren't counted."
         }
       ],
       "supertypes": [
@@ -31125,7 +31125,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "An opponent with one or two cards in his or her graveyard won’t exile any cards."
+          "text": "An opponent with one or two cards in his or her graveyard won't exile any cards."
         },
         {
           "date": "2017-04-18",
@@ -31444,7 +31444,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -31794,7 +31794,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -32008,7 +32008,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -32328,7 +32328,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -35021,6 +35021,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "平原",
+          "multiverseid": 429373
+        },
+        {
           "language": "Chinese Traditional",
           "name": "平原",
           "multiverseid": 429642
@@ -35106,6 +35111,21 @@
           "multiverseid": 428297
         },
         {
+          "language": "Japanese",
+          "name": "平地",
+          "multiverseid": 428302
+        },
+        {
+          "language": "Japanese",
+          "name": "平地",
+          "multiverseid": 428303
+        },
+        {
+          "language": "Japanese",
+          "name": "平地",
+          "multiverseid": 428304
+        },
+        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 428566
@@ -35124,26 +35144,6 @@
           "language": "Korean",
           "name": "들",
           "multiverseid": 428573
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 427490
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 427495
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 427496
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 427497
         }
       ],
       "id": "84b030c317da4d36cf0716004a12a08773096eaf",
@@ -35427,21 +35427,6 @@
           "multiverseid": 427760
         },
         {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 427767
-        },
-        {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 427768
-        },
-        {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 427769
-        },
-        {
           "language": "German",
           "name": "Insel",
           "multiverseid": 427222
@@ -35522,9 +35507,24 @@
           "multiverseid": 428576
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Ilha",
-          "multiverseid": 428836
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 427491
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 427498
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 427499
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 427500
         }
       ],
       "id": "522b4d00cde973e8628974a08182c7ed2143586b",
@@ -36923,11 +36923,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "沼泽",
-          "multiverseid": 429375
-        },
-        {
           "language": "Chinese Traditional",
           "name": "沼澤",
           "multiverseid": 429644
@@ -37033,19 +37028,24 @@
           "multiverseid": 428568
         },
         {
-          "language": "Korean",
-          "name": "늪",
-          "multiverseid": 428577
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 427492
         },
         {
-          "language": "Korean",
-          "name": "늪",
-          "multiverseid": 428578
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 427501
         },
         {
-          "language": "Korean",
-          "name": "늪",
-          "multiverseid": 428579
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 427502
+        },
+        {
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 427503
         }
       ],
       "id": "09bc995a375734e58f4c2d5fc4bd2c9bee802f30",
@@ -37307,6 +37307,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "沼泽",
+          "multiverseid": 429375
+        },
+        {
           "language": "Chinese Traditional",
           "name": "沼澤",
           "multiverseid": 429644
@@ -37412,24 +37417,19 @@
           "multiverseid": 428568
         },
         {
-          "language": "Spanish",
-          "name": "Pantano",
-          "multiverseid": 427492
+          "language": "Korean",
+          "name": "늪",
+          "multiverseid": 428577
         },
         {
-          "language": "Spanish",
-          "name": "Pantano",
-          "multiverseid": 427501
+          "language": "Korean",
+          "name": "늪",
+          "multiverseid": 428578
         },
         {
-          "language": "Spanish",
-          "name": "Pantano",
-          "multiverseid": 427502
-        },
-        {
-          "language": "Spanish",
-          "name": "Pantano",
-          "multiverseid": 427503
+          "language": "Korean",
+          "name": "늪",
+          "multiverseid": 428579
         }
       ],
       "id": "a98fda116fb1f60ca56e6aceee9021ab25ebc68e",
@@ -39697,6 +39697,21 @@
           "multiverseid": 428301
         },
         {
+          "language": "Japanese",
+          "name": "森",
+          "multiverseid": 428314
+        },
+        {
+          "language": "Japanese",
+          "name": "森",
+          "multiverseid": 428315
+        },
+        {
+          "language": "Japanese",
+          "name": "森",
+          "multiverseid": 428316
+        },
+        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 428570
@@ -39717,24 +39732,9 @@
           "multiverseid": 428585
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 427494
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 427507
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 427508
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 427509
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 429108
         }
       ],
       "id": "70aeb63ad07cb3f5b853b01fc2563aad796b679e",
@@ -40092,33 +40092,33 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "All creatures you control get +1/+1 from Gideon’s first ability, not just the ones that it untapped."
+          "text": "All creatures you control get +1/+1 from Gideon's first ability, not just the ones that it untapped."
         },
         {
           "date": "2017-04-18",
-          "text": "The set of creatures affected by Gideon’s first and third abilities is determined as the abilities resolve. Creatures you begin to control later in the turn and permanents you control that become creatures later in the turn won’t get +1/+1 or +2/+2."
+          "text": "The set of creatures affected by Gideon's first and third abilities is determined as the abilities resolve. Creatures you begin to control later in the turn and permanents you control that become creatures later in the turn won't get +1/+1 or +2/+2."
         },
         {
           "date": "2017-04-18",
-          "text": "Gideon’s second ability doesn’t count as a creature entering the battlefield. Gideon was already on the battlefield; he only changed his types."
+          "text": "Gideon's second ability doesn't count as a creature entering the battlefield. Gideon was already on the battlefield; he only changed his types."
         },
         {
           "date": "2017-04-18",
-          "text": "If Gideon becomes a creature the same turn he enters the battlefield, you can’t attack with him or use any of his {T} abilities (if he gains any)."
+          "text": "If Gideon becomes a creature the same turn he enters the battlefield, you can't attack with him or use any of his {T} abilities (if he gains any)."
         },
         {
           "date": "2017-04-18",
-          "text": "Gideon’s second ability causes him to become a creature with the creature types Human and Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: planeswalker is only a type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
+          "text": "Gideon's second ability causes him to become a creature with the creature types Human and Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: planeswalker is only a type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
         },
         {
           "date": "2017-04-18",
-          "text": "If damage that can’t be prevented is dealt to Gideon after his second ability has resolved, that damage will have all applicable results: specifically, the damage is marked on Gideon (since he’s a creature) and that damage causes that many loyalty counters to be removed from him (since he’s a planeswalker). Even though he has indestructible, if Gideon has no loyalty counters on him, he’s put into his owner’s graveyard."
+          "text": "If damage that can't be prevented is dealt to Gideon after his second ability has resolved, that damage will have all applicable results: specifically, the damage is marked on Gideon (since he's a creature) and that damage causes that many loyalty counters to be removed from him (since he's a planeswalker). Even though he has indestructible, if Gideon has no loyalty counters on him, he's put into his owner's graveyard."
         }
       ],
       "subtypes": [
         "Gideon"
       ],
-      "text": "+2: Untap all creatures you control. Those creatures get +1/+1 until end of turn.  \n0: Until end of turn, Gideon, Martial Paragon becomes a 5/5 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n−10: Creatures you control get +2/+2 until end of turn. Tap all creatures your opponents control.",
+      "text": "+2: Untap all creatures you control. Those creatures get +1/+1 until end of turn.\n0: Until end of turn, Gideon, Martial Paragon becomes a 5/5 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n−10: Creatures you control get +2/+2 until end of turn. Tap all creatures your opponents control.",
       "type": "Planeswalker — Gideon",
       "types": [
         "Planeswalker"
@@ -40229,7 +40229,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         }
       ],
       "subtypes": [

--- a/json/ALA.json
+++ b/json/ALA.json
@@ -136,11 +136,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -152,7 +152,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -258,7 +258,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "To activate the ability, you must sacrifice three different creatures. You can’t sacrifice just one three-colored creature, for example."
+          "text": "To activate the ability, you must sacrifice three different creatures. You can't sacrifice just one three-colored creature, for example."
         },
         {
           "date": "2008-10-01",
@@ -378,11 +378,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -394,7 +394,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         },
         {
           "date": "2012-07-01",
@@ -707,11 +707,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -723,11 +723,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         },
         {
           "date": "2009-10-01",
-          "text": "Battlegrace Angel could cause a creature to have multiple instances of lifelink. For example, a creature you control that already has lifelink could attack alone while you control Battlegrace Angel, or a creature you control could attack alone while you control more than one Battlegrace Angel. If a creature has multiple instances of lifelink, they are redundant. You’ll still only gain life equal to the damage dealt."
+          "text": "Battlegrace Angel could cause a creature to have multiple instances of lifelink. For example, a creature you control that already has lifelink could attack alone while you control Battlegrace Angel, or a creature you control could attack alone while you control more than one Battlegrace Angel. If a creature has multiple instances of lifelink, they are redundant. You'll still only gain life equal to the damage dealt."
         }
       ],
       "subtypes": [
@@ -832,11 +832,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You choose a target when the ability triggers. You don’t choose whether to pay {1}{W} until the ability resolves."
+          "text": "You choose a target when the ability triggers. You don't choose whether to pay {1}{W} until the ability resolves."
         },
         {
           "date": "2008-10-01",
-          "text": "Cradle of Vitality triggers just once for each life-gaining event, whether it’s 1 life from Deathgreeter or 8 life from Soul’s Grace. You pay the cost just once, but the targeted creature will get a number of counters equal to the amount of life you gained."
+          "text": "Cradle of Vitality triggers just once for each life-gaining event, whether it's 1 life from Deathgreeter or 8 life from Soul's Grace. You pay the cost just once, but the targeted creature will get a number of counters equal to the amount of life you gained."
         },
         {
           "date": "2014-02-01",
@@ -1045,11 +1045,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren’t permanents and don’t exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
+          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren't permanents and don't exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s a creature whose toughness is 0 or less, or if it’s an Aura that’s either unattached or attached to something illegal."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's a creature whose toughness is 0 or less, or if it's an Aura that's either unattached or attached to something illegal."
         }
       ],
       "subtypes": [
@@ -1166,7 +1166,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This effect takes into account spells that were cast earlier in the turn that Ethersworn Canonist entered the battlefield, including any spells still on the stack. However, any spells on the stack as Ethersworn Canonist enters the battlefield have already been cast by that point, so they’re not affected by it."
+          "text": "This effect takes into account spells that were cast earlier in the turn that Ethersworn Canonist entered the battlefield, including any spells still on the stack. However, any spells on the stack as Ethersworn Canonist enters the battlefield have already been cast by that point, so they're not affected by it."
         }
       ],
       "subtypes": [
@@ -1374,11 +1374,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -1390,7 +1390,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -1496,7 +1496,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability doesn’t target, so it checks the creatures’ powers only once: when the ability resolves. Once the ability resolves, it will continue to apply to the affected creatures no matter what their powers may become later in the turn."
+          "text": "The ability doesn't target, so it checks the creatures' powers only once: when the ability resolves. Once the ability resolves, it will continue to apply to the affected creatures no matter what their powers may become later in the turn."
         }
       ],
       "subtypes": [
@@ -1601,7 +1601,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Invincible Hymn checks the number of cards in your library just once: when it resolves. It doesn’t continuously modify your life total as your library size changes."
+          "text": "Invincible Hymn checks the number of cards in your library just once: when it resolves. It doesn't continuously modify your life total as your library size changes."
         },
         {
           "date": "2008-10-01",
@@ -1609,7 +1609,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, Invincible Hymn will essentially set your team’s life total to the number of cards in your library. For example, suppose your team has 8 life and you have thirty cards in your library. Your life total (being the same as your team’s life total) changes from 8 life to 30 life, for a net gain of 22 life. Your team’s life total becomes 30 (22 + 8)."
+          "text": "In a Two-Headed Giant game, Invincible Hymn will essentially set your team's life total to the number of cards in your library. For example, suppose your team has 8 life and you have thirty cards in your library. Your life total (being the same as your team's life total) changes from 8 life to 30 life, for a net gain of 22 life. Your team's life total becomes 30 (22 + 8)."
         }
       ],
       "text": "Count the number of cards in your library. Your life total becomes that number.",
@@ -1814,11 +1814,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Knight of the White Orchid’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
+          "text": "Knight of the White Orchid's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
         },
         {
           "date": "2015-06-22",
-          "text": "The Plains you search for doesn’t have to be basic. For example, you could put a Sacred Foundry onto the battlefield."
+          "text": "The Plains you search for doesn't have to be basic. For example, you could put a Sacred Foundry onto the battlefield."
         }
       ],
       "subtypes": [
@@ -1924,7 +1924,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can sacrifice any Soldier to activate the second ability. You’re not limited to just the Soldier tokens put onto the battlefield by the first ability."
+          "text": "You can sacrifice any Soldier to activate the second ability. You're not limited to just the Soldier tokens put onto the battlefield by the first ability."
         }
       ],
       "subtypes": [
@@ -2259,11 +2259,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -2479,11 +2479,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Exile target attacking creature.\nCycling {5}{G}{W}{U} ({5}{G}{W}{U}, Discard this card: Draw a card.)\nWhen you cycle Resounding Silence, exile up to two target attacking creatures.",
@@ -2797,7 +2797,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Any permanent that’s an artifact or a land won’t be destroyed, regardless of what other card types it may have."
+          "text": "Any permanent that's an artifact or a land won't be destroyed, regardless of what other card types it may have."
         }
       ],
       "text": "{T}, Sacrifice Scourglass: Destroy all permanents except for artifacts and lands. Activate this ability only during your upkeep.",
@@ -2902,11 +2902,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -2918,7 +2918,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -3028,11 +3028,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -3044,7 +3044,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -3244,7 +3244,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The first ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control a creature with power 5 or greater as your end step begins, and (2) the ability will do nothing if you don’t control a creature with power 5 or greater by the time it resolves. (It doesn’t have to be the same creature as the one that allowed the ability to trigger.) Power-boosting effects that last “until end of turn” will still be in effect when this kind of ability triggers and resolves. An ability like this will trigger a maximum of once per turn, no matter how many applicable creatures you control."
+          "text": "The first ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control a creature with power 5 or greater as your end step begins, and (2) the ability will do nothing if you don't control a creature with power 5 or greater by the time it resolves. (It doesn't have to be the same creature as the one that allowed the ability to trigger.) Power-boosting effects that last \"until end of turn\" will still be in effect when this kind of ability triggers and resolves. An ability like this will trigger a maximum of once per turn, no matter how many applicable creatures you control."
         }
       ],
       "subtypes": [
@@ -3627,6 +3627,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -3648,6 +3652,10 @@
         },
         {
           "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -4303,11 +4311,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -4319,7 +4327,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -4641,11 +4649,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This effect doesn’t change the mana cost or converted mana cost of an artifact spell. Rather, it reduces the total cost of the spell, which is the amount you actually pay while casting it. The total cost takes into account additional or alternative costs."
+          "text": "This effect doesn't change the mana cost or converted mana cost of an artifact spell. Rather, it reduces the total cost of the spell, which is the amount you actually pay while casting it. The total cost takes into account additional or alternative costs."
         },
         {
           "date": "2008-10-01",
-          "text": "This effect can reduce only the generic portion of the artifact spell’s total cost."
+          "text": "This effect can reduce only the generic portion of the artifact spell's total cost."
         }
       ],
       "subtypes": [
@@ -4751,23 +4759,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -4979,39 +4987,39 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Gather Specimens isn’t targeted. It affects creatures that would enter the battlefield under any opponent’s control."
+          "text": "Gather Specimens isn't targeted. It affects creatures that would enter the battlefield under any opponent's control."
         },
         {
           "date": "2008-10-01",
-          "text": "Gather Specimens affects both token creatures and nontoken creatures. It affects creatures that would enter the battlefield by any means. This includes, of course, creature spells that resolve. It also includes creatures put onto the battlefield as a result of a resolving spell (such as Call of the Herd or Zombify), resolving ability (such as Verdant Force’s ability or Doomed Necromancer’s ability), cost (such as Varchild’s War-Riders’s cumulative upkeep cost), replacement effect (such as the one created by Words of Wilding), or any other means."
+          "text": "Gather Specimens affects both token creatures and nontoken creatures. It affects creatures that would enter the battlefield by any means. This includes, of course, creature spells that resolve. It also includes creatures put onto the battlefield as a result of a resolving spell (such as Call of the Herd or Zombify), resolving ability (such as Verdant Force's ability or Doomed Necromancer's ability), cost (such as Varchild's War-Riders's cumulative upkeep cost), replacement effect (such as the one created by Words of Wilding), or any other means."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature spell controlled by an opponent would resolve, it resolves, but the creature enters the battlefield under your control instead of the opponent’s control. Choices made when casting that spell (such as whether it was kicked or the value of X in the spell’s cost) are remembered. Any “enters the battlefield” triggered abilities will trigger after the creature is on the battlefield under your control."
+          "text": "If a creature spell controlled by an opponent would resolve, it resolves, but the creature enters the battlefield under your control instead of the opponent's control. Choices made when casting that spell (such as whether it was kicked or the value of X in the spell's cost) are remembered. Any \"enters the battlefield\" triggered abilities will trigger after the creature is on the battlefield under your control."
         },
         {
           "date": "2008-10-01",
-          "text": "The Gather Specimens replacement effect is applied before any other replacement effects that would also modify how the creature enters the battlefield. These are usually worded “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with.” For example, if your Gather Specimens has resolved, then the following things are true: -- If a creature with devour would enter the battlefield under an opponent's control, you choose and sacrifice your creatures as it enters the battlefield under your control. -- If Voice of All would enter the battlefield under an opponent's control, you choose a color as it enters the battlefield under your control. -- If Clone would enter the battlefield under an opponent's control, you choose which creature it copies as it enters the battlefield under your control. -- If a Wizard would enter the battlefield under an opponent's control and that player controls Sage of Fables, the Wizard will not enter the battlefield with a +1/+1 counter on it as it enters the battlefield under your control. -- If a Wizard would enter the battlefield under an opponent's control and you control Sage of Fables, the Wizard will enter the battlefield with a +1/+1 counter on it as it enters the battlefield under your control."
+          "text": "The Gather Specimens replacement effect is applied before any other replacement effects that would also modify how the creature enters the battlefield. These are usually worded \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with.\" For example, if your Gather Specimens has resolved, then the following things are true: -- If a creature with devour would enter the battlefield under an opponent's control, you choose and sacrifice your creatures as it enters the battlefield under your control. -- If Voice of All would enter the battlefield under an opponent's control, you choose a color as it enters the battlefield under your control. -- If Clone would enter the battlefield under an opponent's control, you choose which creature it copies as it enters the battlefield under your control. -- If a Wizard would enter the battlefield under an opponent's control and that player controls Sage of Fables, the Wizard will not enter the battlefield with a +1/+1 counter on it as it enters the battlefield under your control. -- If a Wizard would enter the battlefield under an opponent's control and you control Sage of Fables, the Wizard will enter the battlefield with a +1/+1 counter on it as it enters the battlefield under your control."
         },
         {
           "date": "2008-10-01",
-          "text": "Gather Specimens won’t retroactively change the control of creatures that have already enter the battlefield that turn."
+          "text": "Gather Specimens won't retroactively change the control of creatures that have already enter the battlefield that turn."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects that put creatures onto the battlefield continue to affect those creatures later on. Although Gather Specimens changes whose control the creature enters the battlefield under, the rest of the effect works as normal. For example, if your opponent activates a creature card’s unearth ability and you cast Gather Specimens, that creature enters the battlefield under your control, but the rest of the unearth ability is unchanged. The creature has haste. It’s exiled at the beginning of the end step. If it would leave the battlefield, it’s exiled instead of being put anywhere else."
+          "text": "Some effects that put creatures onto the battlefield continue to affect those creatures later on. Although Gather Specimens changes whose control the creature enters the battlefield under, the rest of the effect works as normal. For example, if your opponent activates a creature card's unearth ability and you cast Gather Specimens, that creature enters the battlefield under your control, but the rest of the unearth ability is unchanged. The creature has haste. It's exiled at the beginning of the end step. If it would leave the battlefield, it's exiled instead of being put anywhere else."
         },
         {
           "date": "2008-10-01",
-          "text": "If the effect that puts a creature onto the battlefield also creates a delayed triggered ability, Gather Specimens doesn’t change who controls that ability. In the unearth example above, your opponent controls the ability that exiles the creature at the beginning of the end step. On the other hand, if the effect that puts a creature onto the battlefield grants a triggered ability to the creature (with “gains” or “has”), the player who controls the creature at the time the ability triggers will be the player who controls that ability. For example, if your opponent casts Makeshift Mannequin and you cast Gather Specimens in response, the creature will return to the battlefield under your control with a mannequin counter and it will have the ability “When this creature becomes the target of a spell or ability, sacrifice it.” If the ability triggers, you’ll control it, so you’ll have to sacrifice the creature."
+          "text": "If the effect that puts a creature onto the battlefield also creates a delayed triggered ability, Gather Specimens doesn't change who controls that ability. In the unearth example above, your opponent controls the ability that exiles the creature at the beginning of the end step. On the other hand, if the effect that puts a creature onto the battlefield grants a triggered ability to the creature (with \"gains\" or \"has\"), the player who controls the creature at the time the ability triggers will be the player who controls that ability. For example, if your opponent casts Makeshift Mannequin and you cast Gather Specimens in response, the creature will return to the battlefield under your control with a mannequin counter and it will have the ability \"When this creature becomes the target of a spell or ability, sacrifice it.\" If the ability triggers, you'll control it, so you'll have to sacrifice the creature."
         },
         {
           "date": "2008-10-01",
-          "text": "If two or more players have each cast Gather Specimens during the same turn and a creature would enter the battlefield, the creature’s would-be controller (the controller of the creature spell, for example) chooses one of the applicable Gather Specimens to apply. Then the new would-be controller of the creature repeats this process among the remaining Gather Specimens, and so on, until there are no more possible Gather Specimens effects to apply."
+          "text": "If two or more players have each cast Gather Specimens during the same turn and a creature would enter the battlefield, the creature's would-be controller (the controller of the creature spell, for example) chooses one of the applicable Gather Specimens to apply. Then the new would-be controller of the creature repeats this process among the remaining Gather Specimens, and so on, until there are no more possible Gather Specimens effects to apply."
         },
         {
           "date": "2008-10-01",
-          "text": "The above procedure means that if two opposing players have each cast Gather Specimens during the same turn and a creature would enter the battlefield under the control of one of them, it really will enter the battlefield under that player’s control. (The creature would enter the battlefield under player A’s control, so player B’s Gather Specimens affects it. Now that creature would enter the battlefield under player B’s control, so player A’s Gather Specimens affects it. Each replacement effect has now been used, so the creature will enter the battlefield under player A’s control.)"
+          "text": "The above procedure means that if two opposing players have each cast Gather Specimens during the same turn and a creature would enter the battlefield under the control of one of them, it really will enter the battlefield under that player's control. (The creature would enter the battlefield under player A's control, so player B's Gather Specimens affects it. Now that creature would enter the battlefield under player B's control, so player A's Gather Specimens affects it. Each replacement effect has now been used, so the creature will enter the battlefield under player A's control.)"
         }
       ],
       "text": "If a creature would enter the battlefield under an opponent's control this turn, it enters the battlefield under your control instead.",
@@ -5209,23 +5217,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -5330,23 +5338,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -5462,7 +5470,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Since Master of Etherium is an artifact itself, while it’s on the battlefield you will usually control at least one artifact."
+          "text": "Since Master of Etherium is an artifact itself, while it's on the battlefield you will usually control at least one artifact."
         }
       ],
       "subtypes": [
@@ -5667,19 +5675,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If an effect says “You may search your library . . . If you do, shuffle your library,” you can’t choose to search, so you won’t shuffle."
+          "text": "If an effect says \"You may search your library . . . If you do, shuffle your library,\" you can't choose to search, so you won't shuffle."
         },
         {
           "date": "2008-10-01",
-          "text": "If an effect says “Search your library . . . Then shuffle your library,” the search effect fails, but you will have to shuffle."
+          "text": "If an effect says \"Search your library . . . Then shuffle your library,\" the search effect fails, but you will have to shuffle."
         },
         {
           "date": "2008-10-01",
-          "text": "Since players can’t search, players won’t be able to find any cards in a library. The effect applies to all players and all libraries. If a spell or ability’s effect has other parts that don’t depend on searching for or finding cards, they will still work normally."
+          "text": "Since players can't search, players won't be able to find any cards in a library. The effect applies to all players and all libraries. If a spell or ability's effect has other parts that don't depend on searching for or finding cards, they will still work normally."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that tell a player to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word “search” will fail."
+          "text": "Effects that tell a player to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word \"search\" will fail."
         }
       ],
       "text": "Players can't search libraries.",
@@ -5784,11 +5792,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -5800,7 +5808,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -5910,7 +5918,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You can’t sacrifice Protomatter Powder to return itself to the battlefield. First you choose the target (at which time it’s still on the battlefield), then you pay the costs (at which time you sacrifice it)."
+          "text": "You can't sacrifice Protomatter Powder to return itself to the battlefield. First you choose the target (at which time it's still on the battlefield), then you pay the costs (at which time you sacrifice it)."
         }
       ],
       "text": "{4}{W}, {T}, Sacrifice Protomatter Powder: Return target artifact card from your graveyard to the battlefield.",
@@ -6019,11 +6027,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Return target permanent to its owner's hand.\nCycling {5}{W}{U}{B} ({5}{W}{U}{B}, Discard this card: Draw a card.)\nWhen you cycle Resounding Wave, return two target permanents to their owners' hands.",
@@ -6129,7 +6137,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If combat damage is dealt to players by multiple artifact creatures you control (including, perhaps, Sharding Sphinx itself), Sharding Sphinx’s ability will trigger that many times. You’ll get that many Thopter tokens. You’ll get just one token per creature, no matter how much combat damage that creature dealt."
+          "text": "If combat damage is dealt to players by multiple artifact creatures you control (including, perhaps, Sharding Sphinx itself), Sharding Sphinx's ability will trigger that many times. You'll get that many Thopter tokens. You'll get just one token per creature, no matter how much combat damage that creature dealt."
         }
       ],
       "subtypes": [
@@ -6238,19 +6246,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities; they have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities; they have colons in their reminder text."
         },
         {
           "date": "2008-10-01",
-          "text": "If an effect tells you to draw several cards, reveal each one before you draw it. Skill Borrower will momentarily gain the activated abilities of artifact and creature cards revealed this way, but you won’t be able to activate those abilities while the effect is still happening."
+          "text": "If an effect tells you to draw several cards, reveal each one before you draw it. Skill Borrower will momentarily gain the activated abilities of artifact and creature cards revealed this way, but you won't be able to activate those abilities while the effect is still happening."
         },
         {
           "date": "2008-10-01",
-          "text": "If the top card of your library changes while you’re activating one of Skill Borrower’s activated abilities gained from that card, the ability will still be activated and will resolve normally even though Skill Borrower has lost that ability."
+          "text": "If the top card of your library changes while you're activating one of Skill Borrower's activated abilities gained from that card, the ability will still be activated and will resolve normally even though Skill Borrower has lost that ability."
         },
         {
           "date": "2008-10-01",
-          "text": "Skill Borrower may gain activated abilities that it can’t use. For example, if the top card of your library is an artifact or creature card with cycling, Skill Borrower will have cycling. However, since cycling can’t be activated from the battlefield, this won’t have any significant benefit. The same is true for unearth."
+          "text": "Skill Borrower may gain activated abilities that it can't use. For example, if the top card of your library is an artifact or creature card with cycling, Skill Borrower will have cycling. However, since cycling can't be activated from the battlefield, this won't have any significant benefit. The same is true for unearth."
         }
       ],
       "subtypes": [
@@ -6461,7 +6469,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "To activate the ability, you must sacrifice three different creatures. You can’t sacrifice just one three-colored creature, for example."
+          "text": "To activate the ability, you must sacrifice three different creatures. You can't sacrifice just one three-colored creature, for example."
         },
         {
           "date": "2008-10-01",
@@ -6580,7 +6588,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you control two Steelclad Serpents, they’ll enable each other to attack."
+          "text": "If you control two Steelclad Serpents, they'll enable each other to attack."
         }
       ],
       "subtypes": [
@@ -6691,7 +6699,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "For the second ability, you choose the value of X when you activate it. You don’t look through your library until the ability resolves. (In other words, you can’t look through your library, decide what artifact card you want, and then determine what X is.) You can’t choose an X that’s greater than the number of loyalty counters on Tezzeret."
+          "text": "For the second ability, you choose the value of X when you activate it. You don't look through your library until the ability resolves. (In other words, you can't look through your library, decide what artifact card you want, and then determine what X is.) You can't choose an X that's greater than the number of loyalty counters on Tezzeret."
         },
         {
           "date": "2008-10-01",
@@ -6703,11 +6711,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -7016,11 +7024,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Each time you put the revealed card into your hand and lose the appropriate amount of life, you decide whether to continue by revealing another card. In other words, you don’t decide in advance how many cards to put into your hand this way."
+          "text": "Each time you put the revealed card into your hand and lose the appropriate amount of life, you decide whether to continue by revealing another card. In other words, you don't decide in advance how many cards to put into your hand this way."
         },
         {
           "date": "2008-10-01",
-          "text": "You may continue to reveal cards with Ad Nauseam even if your life total has been reduced to 0 or less. If you continue, you will continue to lose life, dropping your life total into negative numbers. As soon as you stop, you’ll lose the game as a state-based action."
+          "text": "You may continue to reveal cards with Ad Nauseam even if your life total has been reduced to 0 or less. If you continue, you will continue to lose life, dropping your life total into negative numbers. As soon as you stop, you'll lose the game as a state-based action."
         }
       ],
       "text": "Reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost. You may repeat this process any number of times.",
@@ -7121,11 +7129,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If Archdemon of Unx is the only non-Zombie creature you control when the triggered ability resolves, you’ll have to sacrifice it. You’ll still get a Zombie token."
+          "text": "If Archdemon of Unx is the only non-Zombie creature you control when the triggered ability resolves, you'll have to sacrifice it. You'll still get a Zombie token."
         },
         {
           "date": "2008-10-01",
-          "text": "If you somehow control no non-Zombie creatures when the triggered ability resolves, you won’t have to sacrifice anything. You’ll still get a Zombie token."
+          "text": "If you somehow control no non-Zombie creatures when the triggered ability resolves, you won't have to sacrifice anything. You'll still get a Zombie token."
         }
       ],
       "subtypes": [
@@ -7229,7 +7237,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The player who loses life is the player who controlled the creature when it was put into a graveyard. This may not be the player whose graveyard it was put into. That player loses life equal to the creature’s toughness as it last existed on the battlefield."
+          "text": "The player who loses life is the player who controlled the creature when it was put into a graveyard. This may not be the player whose graveyard it was put into. That player loses life equal to the creature's toughness as it last existed on the battlefield."
         }
       ],
       "subtypes": [
@@ -7454,11 +7462,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You must sacrifice exactly one creature to cast this spell; you can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast this spell; you can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "Once you begin to cast Bone Splinters, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast Bone Splinters, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         },
         {
           "date": "2017-03-14",
@@ -7565,23 +7573,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -7794,11 +7802,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "A creature that’s both a Skeleton and a Zombie will get the bonus only once."
+          "text": "A creature that's both a Skeleton and a Zombie will get the bonus only once."
         },
         {
           "date": "2008-10-01",
-          "text": "Death Baron doesn’t normally affect itself. If you manage to turn it into a Skeleton, however, then it will give itself +1/+1 and deathtouch."
+          "text": "Death Baron doesn't normally affect itself. If you manage to turn it into a Skeleton, however, then it will give itself +1/+1 and deathtouch."
         }
       ],
       "subtypes": [
@@ -8006,7 +8014,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "To activate the ability, you must sacrifice three different creatures. You can’t sacrifice just one three-colored creature, for example."
+          "text": "To activate the ability, you must sacrifice three different creatures. You can't sacrifice just one three-colored creature, for example."
         },
         {
           "date": "2008-10-01",
@@ -8222,23 +8230,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -8451,11 +8459,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you’ll have to sacrifice Fleshbag Marauder."
+          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you'll have to sacrifice Fleshbag Marauder."
         },
         {
           "date": "2015-06-22",
-          "text": "As Fleshbag Marauder’s ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
+          "text": "As Fleshbag Marauder's ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
         }
       ],
       "subtypes": [
@@ -8771,7 +8779,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The first ability exiles two cards in your graveyard as a cost. You can’t activate this ability unless you have at least two cards in your graveyard. Exiling those two cards can’t be responded to."
+          "text": "The first ability exiles two cards in your graveyard as a cost. You can't activate this ability unless you have at least two cards in your graveyard. Exiling those two cards can't be responded to."
         },
         {
           "date": "2008-10-01",
@@ -8779,7 +8787,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The third ability checks whether your graveyard is empty only at the time it triggers. Putting a card into your graveyard after that doesn’t help. You’ll lose the game when the ability resolves."
+          "text": "The third ability checks whether your graveyard is empty only at the time it triggers. Putting a card into your graveyard after that doesn't help. You'll lose the game when the ability resolves."
         },
         {
           "date": "2008-10-01",
@@ -8787,7 +8795,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Similarly, if the third ability resolves but you don’t lose the game for some reason (because you control Platinum Angel, perhaps), it will immediately trigger again if your graveyard is still empty. Immortal Coil + Platinum Angel + an empty graveyard is an involuntary infinite loop. Unless a player disrupts it, the game will end in a draw."
+          "text": "Similarly, if the third ability resolves but you don't lose the game for some reason (because you control Platinum Angel, perhaps), it will immediately trigger again if your graveyard is still empty. Immortal Coil + Platinum Angel + an empty graveyard is an involuntary infinite loop. Unless a player disrupts it, the game will end in a draw."
         },
         {
           "date": "2008-10-01",
@@ -9100,11 +9108,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The Homunculus you sacrifice due to the second ability isn’t limited to being a Homunculus token put onto the battlefield by Puppet Conjurer."
+          "text": "The Homunculus you sacrifice due to the second ability isn't limited to being a Homunculus token put onto the battlefield by Puppet Conjurer."
         },
         {
           "date": "2008-10-01",
-          "text": "If you control no Homunculi when the second ability resolves, nothing happens. There’s no penalty for failing to sacrifice a Homunculus."
+          "text": "If you control no Homunculi when the second ability resolves, nothing happens. There's no penalty for failing to sacrifice a Homunculus."
         }
       ],
       "subtypes": [
@@ -9219,11 +9227,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Target player discards a card at random.\nCycling {5}{U}{B}{R} ({5}{U}{B}{R}, Discard this card: Draw a card.)\nWhen you cycle Resounding Scream, target player discards two cards at random.",
@@ -9327,11 +9335,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Casting Salvage Titan by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
+          "text": "Casting Salvage Titan by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
         },
         {
           "date": "2008-10-01",
-          "text": "You may activate the second ability only if Salvage Titan is in your graveyard. To pay this ability’s cost, you may exile any three artifact cards in your graveyard — including Salvage Titan itself. If you exile it to pay the cost, however, it won’t be returned to your hand when the ability resolves."
+          "text": "You may activate the second ability only if Salvage Titan is in your graveyard. To pay this ability's cost, you may exile any three artifact cards in your graveyard — including Salvage Titan itself. If you exile it to pay the cost, however, it won't be returned to your hand when the ability resolves."
         }
       ],
       "subtypes": [
@@ -9536,7 +9544,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the targeted card is removed from the graveyard before Shadowfeed resolves, Shadowfeed is countered. You won’t gain 3 life."
+          "text": "If the targeted card is removed from the graveyard before Shadowfeed resolves, Shadowfeed is countered. You won't gain 3 life."
         }
       ],
       "text": "Exile target card from a graveyard. You gain 3 life.",
@@ -9737,7 +9745,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice Skeletal Kathari to pay for its own regeneration ability. If you do, however, it won’t regenerate. It’ll just end up in its owner’s graveyard as a result of the sacrifice."
+          "text": "You may sacrifice Skeletal Kathari to pay for its own regeneration ability. If you do, however, it won't regenerate. It'll just end up in its owner's graveyard as a result of the sacrifice."
         }
       ],
       "subtypes": [
@@ -9846,15 +9854,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         }
       ],
       "subtypes": [
@@ -9959,23 +9967,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -10089,11 +10097,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Vein Drinker had dealt damage to it at any time during that turn. If so, Vein Drinker’s third ability will trigger. It doesn’t matter whether the damage was combat damage or not. It also doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Vein Drinker had dealt damage to it at any time during that turn. If so, Vein Drinker's third ability will trigger. It doesn't matter whether the damage was combat damage or not. It also doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2008-10-01",
-          "text": "If Vein Drinker’s first ability causes Vein Drinker and the targeted creature to deal lethal damage to each other, they’ll be destroyed at the same time. Vein Drinker’s triggered ability will trigger, but it will have been put into a graveyard before it would receive any counters. The ability will do nothing when it resolves."
+          "text": "If Vein Drinker's first ability causes Vein Drinker and the targeted creature to deal lethal damage to each other, they'll be destroyed at the same time. Vein Drinker's triggered ability will trigger, but it will have been put into a graveyard before it would receive any counters. The ability will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -10197,23 +10205,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         },
         {
           "date": "2008-10-01",
@@ -10324,7 +10332,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -10429,7 +10437,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability checks the targeted creature’s power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
+          "text": "The ability checks the targeted creature's power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
         }
       ],
       "subtypes": [
@@ -10538,19 +10546,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         },
         {
           "date": "2008-10-01",
-          "text": "Caldera Hellion will deal 3 damage to itself (as well as to each other creature) when its enters-the-battlefield ability resolves. This damage will be lethal if Caldera Hellion hasn’t devoured any creatures and its toughness hasn’t been increased by any other means."
+          "text": "Caldera Hellion will deal 3 damage to itself (as well as to each other creature) when its enters-the-battlefield ability resolves. This damage will be lethal if Caldera Hellion hasn't devoured any creatures and its toughness hasn't been increased by any other means."
         }
       ],
       "subtypes": [
@@ -10854,7 +10862,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "To activate the ability, you must sacrifice three different creatures. You can’t sacrifice just one three-colored creature, for example."
+          "text": "To activate the ability, you must sacrifice three different creatures. You can't sacrifice just one three-colored creature, for example."
         },
         {
           "date": "2008-10-01",
@@ -10968,7 +10976,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The first ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control a creature with power 5 or greater as your end step begins, and (2) the ability will do nothing if you don’t control a creature with power 5 or greater by the time it resolves. (It doesn’t have to be the same creature as the one that allowed the ability to trigger.) Power-boosting effects that last “until end of turn” will still be in effect when this kind of ability triggers and resolves. An ability like this will trigger a maximum of once per turn, no matter how many applicable creatures you control."
+          "text": "The first ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control a creature with power 5 or greater as your end step begins, and (2) the ability will do nothing if you don't control a creature with power 5 or greater by the time it resolves. (It doesn't have to be the same creature as the one that allowed the ability to trigger.) Power-boosting effects that last \"until end of turn\" will still be in effect when this kind of ability triggers and resolves. An ability like this will trigger a maximum of once per turn, no matter how many applicable creatures you control."
         }
       ],
       "subtypes": [
@@ -11077,7 +11085,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You choose the target when the ability triggers. When the ability resolves, you choose a value for X and decide whether to pay {X}{R}. If you do decide to pay {X}{R}, it’s too late for any player to respond since the ability is already in the midst of resolving."
+          "text": "You choose the target when the ability triggers. When the ability resolves, you choose a value for X and decide whether to pay {X}{R}. If you do decide to pay {X}{R}, it's too late for any player to respond since the ability is already in the midst of resolving."
         }
       ],
       "subtypes": [
@@ -11182,7 +11190,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Goblin Assault’s second ability affects all Goblin creatures controlled by all players. It’s not limited to the tokens created with the first ability."
+          "text": "Goblin Assault's second ability affects all Goblin creatures controlled by all players. It's not limited to the tokens created with the first ability."
         }
       ],
       "text": "At the beginning of your upkeep, create a 1/1 red Goblin creature token with haste.\nGoblin creatures attack each turn if able.",
@@ -11386,23 +11394,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -11871,6 +11879,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -11884,6 +11896,10 @@
         },
         {
           "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -11913,7 +11929,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Magma Spray’s replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Magma Spray deals no damage to it (due to a prevention effect) or Magma Spray deals damage to a different creature (due to a redirection effect)."
+          "text": "Magma Spray's replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Magma Spray deals no damage to it (due to a prevention effect) or Magma Spray deals damage to a different creature (due to a redirection effect)."
         }
       ],
       "text": "Magma Spray deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
@@ -12018,15 +12034,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         }
       ],
       "subtypes": [
@@ -12139,11 +12155,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Resounding Thunder deals 3 damage to target creature or player.\nCycling {5}{B}{R}{G} ({5}{B}{R}{G}, Discard this card: Draw a card.)\nWhen you cycle Resounding Thunder, it deals 6 damage to target creature or player.",
@@ -12451,27 +12467,27 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         },
         {
           "date": "2017-03-14",
-          "text": "Scourge Devil’s triggered ability affects only creatures you control at the time it resolves, including Scourge Devil itself. Creatures you begin to control later in the turn won’t get +1/+0."
+          "text": "Scourge Devil's triggered ability affects only creatures you control at the time it resolves, including Scourge Devil itself. Creatures you begin to control later in the turn won't get +1/+0."
         }
       ],
       "subtypes": [
@@ -12576,7 +12592,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Skeletonize had dealt damage to it during that turn. If so, Skeletonize’s delayed triggered ability will trigger."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Skeletonize had dealt damage to it during that turn. If so, Skeletonize's delayed triggered ability will trigger."
         },
         {
           "date": "2008-10-01",
@@ -12680,7 +12696,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If either target has become illegal by the time Soul’s Fire resolves, the spell will still resolve but have no effect. If the first target is illegal, it can’t perform any actions, so it can’t deal damage. If the second target is illegal, there’s nothing for the first target to deal damage to. If both targets have become illegal, the spell will be countered."
+          "text": "If either target has become illegal by the time Soul's Fire resolves, the spell will still resolve but have no effect. If the first target is illegal, it can't perform any actions, so it can't deal damage. If the second target is illegal, there's nothing for the first target to deal damage to. If both targets have become illegal, the spell will be countered."
         }
       ],
       "text": "Target creature you control on the battlefield deals damage equal to its power to target creature or player.",
@@ -12787,15 +12803,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         }
       ],
       "subtypes": [
@@ -12907,15 +12923,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         }
       ],
       "subtypes": [
@@ -13121,11 +13137,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The player you target doesn’t have to be the controller of the creature that was put into a graveyard."
+          "text": "The player you target doesn't have to be the controller of the creature that was put into a graveyard."
         },
         {
           "date": "2008-10-01",
-          "text": "The number of cards in the targeted opponent’s hand is checked only when the ability resolves."
+          "text": "The number of cards in the targeted opponent's hand is checked only when the ability resolves."
         }
       ],
       "text": "Whenever a creature dies, you may have Vicious Shadows deal damage to target player equal to the number of cards in that player's hand.",
@@ -13227,23 +13243,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -13449,7 +13465,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability checks that creature’s power only once: when that creature enters the battlefield. The trigger checks a creature’s initial power upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it’s on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, boosting its power with a spell (such as Giant Growth), activated ability, or triggered ability won’t allow this ability to trigger; it’s too late by then. Once the ability triggers, it will resolve no matter what the creature’s power may become while the ability is on the stack."
+          "text": "The ability checks that creature's power only once: when that creature enters the battlefield. The trigger checks a creature's initial power upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it's on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, boosting its power with a spell (such as Giant Growth), activated ability, or triggered ability won't allow this ability to trigger; it's too late by then. Once the ability triggers, it will resolve no matter what the creature's power may become while the ability is on the stack."
         }
       ],
       "text": "Whenever a creature with power 5 or greater enters the battlefield under your control, you may have Where Ancients Tread deal 5 damage to target creature or player.",
@@ -13650,7 +13666,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "To activate the ability, you must sacrifice three different creatures. You can’t sacrifice just one three-colored creature, for example."
+          "text": "To activate the ability, you must sacrifice three different creatures. You can't sacrifice just one three-colored creature, for example."
         },
         {
           "date": "2008-10-01",
@@ -13868,11 +13884,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -13884,7 +13900,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -14191,7 +14207,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The first ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control a creature with power 5 or greater as your end step begins, and (2) the ability will do nothing if you don’t control a creature with power 5 or greater by the time it resolves. (It doesn’t have to be the same creature as the one that allowed the ability to trigger.) Power-boosting effects that last “until end of turn” will still be in effect when this kind of ability triggers and resolves. An ability like this will trigger a maximum of once per turn, no matter how many applicable creatures you control."
+          "text": "The first ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control a creature with power 5 or greater as your end step begins, and (2) the ability will do nothing if you don't control a creature with power 5 or greater by the time it resolves. (It doesn't have to be the same creature as the one that allowed the ability to trigger.) Power-boosting effects that last \"until end of turn\" will still be in effect when this kind of ability triggers and resolves. An ability like this will trigger a maximum of once per turn, no matter how many applicable creatures you control."
         }
       ],
       "subtypes": [
@@ -14612,7 +14628,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability checks the targeted creature’s power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
+          "text": "The ability checks the targeted creature's power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
         }
       ],
       "subtypes": [
@@ -14922,7 +14938,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the ability to tap to add {R}, {G}, or {W} to its controller’s mana pool. Lush Growth doesn’t change the enchanted land’s name or whether it’s legendary or basic."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the ability to tap to add {R}, {G}, or {W} to its controller's mana pool. Lush Growth doesn't change the enchanted land's name or whether it's legendary or basic."
         }
       ],
       "subtypes": [
@@ -15025,7 +15041,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability checks that creature’s power only once: when that creature enters the battlefield. The trigger checks a creature’s initial power upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it’s on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, boosting its power with a spell (such as Giant Growth), activated ability, or triggered ability won’t allow this ability to trigger; it’s too late by then. Once the ability triggers, it will resolve no matter what the creature’s power may become while the ability is on the stack."
+          "text": "The ability checks that creature's power only once: when that creature enters the battlefield. The trigger checks a creature's initial power upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it's on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, boosting its power with a spell (such as Giant Growth), activated ability, or triggered ability won't allow this ability to trigger; it's too late by then. Once the ability triggers, it will resolve no matter what the creature's power may become while the ability is on the stack."
         }
       ],
       "text": "Whenever a creature with power 5 or greater enters the battlefield under your control, you may put two +1/+1 counters on it.",
@@ -15127,7 +15143,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Converted mana cost takes into account only the mana symbols printed in the upper right corner of the card. Manaplasm doesn’t care about additional costs, alternative costs, cost-reduction effects, or what you actually paid to cast the spell."
+          "text": "Converted mana cost takes into account only the mana symbols printed in the upper right corner of the card. Manaplasm doesn't care about additional costs, alternative costs, cost-reduction effects, or what you actually paid to cast the spell."
         },
         {
           "date": "2008-10-01",
@@ -15236,7 +15252,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability checks the targeted creature’s power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
+          "text": "The ability checks the targeted creature's power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
         }
       ],
       "subtypes": [
@@ -15350,19 +15366,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         },
         {
           "date": "2008-10-01",
-          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn’t matter where the +1/+1 counters came from."
+          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn't matter where the +1/+1 counters came from."
         }
       ],
       "subtypes": [
@@ -15807,11 +15823,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Target creature gets +3/+3 until end of turn.\nCycling {5}{R}{G}{W} ({5}{R}{G}{W}, Discard this card: Draw a card.)\nWhen you cycle Resounding Roar, target creature gets +6/+6 until end of turn.",
@@ -15916,11 +15932,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -15932,7 +15948,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -16038,15 +16054,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This is a mana ability. It doesn’t use the stack, and it can’t be responded to."
+          "text": "This is a mana ability. It doesn't use the stack, and it can't be responded to."
         },
         {
           "date": "2008-10-01",
-          "text": "You can activate this ability even if you have no creature cards with power 5 or greater in your hand, or you have some but choose not to reveal any of them. In those cases, the ability won’t produce any mana."
+          "text": "You can activate this ability even if you have no creature cards with power 5 or greater in your hand, or you have some but choose not to reveal any of them. In those cases, the ability won't produce any mana."
         },
         {
           "date": "2008-10-01",
-          "text": "While you’re casting a creature spell, that card is on the stack, so you can’t reveal it with Sacellum Godspeaker’s ability to produce mana. You can, however, activate this mana ability and reveal that creature card from your hand before you begin to cast the card as a spell."
+          "text": "While you're casting a creature spell, that card is on the stack, so you can't reveal it with Sacellum Godspeaker's ability to produce mana. You can, however, activate this mana ability and reveal that creature card from your hand before you begin to cast the card as a spell."
         }
       ],
       "subtypes": [
@@ -16257,15 +16273,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         }
       ],
       "subtypes": [
@@ -16464,11 +16480,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability checks the targeted creature’s power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
+          "text": "The ability checks the targeted creature's power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -16573,7 +16589,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Since Topan Ascetic’s activated ability doesn’t have a tap symbol in its cost, you can tap a creature (including Topan Ascetic itself) that hasn’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since Topan Ascetic's activated ability doesn't have a tap symbol in its cost, you can tap a creature (including Topan Ascetic itself) that hasn't been under your control since your most recent turn began to pay the cost."
         }
       ],
       "subtypes": [
@@ -16681,7 +16697,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Wild Nacatl’s abilities check for lands with the subtypes Mountain and Plains. Those lands don’t need to be named Mountain and Plains. Wild Nacatl will get both bonuses if those two subtypes are contained among the lands you control, even if they’re from the same land (such as Plateau or Sacred Foundry)."
+          "text": "Wild Nacatl's abilities check for lands with the subtypes Mountain and Plains. Those lands don't need to be named Mountain and Plains. Wild Nacatl will get both bonuses if those two subtypes are contained among the lands you control, even if they're from the same land (such as Plateau or Sacred Foundry)."
         }
       ],
       "subtypes": [
@@ -16896,11 +16912,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target any permanent with Ajani Vengeant’s first ability. It doesn’t have to be tapped."
+          "text": "You may target any permanent with Ajani Vengeant's first ability. It doesn't have to be tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "The first ability tracks the permanent, but not its controller. If the permanent changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "The first ability tracks the permanent, but not its controller. If the permanent changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -17007,11 +17023,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -17119,7 +17135,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The targeted player will discard two cards even if some or all of Blightning’s damage is prevented or redirected."
+          "text": "The targeted player will discard two cards even if some or all of Blightning's damage is prevented or redirected."
         }
       ],
       "text": "Blightning deals 3 damage to target player. That player discards two cards.",
@@ -17222,11 +17238,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Blood Cultist had dealt any damage to it at any time during that turn. (This includes combat damage.) If so, Blood Cultist’s second ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Blood Cultist had dealt any damage to it at any time during that turn. (This includes combat damage.) If so, Blood Cultist's second ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2008-10-01",
-          "text": "If Blood Cultist and a creature it dealt damage to are both put into a graveyard at the same time, Blood Cultist’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Blood Cultist and a creature it dealt damage to are both put into a graveyard at the same time, Blood Cultist's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -17335,7 +17351,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may choose just the first mode (targeting a creature with flying), just the second mode (targeting a creature without flying), or both modes (targeting a creature with flying and a creature without flying). You can’t choose a mode unless there’s a legal target for it."
+          "text": "You may choose just the first mode (targeting a creature with flying), just the second mode (targeting a creature without flying), or both modes (targeting a creature with flying and a creature without flying). You can't choose a mode unless there's a legal target for it."
         }
       ],
       "text": "Choose one or both —\n• Branching Bolt deals 3 damage to target creature with flying.\n• Branching Bolt deals 3 damage to target creature without flying.",
@@ -17447,19 +17463,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You play cards from the chosen pile as part of the resolution of Brilliant Ultimatum. You may play them in any order. Timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other play restrictions are not (such as “Cast [this card] only during combat”). You play all of the cards you like, putting land onto the battlefield and spells on the stack, then Brilliant Ultimatum finishes resolving and is put into your graveyard. The spells you cast this way will then resolve as normal, one at a time, in the opposite order that they were put on the stack."
+          "text": "You play cards from the chosen pile as part of the resolution of Brilliant Ultimatum. You may play them in any order. Timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other play restrictions are not (such as \"Cast [this card] only during combat\"). You play all of the cards you like, putting land onto the battlefield and spells on the stack, then Brilliant Ultimatum finishes resolving and is put into your graveyard. The spells you cast this way will then resolve as normal, one at a time, in the opposite order that they were put on the stack."
         },
         {
           "date": "2008-10-01",
-          "text": "You can play a land card from the chosen pile only if it’s your turn (which it probably is, since Brilliant Ultimatum is a sorcery) and you haven’t yet played a land this turn. That means that if there are two lands in the chosen pile, you’ll be able to play a maximum of one of them."
+          "text": "You can play a land card from the chosen pile only if it's your turn (which it probably is, since Brilliant Ultimatum is a sorcery) and you haven't yet played a land this turn. That means that if there are two lands in the chosen pile, you'll be able to play a maximum of one of them."
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs, such as conspire costs and kicker costs."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs, such as conspire costs and kicker costs."
         },
         {
           "date": "2008-10-01",
-          "text": "The cards in the pile that wasn’t chosen remain exiled. Likewise, any cards in the chosen pile that you can’t play or you choose not to play remain exiled."
+          "text": "The cards in the pile that wasn't chosen remain exiled. Likewise, any cards in the chosen pile that you can't play or you choose not to play remain exiled."
         }
       ],
       "text": "Exile the top five cards of your library. An opponent separates those cards into two piles. You may play any number of cards from one of those piles without paying their mana costs.",
@@ -17775,7 +17791,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If Carrion Thrash and another creature are put into a graveyard from the battlefield at the same time, you may target the other creature with Carrion Thrash’s ability."
+          "text": "If Carrion Thrash and another creature are put into a graveyard from the battlefield at the same time, you may target the other creature with Carrion Thrash's ability."
         }
       ],
       "subtypes": [
@@ -17884,7 +17900,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This spell has no targets. You don’t choose five permanents you control until Clarion Ultimatum resolves. If you control fewer than five permanents at that time, choose each permanent you do control."
+          "text": "This spell has no targets. You don't choose five permanents you control until Clarion Ultimatum resolves. If you control fewer than five permanents at that time, choose each permanent you do control."
         },
         {
           "date": "2008-10-01",
@@ -17892,7 +17908,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you choose a permanent whose name has been changed by an effect (for example, a Clone that’s copying another creature), you’ll search for a card with the new name, not one with the original name. Note that changing a land’s subtype doesn’t change its name."
+          "text": "If you choose a permanent whose name has been changed by an effect (for example, a Clone that's copying another creature), you'll search for a card with the new name, not one with the original name. Note that changing a land's subtype doesn't change its name."
         },
         {
           "date": "2008-10-01",
@@ -17904,11 +17920,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cards all enter the battlefield at the same time. If one of the cards that’s entering the battlefield is an Aura, it must enter the battlefield attached to a permanent already on the battlefield. It can’t enter the battlefield attached to another permanent entering the battlefield via Clarion Ultimatum. If an Aura can’t enter the battlefield this way, it remains in your library."
+          "text": "The cards all enter the battlefield at the same time. If one of the cards that's entering the battlefield is an Aura, it must enter the battlefield attached to a permanent already on the battlefield. It can't enter the battlefield attached to another permanent entering the battlefield via Clarion Ultimatum. If an Aura can't enter the battlefield this way, it remains in your library."
         },
         {
           "date": "2008-10-01",
-          "text": "If you find a card that isn’t a permanent card while searching (for example, you chose an Illusion token and find the split card Illusion/Reality), that card remains in your library."
+          "text": "If you find a card that isn't a permanent card while searching (for example, you chose an Illusion token and find the split card Illusion/Reality), that card remains in your library."
         }
       ],
       "text": "Choose five permanents you control. For each of those permanents, you may search your library for a card with the same name as that permanent. Put those cards onto the battlefield tapped, then shuffle your library.",
@@ -18017,7 +18033,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Cruel Ultimatum’s only target is an opponent. You don’t choose which creature card in your graveyard you’ll return to your hand until Cruel Ultimatum resolves."
+          "text": "Cruel Ultimatum's only target is an opponent. You don't choose which creature card in your graveyard you'll return to your hand until Cruel Ultimatum resolves."
         },
         {
           "date": "2017-03-14",
@@ -18025,7 +18041,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If, as Cruel Ultimatum begins to resolve, your opponent’s life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent’s life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You’ll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
+          "text": "If, as Cruel Ultimatum begins to resolve, your opponent's life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent's life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You'll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
         }
       ],
       "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
@@ -18340,11 +18356,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -18453,23 +18469,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -18786,11 +18802,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -19004,7 +19020,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You may choose to target a spell that “can’t be countered.” If you do, the first part of Hindering Light’s effect won’t do anything, but you’ll still get to draw a card."
+          "text": "You may choose to target a spell that \"can't be countered.\" If you do, the first part of Hindering Light's effect won't do anything, but you'll still get to draw a card."
         }
       ],
       "text": "Counter target spell that targets you or a permanent you control.\nDraw a card.",
@@ -19211,11 +19227,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -19747,11 +19763,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -19860,7 +19876,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the targeted card is removed from the graveyard before the ability resolves, the ability is countered. You won’t get a Saproling token."
+          "text": "If the targeted card is removed from the graveyard before the ability resolves, the ability is countered. You won't get a Saproling token."
         }
       ],
       "text": "{2}: Exile target creature card from a graveyard. Create a 1/1 green Saproling creature token.",
@@ -19965,15 +19981,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "It doesn’t matter whose graveyard the permanent is put into as long as an opponent controlled it when it last existed on the battlefield."
+          "text": "It doesn't matter whose graveyard the permanent is put into as long as an opponent controlled it when it last existed on the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "If the ability triggers and your opponent chooses not to pay 3 life, you must return the card to the battlefield, even if you don’t want to."
+          "text": "If the ability triggers and your opponent chooses not to pay 3 life, you must return the card to the battlefield, even if you don't want to."
         },
         {
           "date": "2008-10-01",
-          "text": "If the permanent that caused the ability to trigger leaves the graveyard before the ability resolves (because it’s a token and it ceased to exist, or because a spell or ability removed it from the graveyard), the ability will still resolve. The opponent will have the option to pay 3 life. But whether or not that player pays the life, nothing will be returned to the battlefield."
+          "text": "If the permanent that caused the ability to trigger leaves the graveyard before the ability resolves (because it's a token and it ceased to exist, or because a spell or ability removed it from the graveyard), the ability will still resolve. The opponent will have the option to pay 3 life. But whether or not that player pays the life, nothing will be returned to the battlefield."
         }
       ],
       "subtypes": [
@@ -20081,7 +20097,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target a spell that “can’t be countered” with Punish Ignorance. If you do, the first part of Punish Ignorance’s effect won’t do anything, but the life-loss and life-gain effects will still work."
+          "text": "You may target a spell that \"can't be countered\" with Punish Ignorance. If you do, the first part of Punish Ignorance's effect won't do anything, but the life-loss and life-gain effects will still work."
         }
       ],
       "text": "Counter target spell. Its controller loses 3 life and you gain 3 life.",
@@ -20188,15 +20204,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you want to cast Qasali Ambusher by using its second ability, you don’t necessarily have to do it during the declare attackers step. You can do it later in combat (including all the way up through the end of combat step) as long as there’s still a creature attacking you. Of course, if you cast Qasali Ambusher later than the declare attackers step, it won’t be able to block."
+          "text": "If you want to cast Qasali Ambusher by using its second ability, you don't necessarily have to do it during the declare attackers step. You can do it later in combat (including all the way up through the end of combat step) as long as there's still a creature attacking you. Of course, if you cast Qasali Ambusher later than the declare attackers step, it won't be able to block."
         },
         {
           "date": "2008-10-01",
-          "text": "For you to cast Qasali Ambusher as described in its second ability, a creature has to be attacking *you*. If creatures are attacking only planeswalkers, you won’t be able to cast Qasali Ambusher this way. If you’re playing a Two-Headed Giant game and a creature is attacking your team, you will be able to cast Qasali Ambusher this way."
+          "text": "For you to cast Qasali Ambusher as described in its second ability, a creature has to be attacking *you*. If creatures are attacking only planeswalkers, you won't be able to cast Qasali Ambusher this way. If you're playing a Two-Headed Giant game and a creature is attacking your team, you will be able to cast Qasali Ambusher this way."
         },
         {
           "date": "2008-10-01",
-          "text": "Qasali Ambusher’s second ability is looking for lands with the subtypes Forest and Plains. Those lands don’t need to be named Forest and Plains. It’s okay if both subtypes are from the same land (such as Savannah or Temple Garden)."
+          "text": "Qasali Ambusher's second ability is looking for lands with the subtypes Forest and Plains. Those lands don't need to be named Forest and Plains. It's okay if both subtypes are from the same land (such as Savannah or Temple Garden)."
         }
       ],
       "subtypes": [
@@ -20311,11 +20327,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -20327,7 +20343,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -20441,7 +20457,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability checks the targeted creature’s power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
+          "text": "The ability checks the targeted creature's power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
         }
       ],
       "subtypes": [
@@ -20965,11 +20981,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Sarkhan Vol’s first ability affects only creatures you control when that ability resolves."
+          "text": "Sarkhan Vol's first ability affects only creatures you control when that ability resolves."
         },
         {
           "date": "2008-10-01",
-          "text": "You may target any creature with the second ability, not just a creature an opponent controls. If you target a creature you already control, you’ll gain control of it (which will usually have no visible effect), it’ll untap, and it’ll gain haste until end of turn."
+          "text": "You may target any creature with the second ability, not just a creature an opponent controls. If you target a creature you already control, you'll gain control of it (which will usually have no visible effect), it'll untap, and it'll gain haste until end of turn."
         }
       ],
       "subtypes": [
@@ -21077,23 +21093,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -21202,27 +21218,27 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         },
         {
           "date": "2008-10-01",
-          "text": "Despite the appearance of the reminder text, the unearth abilities that Sedris grants are activated abilities of each individual creature card in your graveyard. They’re not activated abilities of Sedris."
+          "text": "Despite the appearance of the reminder text, the unearth abilities that Sedris grants are activated abilities of each individual creature card in your graveyard. They're not activated abilities of Sedris."
         },
         {
           "date": "2008-10-01",
@@ -21448,7 +21464,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the targeted creature becomes an illegal target by the time Sigil Blessing resolves, the entire spell will be countered. Your other creatures won’t get +1/+1."
+          "text": "If the targeted creature becomes an illegal target by the time Sigil Blessing resolves, the entire spell will be countered. Your other creatures won't get +1/+1."
         }
       ],
       "text": "Until end of turn, target creature you control gets +3/+3 and other creatures you control get +1/+1.",
@@ -21879,7 +21895,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Noncreature permanents will untap as normal during their controllers’ untap steps."
+          "text": "Noncreature permanents will untap as normal during their controllers' untap steps."
         }
       ],
       "subtypes": [
@@ -21985,27 +22001,27 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Swerve targets only the spell whose target will be changed. It doesn’t directly affect the original target of that spell or the new target of that spell."
+          "text": "Swerve targets only the spell whose target will be changed. It doesn't directly affect the original target of that spell or the new target of that spell."
         },
         {
           "date": "2008-10-01",
-          "text": "You don’t choose the new target for the spell until Swerve resolves. You must change the target if possible. However, you can’t change the target to an illegal target. If there are no legal targets, the target isn’t changed. It doesn’t matter if the original target of that spell has somehow become illegal."
+          "text": "You don't choose the new target for the spell until Swerve resolves. You must change the target if possible. However, you can't change the target to an illegal target. If there are no legal targets, the target isn't changed. It doesn't matter if the original target of that spell has somehow become illegal."
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast Swerve on a spell that targets a spell on the stack (like Cancel does, for example), you can’t change that spell’s target to itself. You can, however, change that spell’s target to Swerve. If you do, that spell will be countered when it tries to resolve because Swerve will have left the stack by then."
+          "text": "If you cast Swerve on a spell that targets a spell on the stack (like Cancel does, for example), you can't change that spell's target to itself. You can, however, change that spell's target to Swerve. If you do, that spell will be countered when it tries to resolve because Swerve will have left the stack by then."
         },
         {
           "date": "2008-10-01",
-          "text": "If a spell targets multiple things, you can’t target it with Swerve, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Swerve, even if all but one of those targets has become illegal."
         },
         {
           "date": "2008-10-01",
-          "text": "If a spell targets the same player or object multiple times, you can’t target it with Swerve."
+          "text": "If a spell targets the same player or object multiple times, you can't target it with Swerve."
         },
         {
           "date": "2010-03-01",
-          "text": "An Aura spell on the stack targets the object or player which it will enchant upon entering the battlefield. Thus, an Aura spell is a “spell with a single target”, which means you may use Swerve to change that target. Doing so will cause it to enter the battlefield enchanting the new target rather than the original one."
+          "text": "An Aura spell on the stack targets the object or player which it will enchant upon entering the battlefield. Thus, an Aura spell is a \"spell with a single target\", which means you may use Swerve to change that target. Doing so will cause it to enter the battlefield enchanting the new target rather than the original one."
         }
       ],
       "text": "Change the target of target spell with a single target.",
@@ -22434,7 +22450,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature you control already has lifelink, Titanic Ultimatum will give it a second instance of lifelink; however, multiple instances of lifelink are redundant. You still only gain life equal to the amount of damage dealt, regardless of how many instances of lifelink the creature has."
+          "text": "If a creature you control already has lifelink, Titanic Ultimatum will give it a second instance of lifelink; however, multiple instances of lifelink on the same creature are redundant. You still only gain life equal to the amount of damage dealt, regardless of how many instances of lifelink the creature has."
         }
       ],
       "text": "Until end of turn, creatures you control get +5/+5 and gain first strike, lifelink, and trample.",
@@ -22753,11 +22769,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -22769,7 +22785,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -23081,71 +23097,71 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Lich’s Mirror has no effect if a spell or ability (such as the one from Helix Pinnacle) states that a player “wins the game.” If a player wins the game, the game ends immediately."
+          "text": "Lich's Mirror has no effect if a spell or ability (such as the one from Helix Pinnacle) states that a player \"wins the game.\" If a player wins the game, the game ends immediately."
         },
         {
           "date": "2008-10-01",
-          "text": "Lich’s Mirror has no effect if you concede the game. If you concede, you’ll lose."
+          "text": "Lich's Mirror has no effect if you concede the game. If you concede, you'll lose."
         },
         {
           "date": "2008-10-01",
-          "text": "If you can’t lose the game (for example, you control a Platinum Angel), Lich’s Mirror won’t do anything."
+          "text": "If you can't lose the game (for example, you control a Platinum Angel), Lich's Mirror won't do anything."
         },
         {
           "date": "2008-10-01",
-          "text": "Lich’s Mirror shuffles permanents you own into your library, regardless of who controls them."
+          "text": "Lich's Mirror shuffles permanents you own into your library, regardless of who controls them."
         },
         {
           "date": "2008-10-01",
-          "text": "Lich’s Mirror shuffles tokens you own into your library, too. The tokens you own will leave play. However, there’s no point to physically shuffling tokens into your library because you can’t draw them as part of Lich’s Mirror’s effect and they’ll cease to exist immediately afterwards."
+          "text": "Lich's Mirror shuffles tokens you own into your library, too. The tokens you own will leave play. However, there's no point to physically shuffling tokens into your library because you can't draw them as part of Lich's Mirror's effect and they'll cease to exist immediately afterwards."
         },
         {
           "date": "2008-10-01",
-          "text": "Any abilities that trigger when the permanents leave the battlefield will be put on the stack after Lich’s Mirror’s entire effect has been applied."
+          "text": "Any abilities that trigger when the permanents leave the battlefield will be put on the stack after Lich's Mirror's entire effect has been applied."
         },
         {
           "date": "2008-10-01",
-          "text": "Lich’s Mirror doesn’t affect spells on the stack, cards that have been exiled, or permanents you control but don’t own. They’ll stay where they are. Spells on the stack will then resolve as normal."
+          "text": "Lich's Mirror doesn't affect spells on the stack, cards that have been exiled, or permanents you control but don't own. They'll stay where they are. Spells on the stack will then resolve as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Although Lich’s Mirror has you draw a hand of seven cards and sets your life total to 20, this isn’t a game restart. You can’t take a mulligan if you don’t like your new hand of cards."
+          "text": "Although Lich's Mirror has you draw a hand of seven cards and sets your life total to 20, this isn't a game restart. You can't take a mulligan if you don't like your new hand of cards."
         },
         {
           "date": "2008-10-01",
-          "text": "For your life total to become 20, you actually gain or lose the necessary amount of life. Keep in mind that you may have a negative life total when this happens. For example, if your life total is -4 when you would lose the game, Lich’s Mirror’s effect will cause you to gain 24 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For your life total to become 20, you actually gain or lose the necessary amount of life. Keep in mind that you may have a negative life total when this happens. For example, if your life total is -4 when you would lose the game, Lich's Mirror's effect will cause you to gain 24 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2008-10-01",
-          "text": "As part of Lich's Mirror's effect, it typically shuffles itself into your library. If it does, that means that if you'd lose the game *again* immediately after its effect is finished, it can't help you a second time. This can occur in a few different ways. For example: -- You have ten or more poison counters. Lich's Mirror doesn't remove poison counters. If you'd lose the game this way, you'll do what Lich's Mirror says, then you'll lose the game the next time state-based actions are checked. -- Your life total is 0 or less and an effect says that you can't gain life. Since your life total can't be raised, it stays at whatever it is rather than becoming 20, and you'll lose the game the next time state-based actions are checked. -- The number of nontoken permanents you own plus the number of cards in your hand, graveyard, and library is less than seven. When you try to draw seven cards as part of Lich's Mirror's effect, you'll be unable to complete at least one of those draws and you'll lose the game the next time state-based actions are checked. -- You control *but don't own* a permanent such as Immortal Coil with a triggered ability that causes you to lose the game when a certain game state happens (also known as a “state trigger”), and the condition that causes the “lose the game” ability to trigger hasn't changed. If you owned the permanent, Lich's Mirror would shuffle it into your library. In this case, however, it remains on the battlefield and its ability will trigger again."
+          "text": "As part of Lich's Mirror's effect, it typically shuffles itself into your library. If it does, that means that if you'd lose the game *again* immediately after its effect is finished, it can't help you a second time. This can occur in a few different ways. For example: -- You have ten or more poison counters. Lich's Mirror doesn't remove poison counters. If you'd lose the game this way, you'll do what Lich's Mirror says, then you'll lose the game the next time state-based actions are checked. -- Your life total is 0 or less and an effect says that you can't gain life. Since your life total can't be raised, it stays at whatever it is rather than becoming 20, and you'll lose the game the next time state-based actions are checked. -- The number of nontoken permanents you own plus the number of cards in your hand, graveyard, and library is less than seven. When you try to draw seven cards as part of Lich's Mirror's effect, you'll be unable to complete at least one of those draws and you'll lose the game the next time state-based actions are checked. -- You control *but don't own* a permanent such as Immortal Coil with a triggered ability that causes you to lose the game when a certain game state happens (also known as a \"state trigger\"), and the condition that causes the \"lose the game\" ability to trigger hasn't changed. If you owned the permanent, Lich's Mirror would shuffle it into your library. In this case, however, it remains on the battlefield and its ability will trigger again."
         },
         {
           "date": "2008-10-01",
-          "text": "If you control *but don’t own* Lich’s Mirror, Lich’s Mirror itself will still be on the battlefield after its effect is finished. If you would lose the game again for any of the reasons above, Lich’s Mirror has its effect again . . . and again . . . and again. An involuntary infinite loop will be created, and the game will end in a draw. (In the case of the triggered ability example given last in the list above, it’s possible that a player could cause the loop to end while the ability is on the stack. None of the loops caused by state-based actions can be stopped at all.)"
+          "text": "If you control *but don't own* Lich's Mirror, Lich's Mirror itself will still be on the battlefield after its effect is finished. If you would lose the game again for any of the reasons above, Lich's Mirror has its effect again . . . and again . . . and again. An involuntary infinite loop will be created, and the game will end in a draw. (In the case of the triggered ability example given last in the list above, it's possible that a player could cause the loop to end while the ability is on the stack. None of the loops caused by state-based actions can be stopped at all.)"
         },
         {
           "date": "2008-10-01",
-          "text": "If all the players remaining in a game would lose simultaneously but one of them controls Lich’s Mirror, that player does what Lich’s Mirror says instead of losing, and everyone else loses. As a result, the controller of Lich’s Mirror wins the game because all of his or her opponents have lost. (If Lich’s Mirror weren’t in the picture, then the game would be a draw.)"
+          "text": "If all the players remaining in a game would lose simultaneously but one of them controls Lich's Mirror, that player does what Lich's Mirror says instead of losing, and everyone else loses. As a result, the controller of Lich's Mirror wins the game because all of his or her opponents have lost. (If Lich's Mirror weren't in the picture, then the game would be a draw.)"
         },
         {
           "date": "2008-10-01",
-          "text": "If a spell causes you to lose the game the next time state-based actions are checked (by dealing damage to you greater than your life total, for example), that spell will already be in the graveyard by the time Lich’s Mirror’s effect happens. If it’s in your graveyard, it will be shuffled into your library."
+          "text": "If a spell causes you to lose the game the next time state-based actions are checked (by dealing damage to you greater than your life total, for example), that spell will already be in the graveyard by the time Lich's Mirror's effect happens. If it's in your graveyard, it will be shuffled into your library."
         },
         {
           "date": "2008-10-01",
-          "text": "If, during a check of state-based actions, you’d lose the game at the same time a creature you own would be put into your graveyard (due to an Earthquake for 10 or combat damage dealt to both you and the creature, for example), that creature’s controller has a choice to make. The state-based actions rule is trying to simultaneously (a) shuffle that creature card into your library (due to Lich’s Mirror’s replacement effect) and (b) put it into your graveyard. Only one of those things can happen. The creature’s controller chooses which one. If the creature is put into your graveyard, it isn’t shuffled into your library. Abilities that trigger when that creature is put into a graveyard will trigger only if that option is chosen."
+          "text": "If, during a check of state-based actions, you'd lose the game at the same time a creature you own would be put into your graveyard (due to an Earthquake for 10 or combat damage dealt to both you and the creature, for example), that creature's controller has a choice to make. The state-based actions rule is trying to simultaneously (a) shuffle that creature card into your library (due to Lich's Mirror's replacement effect) and (b) put it into your graveyard. Only one of those things can happen. The creature's controller chooses which one. If the creature is put into your graveyard, it isn't shuffled into your library. Abilities that trigger when that creature is put into a graveyard will trigger only if that option is chosen."
         },
         {
           "date": "2008-10-01",
-          "text": "If, during a check of state-based actions, you’d lose the game for multiple reasons (for example, if you were at 1 life and had one card in your library, then Night’s Whisper caused you to draw two cards and lose 2 life), a single Lich’s Mirror will replace all of them. You’ll do what Lich’s Mirror says just once."
+          "text": "If, during a check of state-based actions, you'd lose the game for multiple reasons (for example, if you were at 1 life and had one card in your library, then Night's Whisper caused you to draw two cards and lose 2 life), a single Lich's Mirror will replace all of them. You'll do what Lich's Mirror says just once."
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, if your team would lose the game and you control Lich’s Mirror, your team won’t lose. Instead, you’ll do what Lich’s Mirror says and your teammate won’t do anything. This is true even if the reason your team would lose is because your teammate tried to draw a card with an empty library or was affected by an ability that said he or she lost the game. Your life total (which is the same as your team’s life total) becomes 20. Your team’s life total is adjusted by the amount of life you gain or lose as a result of this, which basically means your team’s life total becomes 20."
+          "text": "In a Two-Headed Giant game, if your team would lose the game and you control Lich's Mirror, your team won't lose. Instead, you'll do what Lich's Mirror says and your teammate won't do anything. This is true even if the reason your team would lose is because your teammate tried to draw a card with an empty library or was affected by an ability that said he or she lost the game. Your life total (which is the same as your team's life total) becomes 20. Your team's life total is adjusted by the amount of life you gain or lose as a result of this, which basically means your team's life total becomes 20."
         }
       ],
       "text": "If you would lose the game, instead shuffle your hand, your graveyard, and all permanents you own into your library, then draw seven cards and your life total becomes 20.",
@@ -23239,15 +23255,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "As the token is created, it checks the printed values of the creature it’s copying, as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, and so on."
+          "text": "As the token is created, it checks the printed values of the creature it's copying, as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, and so on."
         },
         {
           "date": "2008-10-01",
-          "text": "The copiable values of the token’s characteristics are the same as the copiable values of the characteristics of the creature it’s copying, plus haste and “At end of turn, sacrifice this permanent.” That means if something becomes a copy of the token, it will also have haste and it will also have to be sacrificed at the end of the turn."
+          "text": "The copiable values of the token's characteristics are the same as the copiable values of the characteristics of the creature it's copying, plus haste and \"At end of turn, sacrifice this permanent.\" That means if something becomes a copy of the token, it will also have haste and it will also have to be sacrificed at the end of the turn."
         },
         {
           "date": "2008-10-01",
-          "text": "If the creature that caused Minion Reflector’s ability to trigger has already left the battlefield by the time the ability resolves, you can still pay {2}. If you do, you’ll still put a token onto the battlefield. That token has the copiable values of the characteristics of that nontoken creature as it last existed on the battlefield."
+          "text": "If the creature that caused Minion Reflector's ability to trigger has already left the battlefield by the time the ability resolves, you can still pay {2}. If you do, you'll still put a token onto the battlefield. That token has the copiable values of the characteristics of that nontoken creature as it last existed on the battlefield."
         }
       ],
       "text": "Whenever a nontoken creature enters the battlefield under your control, you may pay {2}. If you do, create a token that's a copy of that creature. That token has haste and \"At the beginning of the end step, sacrifice this permanent.\"",
@@ -23813,7 +23829,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "That player loses half his or her life after combat damage has been subtracted from the player’s life total. The amount of life the player loses is determined as the triggered ability resolves."
+          "text": "That player loses half his or her life after combat damage has been subtracted from the player's life total. The amount of life the player loses is determined as the triggered ability resolves."
         },
         {
           "date": "2008-10-01",
@@ -23821,7 +23837,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, if a creature equipped with Quietus Spike would assign combat damage to the defending team, its damage is assigned to only one of the defending players. After combat damage is dealt, Quietus Spike looks at that player’s life total (which is the same as the team’s life total) when determining how much life the team will lose, which basically means the team’s life total is halved. Here’s an example of the math: The team has 19 life, so the player has 19 life. Quietus Spike causes the team to lose 10 life (19 divided by 2, rounded up). The team’s life total becomes 9 (19 minus 10)."
+          "text": "In a Two-Headed Giant game, if a creature equipped with Quietus Spike would assign combat damage to the defending team, its damage is assigned to only one of the defending players. After combat damage is dealt, Quietus Spike looks at that player's life total (which is the same as the team's life total) when determining how much life the team will lose, which basically means the team's life total is halved. Here's an example of the math: The team has 19 life, so the player has 19 life. Quietus Spike causes the team to lose 10 life (19 divided by 2, rounded up). The team's life total becomes 9 (19 minus 10)."
         }
       ],
       "subtypes": [
@@ -23922,11 +23938,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If you activate Relic of Progenitus’s first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
+          "text": "If you activate Relic of Progenitus's first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "You can activate Relic of Progenitus’s second ability even if no players have any cards in their graveyards. You’ll still draw a card."
+          "text": "You can activate Relic of Progenitus's second ability even if no players have any cards in their graveyards. You'll still draw a card."
         }
       ],
       "text": "{T}: Target player exiles a card from his or her graveyard.\n{1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.",
@@ -24019,7 +24035,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Removing a charge counter from Sigil of Distinction is the only way to pay for its equip ability. If it has no charge counters on it, its equip ability can’t be activated."
+          "text": "Removing a charge counter from Sigil of Distinction is the only way to pay for its equip ability. If it has no charge counters on it, its equip ability can't be activated."
         },
         {
           "date": "2008-10-01",

--- a/json/ALL.json
+++ b/json/ALL.json
@@ -199,7 +199,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"The ‘fabled' Order of Stromgald is cast to the four winds, lost for all time. I, for one, give them no thought.\"\n—General Varchild",
+      "flavor": "\"The 'fabled' Order of Stromgald is cast to the four winds, lost for all time. I, for one, give them no thought.\"\n—General Varchild",
       "id": "3632d3f3a3dfbcdcd826523788caa0a86772b904",
       "imageName": "agent of stromgald2",
       "layout": "normal",
@@ -291,7 +291,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "The controller of the countered spell doesn’t choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
+          "text": "The controller of the countered spell doesn't choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
         }
       ],
       "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
@@ -349,7 +349,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "The controller of the countered spell doesn’t choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
+          "text": "The controller of the countered spell doesn't choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
         }
       ],
       "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
@@ -659,7 +659,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the ability is activated during a turn’s Ending phase (after any “at the beginning of the End step” triggers would have triggered that turn), the Graveborn token will remain on the battlefield until the following turn’s End step."
+          "text": "If the ability is activated during a turn's Ending phase (after any \"at the beginning of the End step\" triggers would have triggered that turn), the Graveborn token will remain on the battlefield until the following turn's End step."
         }
       ],
       "subtypes": [
@@ -948,7 +948,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Untapping a tapped land an opponent controls is part of the cost of Benthic Explorers’s ability. If no opponent controls a tapped land, the ability can’t be activated."
+          "text": "Untapping a tapped land an opponent controls is part of the cost of Benthic Explorers's ability. If no opponent controls a tapped land, the ability can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -956,15 +956,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Benthic Explorers checks the effects of all mana-producing abilities of the land untapped to pay its cost, but it doesn’t check the costs of those abilities. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If you untap a tapped Vivid Crag an opponent controls while paying for Benthic Explorers’s ability, you can add one mana of any color to your mana pool. It doesn’t matter whether that Vivid Crag has a charge counter on it."
+          "text": "Benthic Explorers checks the effects of all mana-producing abilities of the land untapped to pay its cost, but it doesn't check the costs of those abilities. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If you untap a tapped Vivid Crag an opponent controls while paying for Benthic Explorers's ability, you can add one mana of any color to your mana pool. It doesn't matter whether that Vivid Crag has a charge counter on it."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what types of mana an opponent’s land could produce, take into account any applicable replacement effects that would apply to that land’s mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what types of mana an opponent's land could produce, take into account any applicable replacement effects that would apply to that land's mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Benthic Explorers doesn’t care about any restrictions or riders an opponent’s land (such as Ancient Ziggurat or Hall of the Bandit Lord) puts on the mana it produces. It just cares about types of mana."
+          "text": "Benthic Explorers doesn't care about any restrictions or riders an opponent's land (such as Ancient Ziggurat or Hall of the Bandit Lord) puts on the mana it produces. It just cares about types of mana."
         }
       ],
       "subtypes": [
@@ -1030,7 +1030,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Untapping a tapped land an opponent controls is part of the cost of Benthic Explorers’s ability. If no opponent controls a tapped land, the ability can’t be activated."
+          "text": "Untapping a tapped land an opponent controls is part of the cost of Benthic Explorers's ability. If no opponent controls a tapped land, the ability can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -1038,15 +1038,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Benthic Explorers checks the effects of all mana-producing abilities of the land untapped to pay its cost, but it doesn’t check the costs of those abilities. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If you untap a tapped Vivid Crag an opponent controls while paying for Benthic Explorers’s ability, you can add one mana of any color to your mana pool. It doesn’t matter whether that Vivid Crag has a charge counter on it."
+          "text": "Benthic Explorers checks the effects of all mana-producing abilities of the land untapped to pay its cost, but it doesn't check the costs of those abilities. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If you untap a tapped Vivid Crag an opponent controls while paying for Benthic Explorers's ability, you can add one mana of any color to your mana pool. It doesn't matter whether that Vivid Crag has a charge counter on it."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what types of mana an opponent’s land could produce, take into account any applicable replacement effects that would apply to that land’s mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what types of mana an opponent's land could produce, take into account any applicable replacement effects that would apply to that land's mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Benthic Explorers doesn’t care about any restrictions or riders an opponent’s land (such as Ancient Ziggurat or Hall of the Bandit Lord) puts on the mana it produces. It just cares about types of mana."
+          "text": "Benthic Explorers doesn't care about any restrictions or riders an opponent's land (such as Ancient Ziggurat or Hall of the Bandit Lord) puts on the mana it produces. It just cares about types of mana."
         }
       ],
       "subtypes": [
@@ -1311,7 +1311,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target any instant spell with Burnout. If it’s blue at the time Burnout resolves, that spell will be countered and you’ll draw a card at the beginning of the next turn’s upkeep. If it’s not blue at the time Burnout resolves, that spell won’t be countered, but you’ll still draw a card at the beginning of the next turn’s upkeep."
+          "text": "You may target any instant spell with Burnout. If it's blue at the time Burnout resolves, that spell will be countered and you'll draw a card at the beginning of the next turn's upkeep. If it's not blue at the time Burnout resolves, that spell won't be countered, but you'll still draw a card at the beginning of the next turn's upkeep."
         }
       ],
       "text": "Counter target instant spell if it's blue.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -1802,7 +1802,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "A card is “directly above” another card in your graveyard if it was put into that graveyard later and there are no cards in between the two."
+          "text": "A card is \"directly above\" another card in your graveyard if it was put into that graveyard later and there are no cards in between the two."
         },
         {
           "date": "2008-10-01",
@@ -1814,11 +1814,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "text": "Death Spark deals 1 damage to target creature or player.\nAt the beginning of your upkeep, if Death Spark is in your graveyard with a creature card directly above it, you may pay {1}. If you do, return Death Spark to your hand.",
@@ -1877,11 +1877,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Diminishing Returns won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "Diminishing Returns won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         },
         {
           "date": "2016-06-08",
-          "text": "The exiled cards are exiled face up. You’ll see them before you choose how many cards to draw."
+          "text": "The exiled cards are exiled face up. You'll see them before you choose how many cards to draw."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library. You exile the top ten cards of your library. Then each player draws up to seven cards.",
@@ -2435,7 +2435,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -2503,7 +2503,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -2642,7 +2642,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"Far too many of our missing ‘dead' seem to be turning up in Varchild's ranks\"\n—King Darien of Kjeldor",
+      "flavor": "\"Far too many of our missing 'dead' seem to be turning up in Varchild's ranks\"\n—King Darien of Kjeldor",
       "id": "f83d5301ced122f26aa66169449745a408ce61ef",
       "imageName": "false demise1",
       "layout": "normal",
@@ -2735,7 +2735,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The opponent chooses which option they want (this is a mode choice). If they choose the “destroy” option, you choose the zero, one, or two targets after that."
+          "text": "The opponent chooses which option they want (this is a mode choice). If they choose the \"destroy\" option, you choose the zero, one, or two targets after that."
         }
       ],
       "text": "An opponent chooses one —\n• You draw three cards.\n• You destroy up to two target creatures that player controls. They can't be regenerated. That player draws up to three cards.",
@@ -3481,7 +3481,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"Beneath serenity may lie\n a hidden rage.\"\n—Jaeuhl Carthalion,\nJuniper Order Advocate",
+      "flavor": "\"Beneath serenity may lie\na hidden rage.\"\n—Jaeuhl Carthalion,\nJuniper Order Advocate",
       "id": "33835c74891ee8a5610cd818b3aa129f5738581d",
       "imageName": "gorilla berserkers2",
       "layout": "normal",
@@ -3776,7 +3776,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"The only ‘art' these beasts possess is the art of noise!\" —Jaya Ballard",
+      "flavor": "\"The only 'art' these beasts possess is the art of noise!\" —Jaya Ballard",
       "id": "f35890c2b9a83f05af9aa6a10e6786ed3ca61cba",
       "imageName": "gorilla war cry1",
       "layout": "normal",
@@ -3811,7 +3811,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Gorilla War Cry only during combat before blockers are declared.\nAll creatures gain menace until end of turn. (They can't be blocked except by two or more creatures.)\nDraw a card at the beginning of the next turn's upkeep.",
@@ -3867,7 +3867,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Gorilla War Cry only during combat before blockers are declared.\nAll creatures gain menace until end of turn. (They can't be blocked except by two or more creatures.)\nDraw a card at the beginning of the next turn's upkeep.",
@@ -4058,7 +4058,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The last ability will trigger when a different player gains control of Gustha’s Scepter, as well as when Gustha’s Scepter leaves the battlefield."
+          "text": "The last ability will trigger when a different player gains control of Gustha's Scepter, as well as when Gustha's Scepter leaves the battlefield."
         }
       ],
       "text": "{T}: Exile a card from your hand face down. You may look at it for as long as it remains exiled.\n{T}: Return a card you own exiled with Gustha's Scepter to your hand.\nWhen you lose control of Gustha's Scepter, put all cards exiled with Gustha's Scepter into their owner's graveyard.",
@@ -4211,11 +4211,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You put the creature card onto the battlefield even if you can’t sacrifice Helm of Obedience (because it’s left the battlefield by the time its ability resolves, for example)."
+          "text": "You put the creature card onto the battlefield even if you can't sacrifice Helm of Obedience (because it's left the battlefield by the time its ability resolves, for example)."
         },
         {
           "date": "2008-10-01",
-          "text": "If an effect like that of Leyline of the Void prevents cards from being put into your opponent’s graveyard, the process described in the first sentence of Helm of Obedience’s effect will never stop. Your opponent’s entire library will be exiled, even if X is 1."
+          "text": "If an effect like that of Leyline of the Void prevents cards from being put into your opponent's graveyard, the process described in the first sentence of Helm of Obedience's effect will never stop. Your opponent's entire library will be exiled, even if X is 1."
         }
       ],
       "text": "{X}, {T}: Target opponent puts cards from the top of his or her library into his or her graveyard until a creature card or X cards are put into that graveyard this way, whichever comes first. If a creature card is put into that graveyard this way, sacrifice Helm of Obedience and put that card onto the battlefield under your control. X can't be 0.",
@@ -4269,7 +4269,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If Inheritance and a creature are each put into a graveyard from the battlefield at the same time, Inheritance’s ability will trigger."
+          "text": "If Inheritance and a creature are each put into a graveyard from the battlefield at the same time, Inheritance's ability will trigger."
         }
       ],
       "text": "Whenever a creature dies, you may pay {3}. If you do, draw a card.",
@@ -4432,7 +4432,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The player who controlled Ivory Gargoyle when it was put into a graveyard will skip his or her next draw step even if Ivory Gargoyle is returned to the battlefield under a different player’s control (because it’s owned by someone else) or isn’t returned to the battlefield at all (because it left the graveyard before the end of the turn, for example)."
+          "text": "The player who controlled Ivory Gargoyle when it was put into a graveyard will skip his or her next draw step even if Ivory Gargoyle is returned to the battlefield under a different player's control (because it's owned by someone else) or isn't returned to the battlefield at all (because it left the graveyard before the end of the turn, for example)."
         },
         {
           "date": "2008-10-01",
@@ -4556,7 +4556,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Kaysa’s ability affects itself."
+          "text": "Kaysa's ability affects itself."
         }
       ],
       "subtypes": [
@@ -4622,7 +4622,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -4679,7 +4679,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -4752,7 +4752,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -4827,11 +4827,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability will trigger only if Kjeldoran Home Guard is still on the battlefield at end of combat. If it’s been dealt lethal combat damage and destroyed during that combat (or has left the battlefield during that combat by any other means), its ability won’t trigger and you won’t get a token."
+          "text": "The ability will trigger only if Kjeldoran Home Guard is still on the battlefield at end of combat. If it's been dealt lethal combat damage and destroyed during that combat (or has left the battlefield during that combat by any other means), its ability won't trigger and you won't get a token."
         },
         {
           "date": "2008-10-01",
-          "text": "You put the Deserter token onto the battlefield even if you can’t put a -0/-1 counter on Kjeldoran Home Guard (because it left the battlefield after its ability triggered but before it resolved, for example)."
+          "text": "You put the Deserter token onto the battlefield even if you can't put a -0/-1 counter on Kjeldoran Home Guard (because it left the battlefield after its ability triggered but before it resolved, for example)."
         }
       ],
       "subtypes": [
@@ -5221,7 +5221,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Shuffling a card from your hand into your library is mandatory. The effect says “if you do” because performing that action might have been impossible. If you fail to shuffle a card into your library because your hand was empty, you won’t draw any cards."
+          "text": "Shuffling a card from your hand into your library is mandatory. The effect says \"if you do\" because performing that action might have been impossible. If you fail to shuffle a card into your library because your hand was empty, you won't draw any cards."
         }
       ],
       "text": "Shuffle a card from your hand into your library. If you do, draw two cards at the beginning of the next turn's upkeep.",
@@ -5278,7 +5278,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Shuffling a card from your hand into your library is mandatory. The effect says “if you do” because performing that action might have been impossible. If you fail to shuffle a card into your library because your hand was empty, you won’t draw any cards."
+          "text": "Shuffling a card from your hand into your library is mandatory. The effect says \"if you do\" because performing that action might have been impossible. If you fail to shuffle a card into your library because your hand was empty, you won't draw any cards."
         }
       ],
       "text": "Shuffle a card from your hand into your library. If you do, draw two cards at the beginning of the next turn's upkeep.",
@@ -5495,7 +5495,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -5556,7 +5556,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "In other words: — Step 1: Look at the top five cards of your library. — Step 2: If you like them, proceed to step 3a. If you don’t like them, proceed to step 3b. — Step 3a: Shuffle the rest of your library, then put those five cards back on top of your library in the order you want. The spell has finished resolving. — Step 3b: Put those five cards on the bottom of your library in the order you want. Pay 1 life. Return to step 1."
+          "text": "In other words: — Step 1: Look at the top five cards of your library. — Step 2: If you like them, proceed to step 3a. If you don't like them, proceed to step 3b. — Step 3a: Shuffle the rest of your library, then put those five cards back on top of your library in the order you want. The spell has finished resolving. — Step 3b: Put those five cards on the bottom of your library in the order you want. Pay 1 life. Return to step 1."
         },
         {
           "date": "2007-09-16",
@@ -5564,7 +5564,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If you have five or fewer cards in your library, you can pay 1 life as many times as you like, but you’ll keep seeing the same cards."
+          "text": "If you have five or fewer cards in your library, you can pay 1 life as many times as you like, but you'll keep seeing the same cards."
         }
       ],
       "text": "Look at the top five cards of your library. As many times as you choose, you may pay 1 life, put those cards on the bottom of your library in any order, then look at the top five cards of your library. Then shuffle your library and put the last cards you looked at this way on top of it in any order.",
@@ -5612,7 +5612,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Up to four” means zero, one, two, three, or four. If you choose zero targets, you still choose a player. That player will draw a card at the beginning of the next turn’s upkeep."
+          "text": "\"Up to four\" means zero, one, two, three, or four. If you choose zero targets, you still choose a player. That player will draw a card at the beginning of the next turn's upkeep."
         }
       ],
       "text": "{1}, {T}, Sacrifice Lodestone Bauble: Put up to four target basic land cards from a player's graveyard on top of his or her library in any order. That player draws a card at the beginning of the next turn's upkeep.",
@@ -5671,7 +5671,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When Lord of Tresserhorn enters the battlefield, if you have zero or one other creature on the battlefield, Lord of Tresserhorn itself will be sacrificed as part of its ability’s effect. Regeneration won’t save it. The rest of the effect still happens."
+          "text": "When Lord of Tresserhorn enters the battlefield, if you have zero or one other creature on the battlefield, Lord of Tresserhorn itself will be sacrificed as part of its ability's effect. Regeneration won't save it. The rest of the effect still happens."
         },
         {
           "date": "2004-10-04",
@@ -5734,7 +5734,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the target stops being a creature, you can’t redirect damage to it until/unless it becomes a creature again."
+          "text": "If the target stops being a creature, you can't redirect damage to it until/unless it becomes a creature again."
         },
         {
           "date": "2004-10-04",
@@ -5797,7 +5797,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the target stops being a creature, you can’t redirect damage to it until/unless it becomes a creature again."
+          "text": "If the target stops being a creature, you can't redirect damage to it until/unless it becomes a creature again."
         },
         {
           "date": "2004-10-04",
@@ -5907,11 +5907,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2008-10-01",
-          "text": "The ability’s effect has no duration. The affected land will remain an artifact, creature, and land until the game ends, it leaves the battlefield, or some other effect changes its types."
+          "text": "The ability's effect has no duration. The affected land will remain an artifact, creature, and land until the game ends, it leaves the battlefield, or some other effect changes its types."
         }
       ],
       "text": "{T}, Sacrifice Mishra's Groundbreaker: Target land becomes a 3/3 artifact creature that's still a land. (This effect lasts indefinitely.)",
@@ -5969,7 +5969,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You don’t need to show the opponent what order you put the cards on top of his or her library."
+          "text": "You don't need to show the opponent what order you put the cards on top of his or her library."
         }
       ],
       "text": "Put up to three target cards from an opponent's graveyard on top of his or her library in any order.",
@@ -6031,7 +6031,7 @@
         "White",
         "Green"
       ],
-      "flavor": "\"Be open to the blessings, whatever their form.\"\n —Kaysa, Elder Druid of the Juniper Order",
+      "flavor": "\"Be open to the blessings, whatever their form.\"\n—Kaysa, Elder Druid of the Juniper Order",
       "id": "059e0c43a3aafbe7a6d0ac92b7a9a754e8db4c57",
       "imageName": "nature's blessing",
       "layout": "normal",
@@ -6180,7 +6180,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Nature’s Wrath cares about who puts the permanent onto the battlefield, not under whose control the permanent enters the battlefield under."
+          "text": "Nature's Wrath cares about who puts the permanent onto the battlefield, not under whose control the permanent enters the battlefield under."
         }
       ],
       "text": "At the beginning of your upkeep, sacrifice Nature's Wrath unless you pay {G}.\nWhenever a player puts an Island or blue permanent onto the battlefield, he or she sacrifices an Island or blue permanent.\nWhenever a player puts a Swamp or black permanent onto the battlefield, he or she sacrifices a Swamp or black permanent.",
@@ -6382,11 +6382,11 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Note that the wording “Effects that alter the creature’s power alter its toughness instead, and vice versa, this turn” has been removed."
+          "text": "Note that the wording \"Effects that alter the creature's power alter its toughness instead, and vice versa, this turn\" has been removed."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that switch power and toughness are always applied last when determining a creature’s power and toughness, even if other power/toughness-changing effects are created later in the turn. For example, if you activate Phantasmal Fiend’s first ability, it will become 2/4. Then if you activate its second ability, it will become 4/2. Then if you activate its first ability again, it will become 3/3."
+          "text": "Effects that switch power and toughness are always applied last when determining a creature's power and toughness, even if other power/toughness-changing effects are created later in the turn. For example, if you activate Phantasmal Fiend's first ability, it will become 2/4. Then if you activate its second ability, it will become 4/2. Then if you activate its first ability again, it will become 3/3."
         },
         {
           "date": "2013-04-15",
@@ -6394,7 +6394,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -6457,11 +6457,11 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Note that the wording “Effects that alter the creature’s power alter its toughness instead, and vice versa, this turn” has been removed."
+          "text": "Note that the wording \"Effects that alter the creature's power alter its toughness instead, and vice versa, this turn\" has been removed."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that switch power and toughness are always applied last when determining a creature’s power and toughness, even if other power/toughness-changing effects are created later in the turn. For example, if you activate Phantasmal Fiend’s first ability, it will become 2/4. Then if you activate its second ability, it will become 4/2. Then if you activate its first ability again, it will become 3/3."
+          "text": "Effects that switch power and toughness are always applied last when determining a creature's power and toughness, even if other power/toughness-changing effects are created later in the turn. For example, if you activate Phantasmal Fiend's first ability, it will become 2/4. Then if you activate its second ability, it will become 4/2. Then if you activate its first ability again, it will become 3/3."
         },
         {
           "date": "2013-04-15",
@@ -6469,7 +6469,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -6749,7 +6749,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Phyrexian Devourer’s first ability continually checks its power as a state trigger. Once it triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again. If the ability resolves, you’ll have to sacrifice Phyrexian Devourer even if its power has been reduced to 6 or less by then."
+          "text": "Phyrexian Devourer's first ability continually checks its power as a state trigger. Once it triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again. If the ability resolves, you'll have to sacrifice Phyrexian Devourer even if its power has been reduced to 6 or less by then."
         }
       ],
       "subtypes": [
@@ -6802,7 +6802,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two piles don’t have to have the same number of cards in them. One of the piles may have zero cards."
+          "text": "The two piles don't have to have the same number of cards in them. One of the piles may have zero cards."
         }
       ],
       "text": "{3}: If your library has ten or more cards in it, target opponent looks at the top ten cards of your library and separates them into two face-down piles. Exile one of those piles. Search the other pile for a card, put it into your hand, then shuffle the rest of that pile into your library.",
@@ -7011,7 +7011,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Primitive Justice can’t target the same artifact more than once."
+          "text": "Primitive Justice can't target the same artifact more than once."
         }
       ],
       "text": "As an additional cost to cast Primitive Justice, you may pay {1}{R} and/or {1}{G} any number of times.\nDestroy target artifact. For each additional {1}{R} you paid, destroy another target artifact. For each additional {1}{G} you paid, destroy another target artifact, and you gain 1 life.",
@@ -7428,11 +7428,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "No choices are made when this ability triggers. After the wage counter is put on Rogue Skycaptain, then you choose whether to pay mana and, if you don’t, which opponent gains control of it."
+          "text": "No choices are made when this ability triggers. After the wage counter is put on Rogue Skycaptain, then you choose whether to pay mana and, if you don't, which opponent gains control of it."
         },
         {
           "date": "2008-10-01",
-          "text": "If you can’t pay the entire payment, none of it is paid."
+          "text": "If you can't pay the entire payment, none of it is paid."
         }
       ],
       "subtypes": [
@@ -7492,7 +7492,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Royal Decree’s ability will trigger a maximum of once for each permanent that becomes tapped, even if that permanent meets multiple criteria. (For example, Badlands is both a Swamp and a Mountain.)"
+          "text": "Royal Decree's ability will trigger a maximum of once for each permanent that becomes tapped, even if that permanent meets multiple criteria. (For example, Badlands is both a Swamp and a Mountain.)"
         }
       ],
       "text": "Cumulative upkeep {W} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever a Swamp, Mountain, black permanent, or red permanent becomes tapped, Royal Decree deals 1 damage to that permanent's controller.",
@@ -8640,15 +8640,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Spiny Starfish’s first ability creates a regeneration shield for it. Spiny Starfish’s second ability checks whether it _used_ any regeneration shields that turn, not whether any regeneration shields were created for it."
+          "text": "Spiny Starfish's first ability creates a regeneration shield for it. Spiny Starfish's second ability checks whether it _used_ any regeneration shields that turn, not whether any regeneration shields were created for it."
         },
         {
           "date": "2009-10-01",
-          "text": "The second ability doesn’t care where the regeneration shields Spiny Starfish used that turn came from. If it regenerated due to a regeneration shield from Refresh, for example, the ability will still put a Starfish token onto the battlefield."
+          "text": "The second ability doesn't care where the regeneration shields Spiny Starfish used that turn came from. If it regenerated due to a regeneration shield from Refresh, for example, the ability will still put a Starfish token onto the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "The second ability has an “intervening ‘if’ clause,” so it won’t trigger at all unless Spiny Starfish had regenerated that turn. However, the number of tokens that are created isn’t determined until the ability resolves (in case it regenerates again before that time)."
+          "text": "The second ability has an \"intervening 'if' clause,\" so it won't trigger at all unless Spiny Starfish had regenerated that turn. However, the number of tokens that are created isn't determined until the ability resolves (in case it regenerates again before that time)."
         },
         {
           "date": "2009-10-01",
@@ -8849,11 +8849,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a land is tapped for mana and sacrificed all in one action, it goes to the graveyard before the Cauldron can return it to the player’s hand."
+          "text": "If a land is tapped for mana and sacrificed all in one action, it goes to the graveyard before the Cauldron can return it to the player's hand."
         },
         {
           "date": "2004-10-04",
-          "text": "If a land is tapped for mana, it is returned to its owner’s hand as a triggered ability."
+          "text": "If a land is tapped for mana, it is returned to its owner's hand as a triggered ability."
         },
         {
           "date": "2004-10-04",
@@ -9042,11 +9042,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Even though the two activated abilities have the same cost, they’re separate. You choose which one you’re activating before you exile the top card of your library (and see what it is)."
+          "text": "Even though the two activated abilities have the same cost, they're separate. You choose which one you're activating before you exile the top card of your library (and see what it is)."
         },
         {
           "date": "2008-10-01",
-          "text": "If you activate Storm Elemental’s third ability and the exiled card is not a snow land, the ability has no effect."
+          "text": "If you activate Storm Elemental's third ability and the exiled card is not a snow land, the ability has no effect."
         }
       ],
       "subtypes": [
@@ -9219,7 +9219,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -9276,7 +9276,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It means “red instant or red sorcery” not “red instant or any sorcery”."
+          "text": "It means \"red instant or red sorcery\" not \"red instant or any sorcery\"."
         }
       ],
       "text": "Cast Suffocation only if you were dealt damage this turn by a red instant or sorcery spell.\nSuffocation deals 4 damage to the controller of the last red instant or sorcery spell that dealt damage to you this turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -9384,15 +9384,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         },
         {
           "date": "2008-10-01",
-          "text": "The second ability applies only if your life total is being reduced by damage. Other effects or costs (such as “lose 1 life” or “pay 1 life”) can reduce your life total below 1 as normal."
+          "text": "The second ability applies only if your life total is being reduced by damage. Other effects or costs (such as \"lose 1 life\" or \"pay 1 life\") can reduce your life total below 1 as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "If an effect asks you to pay life, you can’t pay more life than you have."
+          "text": "If an effect asks you to pay life, you can't pay more life than you have."
         },
         {
           "date": "2008-10-01",
@@ -9400,11 +9400,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The ability doesn’t change how much damage is dealt; it just changes how much life that damage makes you lose. An effect such as Spirit Link will see the full amount of damage being dealt."
+          "text": "The ability doesn't change how much damage is dealt; it just changes how much life that damage makes you lose. An effect such as Spirit Link will see the full amount of damage being dealt."
         },
         {
           "date": "2008-10-01",
-          "text": "Sustaining Spirit won’t prevent you from losing the game if your life total is 0 or less or some other effect causes you to lose the game."
+          "text": "Sustaining Spirit won't prevent you from losing the game if your life total is 0 or less or some other effect causes you to lose the game."
         }
       ],
       "subtypes": [
@@ -9474,7 +9474,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -9546,7 +9546,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -9607,7 +9607,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -9762,7 +9762,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Thawing Glaciers enters the battlefield tapped.\n{1}, {T}: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library. Return Thawing Glaciers to its owner's hand at the beginning of the next cleanup step.",
@@ -9816,11 +9816,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you don’t pay Thought Lash’s cumulative upkeep, you’ll sacrifice Thought Lash as normal, then, when its triggered ability resolves, you’ll exile all cards in your library."
+          "text": "If you don't pay Thought Lash's cumulative upkeep, you'll sacrifice Thought Lash as normal, then, when its triggered ability resolves, you'll exile all cards in your library."
         },
         {
           "date": "2008-10-01",
-          "text": "If your library has no cards in it, you can’t activate the last ability."
+          "text": "If your library has no cards in it, you can't activate the last ability."
         }
       ],
       "text": "Cumulative upkeep—Exile the top card of your library. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen a player doesn't pay Thought Lash's cumulative upkeep, that player exiles all cards from his or her library.\nExile the top card of your library: Prevent the next 1 damage that would be dealt to you this turn.",
@@ -10128,7 +10128,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -10317,7 +10317,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -10374,7 +10374,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Is put into its owner’s graveyard if you lose control of the creature."
+          "text": "Is put into its owner's graveyard if you lose control of the creature."
         }
       ],
       "subtypes": [
@@ -10432,7 +10432,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Is put into its owner’s graveyard if you lose control of the creature."
+          "text": "Is put into its owner's graveyard if you lose control of the creature."
         }
       ],
       "subtypes": [
@@ -10658,11 +10658,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The second ability checks that the targeted creature is a Cleric or Wizard only at the time the ability is activated and at the time it resolves. It doesn’t check at the time the damage is actually prevented."
+          "text": "The second ability checks that the targeted creature is a Cleric or Wizard only at the time the ability is activated and at the time it resolves. It doesn't check at the time the damage is actually prevented."
         },
         {
           "date": "2009-10-01",
-          "text": "If you activate Wandering Mage’s third ability, you put the -1/-1 counter on a creature you control as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the only creature you control to have 0 toughness, it’s put into the graveyard before you can pay the cost again."
+          "text": "If you activate Wandering Mage's third ability, you put the -1/-1 counter on a creature you control as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the only creature you control to have 0 toughness, it's put into the graveyard before you can pay the cost again."
         }
       ],
       "subtypes": [
@@ -10824,7 +10824,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If your library has fewer than two cards in it, you can’t activate the ability."
+          "text": "If your library has fewer than two cards in it, you can't activate the ability."
         }
       ],
       "text": "{2}, Exile the top two cards of your library: Whirling Catapult deals 1 damage to each creature with flying and each player.",
@@ -10992,15 +10992,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a land affected by Winter’s Night is untapped at the time its controller’s next untap step begins, the “doesn’t untap” effect doesn’t do anything. It won’t apply at some later time when that land is tapped."
+          "text": "If a land affected by Winter's Night is untapped at the time its controller's next untap step begins, the \"doesn't untap\" effect doesn't do anything. It won't apply at some later time when that land is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Winter’s Night doesn’t track the lands’ controllers. If an affected land changes controllers before its old controller’s next untap step, Winter’s Night will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Winter's Night doesn't track the lands' controllers. If an affected land changes controllers before its old controller's next untap step, Winter's Night will prevent it from being untapped during its new controller's next untap step."
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -11171,7 +11171,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [

--- a/json/APC.json
+++ b/json/APC.json
@@ -168,7 +168,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If this card is ever on a creature you don’t control, it is put into the graveyard as a State-Based Action."
+          "text": "If this card is ever on a creature you don't control, it is put into the graveyard as a State-Based Action."
         }
       ],
       "subtypes": [
@@ -244,15 +244,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Any player’s Flagbearer may be targeted. For example, if each player controls a Coalition Honor Guard, Seal of Strength’s ability may target any of them."
+          "text": "Any player's Flagbearer may be targeted. For example, if each player controls a Coalition Honor Guard, Seal of Strength's ability may target any of them."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text. Triggered abilities (written with “when,” “whenever,” or “at”) don’t have to target a Flagbearer."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text. Triggered abilities (written with \"when,\" \"whenever,\" or \"at\") don't have to target a Flagbearer."
         },
         {
           "date": "2016-06-08",
-          "text": "If a spell or ability’s targets are changed, or if a copy of a spell or ability is put onto the stack and has new targets chosen, it doesn’t have to target a Flagbearer."
+          "text": "If a spell or ability's targets are changed, or if a copy of a spell or ability is put onto the stack and has new targets chosen, it doesn't have to target a Flagbearer."
         }
       ],
       "subtypes": [
@@ -741,11 +741,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card’s ability does not change the color of any permanents."
+          "text": "This card's ability does not change the color of any permanents."
         },
         {
           "date": "2004-10-04",
-          "text": "This card’s ability does not change any lands into Plains."
+          "text": "This card's ability does not change any lands into Plains."
         }
       ],
       "text": "Until end of turn, spells and abilities you control that would add colored mana to your mana pool add that much white mana instead. Until end of turn, you may spend white mana as though it were mana of any color.\nDraw a card.",
@@ -1672,7 +1672,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Counter target spell unless its controller pays {1} for each basic land type among lands you control.",
@@ -2371,7 +2371,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It can target spells of type instant or sorcery, and not spells of other types that say they can be cast “any time you could cast” an instant or sorcery."
+          "text": "It can target spells of type instant or sorcery, and not spells of other types that say they can be cast \"any time you could cast\" an instant or sorcery."
         }
       ],
       "subtypes": [
@@ -2737,7 +2737,8 @@
       "originalType": "Creature — Angel",
       "power": "5",
       "printings": [
-        "APC"
+        "APC",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "subtypes": [
@@ -3632,7 +3633,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — All creatures get -1/-1 until end of turn for each basic land type among lands you control.",
@@ -3846,7 +3847,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you chose at least one target and all targets are illegal on resolution, you won’t draw a card."
+          "text": "If you chose at least one target and all targets are illegal on resolution, you won't draw a card."
         }
       ],
       "text": "Return up to two target creature cards from your graveyard to your hand.\nDraw a card.",
@@ -4134,7 +4135,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If this card is ever on a creature you don’t control, it is put into the graveyard as a State-Based Action."
+          "text": "If this card is ever on a creature you don't control, it is put into the graveyard as a State-Based Action."
         }
       ],
       "subtypes": [
@@ -5845,7 +5846,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
@@ -6627,7 +6628,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the first target is no longer on the battlefield, then the damage will not be dealt at all, so it can’t be redirected by this ability."
+          "text": "If the first target is no longer on the battlefield, then the damage will not be dealt at all, so it can't be redirected by this ability."
         }
       ],
       "text": "The next X damage that would be dealt to target creature or player this turn is dealt to another target creature or player instead.",
@@ -7496,7 +7497,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The tokens are named “Goblin Soldier” and have the creature types “Goblin” and “Soldier”."
+          "text": "The tokens are named \"Goblin Soldier\" and have the creature types \"Goblin\" and \"Soldier\"."
         }
       ],
       "text": "{2}, Sacrifice a land: Create two 1/1 red and white Goblin Soldier creature tokens.",
@@ -9579,7 +9580,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All lands you control become 1/1 creatures until end of turn. They're still lands.",
@@ -9670,7 +9671,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All lands you control become 1/1 creatures until end of turn. They're still lands.",
@@ -10492,7 +10493,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -10572,7 +10573,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -10650,7 +10651,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -10728,7 +10729,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -10806,7 +10807,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",

--- a/json/ARB.json
+++ b/json/ARB.json
@@ -148,11 +148,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -259,7 +259,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "If the second ability affects a creature, it doesn’t cause that creature to lose any of its abilities. It just gives that creature flying as well."
+          "text": "If the second ability affects a creature, it doesn't cause that creature to lose any of its abilities. It just gives that creature flying as well."
         },
         {
           "date": "2009-05-01",
@@ -267,15 +267,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "You may put a feather counter on a creature that already has a feather counter on it. Doing so has no visible effect unless some other effect has changed the creature’s power or toughness, or caused it to lose flying, since the last feather counter was put on it."
+          "text": "You may put a feather counter on a creature that already has a feather counter on it. Doing so has no visible effect unless some other effect has changed the creature's power or toughness, or caused it to lose flying, since the last feather counter was put on it."
         },
         {
           "date": "2009-05-01",
-          "text": "If all feather counters on a creature are moved to a different creature, the ability doesn’t follow them. The first creature stops being affected by the ability because it no longer has a feather counter on it. The second creature is not affected by the ability because Aven Mimeomancer didn’t target it."
+          "text": "If all feather counters on a creature are moved to a different creature, the ability doesn't follow them. The first creature stops being affected by the ability because it no longer has a feather counter on it. The second creature is not affected by the ability because Aven Mimeomancer didn't target it."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -488,7 +488,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "When Ethersworn Shieldmage’s triggered ability resolves, it doesn’t lock in which permanents will be affected. For the rest of the turn, any time damage would be dealt to a permanent, check whether it’s an artifact creature at that time. If it is, that damage is prevented."
+          "text": "When Ethersworn Shieldmage's triggered ability resolves, it doesn't lock in which permanents will be affected. For the rest of the turn, any time damage would be dealt to a permanent, check whether it's an artifact creature at that time. If it is, that damage is prevented."
         }
       ],
       "subtypes": [
@@ -596,7 +596,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Casting this card by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn’t change the spell’s mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting this card by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn't change the spell's mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-05-01",
@@ -604,11 +604,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner’s hand, regardless of that land’s subtype or whether it’s tapped."
+          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner's hand, regardless of that land's subtype or whether it's tapped."
         },
         {
           "date": "2009-05-01",
-          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell’s costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card’s alternative cost. (Of course, you can return a different basic land instead.)"
+          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell's costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card's alternative cost. (Of course, you can return a different basic land instead.)"
         }
       ],
       "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Fieldmist Borderpost's mana cost.\nFieldmist Borderpost enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
@@ -713,7 +713,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Filigree Angel’s enters-the-battlefield ability counts Filigree Angel itself, assuming that it’s still on the battlefield and still an artifact by the time the ability resolves."
+          "text": "Filigree Angel's enters-the-battlefield ability counts Filigree Angel itself, assuming that it's still on the battlefield and still an artifact by the time the ability resolves."
         }
       ],
       "subtypes": [
@@ -935,19 +935,19 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "No one can cast spells or activate abilities between the time a card is named and the time that Meddling Mage’s ability starts to work."
+          "text": "No one can cast spells or activate abilities between the time a card is named and the time that Meddling Mage's ability starts to work."
         },
         {
           "date": "2009-05-01",
-          "text": "Spells with the chosen name that somehow happen to already be on the stack when Meddling Mage enters the battlefield are not affected by Meddling Mage’s ability."
+          "text": "Spells with the chosen name that somehow happen to already be on the stack when Meddling Mage enters the battlefield are not affected by Meddling Mage's ability."
         },
         {
           "date": "2009-05-01",
-          "text": "Although the named card can’t be cast, it can still be put onto the battlefield by a spell or ability (if it’s a permanent card)."
+          "text": "Although the named card can't be cast, it can still be put onto the battlefield by a spell or ability (if it's a permanent card)."
         },
         {
           "date": "2009-05-01",
-          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can’t be cast. The other half is unaffected."
+          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can't be cast. The other half is unaffected."
         },
         {
           "date": "2009-05-01",
@@ -1062,7 +1062,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "You gain 4 life whether or not the targeted spell’s controller pays {4} and whether or not the targeted spell is countered."
+          "text": "You gain 4 life whether or not the targeted spell's controller pays {4} and whether or not the targeted spell is countered."
         }
       ],
       "text": "Counter target spell unless its controller pays {4}. You gain 4 life.",
@@ -1164,7 +1164,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -1176,7 +1176,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -1286,15 +1286,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "When the equipped creature blocks a creature, Shield of the Righteous’s second ability doesn’t tap the blocked creature (in case it happens to be untapped due to vigilance, for example). It just causes that creature to not untap during its controller’s next untap step."
+          "text": "When the equipped creature blocks a creature, Shield of the Righteous's second ability doesn't tap the blocked creature (in case it happens to be untapped due to vigilance, for example). It just causes that creature to not untap during its controller's next untap step."
         },
         {
           "date": "2009-05-01",
-          "text": "If the blocked creature is already untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when that creature is tapped."
+          "text": "If the blocked creature is already untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2009-05-01",
-          "text": "Shield of the Righteous’s second ability doesn’t track the blocked creature’s controller. If that creature changes controllers before its old controller’s next untap step, this ability will prevent it from untapping during its new controller’s next untap step."
+          "text": "Shield of the Righteous's second ability doesn't track the blocked creature's controller. If that creature changes controllers before its old controller's next untap step, this ability will prevent it from untapping during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -1399,7 +1399,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Any Aura card you find with Sovereigns of Lost Alara’s second ability must be able to enchant the attacking creature as it currently exists. You need to check the Aura’s enchant ability as well as any effects, such as protection, that would make it illegal to attach that Aura to the attacking creature. For example, if the attacking creature were an artifact creature with protection from blue, you could find an Aura with “enchant artifact,” but you could not find a blue Aura."
+          "text": "Any Aura card you find with Sovereigns of Lost Alara's second ability must be able to enchant the attacking creature as it currently exists. You need to check the Aura's enchant ability as well as any effects, such as protection, that would make it illegal to attach that Aura to the attacking creature. For example, if the attacking creature were an artifact creature with protection from blue, you could find an Aura with \"enchant artifact,\" but you could not find a blue Aura."
         },
         {
           "date": "2009-05-01",
@@ -1411,7 +1411,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If the attacking creature has left the battlefield by the time Sovereigns of Lost Alara’s second ability resolves, you can’t put an Aura onto the battlefield this way. You may still choose to search your library just to shuffle it."
+          "text": "If the attacking creature has left the battlefield by the time Sovereigns of Lost Alara's second ability resolves, you can't put an Aura onto the battlefield this way. You may still choose to search your library just to shuffle it."
         }
       ],
       "subtypes": [
@@ -1532,11 +1532,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -2060,7 +2060,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "When Brainbite resolves, you’ll draw a card even if the targeted opponent has no cards in hand."
+          "text": "When Brainbite resolves, you'll draw a card even if the targeted opponent has no cards in hand."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose a card from it. That player discards that card.\nDraw a card.",
@@ -2179,11 +2179,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -2392,7 +2392,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "If you cast a spell, the spell goes on the stack, then Illusory Demon’s triggered ability goes on the stack on top of it. The triggered ability will resolve (and you’ll sacrifice Illusory Demon) before the spell resolves."
+          "text": "If you cast a spell, the spell goes on the stack, then Illusory Demon's triggered ability goes on the stack on top of it. The triggered ability will resolve (and you'll sacrifice Illusory Demon) before the spell resolves."
         }
       ],
       "subtypes": [
@@ -2500,7 +2500,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -2512,7 +2512,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -2640,11 +2640,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -2755,7 +2755,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "The second ability counts all Zombies you control, not just the tokens put onto the battlefield with the first ability. It will count Lich Lord of Unx itself if it’s still under your control and still a Zombie when the ability resolves."
+          "text": "The second ability counts all Zombies you control, not just the tokens put onto the battlefield with the first ability. It will count Lich Lord of Unx itself if it's still under your control and still a Zombie when the ability resolves."
         }
       ],
       "subtypes": [
@@ -2861,7 +2861,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "If a Mask of Riddles you control somehow winds up equipping a creature you don’t control, Mask of Riddles’s triggered ability will still trigger whenever that creature deals combat damage to a player (even if that player is you). You will control that ability, so you may draw a card."
+          "text": "If a Mask of Riddles you control somehow winds up equipping a creature you don't control, Mask of Riddles's triggered ability will still trigger whenever that creature deals combat damage to a player (even if that player is you). You will control that ability, so you may draw a card."
         }
       ],
       "subtypes": [
@@ -2967,7 +2967,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "The four land cards, as well as all the other cards revealed during this process, are put into the graveyard. If there aren’t four land cards left in the targeted opponent’s library, that player’s entire library is put into the graveyard."
+          "text": "The four land cards, as well as all the other cards revealed during this process, are put into the graveyard. If there aren't four land cards left in the targeted opponent's library, that player's entire library is put into the graveyard."
         }
       ],
       "text": "Target opponent reveals cards from the top of his or her library until four land cards are revealed. That player puts all cards revealed this way into his or her graveyard.",
@@ -3069,7 +3069,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Casting this card by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn’t change the spell’s mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting this card by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn't change the spell's mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-05-01",
@@ -3077,11 +3077,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner’s hand, regardless of that land’s subtype or whether it’s tapped."
+          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner's hand, regardless of that land's subtype or whether it's tapped."
         },
         {
           "date": "2009-05-01",
-          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell’s costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card’s alternative cost. (Of course, you can return a different basic land instead.)"
+          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell's costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card's alternative cost. (Of course, you can return a different basic land instead.)"
         }
       ],
       "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Mistvein Borderpost's mana cost.\nMistvein Borderpost enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
@@ -3184,7 +3184,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "If the defending player has fewer than ten cards in his or her library, that player’s entire library is put into his or her graveyard."
+          "text": "If the defending player has fewer than ten cards in his or her library, that player's entire library is put into his or her graveyard."
         }
       ],
       "subtypes": [
@@ -3293,11 +3293,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "You may choose just the first mode (targeting a creature spell), just the second mode (targeting a creature card in your graveyard), or both modes (targeting a creature spell and a creature card in your graveyard). You can’t choose a mode unless there’s a legal target for it."
+          "text": "You may choose just the first mode (targeting a creature spell), just the second mode (targeting a creature card in your graveyard), or both modes (targeting a creature spell and a creature card in your graveyard). You can't choose a mode unless there's a legal target for it."
         },
         {
           "date": "2009-05-01",
-          "text": "If you choose both modes, you choose their targets at the same time. You can’t counter your own creature spell and then return that card from your graveyard to your hand."
+          "text": "If you choose both modes, you choose their targets at the same time. You can't counter your own creature spell and then return that card from your graveyard to your hand."
         }
       ],
       "text": "Choose one or both —\n• Counter target creature spell.\n• Return target creature card from your graveyard to your hand.",
@@ -3821,11 +3821,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -4256,11 +4256,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -4370,11 +4370,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Once Demonspine Whip’s ability resolves and gives the +X/+0 bonus to a creature, that bonus stays with that creature for the rest of the turn even if Demonspine Whip moves to another creature or leaves the battlefield."
+          "text": "Once Demonspine Whip's ability resolves and gives the +X/+0 bonus to a creature, that bonus stays with that creature for the rest of the turn even if Demonspine Whip moves to another creature or leaves the battlefield."
         },
         {
           "date": "2009-05-01",
-          "text": "If Demonspine Whip is no longer on the battlefield by the time its first ability resolves, the game checks whether it was attached to a creature at the time it left the battlefield. If it was, that creature gets the +X/+0 bonus. If it wasn’t, no creature gets the bonus."
+          "text": "If Demonspine Whip is no longer on the battlefield by the time its first ability resolves, the game checks whether it was attached to a creature at the time it left the battlefield. If it was, that creature gets the +X/+0 bonus. If it wasn't, no creature gets the bonus."
         }
       ],
       "subtypes": [
@@ -4480,7 +4480,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -4492,7 +4492,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -4604,7 +4604,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "When Kathari Bomber’s triggered ability resolves, you create two Goblin tokens regardless of how much combat damage Kathari Bomber dealt to the player. You create the tokens even if you can’t sacrifice Kathari Bomber."
+          "text": "When Kathari Bomber's triggered ability resolves, you create two Goblin tokens regardless of how much combat damage Kathari Bomber dealt to the player. You create the tokens even if you can't sacrifice Kathari Bomber."
         }
       ],
       "subtypes": [
@@ -5230,11 +5230,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "The card is named as Thought Hemorrhage resolves. Spells and abilities can’t be cast or activated between the time a card is named and the time that Thought Hemorrhage has the rest of its effect."
+          "text": "The card is named as Thought Hemorrhage resolves. Spells and abilities can't be cast or activated between the time a card is named and the time that Thought Hemorrhage has the rest of its effect."
         },
         {
           "date": "2009-05-01",
-          "text": "If the targeted player has multiple cards with the chosen name in his or her hand, the damage dealt by Thought Hemorrhage is all considered to be the same instance of damage. A single effect that prevents “the next time a source would deal damage,” for example, will prevent all of it."
+          "text": "If the targeted player has multiple cards with the chosen name in his or her hand, the damage dealt by Thought Hemorrhage is all considered to be the same instance of damage. A single effect that prevents \"the next time a source would deal damage,\" for example, will prevent all of it."
         },
         {
           "date": "2009-05-01",
@@ -5242,7 +5242,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The cards you’re searching for must be found if they’re in the graveyard, because that’s a zone everyone can see. Finding those cards in the hand and library is optional, though. This is true even though the targeted player has revealed his or her hand."
+          "text": "The cards you're searching for must be found if they're in the graveyard, because that's a zone everyone can see. Finding those cards in the hand and library is optional, though. This is true even though the targeted player has revealed his or her hand."
         },
         {
           "date": "2014-02-01",
@@ -5347,7 +5347,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Casting this card by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn’t change the spell’s mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting this card by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn't change the spell's mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-05-01",
@@ -5355,11 +5355,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner’s hand, regardless of that land’s subtype or whether it’s tapped."
+          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner's hand, regardless of that land's subtype or whether it's tapped."
         },
         {
           "date": "2009-05-01",
-          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell’s costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card’s alternative cost. (Of course, you can return a different basic land instead.)"
+          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell's costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card's alternative cost. (Of course, you can return a different basic land instead.)"
         }
       ],
       "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Veinfire Borderpost's mana cost.\nVeinfire Borderpost enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
@@ -5462,11 +5462,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Blitz Hellion’s last ability triggers at the end of each turn in which it’s on the battlefield. If it’s not on the battlefield by the time this ability resolves, nothing happens. Blitz Hellion stays wherever it is, and its owner doesn’t shuffle his or her library."
+          "text": "Blitz Hellion's last ability triggers at the end of each turn in which it's on the battlefield. If it's not on the battlefield by the time this ability resolves, nothing happens. Blitz Hellion stays wherever it is, and its owner doesn't shuffle his or her library."
         },
         {
           "date": "2009-05-01",
-          "text": "A token that’s copying Blitz Hellion will be shuffled into its owner’s library when this ability resolves, then will cease to exist. For practical purposes, the token should not actually be put into the library, though the library is still shuffled."
+          "text": "A token that's copying Blitz Hellion will be shuffled into its owner's library when this ability resolves, then will cease to exist. For practical purposes, the token should not actually be put into the library, though the library is still shuffled."
         }
       ],
       "subtypes": [
@@ -5593,11 +5593,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -5811,7 +5811,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The enters-the-battlefield ability is mandatory. If you’re the only player who controls a creature with flying, you must target one of those creatures."
+          "text": "The enters-the-battlefield ability is mandatory. If you're the only player who controls a creature with flying, you must target one of those creatures."
         }
       ],
       "subtypes": [
@@ -5922,7 +5922,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "In a Two-Headed Giant game, Dragon Broodmother’s second ability triggers only once at the beginning of each team’s upkeep, not once for each player. You’ll get one Dragon token at the beginning of your team’s upkeep and one Dragon token at the beginning of the opposing team’s upkeep."
+          "text": "In a Two-Headed Giant game, Dragon Broodmother's second ability triggers only once at the beginning of each team's upkeep, not once for each player. You'll get one Dragon token at the beginning of your team's upkeep and one Dragon token at the beginning of the opposing team's upkeep."
         }
       ],
       "subtypes": [
@@ -6027,7 +6027,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Casting this card by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn’t change the spell’s mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting this card by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn't change the spell's mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-05-01",
@@ -6035,11 +6035,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner’s hand, regardless of that land’s subtype or whether it’s tapped."
+          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner's hand, regardless of that land's subtype or whether it's tapped."
         },
         {
           "date": "2009-05-01",
-          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell’s costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card’s alternative cost. (Of course, you can return a different basic land instead.)"
+          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell's costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card's alternative cost. (Of course, you can return a different basic land instead.)"
         }
       ],
       "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Firewild Borderpost's mana cost.\nFirewild Borderpost enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
@@ -6454,15 +6454,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Predatory Advantage’s ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless the opponent whose turn it is didn’t cast a creature spell that turn, and (2) the ability will do nothing unless the opponent whose turn it is still hasn’t cast a creature spell by the time it resolves."
+          "text": "Predatory Advantage's ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless the opponent whose turn it is didn't cast a creature spell that turn, and (2) the ability will do nothing unless the opponent whose turn it is still hasn't cast a creature spell by the time it resolves."
         },
         {
           "date": "2009-05-01",
-          "text": "Predatory Advantage checks whether a player cast a creature spell, not whether a creature entered the battlefield under that player’s control. If that player cast a creature spell but you countered it, for example, you won’t get a Lizard token that turn."
+          "text": "Predatory Advantage checks whether a player cast a creature spell, not whether a creature entered the battlefield under that player's control. If that player cast a creature spell but you countered it, for example, you won't get a Lizard token that turn."
         },
         {
           "date": "2009-05-01",
-          "text": "In a Two-Headed Giant game, Predatory Advantage’s ability triggers twice at the end of the opposing team’s turn: once for each player. If neither of those players cast a creature spell that turn, you’ll get two Lizards. If one of those players cast a creature spell but the other didn’t, you’ll get one Lizard."
+          "text": "In a Two-Headed Giant game, Predatory Advantage's ability triggers twice at the end of the opposing team's turn: once for each player. If neither of those players cast a creature spell that turn, you'll get two Lizards. If one of those players cast a creature spell but the other didn't, you'll get one Lizard."
         }
       ],
       "text": "At the beginning of each opponent's end step, if that player didn't cast a creature spell this turn, create a 2/2 green Lizard creature token.",
@@ -6666,15 +6666,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Any spells or abilities that would counter Spellbreaker Behemoth or (once it’s on the battlefield) a creature spell you control with power 5 or greater can still be cast or activated and will still resolve. They just won’t counter that spell. Any other effects they have will happen as normal."
+          "text": "Any spells or abilities that would counter Spellbreaker Behemoth or (once it's on the battlefield) a creature spell you control with power 5 or greater can still be cast or activated and will still resolve. They just won't counter that spell. Any other effects they have will happen as normal."
         },
         {
           "date": "2009-05-01",
-          "text": "Effects that affect a creature’s power (such as the one from Glorious Anthem, for example) apply only to creatures on the battlefield, not to creature spells on the stack."
+          "text": "Effects that affect a creature's power (such as the one from Glorious Anthem, for example) apply only to creatures on the battlefield, not to creature spells on the stack."
         },
         {
           "date": "2009-05-01",
-          "text": "If a creature card has “*” in its power, the ability that defines “*” works in all zones, including the stack."
+          "text": "If a creature card has \"*\" in its power, the ability that defines \"*\" works in all zones, including the stack."
         }
       ],
       "subtypes": [
@@ -6783,7 +6783,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -6795,7 +6795,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -6910,15 +6910,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "You can return a land card to your hand with Vengeful Rebirth. It just won’t deal any damage to the targeted creature or player if you do."
+          "text": "You can return a land card to your hand with Vengeful Rebirth. It just won't deal any damage to the targeted creature or player if you do."
         },
         {
           "date": "2009-05-01",
-          "text": "If the targeted creature or player becomes an illegal target but the targeted card in your graveyard doesn’t, Vengeful Rebirth will still return that card from your graveyard to your hand, but it won’t deal any damage. Vengeful Rebirth will then be exiled."
+          "text": "If the targeted creature or player becomes an illegal target but the targeted card in your graveyard doesn't, Vengeful Rebirth will still return that card from your graveyard to your hand, but it won't deal any damage. Vengeful Rebirth will then be exiled."
         },
         {
           "date": "2009-05-01",
-          "text": "If the targeted card in your graveyard becomes an illegal target but the targeted creature or player doesn’t, Vengeful Rebirth won’t return that card to your hand and it won’t deal any damage (because you didn’t return a nonland card to your hand this way). Vengeful Rebirth will still be exiled, though."
+          "text": "If the targeted card in your graveyard becomes an illegal target but the targeted creature or player doesn't, Vengeful Rebirth won't return that card to your hand and it won't deal any damage (because you didn't return a nonland card to your hand this way). Vengeful Rebirth will still be exiled, though."
         },
         {
           "date": "2009-05-01",
@@ -7039,11 +7039,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -7150,7 +7150,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "The enters-the-battlefield ability is mandatory. If you’re the only player who controls any artifacts, you must target one of them."
+          "text": "The enters-the-battlefield ability is mandatory. If you're the only player who controls any artifacts, you must target one of them."
         }
       ],
       "subtypes": [
@@ -7259,7 +7259,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Multiple instances of lifelink are redundant. If a creature with multiple instances of lifelink deals damage, its controller still only gains life equal to the damage dealt."
+          "text": "multiple instances of lifelink on the same creature are redundant. If a creature with multiple instances of lifelink deals damage, its controller still only gains life equal to the damage dealt."
         }
       ],
       "subtypes": [
@@ -7379,11 +7379,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -7491,7 +7491,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Once Dauntless Escort’s ability resolves, the set of creatures it affects is locked in. It won’t affect creatures that enter the battlefield after the ability has finished resolving."
+          "text": "Once Dauntless Escort's ability resolves, the set of creatures it affects is locked in. It won't affect creatures that enter the battlefield after the ability has finished resolving."
         },
         {
           "date": "2013-07-01",
@@ -7499,7 +7499,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -7625,11 +7625,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -8166,15 +8166,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Mycoid Shepherd’s ability will trigger when it’s put into a graveyard from the battlefield no matter what its power is at that time."
+          "text": "Mycoid Shepherd's ability will trigger when it's put into a graveyard from the battlefield no matter what its power is at that time."
         },
         {
           "date": "2009-05-01",
-          "text": "If another creature you control is put into a graveyard from the battlefield, Mycoid Shepherd’s ability checks that creature’s power as it last existed on the battlefield. If it was 5 or greater, the ability will trigger."
+          "text": "If another creature you control is put into a graveyard from the battlefield, Mycoid Shepherd's ability checks that creature's power as it last existed on the battlefield. If it was 5 or greater, the ability will trigger."
         },
         {
           "date": "2009-05-01",
-          "text": "If Mycoid Shepherd and another creature you control with power 5 or greater are put into a graveyard from the battlefield at the same time, Mycoid Shepherd’s ability will trigger twice."
+          "text": "If Mycoid Shepherd and another creature you control with power 5 or greater are put into a graveyard from the battlefield at the same time, Mycoid Shepherd's ability will trigger twice."
         }
       ],
       "subtypes": [
@@ -8281,7 +8281,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -8293,7 +8293,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -8605,15 +8605,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Sigil Captain’s ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless the creature that enters the battlefield under your control is 1/1, and (2) the ability will do nothing unless that creature is still 1/1 at the time the ability resolves."
+          "text": "Sigil Captain's ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless the creature that enters the battlefield under your control is 1/1, and (2) the ability will do nothing unless that creature is still 1/1 at the time the ability resolves."
         },
         {
           "date": "2009-05-01",
-          "text": "For that reason, two Sigil Captains don’t work well together. When a 1/1 creature enters the battlefield under your control, the abilities of both Sigil Captains will trigger. When the first resolves, two +1/+1 counters are put on the 1/1 creature. When the second resolves, it will do nothing because the creature that entered the battlefield is now 3/3."
+          "text": "For that reason, two Sigil Captains don't work well together. When a 1/1 creature enters the battlefield under your control, the abilities of both Sigil Captains will trigger. When the first resolves, two +1/+1 counters are put on the 1/1 creature. When the second resolves, it will do nothing because the creature that entered the battlefield is now 3/3."
         },
         {
           "date": "2009-05-01",
-          "text": "Sigil Captain’s ability checks a creature’s initial power and toughness upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it’s on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, changing its power and toughness to 1/1 with a spell, activated ability, or triggered ability won’t allow this ability to trigger; it’s too late by then."
+          "text": "Sigil Captain's ability checks a creature's initial power and toughness upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it's on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, changing its power and toughness to 1/1 with a spell, activated ability, or triggered ability won't allow this ability to trigger; it's too late by then."
         },
         {
           "date": "2009-05-01",
@@ -8728,7 +8728,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Sigil of the Nayan Gods’s ability counts the number of creatures you control, regardless of who controls the creature the Aura is enchanting. If you control the creature it’s enchanting, the bonus will include that creature too."
+          "text": "Sigil of the Nayan Gods's ability counts the number of creatures you control, regardless of who controls the creature the Aura is enchanting. If you control the creature it's enchanting, the bonus will include that creature too."
         }
       ],
       "subtypes": [
@@ -8933,7 +8933,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Casting this card by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn’t change the spell’s mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting this card by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn't change the spell's mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-05-01",
@@ -8941,11 +8941,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner’s hand, regardless of that land’s subtype or whether it’s tapped."
+          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner's hand, regardless of that land's subtype or whether it's tapped."
         },
         {
           "date": "2009-05-01",
-          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell’s costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card’s alternative cost. (Of course, you can return a different basic land instead.)"
+          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell's costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card's alternative cost. (Of course, you can return a different basic land instead.)"
         }
       ],
       "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Wildfield Borderpost's mana cost.\nWildfield Borderpost enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
@@ -9147,7 +9147,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Necromancer’s Covenant grants lifelink to all Zombies you control, not just the tokens put onto the battlefield with its first ability."
+          "text": "Necromancer's Covenant grants lifelink to all Zombies you control, not just the tokens put onto the battlefield with its first ability."
         }
       ],
       "text": "When Necromancer's Covenant enters the battlefield, exile all creature cards from target player's graveyard, then create a 2/2 black Zombie creature token for each card exiled this way.\nZombies you control have lifelink.",
@@ -9249,19 +9249,19 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Tainted Sigil’s ability counts the life lost by all players, including you."
+          "text": "Tainted Sigil's ability counts the life lost by all players, including you."
         },
         {
           "date": "2009-05-01",
-          "text": "When Tainted Sigil’s ability resolves, it checks how much life each player lost over the course of the turn, then it totals that number and you gain that much life in one shot. It doesn’t matter how a player lost life or what caused it. It also doesn’t matter if Tainted Sigil wasn’t on the battlefield when some or all of the life was lost."
+          "text": "When Tainted Sigil's ability resolves, it checks how much life each player lost over the course of the turn, then it totals that number and you gain that much life in one shot. It doesn't matter how a player lost life or what caused it. It also doesn't matter if Tainted Sigil wasn't on the battlefield when some or all of the life was lost."
         },
         {
           "date": "2009-05-01",
-          "text": "If you lose enough life to lower your life total to 0 or less, you’ll lose the game as a state-based actions before you activate Tainted Sigil’s ability."
+          "text": "If you lose enough life to lower your life total to 0 or less, you'll lose the game as a state-based actions before you activate Tainted Sigil's ability."
         },
         {
           "date": "2009-05-01",
-          "text": "Tainted Sigil’s ability checks only whether life was lost. It doesn’t care whether life was also gained. For example, say one player lost 4 life during the turn and no one else lost any, but that same player also gained 6 life that turn. That player has a higher life total than he or she started the turn with — but Tainted Sigil’s ability counts only the life loss, so you’ll gain 4 life."
+          "text": "Tainted Sigil's ability checks only whether life was lost. It doesn't care whether life was also gained. For example, say one player lost 4 life during the turn and no one else lost any, but that same player also gained 6 life that turn. That player has a higher life total than he or she started the turn with — but Tainted Sigil's ability counts only the life loss, so you'll gain 4 life."
         }
       ],
       "text": "{T}, Sacrifice Tainted Sigil: You gain life equal to the total life lost by all players this turn. (Damage causes loss of life.)",
@@ -9565,15 +9565,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "This ability triggers only once for each multicolored instant or sorcery spell you cast. You can’t use a single Cloven Casting to copy the same spell twice."
+          "text": "This ability triggers only once for each multicolored instant or sorcery spell you cast. You can't use a single Cloven Casting to copy the same spell twice."
         },
         {
           "date": "2009-05-01",
-          "text": "You can copy the spell that caused Cloven Casting’s ability to trigger even if it’s been countered by the time that ability resolves."
+          "text": "You can copy the spell that caused Cloven Casting's ability to trigger even if it's been countered by the time that ability resolves."
         },
         {
           "date": "2009-05-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. The new targets must be legal."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. The new targets must be legal."
         },
         {
           "date": "2009-05-01",
@@ -9581,7 +9581,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Abilities that trigger when a spell is cast (such as this ability or cascade) won’t trigger when you create a copy this way."
+          "text": "Abilities that trigger when a spell is cast (such as this ability or cascade) won't trigger when you create a copy this way."
         }
       ],
       "text": "Whenever you cast a multicolored instant or sorcery spell, you may pay {1}. If you do, copy that spell. You may choose new targets for the copy.",
@@ -9691,7 +9691,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "It’s unusual for a player to cast a spell in response to his or her own spell, and that will be specifically called out when it happens. Under normal circumstances, if a player casts a spell, it is assumed that the player passes priority afterward. If that player casts another spell, it is assumed that each other player has also passed priority, which caused the first spell to resolve and the first player to receive priority again. Unless the first player says otherwise, only one spell will be on the stack at a time in that scenario."
+          "text": "It's unusual for a player to cast a spell in response to his or her own spell, and that will be specifically called out when it happens. Under normal circumstances, if a player casts a spell, it is assumed that the player passes priority afterward. If that player casts another spell, it is assumed that each other player has also passed priority, which caused the first spell to resolve and the first player to receive priority again. Unless the first player says otherwise, only one spell will be on the stack at a time in that scenario."
         }
       ],
       "text": "Counter up to two target spells.",
@@ -10002,7 +10002,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "You’ll discard a card even if some other effect replaces the draw."
+          "text": "You'll discard a card even if some other effect replaces the draw."
         }
       ],
       "subtypes": [
@@ -10103,7 +10103,8 @@
       "originalType": "Creature — Elemental",
       "power": "*",
       "printings": [
-        "ARB"
+        "ARB",
+        "MPS_AKH"
       ],
       "rarity": "Mythic Rare",
       "subtypes": [
@@ -10216,15 +10217,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The name of a creature token is the same as its creature types unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 1/1 Soldier creature token is named “Soldier.”"
+          "text": "The name of a creature token is the same as its creature types unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 1/1 Soldier creature token is named \"Soldier.\""
         },
         {
           "date": "2009-05-01",
-          "text": "A face-down creature has no name, so it doesn’t have the same name as anything else."
+          "text": "A face-down creature has no name, so it doesn't have the same name as anything else."
         },
         {
           "date": "2013-07-01",
-          "text": "If Maelstrom Pulse resolves but the targeted permanent isn’t destroyed (perhaps because it regenerates or has indestructible), all other permanents with the same name as it will still be destroyed (unless they also have indestructible."
+          "text": "If Maelstrom Pulse resolves but the targeted permanent isn't destroyed (perhaps because it regenerates or has indestructible), all other permanents with the same name as it will still be destroyed (unless they also have indestructible."
         }
       ],
       "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
@@ -10427,11 +10428,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "If the targeted card is removed from the graveyard before Morbid Bloom resolves, the spell is countered. You won’t get any Saproling tokens."
+          "text": "If the targeted card is removed from the graveyard before Morbid Bloom resolves, the spell is countered. You won't get any Saproling tokens."
         },
         {
           "date": "2009-05-01",
-          "text": "If a creature card has “*” in its toughness, the ability that defines “*” works in all zones. The value of X is equal to the toughness of the targeted creature card as it last existed in the graveyard."
+          "text": "If a creature card has \"*\" in its toughness, the ability that defines \"*\" works in all zones. The value of X is equal to the toughness of the targeted creature card as it last existed in the graveyard."
         }
       ],
       "text": "Exile target creature card from a graveyard, then create X 1/1 green Saproling creature tokens, where X is the exiled card's toughness.",
@@ -10739,19 +10740,19 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
         },
         {
           "date": "2009-05-01",
-          "text": "A “blocked creature” is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocked creature\" is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
         },
         {
           "date": "2009-05-01",
-          "text": "Attacking creatures that haven’t been blocked are unaffected by Fight to the Death."
+          "text": "Attacking creatures that haven't been blocked are unaffected by Fight to the Death."
         },
         {
           "date": "2009-05-01",
-          "text": "If Fight to the Death is cast before blockers are declared or after combat ends, it won’t do anything."
+          "text": "If Fight to the Death is cast before blockers are declared or after combat ends, it won't do anything."
         }
       ],
       "text": "Destroy all blocking creatures and all blocked creatures.",
@@ -10854,7 +10855,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "There is never a point at which Glory of Warfare will give a creature you control +2/+2 or +0/+0. A creature that’s normally 1/1, for example, will change from being 3/1 to being 1/3 when your turn ends and another player’s turn begins. At no time will it be 3/3 or 1/1."
+          "text": "There is never a point at which Glory of Warfare will give a creature you control +2/+2 or +0/+0. A creature that's normally 1/1, for example, will change from being 3/1 to being 1/3 when your turn ends and another player's turn begins. At no time will it be 3/3 or 1/1."
         }
       ],
       "text": "As long as it's your turn, creatures you control get +2/+0.\nAs long as it's not your turn, creatures you control get +0/+2.",
@@ -10964,7 +10965,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "For the second part of Intimidation Bolt’s effect to do anything, it must be cast before attackers are declared."
+          "text": "For the second part of Intimidation Bolt's effect to do anything, it must be cast before attackers are declared."
         }
       ],
       "text": "Intimidation Bolt deals 3 damage to target creature. Other creatures can't attack this turn.",
@@ -11173,11 +11174,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "If a spell or ability causes you to draw multiple cards, Lorescale Coatl’s ability triggers that many times."
+          "text": "If a spell or ability causes you to draw multiple cards, Lorescale Coatl's ability triggers that many times."
         },
         {
           "date": "2009-05-01",
-          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word “draw,” Lorescale Coatl’s ability won’t trigger."
+          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word \"draw,\" Lorescale Coatl's ability won't trigger."
         }
       ],
       "subtypes": [
@@ -11284,11 +11285,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Nulltread Gargantuan’s ability doesn’t target the creature you put on top of its owner’s library. You don’t choose one until the ability resolves. No one can respond to the choice."
+          "text": "Nulltread Gargantuan's ability doesn't target the creature you put on top of its owner's library. You don't choose one until the ability resolves. No one can respond to the choice."
         },
         {
           "date": "2009-05-01",
-          "text": "If you control no other creatures, you’ll have to put Nulltread Gargantuan on top of its owner’s library."
+          "text": "If you control no other creatures, you'll have to put Nulltread Gargantuan on top of its owner's library."
         }
       ],
       "subtypes": [
@@ -11395,15 +11396,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Other players don’t get to see the order that you put the cards on the bottom of your library."
+          "text": "Other players don't get to see the order that you put the cards on the bottom of your library."
         },
         {
           "date": "2009-05-01",
-          "text": "If an effect would cause you to draw multiple cards, each individual draw is replaced by Sages of the Anima’s effect. Process the draws one at a time."
+          "text": "If an effect would cause you to draw multiple cards, each individual draw is replaced by Sages of the Anima's effect. Process the draws one at a time."
         },
         {
           "date": "2009-05-01",
-          "text": "If there are fewer than three cards in your library, you’ll reveal all of them."
+          "text": "If there are fewer than three cards in your library, you'll reveal all of them."
         },
         {
           "date": "2009-05-01",
@@ -11411,11 +11412,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word “draw,” Sages of the Anima’s ability won’t affect it."
+          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word \"draw,\" Sages of the Anima's ability won't affect it."
         },
         {
           "date": "2009-05-01",
-          "text": "If two or more replacement effects would apply to a card-drawing event, the player who’s drawing the card chooses what order to apply them. It’s possible that after applying one of them, the others will no longer be applicable because the player would no longer draw a card. For example, if you have more than one Sages of the Anima on the battlefield and you would draw a card, each Sages of the Anima’s replacement effect could apply. Once you use one, the rest are no longer applicable."
+          "text": "If two or more replacement effects would apply to a card-drawing event, the player who's drawing the card chooses what order to apply them. It's possible that after applying one of them, the others will no longer be applicable because the player would no longer draw a card. For example, if you have more than one Sages of the Anima on the battlefield and you would draw a card, each Sages of the Anima's replacement effect could apply. Once you use one, the rest are no longer applicable."
         }
       ],
       "subtypes": [
@@ -11523,7 +11524,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Vedalken Heretic’s ability triggers when it deals any damage to an opponent, not just combat damage."
+          "text": "Vedalken Heretic's ability triggers when it deals any damage to an opponent, not just combat damage."
         }
       ],
       "subtypes": [
@@ -11753,23 +11754,23 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2009-05-01",
-          "text": "After Enigma Sphinx’s middle ability triggers, if Enigma Sphinx is removed from your graveyard in response, it won’t be put into your library."
+          "text": "After Enigma Sphinx's middle ability triggers, if Enigma Sphinx is removed from your graveyard in response, it won't be put into your library."
         },
         {
           "date": "2009-05-01",
-          "text": "If you have zero or one card left in your library when Enigma Sphinx’s middle ability resolves, Enigma Sphinx is put on the bottom of your library."
+          "text": "If you have zero or one card left in your library when Enigma Sphinx's middle ability resolves, Enigma Sphinx is put on the bottom of your library."
         },
         {
           "date": "2009-05-01",
-          "text": "If you control an Enigma Sphinx that’s owned by another player, it’s put into that player’s graveyard from the battlefield, so Enigma Sphinx’s middle ability won’t trigger."
+          "text": "If you control an Enigma Sphinx that's owned by another player, it's put into that player's graveyard from the battlefield, so Enigma Sphinx's middle ability won't trigger."
         },
         {
           "date": "2017-04-18",
@@ -11895,11 +11896,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2009-05-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -12118,39 +12119,39 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Playing a card this way works just like playing any other card, with one exception: You're playing the card from your opponent's hand rather than your own. To be specific: -- A card played this way follows the normal timing rules for its card type, as well as any other applicable restrictions such as “Cast [this card] only during combat.” For example, you can't play a card from the targeted opponent's hand during your end step unless it's an instant or has flash. -- To cast a nonland card from your opponent's hand this way, you must pay its mana cost. -- You can play a land card from the targeted opponent's hand only if you haven't played a land yet that turn."
+          "text": "Playing a card this way works just like playing any other card, with one exception: You're playing the card from your opponent's hand rather than your own. To be specific: -- A card played this way follows the normal timing rules for its card type, as well as any other applicable restrictions such as \"Cast [this card] only during combat.\" For example, you can't play a card from the targeted opponent's hand during your end step unless it's an instant or has flash. -- To cast a nonland card from your opponent's hand this way, you must pay its mana cost. -- You can play a land card from the targeted opponent's hand only if you haven't played a land yet that turn."
         },
         {
           "date": "2009-05-01",
-          "text": "You control the spells you cast from your opponent’s hand, so you make decisions for them as appropriate. For example, if one of those spells says “target creature you control,” you’ll target one of your creatures, not one of your opponent’s creatures."
+          "text": "You control the spells you cast from your opponent's hand, so you make decisions for them as appropriate. For example, if one of those spells says \"target creature you control,\" you'll target one of your creatures, not one of your opponent's creatures."
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast a spell with cascade this way, you’ll control the cascade ability. When it resolves, you’ll find a new card to cast from your own library."
+          "text": "If you cast a spell with cascade this way, you'll control the cascade ability. When it resolves, you'll find a new card to cast from your own library."
         },
         {
           "date": "2009-05-01",
-          "text": "You can cast spells from the targeted player’s hand, but you can’t activate abilities. Specifically, you can’t cycle cards in that player’s hand."
+          "text": "You can cast spells from the targeted player's hand, but you can't activate abilities. Specifically, you can't cycle cards in that player's hand."
         },
         {
           "date": "2009-05-01",
-          "text": "This ability doesn’t prevent the targeted opponent’s triggered abilities from triggering. If one does, that player puts it on the stack and, if applicable, chooses targets for it. Those abilities will resolve as normal."
+          "text": "This ability doesn't prevent the targeted opponent's triggered abilities from triggering. If one does, that player puts it on the stack and, if applicable, chooses targets for it. Those abilities will resolve as normal."
         },
         {
           "date": "2009-05-01",
-          "text": "If the resolution of a spell or ability involves having the targeted player cast a spell, that part of the effect simply won’t work."
+          "text": "If the resolution of a spell or ability involves having the targeted player cast a spell, that part of the effect simply won't work."
         },
         {
           "date": "2009-05-01",
-          "text": "After this ability resolves, the targeted player still gets priority at the appropriate times, and can still perform special actions (such as turning a face-down creature face up). However, since that player can’t cast any spells or activate abilities — including mana abilities — there’s not much he or she can actually accomplish this way."
+          "text": "After this ability resolves, the targeted player still gets priority at the appropriate times, and can still perform special actions (such as turning a face-down creature face up). However, since that player can't cast any spells or activate abilities — including mana abilities — there's not much he or she can actually accomplish this way."
         },
         {
           "date": "2009-05-01",
-          "text": "If you start to play a card from the targeted opponent’s hand, there’s no way for the opponent to get rid of that card in response (like discarding it to pay Gathan Raiders’s morph cost, for example). That’s because the first thing that happens when you start to cast a spell is that it moves to the stack, so it’s not in your opponent’s hand anymore."
+          "text": "If you start to play a card from the targeted opponent's hand, there's no way for the opponent to get rid of that card in response (like discarding it to pay Gathan Raiders's morph cost, for example). That's because the first thing that happens when you start to cast a spell is that it moves to the stack, so it's not in your opponent's hand anymore."
         },
         {
           "date": "2009-05-01",
-          "text": "Once Sen Triplets’s ability resolves, it remains in effect for the rest of the turn whether or not you still control Sen Triplets."
+          "text": "Once Sen Triplets's ability resolves, it remains in effect for the rest of the turn whether or not you still control Sen Triplets."
         }
       ],
       "subtypes": [
@@ -12370,15 +12371,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "You discard your hand as part of Drastic Revelation’s effect, not as an additional cost. If you have no cards in hand at this point, you simply don’t discard any; the rest of the spell will still have its effect."
+          "text": "You discard your hand as part of Drastic Revelation's effect, not as an additional cost. If you have no cards in hand at this point, you simply don't discard any; the rest of the spell will still have its effect."
         },
         {
           "date": "2009-05-01",
-          "text": "You’ll discard three cards at random even if some other effect replaces your seven draws."
+          "text": "You'll discard three cards at random even if some other effect replaces your seven draws."
         },
         {
           "date": "2009-05-01",
-          "text": "If there are fewer than seven cards left in your library, you’ll draw all the cards in your library, then you’ll discard three cards at random. Then you’ll lose the game as a state-based action."
+          "text": "If there are fewer than seven cards left in your library, you'll draw all the cards in your library, then you'll discard three cards at random. Then you'll lose the game as a state-based action."
         }
       ],
       "text": "Discard your hand. Draw seven cards, then discard three cards at random.",
@@ -12494,15 +12495,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2009-05-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         },
         {
           "date": "2009-05-01",
-          "text": "Grixis Sojourner’s triggered ability may target Grixis Sojourners itself. By the time the ability triggers, Grixis Sojourner will already be in your graveyard."
+          "text": "Grixis Sojourner's triggered ability may target Grixis Sojourners itself. By the time the ability triggers, Grixis Sojourner will already be in your graveyard."
         }
       ],
       "subtypes": [
@@ -12613,11 +12614,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Thraximundar’s middle ability resolves during the declare attackers step. The defending player sacrifices a creature before it would get a chance to block."
+          "text": "Thraximundar's middle ability resolves during the declare attackers step. The defending player sacrifices a creature before it would get a chance to block."
         },
         {
           "date": "2009-05-01",
-          "text": "Thraximundar’s last ability triggers whenever any player (including you) sacrifices a creature for any reason. It doesn’t trigger only when a creature is sacrificed due to its middle ability. Note that Thraximundar itself doesn’t allow you to sacrifice any creatures."
+          "text": "Thraximundar's last ability triggers whenever any player (including you) sacrifices a creature for any reason. It doesn't trigger only when a creature is sacrificed due to its middle ability. Note that Thraximundar itself doesn't allow you to sacrifice any creatures."
         }
       ],
       "subtypes": [
@@ -12728,15 +12729,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Whenever a creature is put into a graveyard from the battlefield, check whether that creature had been dealt damage this turn by the creature that Unscythe is currently attached to. If so, Unscythe’s second ability will trigger. This is true even if Unscythe wasn’t attached to the creature at the time it dealt that damage. Only the currently equipped creature is checked, not any creatures that Unscythe may have been attached to earlier in the turn."
+          "text": "Whenever a creature is put into a graveyard from the battlefield, check whether that creature had been dealt damage this turn by the creature that Unscythe is currently attached to. If so, Unscythe's second ability will trigger. This is true even if Unscythe wasn't attached to the creature at the time it dealt that damage. Only the currently equipped creature is checked, not any creatures that Unscythe may have been attached to earlier in the turn."
         },
         {
           "date": "2009-05-01",
-          "text": "Unscythe’s second ability cares about any damage, not just combat damage."
+          "text": "Unscythe's second ability cares about any damage, not just combat damage."
         },
         {
           "date": "2009-05-01",
-          "text": "If Unscythe’s second ability triggers, but the creature that was put into a graveyard is somehow removed from the graveyard in response (or it was a token), it won’t be able to be exiled with Unscythe’s ability. You won’t get a Zombie token."
+          "text": "If Unscythe's second ability triggers, but the creature that was put into a graveyard is somehow removed from the graveyard in response (or it was a token), it won't be able to be exiled with Unscythe's ability. You won't get a Zombie token."
         }
       ],
       "subtypes": [
@@ -12846,7 +12847,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Dragon Appeasement itself doesn’t allow you to sacrifice any creatures. Its last ability triggers whenever you sacrifice a creature because some other spell, ability, or cost instructed you to."
+          "text": "Dragon Appeasement itself doesn't allow you to sacrifice any creatures. Its last ability triggers whenever you sacrifice a creature because some other spell, ability, or cost instructed you to."
         }
       ],
       "text": "Skip your draw step.\nWhenever you sacrifice a creature, you may draw a card.",
@@ -12962,11 +12963,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2009-05-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -13075,11 +13076,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "The triggered ability’s control-change effect has no duration. Each Dragon you gain control of this way will remain under your control until the game ends, that permanent leaves the battlefield, or some other effect changes its controller."
+          "text": "The triggered ability's control-change effect has no duration. Each Dragon you gain control of this way will remain under your control until the game ends, that permanent leaves the battlefield, or some other effect changes its controller."
         },
         {
           "date": "2009-05-01",
-          "text": "When the triggered ability resolves, you’ll gain control of all Dragons, including the Dragons you already control (such as Karrthus itself). Usually this will have no appreciable effect, though it will override any previous control-change abilities (such as if you had gained control of one of those Dragons only for the rest of the turn). Then you’ll untap all Dragons, including the ones you already controlled and Karrthus itself (if it had somehow managed to become tapped by then)."
+          "text": "When the triggered ability resolves, you'll gain control of all Dragons, including the Dragons you already control (such as Karrthus itself). Usually this will have no appreciable effect, though it will override any previous control-change abilities (such as if you had gained control of one of those Dragons only for the rest of the turn). Then you'll untap all Dragons, including the ones you already controlled and Karrthus itself (if it had somehow managed to become tapped by then)."
         }
       ],
       "subtypes": [
@@ -13195,7 +13196,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Because Lavalanche doesn’t target any creatures, it will deal damage to creatures with shroud. Any damage it would deal to creatures with appropriate protection abilities will still be prevented, however."
+          "text": "Because Lavalanche doesn't target any creatures, it will deal damage to creatures with shroud. Any damage it would deal to creatures with appropriate protection abilities will still be prevented, however."
         }
       ],
       "text": "Lavalanche deals X damage to target player and each creature he or she controls.",
@@ -13516,7 +13517,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The three parts of the ability happen sequentially. For example, if you control a creature with 9 power when the ability starts to resolve, you’ll put a +1/+1 counter on each creature you control — and now, since you control a creature with 10 power, you’ll gain 10 life."
+          "text": "The three parts of the ability happen sequentially. For example, if you control a creature with 9 power when the ability starts to resolve, you'll put a +1/+1 counter on each creature you control — and now, since you control a creature with 10 power, you'll gain 10 life."
         }
       ],
       "text": "At the beginning of your upkeep, put a +1/+1 counter on each creature you control if you control a creature with power 5 or greater. Then you gain 10 life if you control a creature with power 10 or greater. Then you win the game if you control a creature with power 20 or greater.",
@@ -13634,11 +13635,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2009-05-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -13753,19 +13754,19 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If a spell causes damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Breath of Malfegor says “Breath of Malfegor deals 5 damage to each opponent.”"
+          "text": "If a spell causes damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Breath of Malfegor says \"Breath of Malfegor deals 5 damage to each opponent.\""
         },
         {
           "date": "2009-05-01",
-          "text": "If an ability causes damage to be dealt, that ability will always identify the source of the damage. The ability itself is never the source. However, the source of the ability is often the source of the damage. For example, Deathbringer Thoctar’s ability says “Deathbringer Thoctar deals 1 damage to target creature or player.”"
+          "text": "If an ability causes damage to be dealt, that ability will always identify the source of the damage. The ability itself is never the source. However, the source of the ability is often the source of the damage. For example, Deathbringer Thoctar's ability says \"Deathbringer Thoctar deals 1 damage to target creature or player.\""
         },
         {
           "date": "2009-05-01",
-          "text": "If the source of the damage is a permanent, Retaliator Griffin checks whether an opponent controls that permanent at the time that damage is dealt. If the permanent has left the battlefield by then, its last known information is used. If the source of the damage is a spell, whether it’s controlled by an opponent is obvious. If the source of the damage is a card in some other zone (such as a cycled Jund Sojourners), Retaliator Griffin checks whether the card’s owner, rather than its controller, is an opponent."
+          "text": "If the source of the damage is a permanent, Retaliator Griffin checks whether an opponent controls that permanent at the time that damage is dealt. If the permanent has left the battlefield by then, its last known information is used. If the source of the damage is a spell, whether it's controlled by an opponent is obvious. If the source of the damage is a card in some other zone (such as a cycled Jund Sojourners), Retaliator Griffin checks whether the card's owner, rather than its controller, is an opponent."
         },
         {
           "date": "2009-05-01",
-          "text": "If Retaliator Griffin is dealt lethal damage at the same time that you’re dealt damage by a source an opponent controls, Retaliator Griffin will be put into a graveyard before it would receive any counters. Its ability will still trigger, but it will do nothing when it resolves."
+          "text": "If Retaliator Griffin is dealt lethal damage at the same time that you're dealt damage by a source an opponent controls, Retaliator Griffin will be put into a graveyard before it would receive any counters. Its ability will still trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -13992,7 +13993,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -14100,11 +14101,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Finest Hour’s second ability has an “intervening ‘if’ clause.” The ability won’t trigger at all unless it’s the first combat phase of the turn."
+          "text": "Finest Hour's second ability has an \"intervening 'if' clause.\" The ability won't trigger at all unless it's the first combat phase of the turn."
         },
         {
           "date": "2009-05-01",
-          "text": "Unlike other similar cards, Finest Hour doesn’t create a main phase in between the two combat phases. The second combat phase will begin immediately after the current one ends."
+          "text": "Unlike other similar cards, Finest Hour doesn't create a main phase in between the two combat phases. The second combat phase will begin immediately after the current one ends."
         }
       ],
       "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, if it's the first combat phase of the turn, untap that creature. After this phase, there is an additional combat phase.",
@@ -14208,15 +14209,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-05-01",
-          "text": "Flurry of Wings counts the number of creatures that are attacking as it resolves. It doesn’t matter how many creatures were originally declared as attackers that turn. It also doesn’t matter who controls those creatures, or who or what they’re attacking."
+          "text": "Flurry of Wings counts the number of creatures that are attacking as it resolves. It doesn't matter how many creatures were originally declared as attackers that turn. It also doesn't matter who controls those creatures, or who or what they're attacking."
         },
         {
           "date": "2009-05-01",
-          "text": "If Flurry of Wings is cast before attackers have been declared or after combat ends, it won’t do anything."
+          "text": "If Flurry of Wings is cast before attackers have been declared or after combat ends, it won't do anything."
         }
       ],
       "text": "Create X 1/1 white Bird Soldier creature tokens with flying, where X is the number of attacking creatures.",
@@ -14431,7 +14432,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "You may always find a permanent card with converted mana cost 0. (If X is 0, that’s all you can find.) Cards with no mana cost (such as land cards), cards with mana cost {0}, and cards with mana cost {X} all have converted mana cost 0."
+          "text": "You may always find a permanent card with converted mana cost 0. (If X is 0, that's all you can find.) Cards with no mana cost (such as land cards), cards with mana cost {0}, and cards with mana cost {X} all have converted mana cost 0."
         }
       ],
       "text": "Search your library for a permanent card with converted mana cost X or less, put it onto the battlefield, then shuffle your library.",
@@ -14554,11 +14555,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2009-05-01",
@@ -14566,15 +14567,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If the first spell you cast in a turn already has cascade, both cascade abilities will trigger separately. Deal with them one at a time: First one cascade ability will resolve, and you’ll cast the applicable card if you want. That new spell will resolve. Then the other cascade ability will resolve in the same way. Finally, the original spell will resolve."
+          "text": "If the first spell you cast in a turn already has cascade, both cascade abilities will trigger separately. Deal with them one at a time: First one cascade ability will resolve, and you'll cast the applicable card if you want. That new spell will resolve. Then the other cascade ability will resolve in the same way. Finally, the original spell will resolve."
         },
         {
           "date": "2009-05-01",
-          "text": "This effect takes into account spells that were cast earlier in the turn that Maelstrom Nexus entered the battlefield, including any spells still on the stack. If you’ve already cast any spells that turn (including Maelstrom Nexus itself), this ability won’t give any of your spells cascade that turn."
+          "text": "This effect takes into account spells that were cast earlier in the turn that Maelstrom Nexus entered the battlefield, including any spells still on the stack. If you've already cast any spells that turn (including Maelstrom Nexus itself), this ability won't give any of your spells cascade that turn."
         },
         {
           "date": "2009-05-01",
-          "text": "A spell’s converted mana cost is determined solely by the mana symbols printed in its upper right corner. If its mana cost includes {X}, take the chosen value of X into account. Ignore any alternative costs, additional costs, cost increases, or cost reductions."
+          "text": "A spell's converted mana cost is determined solely by the mana symbols printed in its upper right corner. If its mana cost includes {X}, take the chosen value of X into account. Ignore any alternative costs, additional costs, cost increases, or cost reductions."
         },
         {
           "date": "2017-04-18",
@@ -15221,7 +15222,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you don’t control the targeted creature when the “at end of turn” ability resolves, it won’t be sacrificed. If it’s still on the battlefield but under another player’s control, the ability won’t try to have you sacrifice it again at the end of the turn after that."
+          "text": "If you don't control the targeted creature when the \"at end of turn\" ability resolves, it won't be sacrificed. If it's still on the battlefield but under another player's control, the ability won't try to have you sacrifice it again at the end of the turn after that."
         }
       ],
       "text": "Gain control of target creature. Untap that creature. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
@@ -15330,15 +15331,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Deciding to have the targeted creature block doesn’t force you to attack with Giant Ambush Beetle that turn. If Giant Ambush Beetle doesn’t attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "Deciding to have the targeted creature block doesn't force you to attack with Giant Ambush Beetle that turn. If Giant Ambush Beetle doesn't attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2009-05-01",
-          "text": "If you choose to have the targeted creature block but that creature isn’t able to block Giant Ambush Beetle (for example, because the targeted creature can block only creatures with flying), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "If you choose to have the targeted creature block but that creature isn't able to block Giant Ambush Beetle (for example, because the targeted creature can block only creatures with flying), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2009-05-01",
-          "text": "Tapped creatures, creatures that can’t block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren’t controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Giant Ambush Beetle’s ability, but the requirement to block does nothing."
+          "text": "Tapped creatures, creatures that can't block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren't controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Giant Ambush Beetle's ability, but the requirement to block does nothing."
         }
       ],
       "subtypes": [
@@ -16063,7 +16064,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "When the enchanted creature becomes the target of a spell or ability, Crystallization’s last ability will trigger. When that ability resolves, that creature will be exiled, even if Crystallization has left the battlefield or is enchanting a different creature by that time. If Crystallization is still enchanting the same creature, Crystallization will then be put into its owner’s graveyard as a state-based action."
+          "text": "When the enchanted creature becomes the target of a spell or ability, Crystallization's last ability will trigger. When that ability resolves, that creature will be exiled, even if Crystallization has left the battlefield or is enchanting a different creature by that time. If Crystallization is still enchanting the same creature, Crystallization will then be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [

--- a/json/ARC.json
+++ b/json/ARC.json
@@ -280,15 +280,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The effect doesn’t wear off until just before your next untap step (even if an effect will cause that untap step to be skipped)."
+          "text": "The effect doesn't wear off until just before your next untap step (even if an effect will cause that untap step to be skipped)."
         },
         {
           "date": "2010-06-15",
-          "text": "This ability applies no matter who or what the damage would be dealt to: a creature, a player, or a planeswalker. It also doesn’t matter who controls the source."
+          "text": "This ability applies no matter who or what the damage would be dealt to: a creature, a player, or a planeswalker. It also doesn't matter who controls the source."
         },
         {
           "date": "2010-06-15",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the permanent that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn” and Lava Axe says “Lava Axe deals 5 damage to target player.” Suppose a Lava Axe would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let this scheme’s effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the permanent that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn\" and Lava Axe says \"Lava Axe deals 5 damage to target player.\" Suppose a Lava Axe would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let this scheme's effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         },
         {
           "date": "2010-06-15",
@@ -371,11 +371,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -489,11 +489,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature’s controller won’t search for a basic land card."
+          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature's controller won't search for a basic land card."
         },
         {
           "date": "2017-03-14",
-          "text": "The controller of the exiled creature isn’t required to search his or her library for a basic land. If that player doesn’t, the player won’t shuffle his or her library."
+          "text": "The controller of the exiled creature isn't required to search his or her library for a basic land. If that player doesn't, the player won't shuffle his or her library."
         }
       ],
       "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
@@ -547,11 +547,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The effect doesn’t wear off until just before your next untap step (even if an effect will cause that untap step to be skipped)."
+          "text": "The effect doesn't wear off until just before your next untap step (even if an effect will cause that untap step to be skipped)."
         },
         {
           "date": "2010-06-15",
-          "text": "The player is chosen as the ability resolves. Once a player is chosen, it’s too late for other players to respond by casting spells."
+          "text": "The player is chosen as the ability resolves. Once a player is chosen, it's too late for other players to respond by casting spells."
         },
         {
           "date": "2010-06-15",
@@ -683,11 +683,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You’ll put just one creature card onto the battlefield this way. The other revealed creature cards, and all the revealed noncreature cards, will wind up in their owners’ graveyards."
+          "text": "You'll put just one creature card onto the battlefield this way. The other revealed creature cards, and all the revealed noncreature cards, will wind up in their owners' graveyards."
         },
         {
           "date": "2010-06-15",
-          "text": "If an opponent has no creature cards left in his or her library, that player will wind up revealing his or her entire library and putting it into his or her graveyard. You’ll still get to choose a creature card revealed by another player."
+          "text": "If an opponent has no creature cards left in his or her library, that player will wind up revealing his or her entire library and putting it into his or her graveyard. You'll still get to choose a creature card revealed by another player."
         }
       ],
       "text": "When you set this scheme in motion, each opponent reveals cards from the top of his or her library until he or she reveals a creature card. Choose one of the revealed creature cards and put it onto the battlefield under your control. Put all other cards revealed this way into their owners' graveyards.",
@@ -750,7 +750,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If an Equipment becomes a creature, it can no longer equip a creature. If it’s currently attached to a creature, it becomes unattached (but remains on the battlefield). You can activate the Equipment’s equip ability, but it won’t do anything."
+          "text": "If an Equipment becomes a creature, it can no longer equip a creature. If it's currently attached to a creature, it becomes unattached (but remains on the battlefield). You can activate the Equipment's equip ability, but it won't do anything."
         },
         {
           "date": "2004-12-01",
@@ -758,11 +758,11 @@
         },
         {
           "date": "2007-07-15",
-          "text": "If a noncreature artifact becomes an artifact creature this way and then another effect animates it, the new effect overrides March of the Machines’s effect. For example, Chimeric Staff is a 4/4 creature while March of the Machines is on the battlefield. If you activate Chimeric Staff’s ability and choose X = 5, Chimeric Staff will be a 5/5 artifact creature for the rest of the turn."
+          "text": "If a noncreature artifact becomes an artifact creature this way and then another effect animates it, the new effect overrides March of the Machines's effect. For example, Chimeric Staff is a 4/4 creature while March of the Machines is on the battlefield. If you activate Chimeric Staff's ability and choose X = 5, Chimeric Staff will be a 5/5 artifact creature for the rest of the turn."
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         }
       ],
       "text": "Each noncreature artifact is an artifact creature with power and toughness each equal to its converted mana cost. (Equipment that's a creature can't equip a creature.)",
@@ -816,7 +816,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "For each opponent, you may choose not to target any creature cards in that player’s graveyard."
+          "text": "For each opponent, you may choose not to target any creature cards in that player's graveyard."
         },
         {
           "date": "2010-06-15",
@@ -824,15 +824,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If, during your declare attackers step, one of these creatures is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having that creature attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, one of these creatures is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having that creature attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If one of these creatures can’t attack its owner during any given turn (due to a spell or ability such as Chronomantic Escape, or because a player on the opposing team has gained control of it, for example), it may attack another player, attack a planeswalker an opponent controls, or not attack at all. If there’s a cost associated with having that creature attack its owner, you aren’t forced to pay that cost, so it may attack another player, attack a planeswalker an opponent controls, or not attack at all."
+          "text": "If one of these creatures can't attack its owner during any given turn (due to a spell or ability such as Chronomantic Escape, or because a player on the opposing team has gained control of it, for example), it may attack another player, attack a planeswalker an opponent controls, or not attack at all. If there's a cost associated with having that creature attack its owner, you aren't forced to pay that cost, so it may attack another player, attack a planeswalker an opponent controls, or not attack at all."
         },
         {
           "date": "2010-06-15",
-          "text": "If there are multiple combat phases in a turn, each of these creatures must attack its owner in each of them that it’s able to."
+          "text": "If there are multiple combat phases in a turn, each of these creatures must attack its owner in each of them that it's able to."
         }
       ],
       "text": "When you set this scheme in motion, for each opponent, put up to one target creature card from that player's graveyard onto the battlefield under your control. Each of those creatures attacks its owner each combat if able.",
@@ -892,7 +892,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Returning an artifact you control to its owner’s hand is part of the cost of Master Transmuter’s activated ability. Paying a cost can’t be responded to (with Naturalize, for example)."
+          "text": "Returning an artifact you control to its owner's hand is part of the cost of Master Transmuter's activated ability. Paying a cost can't be responded to (with Naturalize, for example)."
         },
         {
           "date": "2009-02-01",
@@ -964,7 +964,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "The effect doesn’t wear off until just before your next untap step (even if an effect will cause that untap step to be skipped)."
+          "text": "The effect doesn't wear off until just before your next untap step (even if an effect will cause that untap step to be skipped)."
         },
         {
           "date": "2010-06-15",
@@ -972,11 +972,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a land produces more than one type of mana at a single time (as Boros Garrison does, for example), the land’s controller chooses which one of those types of mana is produced by the delayed triggered ability."
+          "text": "If a land produces more than one type of mana at a single time (as Boros Garrison does, for example), the land's controller chooses which one of those types of mana is produced by the delayed triggered ability."
         },
         {
           "date": "2010-06-15",
-          "text": "If a land is tapped for mana but doesn’t produce any (for example, if you tap Gaea’s Cradle for mana while you control no creatures), the delayed triggered ability won’t trigger."
+          "text": "If a land is tapped for mana but doesn't produce any (for example, if you tap Gaea's Cradle for mana while you control no creatures), the delayed triggered ability won't trigger."
         }
       ],
       "text": "When you set this scheme in motion, until your next turn, whenever a player taps a land for mana, that player adds one mana to his or her mana pool of any type that land produced.",
@@ -1034,7 +1034,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The opponent chosen for the fateseal action doesn’t have to be the player who controlled the target creature."
+          "text": "The opponent chosen for the fateseal action doesn't have to be the player who controlled the target creature."
         }
       ],
       "text": "Put target creature on top of its owner's library, then fateseal 2. (To fateseal 2, look at the top two cards of an opponent's library, then put any number of them on the bottom of that player's library and the rest on top in any order.)",
@@ -1144,7 +1144,8 @@
         "ARC",
         "CMD",
         "PD3",
-        "CN2"
+        "CN2",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -1208,7 +1209,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "First you choose a nonland card in each opponent’s hand (if he or she has any). Then all the chosen cards are discarded at the same time."
+          "text": "First you choose a nonland card in each opponent's hand (if he or she has any). Then all the chosen cards are discarded at the same time."
         }
       ],
       "text": "When you set this scheme in motion, each opponent reveals his or her hand. Choose a nonland card from each of those hands. Those players discard those cards.",
@@ -1270,7 +1271,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Put target artifact or creature card from a graveyard onto the battlefield under your control. Shuffle Beacon of Unrest into its owner's library.",
@@ -1324,7 +1325,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You choose the target player when the ability triggers. As the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it’s too late for any player to respond since the ability is already in the midst of resolving."
+          "text": "You choose the target player when the ability triggers. As the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it's too late for any player to respond since the ability is already in the midst of resolving."
         }
       ],
       "text": "When you set this scheme in motion, you may pay {X}. If you do, put each nonland permanent target player controls with converted mana cost X or less on the bottom of its owner's library.",
@@ -1494,7 +1495,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The creature card in a graveyard is exiled as part of the activated ability’s effect, not as a cost. If that card has left the graveyard by the time the ability would resolve, the ability is countered and you don’t get a Zombie token."
+          "text": "The creature card in a graveyard is exiled as part of the activated ability's effect, not as a cost. If that card has left the graveyard by the time the ability would resolve, the ability is countered and you don't get a Zombie token."
         }
       ],
       "subtypes": [
@@ -1551,15 +1552,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The targeted player may choose “self” even if he or she can’t perform the resulting action. For example, a player targeted with Feed the Machine may choose “self” even if he or she controls no creatures."
+          "text": "The targeted player may choose \"self\" even if he or she can't perform the resulting action. For example, a player targeted with Feed the Machine may choose \"self\" even if he or she controls no creatures."
         },
         {
           "date": "2010-06-15",
-          "text": "The targeted player may choose “others” even if there are no others (because all of his or her teammates have lost the game, for example), or the archenemy’s other opponents can’t perform the resulting action."
+          "text": "The targeted player may choose \"others\" even if there are no others (because all of his or her teammates have lost the game, for example), or the archenemy's other opponents can't perform the resulting action."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Supervillain Rumble game, the targeted player may still choose “others.” Each player who isn’t the active player or the targeted player will thus be affected."
+          "text": "In a Supervillain Rumble game, the targeted player may still choose \"others.\" Each player who isn't the active player or the targeted player will thus be affected."
         }
       ],
       "text": "When you set this scheme in motion, target opponent chooses self or others. If that player chooses self, this scheme deals 6 damage to him or her. If the player chooses others, this scheme deals 3 damage to each of your other opponents.",
@@ -1620,23 +1621,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -1695,15 +1696,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The targeted player may choose “self” even if he or she can’t perform the resulting action. For example, a player targeted with Feed the Machine may choose “self” even if he or she controls no creatures."
+          "text": "The targeted player may choose \"self\" even if he or she can't perform the resulting action. For example, a player targeted with Feed the Machine may choose \"self\" even if he or she controls no creatures."
         },
         {
           "date": "2010-06-15",
-          "text": "The targeted player may choose “others” even if there are no others (because all of his or her teammates have lost the game, for example), or the archenemy’s other opponents can’t perform the resulting action."
+          "text": "The targeted player may choose \"others\" even if there are no others (because all of his or her teammates have lost the game, for example), or the archenemy's other opponents can't perform the resulting action."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Supervillain Rumble game, the targeted player may still choose “others.” Each player who isn’t the active player or the targeted player will thus be affected."
+          "text": "In a Supervillain Rumble game, the targeted player may still choose \"others.\" Each player who isn't the active player or the targeted player will thus be affected."
         }
       ],
       "text": "When you set this scheme in motion, target opponent chooses self or others. If that player chooses self, he or she sacrifices two creatures. If the player chooses others, each of your other opponents sacrifices a creature.",
@@ -1766,23 +1767,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -1839,15 +1840,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Players can’t respond to the action of setting a scheme in motion. That means that if this scheme is turned face up, your opponents can’t cast spells before the static ability takes effect."
+          "text": "Players can't respond to the action of setting a scheme in motion. That means that if this scheme is turned face up, your opponents can't cast spells before the static ability takes effect."
         },
         {
           "date": "2010-06-15",
-          "text": "If any of your opponents cast a spell during your upkeep or draw step, that player can’t cast another spell during the turn this scheme is set in motion."
+          "text": "If any of your opponents cast a spell during your upkeep or draw step, that player can't cast another spell during the turn this scheme is set in motion."
         },
         {
           "date": "2010-06-15",
-          "text": "The scheme is abandoned if all your opponents refrain from casting spells during their entire turn, and during your subsequent upkeep before this scheme’s last ability resolves. They may still activate abilities and perform special actions."
+          "text": "The scheme is abandoned if all your opponents refrain from casting spells during their entire turn, and during your subsequent upkeep before this scheme's last ability resolves. They may still activate abilities and perform special actions."
         }
       ],
       "supertypes": [
@@ -1913,11 +1914,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon’s triggered ability will trigger."
+          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon's triggered ability will trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "You can target any player with Extractor Demon’s triggered ability. The target doesn’t have to be the controller of the creature that left the battlefield."
+          "text": "You can target any player with Extractor Demon's triggered ability. The target doesn't have to be the controller of the creature that left the battlefield."
         }
       ],
       "subtypes": [
@@ -1974,11 +1975,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Your opponents each find a card in whatever order they like. They may consult with each other during this process. You’ll know what cards they’ve found before you search."
+          "text": "Your opponents each find a card in whatever order they like. They may consult with each other during this process. You'll know what cards they've found before you search."
         },
         {
           "date": "2010-06-15",
-          "text": "You don’t reveal the cards for which you search."
+          "text": "You don't reveal the cards for which you search."
         }
       ],
       "text": "When you set this scheme in motion, each other player searches his or her library for a card, reveals it, and puts it into his or her hand. Then you search your library for two cards and put them into your hand. Each player shuffles his or her library.",
@@ -2095,7 +2096,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The amount of life a player can lose is not bounded by his or her life total. For example, if your opponents have 1, 2, and 10 life, respectively, when this scheme’s ability resolves, each of them will lose 3 life. This brings their life totals to -2, -1, and 7 life, respectively. You gain 9 life. Then the first two opponents lose the game as a state-based action. (If the first two opponents concede before the triggered ability resolves, however, you’ll gain only 3 life.)"
+          "text": "The amount of life a player can lose is not bounded by his or her life total. For example, if your opponents have 1, 2, and 10 life, respectively, when this scheme's ability resolves, each of them will lose 3 life. This brings their life totals to -2, -1, and 7 life, respectively. You gain 9 life. Then the first two opponents lose the game as a state-based action. (If the first two opponents concede before the triggered ability resolves, however, you'll gain only 3 life.)"
         }
       ],
       "text": "When you set this scheme in motion, each opponent loses 3 life. You gain life equal to the life lost this way.",
@@ -2155,7 +2156,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You must target three different creatures. If you can’t, you can’t cast Incremental Blight."
+          "text": "You must target three different creatures. If you can't, you can't cast Incremental Blight."
         }
       ],
       "text": "Put a -1/-1 counter on target creature, two -1/-1 counters on another target creature, and three -1/-1 counters on a third target creature.",
@@ -2208,7 +2209,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "As an opponent’s untap step begins, if you control this face-up scheme card, all your permanents untap during that untap step. You have no choice about what untaps. Those permanents untap at the same time as the active players’ permanents."
+          "text": "As an opponent's untap step begins, if you control this face-up scheme card, all your permanents untap during that untap step. You have no choice about what untaps. Those permanents untap at the same time as the active players' permanents."
         },
         {
           "date": "2010-06-15",
@@ -2216,23 +2217,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "During an opponent’s untap step, effects that would otherwise cause your permanents to stay tapped don’t apply because they apply only during *your* untap step. For example, if you control a Deep-Slumber Titan (a creature that says “Deep-Slumber Titan doesn’t untap during your untap step”), you untap Deep-Slumber Titan during each opponent’s untap step."
+          "text": "During an opponent's untap step, effects that would otherwise cause your permanents to stay tapped don't apply because they apply only during *your* untap step. For example, if you control a Deep-Slumber Titan (a creature that says \"Deep-Slumber Titan doesn't untap during your untap step\"), you untap Deep-Slumber Titan during each opponent's untap step."
         },
         {
           "date": "2010-06-15",
-          "text": "Controlling more than one face-up I Know All, I See All card is redundant. You can’t untap your permanents more than once in a single untap step."
+          "text": "Controlling more than one face-up I Know All, I See All card is redundant. You can't untap your permanents more than once in a single untap step."
         },
         {
           "date": "2010-06-15",
-          "text": "The last ability won’t trigger at all unless, as an end step starts, three or more cards have already been put into your graveyard that turn. Those cards don’t still need to be in your graveyard at that time."
+          "text": "The last ability won't trigger at all unless, as an end step starts, three or more cards have already been put into your graveyard that turn. Those cards don't still need to be in your graveyard at that time."
         },
         {
           "date": "2010-06-15",
-          "text": "The last ability of this scheme counts the number of cards put into your graveyard over the course of the entire turn, even if it wasn’t face up the whole time. Specifically, during the turn you set this scheme in motion, its last ability will count cards that were put into your graveyard during your upkeep or draw step."
+          "text": "The last ability of this scheme counts the number of cards put into your graveyard over the course of the entire turn, even if it wasn't face up the whole time. Specifically, during the turn you set this scheme in motion, its last ability will count cards that were put into your graveyard during your upkeep or draw step."
         },
         {
           "date": "2010-06-15",
-          "text": "The last ability doesn’t count tokens that were put into your graveyard from the battlefield, because they’re not cards. The same is true for copies of spells that were put into your graveyard when they resolved or were countered."
+          "text": "The last ability doesn't count tokens that were put into your graveyard from the battlefield, because they're not cards. The same is true for copies of spells that were put into your graveyard when they resolved or were countered."
         }
       ],
       "supertypes": [
@@ -2353,11 +2354,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "The token that’s put onto the battlefield copies exactly what’s printed on the targeted permanent (unless that permanent is copying something else or it’s a token; see below). It doesn’t copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras attached to it, or whether it’s been affected by any noncopy effects that changed its power, toughness, types, color, or so on."
+          "text": "The token that's put onto the battlefield copies exactly what's printed on the targeted permanent (unless that permanent is copying something else or it's a token; see below). It doesn't copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras attached to it, or whether it's been affected by any noncopy effects that changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted permanent is copying something else when the ability resolves (for example, if it’s a Clone), then the token enters the battlefield as a copy of whatever that permanent is copying."
+          "text": "If the targeted permanent is copying something else when the ability resolves (for example, if it's a Clone), then the token enters the battlefield as a copy of whatever that permanent is copying."
         },
         {
           "date": "2010-06-15",
@@ -2369,15 +2370,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Any enters-the-battlefield abilities of the targeted permanent will trigger when the token is put onto the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of that permanent will also work."
+          "text": "Any enters-the-battlefield abilities of the targeted permanent will trigger when the token is put onto the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of that permanent will also work."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted permanent leaves the battlefield before the ability resolves, the ability is countered. You don’t get a token."
+          "text": "If the targeted permanent leaves the battlefield before the ability resolves, the ability is countered. You don't get a token."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted permanent is an Aura, you choose a legal permanent, player, or other card for the token to enchant as it enters the battlefield. A permanent you choose must be able to be enchanted by the token. (For example, if the Aura it’s copying is red and has “enchant creature,” the permanent must be a creature, and it can’t have protection from red.) Since the token Aura wasn’t cast as a spell, it doesn’t target what it will enchant; you may choose something that has shroud, for example. As the ability resolves, no player can respond between the time you choose what the token will enchant and the time it enters the battlefield. If you can’t choose something for the token to enchant, it enters the battlefield unattached, then is put into your graveyard as a state-based action."
+          "text": "If the targeted permanent is an Aura, you choose a legal permanent, player, or other card for the token to enchant as it enters the battlefield. A permanent you choose must be able to be enchanted by the token. (For example, if the Aura it's copying is red and has \"enchant creature,\" the permanent must be a creature, and it can't have protection from red.) Since the token Aura wasn't cast as a spell, it doesn't target what it will enchant; you may choose something that has shroud, for example. As the ability resolves, no player can respond between the time you choose what the token will enchant and the time it enters the battlefield. If you can't choose something for the token to enchant, it enters the battlefield unattached, then is put into your graveyard as a state-based action."
         }
       ],
       "text": "When you set this scheme in motion, create a token that's a copy of target permanent an opponent controls.",
@@ -2599,7 +2600,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You choose this ability’s mode as you put it on the stack."
+          "text": "You choose this ability's mode as you put it on the stack."
         }
       ],
       "text": "When you set this scheme in motion, choose one —\n• Search your library for a creature card, reveal it, put it into your hand, then shuffle your library.\n• You may put a creature card from your hand onto the battlefield.",
@@ -2659,7 +2660,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You lose life equal to the converted mana cost of the card you’re bringing back, so if you Reanimate Volrath’s Shapeshifter, you lose three life, regardless of what the next card down is."
+          "text": "You lose life equal to the converted mana cost of the card you're bringing back, so if you Reanimate Volrath's Shapeshifter, you lose three life, regardless of what the next card down is."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
@@ -3048,15 +3049,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The targeted player may choose “self” even if he or she can’t perform the resulting action. For example, a player targeted with Feed the Machine may choose “self” even if he or she controls no creatures."
+          "text": "The targeted player may choose \"self\" even if he or she can't perform the resulting action. For example, a player targeted with Feed the Machine may choose \"self\" even if he or she controls no creatures."
         },
         {
           "date": "2010-06-15",
-          "text": "The targeted player may choose “others” even if there are no others (because all of his or her teammates have lost the game, for example), or the archenemy’s other opponents can’t perform the resulting action."
+          "text": "The targeted player may choose \"others\" even if there are no others (because all of his or her teammates have lost the game, for example), or the archenemy's other opponents can't perform the resulting action."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Supervillain Rumble game, the targeted player may still choose “others.” Each player who isn’t the active player or the targeted player will thus be affected."
+          "text": "In a Supervillain Rumble game, the targeted player may still choose \"others.\" Each player who isn't the active player or the targeted player will thus be affected."
         }
       ],
       "text": "When you set this scheme in motion, target opponent chooses self or others. If that player chooses self, he or she sacrifices two lands. If the player chooses others, each of your other opponents sacrifices a land.",
@@ -3168,7 +3169,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "For a player’s life total to become a certain number that’s lower than his or her current life total, what actually happens is that the player loses the appropriate amount of life. For example, if the lowest life total among your opponents is 5 and another opponent has 12 life, this scheme’s ability will cause that player to lose 7 life. Abilities that interact with life loss will interact with this effect accordingly."
+          "text": "For a player's life total to become a certain number that's lower than his or her current life total, what actually happens is that the player loses the appropriate amount of life. For example, if the lowest life total among your opponents is 5 and another opponent has 12 life, this scheme's ability will cause that player to lose 7 life. Abilities that interact with life loss will interact with this effect accordingly."
         }
       ],
       "text": "When you set this scheme in motion, each opponent's life total becomes the lowest life total among your opponents.",
@@ -3237,7 +3238,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2016-06-08",
@@ -3311,19 +3312,19 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Any of those permanents that are creatures at the time your declare attackers step begins must attack its owner if able. This includes permanents that became creatures after you gained control of them, such as an animated Chimeric Staff. Any of those permanents that aren’t creatures at that time can’t attack."
+          "text": "Any of those permanents that are creatures at the time your declare attackers step begins must attack its owner if able. This includes permanents that became creatures after you gained control of them, such as an animated Chimeric Staff. Any of those permanents that aren't creatures at that time can't attack."
         },
         {
           "date": "2010-06-15",
-          "text": "If, during your declare attackers step, one of the creatures you gained control of this way is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having that creature attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, one of the creatures you gained control of this way is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having that creature attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If one of those creatures can’t attack its owner that turn due to a spell or ability (such as Chronomantic Escape), you may have it attack another player, attack a planeswalker an opponent controls, or not attack at all. If there’s a cost with having that creature attack its owner, you aren’t forced to pay that cost, so you may have it attack another player, attack a planeswalker an opponent controls, or not attack at all."
+          "text": "If one of those creatures can't attack its owner that turn due to a spell or ability (such as Chronomantic Escape), you may have it attack another player, attack a planeswalker an opponent controls, or not attack at all. If there's a cost with having that creature attack its owner, you aren't forced to pay that cost, so you may have it attack another player, attack a planeswalker an opponent controls, or not attack at all."
         },
         {
           "date": "2010-06-15",
-          "text": "If there are multiple combat phases that turn, each of those permanents must attack its owner only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases that turn, each of those permanents must attack its owner only in the first one in which it's able to."
         }
       ],
       "text": "When you set this scheme in motion, gain control of all nonland permanents your opponents control until end of turn. Untap those permanents. They gain haste until end of turn. Each of them attacks its owner this turn if able.",
@@ -3438,7 +3439,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "As the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it’s too late for any player to respond since the ability is already in the midst of resolving."
+          "text": "As the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it's too late for any player to respond since the ability is already in the midst of resolving."
         }
       ],
       "text": "When you set this scheme in motion, you may pay {X}. If you do, you gain X life and draw X cards.",
@@ -3663,19 +3664,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You choose a total of one card, and that card can’t be a creature or a land."
+          "text": "You choose a total of one card, and that card can't be a creature or a land."
         },
         {
           "date": "2010-06-15",
-          "text": "If you choose a card, you cast it as part of the resolution of this ability. Timing restrictions based on the card’s type are ignored. Other restrictions are not (such as “Cast [this card] only during your end step”)."
+          "text": "If you choose a card, you cast it as part of the resolution of this ability. Timing restrictions based on the card's type are ignored. Other restrictions are not (such as \"Cast [this card] only during your end step\")."
         },
         {
           "date": "2010-06-15",
-          "text": "If you choose a card you can’t cast (because there are no legal targets for the spell, for example), nothing happens to it. It remains in its owner’s hand."
+          "text": "If you choose a card you can't cast (because there are no legal targets for the spell, for example), nothing happens to it. It remains in its owner's hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card “without paying its mana cost,” the value of any X in the card’s mana cost must be 0. You can’t pay any alternative costs for that card. On the other hand, if the card has optional additional costs (such as kicker or replicate), you may pay those when you cast the card. If the card has mandatory additional costs (such as Fling does), you must pay those when you cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" the value of any X in the card's mana cost must be 0. You can't pay any alternative costs for that card. On the other hand, if the card has optional additional costs (such as kicker or replicate), you may pay those when you cast the card. If the card has mandatory additional costs (such as Fling does), you must pay those when you cast the card."
         }
       ],
       "text": "When you set this scheme in motion, each opponent reveals his or her hand. You may choose a noncreature, nonland card revealed this way and cast it without paying its mana cost.",
@@ -3787,11 +3788,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "The four permanents are put on top of their owners’ libraries in sequence. That means that a single artifact creature, for example, can’t be chosen as both the creature and as the artifact."
+          "text": "The four permanents are put on top of their owners' libraries in sequence. That means that a single artifact creature, for example, can't be chosen as both the creature and as the artifact."
         },
         {
           "date": "2010-06-15",
-          "text": "If there are no applicable choices for one of the permanent types, it’s simply skipped. The process is still repeated for the other listed permanent types."
+          "text": "If there are no applicable choices for one of the permanent types, it's simply skipped. The process is still repeated for the other listed permanent types."
         },
         {
           "date": "2010-06-15",
@@ -3803,7 +3804,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If one of the chosen permanents is controlled by an opponent but owned by you, you’ll wind up shuffling your library."
+          "text": "If one of the chosen permanents is controlled by an opponent but owned by you, you'll wind up shuffling your library."
         }
       ],
       "text": "When you set this scheme in motion, target opponent chooses a creature you don't control and puts it on top of its owner's library, then repeats this process for an artifact, an enchantment, and a land. Then the owner of each permanent chosen this way shuffles his or her library.",
@@ -3907,27 +3908,27 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You’re the defending player if a creature is attacking you or a planeswalker you control."
+          "text": "You're the defending player if a creature is attacking you or a planeswalker you control."
         },
         {
           "date": "2010-06-15",
-          "text": "For each unblocked creature attacking you, you must put a Plant token onto the battlefield blocking it, even if you don’t want to."
+          "text": "For each unblocked creature attacking you, you must put a Plant token onto the battlefield blocking it, even if you don't want to."
         },
         {
           "date": "2010-06-15",
-          "text": "The Plant token blocks the attacking creature even if the block couldn’t legally be declared (for example, if the attacking creature has flying)."
+          "text": "The Plant token blocks the attacking creature even if the block couldn't legally be declared (for example, if the attacking creature has flying)."
         },
         {
           "date": "2010-06-15",
-          "text": "Putting a blocking creature onto the battlefield doesn’t trigger “Whenever a creature blocks” abilities. It also won’t check blocking restrictions, costs, or requirements."
+          "text": "Putting a blocking creature onto the battlefield doesn't trigger \"Whenever a creature blocks\" abilities. It also won't check blocking restrictions, costs, or requirements."
         },
         {
           "date": "2010-06-15",
-          "text": "Putting a blocking creature onto the battlefield will trigger “When this creature becomes blocked by a creature” abilities. It will also trigger “When this creature becomes blocked” abilities in this case, because the attacking creature had not yet been blocked that combat."
+          "text": "Putting a blocking creature onto the battlefield will trigger \"When this creature becomes blocked by a creature\" abilities. It will also trigger \"When this creature becomes blocked\" abilities in this case, because the attacking creature had not yet been blocked that combat."
         },
         {
           "date": "2010-06-15",
-          "text": "The last ability triggers only if four or more creatures were declared as attackers during your opponents’ declare attackers step. Only creatures attacking you are counted; creatures attacking your planeswalkers are not. The creatures may be controlled by different players."
+          "text": "The last ability triggers only if four or more creatures were declared as attackers during your opponents' declare attackers step. Only creatures attacking you are counted; creatures attacking your planeswalkers are not. The creatures may be controlled by different players."
         }
       ],
       "supertypes": [
@@ -3989,7 +3990,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target creature is an illegal target by the time Chandra’s Outrage resolves, the entire spell is countered. No player is dealt damage."
+          "text": "If the target creature is an illegal target by the time Chandra's Outrage resolves, the entire spell is countered. No player is dealt damage."
         }
       ],
       "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
@@ -4046,11 +4047,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "The prevention effect doesn’t affect damage dealt directly to a planeswalker you control (such as combat damage). It can prevent noncombat damage that’s redirected from you to a planeswalker you control if you apply this effect first."
+          "text": "The prevention effect doesn't affect damage dealt directly to a planeswalker you control (such as combat damage). It can prevent noncombat damage that's redirected from you to a planeswalker you control if you apply this effect first."
         },
         {
           "date": "2010-06-15",
-          "text": "The last ability won’t trigger at all unless, as an end step starts, you have already been dealt 5 or more damage that turn. It doesn’t matter whether any of it was combat damage or not, nor does it matter who controlled the sources of that damage. (In other words, it will count damage dealt to you by sources you control.)"
+          "text": "The last ability won't trigger at all unless, as an end step starts, you have already been dealt 5 or more damage that turn. It doesn't matter whether any of it was combat damage or not, nor does it matter who controlled the sources of that damage. (In other words, it will count damage dealt to you by sources you control.)"
         },
         {
           "date": "2010-06-15",
@@ -4162,7 +4163,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Each opponent who can sacrifice a creature must do so, and thus won’t discard any cards. Each opponent who can’t sacrifice a creature (either because he or she doesn’t control any, or because he or she controls Tajuru Preserver) will wind up discarding two cards. Your opponents have no choice in the matter."
+          "text": "Each opponent who can sacrifice a creature must do so, and thus won't discard any cards. Each opponent who can't sacrifice a creature (either because he or she doesn't control any, or because he or she controls Tajuru Preserver) will wind up discarding two cards. Your opponents have no choice in the matter."
         }
       ],
       "text": "When you set this scheme in motion, each opponent sacrifices a creature. Then each opponent who didn't sacrifice a creature discards two cards.",
@@ -4343,11 +4344,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -4585,7 +4586,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -4597,7 +4598,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -4655,7 +4656,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "For each Zombie token you put onto the battlefield this way, make sure it’s clear who its designated player is. A token’s designated player won’t change for the rest of the game."
+          "text": "For each Zombie token you put onto the battlefield this way, make sure it's clear who its designated player is. A token's designated player won't change for the rest of the game."
         },
         {
           "date": "2010-06-15",
@@ -4663,15 +4664,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If, during your declare attackers step, one of these Zombies is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having that creature attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, one of these Zombies is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having that creature attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If one of these Zombies can’t attack its designated player during any given turn (because that player has left the game, due to a spell or ability such as Chronomantic Escape, or because a player on the opposing team has gained control of it, for example), it may attack another player, attack a planeswalker an opponent controls, or not attack at all. If there’s a cost with having that creature attack its designated player, you aren’t forced to pay that cost, so it may attack another player, attack a planeswalker an opponent controls, or not attack at all."
+          "text": "If one of these Zombies can't attack its designated player during any given turn (because that player has left the game, due to a spell or ability such as Chronomantic Escape, or because a player on the opposing team has gained control of it, for example), it may attack another player, attack a planeswalker an opponent controls, or not attack at all. If there's a cost with having that creature attack its designated player, you aren't forced to pay that cost, so it may attack another player, attack a planeswalker an opponent controls, or not attack at all."
         },
         {
           "date": "2010-06-15",
-          "text": "If there are multiple combat phases in a turn, each of these Zombies must attack its designated player in each of them that it’s able to."
+          "text": "If there are multiple combat phases in a turn, each of these Zombies must attack its designated player in each of them that it's able to."
         }
       ],
       "text": "When you set this scheme in motion, for each opponent, create a 2/2 black Zombie creature token that attacks that player each combat if able.",
@@ -4732,7 +4733,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You choose the target when the ability triggers. When the ability resolves, you choose a value for X and decide whether to pay {X}{R}. If you do decide to pay {X}{R}, it’s too late for any player to respond since the ability is already in the midst of resolving."
+          "text": "You choose the target when the ability triggers. When the ability resolves, you choose a value for X and decide whether to pay {X}{R}. If you do decide to pay {X}{R}, it's too late for any player to respond since the ability is already in the midst of resolving."
         }
       ],
       "subtypes": [
@@ -4790,15 +4791,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The targeted player may choose “self” even if he or she can’t perform the resulting action. For example, a player targeted with Feed the Machine may choose “self” even if he or she controls no creatures."
+          "text": "The targeted player may choose \"self\" even if he or she can't perform the resulting action. For example, a player targeted with Feed the Machine may choose \"self\" even if he or she controls no creatures."
         },
         {
           "date": "2010-06-15",
-          "text": "The targeted player may choose “others” even if there are no others (because all of his or her teammates have lost the game, for example), or the archenemy’s other opponents can’t perform the resulting action."
+          "text": "The targeted player may choose \"others\" even if there are no others (because all of his or her teammates have lost the game, for example), or the archenemy's other opponents can't perform the resulting action."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Supervillain Rumble game, the targeted player may still choose “others.” Each player who isn’t the active player or the targeted player will thus be affected."
+          "text": "In a Supervillain Rumble game, the targeted player may still choose \"others.\" Each player who isn't the active player or the targeted player will thus be affected."
         }
       ],
       "text": "When you set this scheme in motion, target opponent chooses self or others. If that player chooses self, he or she discards four cards. If the player chooses others, each of your other opponents discards two cards.",
@@ -5085,7 +5086,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You decide whether to pay {5}{R}{R} as Hellkite Charger’s ability resolves."
+          "text": "You decide whether to pay {5}{R}{R} as Hellkite Charger's ability resolves."
         },
         {
           "date": "2009-10-01",
@@ -5093,7 +5094,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Hellkite Charger’s ability may trigger multiple times in the same turn, since its own ability gives it multiple chances to attack. Each time it resolves, you may create an additional combat phase."
+          "text": "Hellkite Charger's ability may trigger multiple times in the same turn, since its own ability gives it multiple chances to attack. Each time it resolves, you may create an additional combat phase."
         },
         {
           "date": "2009-10-01",
@@ -5155,7 +5156,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You choose the target opponent when the ability triggers. As the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it’s too late for any player to respond since the ability is already in the midst of resolving."
+          "text": "You choose the target opponent when the ability triggers. As the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it's too late for any player to respond since the ability is already in the midst of resolving."
         }
       ],
       "text": "When you set this scheme in motion, you may pay {X}. If you do, this scheme deals X damage to target opponent and each creature he or she controls.",
@@ -5326,11 +5327,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -5338,11 +5339,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Inferno Trap’s alternative cost condition checks for any damage, not just combat damage."
+          "text": "Inferno Trap's alternative cost condition checks for any damage, not just combat damage."
         },
         {
           "date": "2009-10-01",
-          "text": "The alternative cost condition doesn’t check who controlled the creatures that dealt damage to you. Damage dealt to you by your own creatures counts."
+          "text": "The alternative cost condition doesn't check who controlled the creatures that dealt damage to you. Damage dealt to you by your own creatures counts."
         },
         {
           "date": "2009-10-01",
@@ -5411,11 +5412,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "The effect doesn’t wear off until just before your next untap step (even if an effect will cause that untap step to be skipped). Effectively, that means it removes your maximum hand size just during the turn in which you set it in motion."
+          "text": "The effect doesn't wear off until just before your next untap step (even if an effect will cause that untap step to be skipped). Effectively, that means it removes your maximum hand size just during the turn in which you set it in motion."
         },
         {
           "date": "2010-06-15",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and later set this scheme in motion, you’ll have no maximum hand size until your next turn. However, if you set this scheme in motion and then put Null Profusion onto the battlefield that turn, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and later set this scheme in motion, you'll have no maximum hand size until your next turn. However, if you set this scheme in motion and then put Null Profusion onto the battlefield that turn, your maximum hand size would be two."
         }
       ],
       "text": "When you set this scheme in motion, draw four cards. You have no maximum hand size until your next turn.",
@@ -5523,7 +5524,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may target any creature an opponent controls, even one that’s already untapped."
+          "text": "You may target any creature an opponent controls, even one that's already untapped."
         }
       ],
       "text": "When you set this scheme in motion, gain control of target creature an opponent controls until end of turn. Untap that creature. It gets +3/+3 and gains trample and haste until end of turn.",
@@ -5936,7 +5937,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Volcanic Fallout can be targeted by spells that try to counter it (such as Countersquall). Those spells will still resolve, but the part of their effect that would counter Volcanic Fallout won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Volcanic Fallout can be targeted by spells that try to counter it (such as Countersquall). Those spells will still resolve, but the part of their effect that would counter Volcanic Fallout won't do anything. Any other effects those spells have will work as normal."
         }
       ],
       "text": "Volcanic Fallout can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
@@ -6117,7 +6118,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Although the targeted player doesn’t need to find a basic land card if he or she doesn’t want to, that player must shuffle his or her library."
+          "text": "Although the targeted player doesn't need to find a basic land card if he or she doesn't want to, that player must shuffle his or her library."
         }
       ],
       "subtypes": [
@@ -6577,7 +6578,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -6655,7 +6656,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -6909,11 +6910,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Primal Command’s modes are performed in the order listed. If you put a noncreature permanent on top of its owner’s library and have that player shuffle his or her graveyard into his or her library, that card is shuffled away."
+          "text": "Primal Command's modes are performed in the order listed. If you put a noncreature permanent on top of its owner's library and have that player shuffle his or her graveyard into his or her library, that card is shuffled away."
         },
         {
           "date": "2017-03-14",
-          "text": "Primal Command won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect if you target yourself with its third mode."
+          "text": "Primal Command won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect if you target yourself with its third mode."
         }
       ],
       "text": "Choose two —\n• Target player gains 7 life.\n• Put target noncreature permanent on top of its owner's library.\n• Target player shuffles his or her graveyard into his or her library.\n• Search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
@@ -6979,7 +6980,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -7164,11 +7165,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -7176,15 +7177,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -7192,15 +7193,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -7332,7 +7333,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Verdeloth won’t give himself +1/+1 unless he somehow becomes a Saproling."
+          "text": "Verdeloth won't give himself +1/+1 unless he somehow becomes a Saproling."
         }
       ],
       "subtypes": [
@@ -7523,7 +7524,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You may target yourself with Yavimaya Dryad’s ability."
+          "text": "You may target yourself with Yavimaya Dryad's ability."
         }
       ],
       "subtypes": [
@@ -7718,11 +7719,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "While Armadillo Cloak’s last ability is similar to lifelink, it isn’t lifelink—it’s a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you’ll gain that much life for lifelink, and then Armadillo Cloak’s triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak’s triggered ability do trigger separately."
+          "text": "While Armadillo Cloak's last ability is similar to lifelink, it isn't lifelink—it's a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you'll gain that much life for lifelink, and then Armadillo Cloak's triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak's triggered ability do trigger separately."
         },
         {
           "date": "2016-06-08",
-          "text": "If Armadillo Cloak enchants a creature you don’t control, you’ll gain life when it deals damage, as long as that damage hasn’t already caused you to lose the game."
+          "text": "If Armadillo Cloak enchants a creature you don't control, you'll gain life when it deals damage, as long as that damage hasn't already caused you to lose the game."
         }
       ],
       "subtypes": [
@@ -7850,7 +7851,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn’t matter how much mana of that color was spent."
+          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn't matter how much mana of that color was spent."
         },
         {
           "date": "2008-08-01",
@@ -7934,11 +7935,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -8004,7 +8005,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may choose just the first mode (targeting a creature with flying), just the second mode (targeting a creature without flying), or both modes (targeting a creature with flying and a creature without flying). You can’t choose a mode unless there’s a legal target for it."
+          "text": "You may choose just the first mode (targeting a creature with flying), just the second mode (targeting a creature without flying), or both modes (targeting a creature with flying and a creature without flying). You can't choose a mode unless there's a legal target for it."
         }
       ],
       "text": "Choose one or both —\n• Branching Bolt deals 3 damage to target creature with flying.\n• Branching Bolt deals 3 damage to target creature without flying.",
@@ -8121,7 +8122,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "When Ethersworn Shieldmage’s triggered ability resolves, it doesn’t lock in which permanents will be affected. For the rest of the turn, any time damage would be dealt to a permanent, check whether it’s an artifact creature at that time. If it is, that damage is prevented."
+          "text": "When Ethersworn Shieldmage's triggered ability resolves, it doesn't lock in which permanents will be affected. For the rest of the turn, any time damage would be dealt to a permanent, check whether it's an artifact creature at that time. If it is, that damage is prevented."
         }
       ],
       "subtypes": [
@@ -8187,7 +8188,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Casting this card by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn’t change the spell’s mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting this card by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn't change the spell's mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-05-01",
@@ -8195,11 +8196,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner’s hand, regardless of that land’s subtype or whether it’s tapped."
+          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner's hand, regardless of that land's subtype or whether it's tapped."
         },
         {
           "date": "2009-05-01",
-          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell’s costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card’s alternative cost. (Of course, you can return a different basic land instead.)"
+          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell's costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card's alternative cost. (Of course, you can return a different basic land instead.)"
         }
       ],
       "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Fieldmist Borderpost's mana cost.\nFieldmist Borderpost enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
@@ -8449,11 +8450,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "For a player’s life total to become 10, what actually happens is that the player gains or loses the appropriate amount of life. For example, if the targeted player’s life total is 4 when this ability resolves, it will cause that player to gain 6 life; alternately, if the targeted player’s life total is 17 when this ability resolves, it will cause that player to lose 7 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For a player's life total to become 10, what actually happens is that the player gains or loses the appropriate amount of life. For example, if the targeted player's life total is 4 when this ability resolves, it will cause that player to gain 6 life; alternately, if the targeted player's life total is 17 when this ability resolves, it will cause that player to lose 7 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, this ability basically causes the team’s life total to become 10, but only the targeted player is considered to have actually gained or lost life."
+          "text": "In a Two-Headed Giant game, this ability basically causes the team's life total to become 10, but only the targeted player is considered to have actually gained or lost life."
         }
       ],
       "subtypes": [
@@ -8518,7 +8519,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Casting this card by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn’t change the spell’s mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting this card by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast an artifact spell. It also doesn't change the spell's mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-05-01",
@@ -8526,11 +8527,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner’s hand, regardless of that land’s subtype or whether it’s tapped."
+          "text": "To satisfy the alternative cost, you may return any basic land you control to its owner's hand, regardless of that land's subtype or whether it's tapped."
         },
         {
           "date": "2009-05-01",
-          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell’s costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card’s alternative cost. (Of course, you can return a different basic land instead.)"
+          "text": "As you cast a spell, you get a chance to activate mana abilities before you pay that spell's costs. Therefore, you may tap a basic land for mana, then both spend that mana and return that land to your hand to pay this card's alternative cost. (Of course, you can return a different basic land instead.)"
         }
       ],
       "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Mistvein Borderpost's mana cost.\nMistvein Borderpost enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
@@ -8591,7 +8592,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -8603,7 +8604,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -8673,7 +8674,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If the second ability is activated during the End step, the token won’t be exiled until the following turn’s End step."
+          "text": "If the second ability is activated during the End step, the token won't be exiled until the following turn's End step."
         }
       ],
       "subtypes": [
@@ -8941,7 +8942,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -9542,11 +9543,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Duplicant’s base power and toughness change to the imprinted card’s power and toughness. Counters and other effects that modify Duplicant’s power and toughness still apply."
+          "text": "Duplicant's base power and toughness change to the imprinted card's power and toughness. Counters and other effects that modify Duplicant's power and toughness still apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Abilities that define a creature’s power and toughness apply while that card is in exile, but abilities that add or subtract from it don’t. For example, the ability of Battle Squadron applies to determine Duplicant’s power and toughness, but the ability of Werebear doesn’t. Duplicant’s power and toughness are constantly updated if the exiled card’s power and/or toughness change."
+          "text": "Abilities that define a creature's power and toughness apply while that card is in exile, but abilities that add or subtract from it don't. For example, the ability of Battle Squadron applies to determine Duplicant's power and toughness, but the ability of Werebear doesn't. Duplicant's power and toughness are constantly updated if the exiled card's power and/or toughness change."
         },
         {
           "date": "2016-06-08",
@@ -9554,7 +9555,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If a melded permanent is exiled by Duplicant’s triggered ability, that ability’s controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
+          "text": "If a melded permanent is exiled by Duplicant's triggered ability, that ability's controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
         }
       ],
       "subtypes": [
@@ -9737,11 +9738,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -9806,7 +9807,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You are not allowed to “unequip” equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won’t be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
+          "text": "You are not allowed to \"unequip\" equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won't be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
         }
       ],
       "subtypes": [
@@ -9864,15 +9865,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The ability affects each spell that’s not an artifact spell, including your own."
+          "text": "The ability affects each spell that's not an artifact spell, including your own."
         },
         {
           "date": "2010-03-01",
-          "text": "The ability affects the total cost of each nonartifact spell, but it doesn’t change that spell’s mana cost or converted mana cost. The extra mana also doesn’t change how many times you kicked the spell or what the value of X is (if applicable)."
+          "text": "The ability affects the total cost of each nonartifact spell, but it doesn't change that spell's mana cost or converted mana cost. The extra mana also doesn't change how many times you kicked the spell or what the value of X is (if applicable)."
         },
         {
           "date": "2010-03-01",
-          "text": "When determining a spell’s total cost, effects that increase the cost are applied before effects that reduce the cost."
+          "text": "When determining a spell's total cost, effects that increase the cost are applied before effects that reduce the cost."
         }
       ],
       "subtypes": [
@@ -9935,7 +9936,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The effects of Memnarch’s abilities don’t end at end of turn, and they don’t end when Memnarch leaves the battlefield. Both effects last until the affected permanent leaves the battlefield."
+          "text": "The effects of Memnarch's abilities don't end at end of turn, and they don't end when Memnarch leaves the battlefield. Both effects last until the affected permanent leaves the battlefield."
         },
         {
           "date": "2004-12-01",
@@ -10108,11 +10109,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Skullcage’s ability deals damage if the player has zero, one, two, five, or more than five cards in hand when its ability resolves."
+          "text": "Skullcage's ability deals damage if the player has zero, one, two, five, or more than five cards in hand when its ability resolves."
         },
         {
           "date": "2004-12-01",
-          "text": "Skullcage doesn’t check hand size when it triggers, only when it resolves."
+          "text": "Skullcage doesn't check hand size when it triggers, only when it resolves."
         }
       ],
       "text": "At the beginning of each opponent's upkeep, Skullcage deals 2 damage to that player unless he or she has exactly three or exactly four cards in hand.",
@@ -10165,7 +10166,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If you no longer control Sorcerer’s Strongbox by the time you win the flip, you won’t be able to sacrifice it. You’ll still draw three cards, though."
+          "text": "If you no longer control Sorcerer's Strongbox by the time you win the flip, you won't be able to sacrifice it. You'll still draw three cards, though."
         }
       ],
       "text": "{2}, {T}: Flip a coin. If you win the flip, sacrifice Sorcerer's Strongbox and draw three cards.",
@@ -10273,11 +10274,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Sundering Titan’s two abilities aren’t targeted. When one of the abilities resolves, the Titan’s controller must choose one land for each basic land type (Plains, Island, Swamp, Mountain, and Forest)."
+          "text": "Sundering Titan's two abilities aren't targeted. When one of the abilities resolves, the Titan's controller must choose one land for each basic land type (Plains, Island, Swamp, Mountain, and Forest)."
         },
         {
           "date": "2004-12-01",
-          "text": "If one of the basic land types isn’t present, it isn’t chosen. If the only land of a certain type is one you control, you must choose it."
+          "text": "If one of the basic land types isn't present, it isn't chosen. If the only land of a certain type is one you control, you must choose it."
         },
         {
           "date": "2004-12-01",
@@ -10489,7 +10490,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If Thunderstaff is untapped, it prevents 1 damage from each creature, each time it would deal combat damage to you. So if three creatures with double strike attack you and aren’t blocked, Thunderstaff will prevent a total of 6 damage."
+          "text": "If Thunderstaff is untapped, it prevents 1 damage from each creature, each time it would deal combat damage to you. So if three creatures with double strike attack you and aren't blocked, Thunderstaff will prevent a total of 6 damage."
         }
       ],
       "text": "As long as Thunderstaff is untapped, if a creature would deal combat damage to you, prevent 1 of that damage.\n{2}, {T}: Attacking creatures get +1/+0 until end of turn.",
@@ -10547,15 +10548,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -10873,7 +10874,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The +1/+1 counter won’t affect Llanowar Reborn in any way unless another effect turns it into a creature."
+          "text": "The +1/+1 counter won't affect Llanowar Reborn in any way unless another effect turns it into a creature."
         }
       ],
       "text": "Llanowar Reborn enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nGraft 1 (This land enters the battlefield with a +1/+1 counter on it. Whenever a creature enters the battlefield, you may move a +1/+1 counter from this land onto it.)",
@@ -10974,11 +10975,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\nThreshold — {G}{W}: Nantuko Monastery becomes a 4/4 green and white Insect Monk creature with first strike until end of turn. It's still a land. Activate this ability only if seven or more cards are in your graveyard.",

--- a/json/ARN.json
+++ b/json/ARN.json
@@ -109,7 +109,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Aladdin’s ability can take control of more than one artifact, although only one each time the ability is used."
+          "text": "Aladdin's ability can take control of more than one artifact, although only one each time the ability is used."
         },
         {
           "date": "2008-08-01",
@@ -228,7 +228,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"When he reached the entrance of the cavern, he pronounced the words, ‘Open, Sesame!'\" —The Arabian Nights, Junior Classics trans.",
+      "flavor": "\"When he reached the entrance of the cavern, he pronounced the words, 'Open, Sesame!'\" —The Arabian Nights, Junior Classics trans.",
       "id": "249073e519aec9b49786df1b5c87182ed8a78522",
       "imageName": "ali baba",
       "layout": "normal",
@@ -261,11 +261,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This ability may be used to tap more than one Wall per turn if you have enough mana, since tapping isn’t part of the activation cost."
+          "text": "This ability may be used to tap more than one Wall per turn if you have enough mana, since tapping isn't part of the activation cost."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability may tap walls even when Ali Baba is tapped or just entered the battlefield, since the activation cost doesn’t include {T}."
+          "text": "The ability may tap walls even when Ali Baba is tapped or just entered the battlefield, since the activation cost doesn't include {T}."
         }
       ],
       "subtypes": [
@@ -466,7 +466,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t cast spells or activate mana abilities before discarding the extra cards."
+          "text": "You can't cast spells or activate mana abilities before discarding the extra cards."
         }
       ],
       "text": "{T}: Draw two cards, then discard three cards.",
@@ -726,7 +726,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -847,7 +847,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass’s triggered ability is put on the stack on top of it. City of Brass’s ability will resolve first."
+          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass's triggered ability is put on the stack on top of it. City of Brass's ability will resolve first."
         },
         {
           "date": "2004-10-04",
@@ -903,7 +903,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different opposing player each time it is used. You also don’t have to choose the same player that you targeted with the effect (or whose creature you targeted)."
+          "text": "In multiplayer games you can choose a different opposing player each time it is used. You also don't have to choose the same player that you targeted with the effect (or whose creature you targeted)."
         },
         {
           "date": "2004-10-04",
@@ -1125,11 +1125,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be used on any player’s attacking creatures. This includes your own and creatures in an attack you are not involved in (for multiplayer games)."
+          "text": "The ability can be used on any player's attacking creatures. This includes your own and creatures in an attack you are not involved in (for multiplayer games)."
         },
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -1321,7 +1321,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "This card’s ability is not targeted, so even untargetable creatures or those with Protection can be chosen."
+          "text": "This card's ability is not targeted, so even untargetable creatures or those with Protection can be chosen."
         },
         {
           "date": "2013-07-01",
@@ -1329,7 +1329,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If there are multiple creatures tied for least power and some but not all of them have indestructible, the ones with indestructible can’t be chosen."
+          "text": "If there are multiple creatures tied for least power and some but not all of them have indestructible, the ones with indestructible can't be chosen."
         }
       ],
       "text": "At the beginning of your upkeep, destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them.\nWhen there are no creatures on the battlefield, sacrifice Drop of Honey.",
@@ -1620,7 +1620,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different player’s creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
+          "text": "In multiplayer games you can choose a different player's creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
         },
         {
           "date": "2004-10-04",
@@ -2428,7 +2428,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "text": "{T}: Target creature with flying has base power 0 until end of turn.",
@@ -2471,7 +2471,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you do not have the card still in your hand, you can’t pay the cost. There is currently no way to prove that it was the card you drew except to get a judge or 3rd party involved, or to put cards you draw aside until you decide whether or not to use this."
+          "text": "If you do not have the card still in your hand, you can't pay the cost. There is currently no way to prove that it was the card you drew except to get a judge or 3rd party involved, or to put cards you draw aside until you decide whether or not to use this."
         },
         {
           "date": "2004-10-04",
@@ -3006,7 +3006,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -3556,7 +3556,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The player can pay the {1} mana at any time after damage is done before the draw step of that player’s turn. People commonly pay during upkeep."
+          "text": "The player can pay the {1} mana at any time after damage is done before the draw step of that player's turn. People commonly pay during upkeep."
         },
         {
           "date": "2004-10-04",
@@ -3624,7 +3624,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The player can pay the {1} mana at any time after damage is done before the draw step of that player’s turn. People commonly pay during upkeep."
+          "text": "The player can pay the {1} mana at any time after damage is done before the draw step of that player's turn. People commonly pay during upkeep."
         },
         {
           "date": "2004-10-04",
@@ -3730,15 +3730,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Old Man of the Sea stops being tapped before its ability resolves — even if it becomes tapped again right away — you won’t gain control of the targeted creature at all. The same is true if the targeted creature’s power becomes greater than Old Man of the Sea’s power before the ability resolves."
+          "text": "If Old Man of the Sea stops being tapped before its ability resolves — even if it becomes tapped again right away — you won't gain control of the targeted creature at all. The same is true if the targeted creature's power becomes greater than Old Man of the Sea's power before the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "The ability doesn’t care whether Old Man of the Sea remains under your control, only that Old Man of the Sea remains tapped and its power remains large enough. If an opponent gains control of Old Man of the Sea, you’ll keep control of the affected creature (until Old Man of the Sea stops being tapped or it no longer has enough power)."
+          "text": "The ability doesn't care whether Old Man of the Sea remains under your control, only that Old Man of the Sea remains tapped and its power remains large enough. If an opponent gains control of Old Man of the Sea, you'll keep control of the affected creature (until Old Man of the Sea stops being tapped or it no longer has enough power)."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the targeted permanent remains a legal target for the ability, only that it’s on the battlefield and its power remains small enough. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason. If it stops being a creature, its power is considered to be 0."
+          "text": "Once the ability resolves, it doesn't care whether the targeted permanent remains a legal target for the ability, only that it's on the battlefield and its power remains small enough. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason. If it stops being a creature, its power is considered to be 0."
         }
       ],
       "subtypes": [
@@ -3798,7 +3798,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can’t be enchanted by an Aura that was also exiled by Oubliette, that Aura will remain exiled."
+          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can't be enchanted by an Aura that was also exiled by Oubliette, that Aura will remain exiled."
         }
       ],
       "text": "When Oubliette enters the battlefield, exile target creature and all Auras attached to it. Note the number and kind of counters that were on that creature.\nWhen Oubliette leaves the battlefield, return that exiled card to the battlefield under its owner's control tapped with the noted number and kind of counters on it. If you do, return the other exiled cards to the battlefield under their owner's control attached to that permanent.",
@@ -3857,7 +3857,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can’t be enchanted by an Aura that was also exiled by Oubliette, that Aura will remain exiled."
+          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can't be enchanted by an Aura that was also exiled by Oubliette, that Aura will remain exiled."
         }
       ],
       "text": "When Oubliette enters the battlefield, exile target creature and all Auras attached to it. Note the number and kind of counters that were on that creature.\nWhen Oubliette leaves the battlefield, return that exiled card to the battlefield under its owner's control tapped with the noted number and kind of counters on it. If you do, return the other exiled cards to the battlefield under their owner's control attached to that permanent.",
@@ -4083,7 +4083,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "Ring of Ma’rûf works a little differently than the Wishes from others sets. Rather than letting you simply put a card into your hand from outside the game, this ability replaces your next draw. If you wouldn’t draw a card during the rest of the turn, the ability won’t have any effect."
+          "text": "Ring of Ma'rûf works a little differently than the Wishes from others sets. Rather than letting you simply put a card into your hand from outside the game, this ability replaces your next draw. If you wouldn't draw a card during the rest of the turn, the ability won't have any effect."
         }
       ],
       "text": "{5}, {T}, Exile Ring of Ma'rûf: The next time you would draw a card this turn, instead choose a card you own from outside the game and put it into your hand.",
@@ -4487,7 +4487,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "At the end of a subgame, each player puts all cards he or she owns that are in the subgame into his or her library in the main game, then shuffles them. This includes cards in the subgame’s Exile zone (this is a change from previous rulings)."
+          "text": "At the end of a subgame, each player puts all cards he or she owns that are in the subgame into his or her library in the main game, then shuffles them. This includes cards in the subgame's Exile zone."
         }
       ],
       "text": "Players play a MAGIC subgame, using their libraries as their decks. Each player who doesn't win the subgame loses half his or her life, rounded up.",
@@ -4546,7 +4546,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If the draw is replaced by another effect, none of the rest of Sindbad’s ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
+          "text": "If the draw is replaced by another effect, none of the rest of Sindbad's ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
         },
         {
           "date": "2006-09-25",
@@ -4605,11 +4605,11 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Changes creature’s current power to zero (as opposed to giving it -X/-0, like before) but does not prevent raising it after the Tree has been used on it."
+          "text": "Changes creature's current power to zero (as opposed to giving it -X/-0, like before) but does not prevent raising it after the Tree has been used on it."
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -4879,7 +4879,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -4948,7 +4948,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",

--- a/json/ATQ.json
+++ b/json/ATQ.json
@@ -556,7 +556,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "It’s the ability, not the counter that makes the creature an artifact. The creature remains an artifact even if the +1/+1 counter is removed."
+          "text": "It's the ability, not the counter that makes the creature an artifact. The creature remains an artifact even if the +1/+1 counter is removed."
         }
       ],
       "text": "{T}, Sacrifice Ashnod's Transmogrant: Put a +1/+1 counter on target nonartifact creature. That creature becomes an artifact in addition to its other types.",
@@ -663,7 +663,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -727,11 +727,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t choose to pay 10 life if you have less than 10 life, but you may choose to give up the game immediately. This has roughly the same effect."
+          "text": "You can't choose to pay 10 life if you have less than 10 life, but you may choose to give up the game immediately. This has roughly the same effect."
         },
         {
           "date": "2004-10-04",
-          "text": "You can take control of your opponent’s Tablet and in the trade you only have to give them back their Tablet."
+          "text": "You can take control of your opponent's Tablet and in the trade you only have to give them back their Tablet."
         },
         {
           "date": "2004-10-04",
@@ -784,7 +784,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You may untap your opponent’s lands if desired."
+          "text": "You may untap your opponent's lands if desired."
         },
         {
           "date": "2004-10-04",
@@ -1956,7 +1956,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have four or fewer cards in your hand when Ivory Tower’s ability resolves, the ability has no effect."
+          "text": "If you have four or fewer cards in your hand when Ivory Tower's ability resolves, the ability has no effect."
         }
       ],
       "text": "At the beginning of your upkeep, you gain X life, where X is the number of cards in your hand minus 4.",
@@ -2211,19 +2211,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Once turned into a creature, Mishra’s Factory’s last ability can target itself. If it’s already blocking, this won’t remove it from combat."
+          "text": "Once turned into a creature, Mishra's Factory's last ability can target itself. If it's already blocking, this won't remove it from combat."
         },
         {
           "date": "2016-06-08",
-          "text": "If you turn Mishra’s Factory into a creature but haven’t controlled it continuously since your most recent turn began, you won’t be able to activate its first or last ability."
+          "text": "If you turn Mishra's Factory into a creature but haven't controlled it continuously since your most recent turn began, you won't be able to activate its first or last ability."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
@@ -2276,19 +2276,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Once turned into a creature, Mishra’s Factory’s last ability can target itself. If it’s already blocking, this won’t remove it from combat."
+          "text": "Once turned into a creature, Mishra's Factory's last ability can target itself. If it's already blocking, this won't remove it from combat."
         },
         {
           "date": "2016-06-08",
-          "text": "If you turn Mishra’s Factory into a creature but haven’t controlled it continuously since your most recent turn began, you won’t be able to activate its first or last ability."
+          "text": "If you turn Mishra's Factory into a creature but haven't controlled it continuously since your most recent turn began, you won't be able to activate its first or last ability."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
@@ -2341,19 +2341,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Once turned into a creature, Mishra’s Factory’s last ability can target itself. If it’s already blocking, this won’t remove it from combat."
+          "text": "Once turned into a creature, Mishra's Factory's last ability can target itself. If it's already blocking, this won't remove it from combat."
         },
         {
           "date": "2016-06-08",
-          "text": "If you turn Mishra’s Factory into a creature but haven’t controlled it continuously since your most recent turn began, you won’t be able to activate its first or last ability."
+          "text": "If you turn Mishra's Factory into a creature but haven't controlled it continuously since your most recent turn began, you won't be able to activate its first or last ability."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
@@ -2406,19 +2406,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Once turned into a creature, Mishra’s Factory’s last ability can target itself. If it’s already blocking, this won’t remove it from combat."
+          "text": "Once turned into a creature, Mishra's Factory's last ability can target itself. If it's already blocking, this won't remove it from combat."
         },
         {
           "date": "2016-06-08",
-          "text": "If you turn Mishra’s Factory into a creature but haven’t controlled it continuously since your most recent turn began, you won’t be able to activate its first or last ability."
+          "text": "If you turn Mishra's Factory into a creature but haven't controlled it continuously since your most recent turn began, you won't be able to activate its first or last ability."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
@@ -2468,11 +2468,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You may choose to take damage or to discard. You can’t avoid taking damage if you have no cards to discard."
+          "text": "You may choose to take damage or to discard. You can't avoid taking damage if you have no cards to discard."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -2533,11 +2533,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can spend the mana on costs on the spell’s text."
+          "text": "You can spend the mana on costs on the spell's text."
         },
         {
           "date": "2004-10-04",
-          "text": "The mana can’t be used to pay Echo costs."
+          "text": "The mana can't be used to pay Echo costs."
         },
         {
           "date": "2004-10-04",
@@ -2809,7 +2809,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The target artifact can’t untap if the Gremlins and the artifact are tapped during untap, even if it is your artifact, and you plan on untapping the Gremlins."
+          "text": "The target artifact can't untap if the Gremlins and the artifact are tapped during untap, even if it is your artifact, and you plan on untapping the Gremlins."
         },
         {
           "date": "2004-10-04",
@@ -2879,11 +2879,11 @@
         },
         {
           "date": "2006-07-15",
-          "text": "Can’t reduce Snow mana costs."
+          "text": "Can't reduce Snow mana costs."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -3041,11 +3041,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         },
         {
           "date": "2012-07-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -3403,7 +3403,8 @@
         "3ED",
         "5ED",
         "6ED",
-        "10E"
+        "10E",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all artifacts. They can't be regenerated.",
@@ -3668,7 +3669,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -3763,19 +3764,19 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can’t be enchanted by an Aura that was also exiled by Tawnos’s Coffin, that Aura will remain exiled."
+          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can't be enchanted by an Aura that was also exiled by Tawnos's Coffin, that Aura will remain exiled."
         },
         {
           "date": "2007-09-16",
-          "text": "If Tawnos’s Coffin leaves the battlefield before its ability has resolved, it will exile the targeted creature forever, since its delayed triggered ability will never trigger."
+          "text": "If Tawnos's Coffin leaves the battlefield before its ability has resolved, it will exile the targeted creature forever, since its delayed triggered ability will never trigger."
         },
         {
           "date": "2008-04-01",
-          "text": "Because the new wording doesn’t use phasing, the exiled card will suffer from summoning sickness upon its return to the battlefield."
+          "text": "Because the new wording doesn't use phasing, the exiled card will suffer from summoning sickness upon its return to the battlefield."
         },
         {
           "date": "2008-04-01",
-          "text": "The effect doesn’t care what types the card has after it is exiled, only that it have been a creature while on the battlefield."
+          "text": "The effect doesn't care what types the card has after it is exiled, only that it have been a creature while on the battlefield."
         }
       ],
       "text": "You may choose not to untap Tawnos's Coffin during your untap step.\n{3}, {T}: Exile target creature and all Auras attached to it. Note the number and kind of counters that were on that creature. When Tawnos's Coffin leaves the battlefield or becomes untapped, return that exiled card to the battlefield under its owner's control tapped with the noted number and kind of counters on it. If you do, return the other exiled cards to the battlefield under their owner's control attached to that permanent.",
@@ -3906,7 +3907,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Only Tetravites from this specific Tetravus may be used for the ability. Ones from a different Tetravus can’t."
+          "text": "Only Tetravites from this specific Tetravus may be used for the ability. Ones from a different Tetravus can't."
         },
         {
           "date": "2008-08-01",
@@ -4022,7 +4023,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Each noncreature artifact loses all abilities and becomes an artifact creature with power and toughness each equal to its converted mana cost. If Titania's Song leaves the battlefield, this effect continues until end of turn.",
@@ -4080,7 +4081,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t sacrifice more than one artifact to this spell."
+          "text": "You can't sacrifice more than one artifact to this spell."
         },
         {
           "date": "2004-10-04",
@@ -4088,7 +4089,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2011-01-01",
@@ -4148,11 +4149,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it’ll be destroyed before you get a chance to activate its ability."
+          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it'll be destroyed before you get a chance to activate its ability."
         },
         {
           "date": "2010-08-15",
-          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won’t be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
+          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won't be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
         }
       ],
       "subtypes": [
@@ -4302,7 +4303,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -4360,7 +4361,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -4418,7 +4419,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -4476,7 +4477,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -4572,7 +4573,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -4630,7 +4631,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -4688,7 +4689,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -4746,7 +4747,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -5116,7 +5117,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [

--- a/json/AVR.json
+++ b/json/AVR.json
@@ -260,7 +260,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If a spell or activated ability has a cost that requires a player to pay life (as Griselbrand’s activated ability does) or sacrifice a creature (as Fling does), that spell or ability can’t be cast or activated."
+          "text": "If a spell or activated ability has a cost that requires a player to pay life (as Griselbrand's activated ability does) or sacrifice a creature (as Fling does), that spell or ability can't be cast or activated."
         },
         {
           "date": "2012-05-01",
@@ -268,7 +268,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Angel of Jubilation’s last ability doesn’t look for specific words on other cards. Rather, it stops players from taking specific actions. For example, you couldn’t activate an ability with an activation of cost of “Sacrifice an artifact:” by sacrificing an artifact creature (although you could sacrifice a noncreature artifact)."
+          "text": "Angel of Jubilation's last ability doesn't look for specific words on other cards. Rather, it stops players from taking specific actions. For example, you couldn't activate an ability with an activation of cost of \"Sacrifice an artifact:\" by sacrificing an artifact creature (although you could sacrifice a noncreature artifact)."
         }
       ],
       "subtypes": [
@@ -727,11 +727,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Creatures with indestructible still have damage marked on them, even though that damage won’t destroy them. If Avacyn leaves the battlefield, creatures that lose indestructible and have lethal damage marked on them will be destroyed."
+          "text": "Creatures with indestructible still have damage marked on them, even though that damage won't destroy them. If Avacyn leaves the battlefield, creatures that lose indestructible and have lethal damage marked on them will be destroyed."
         },
         {
           "date": "2013-07-01",
-          "text": "A permanent with indestructible can’t be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
+          "text": "A permanent with indestructible can't be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
         }
       ],
       "subtypes": [
@@ -1056,7 +1056,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If the enchanted creature becomes black, Call to Serve will be put into its owner’s graveyard the next time state-based actions are performed."
+          "text": "If the enchanted creature becomes black, Call to Serve will be put into its owner's graveyard the next time state-based actions are performed."
         }
       ],
       "subtypes": [
@@ -1171,7 +1171,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The creature that entered the battlefield and caused the ability to trigger will also get a +1/+1 counter, provided it’s still on the battlefield when the ability resolves."
+          "text": "The creature that entered the battlefield and caused the ability to trigger will also get a +1/+1 counter, provided it's still on the battlefield when the ability resolves."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
@@ -1609,7 +1609,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If the enchantment is an illegal target when Cursebreak tries to resolve, it’ll be countered and none of its effects will happen. You won’t gain 2 life."
+          "text": "If the enchantment is an illegal target when Cursebreak tries to resolve, it'll be countered and none of its effects will happen. You won't gain 2 life."
         }
       ],
       "text": "Destroy target enchantment. You gain 2 life.",
@@ -1826,11 +1826,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "No player can cast spells or activate abilities between returning the creature card to the battlefield and checking whether it’s an Angel."
+          "text": "No player can cast spells or activate abilities between returning the creature card to the battlefield and checking whether it's an Angel."
         },
         {
           "date": "2012-05-01",
-          "text": "If the creature is an Angel only on the battlefield (perhaps because it’s a non-Angel creature card and Xenograft is on the battlefield), it will get the +1/+1 counters."
+          "text": "If the creature is an Angel only on the battlefield (perhaps because it's a non-Angel creature card and Xenograft is on the battlefield), it will get the +1/+1 counters."
         }
       ],
       "text": "Return target creature card from your graveyard to the battlefield. If it's an Angel, put two +1/+1 counters on it.",
@@ -1941,7 +1941,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You can tap any two untapped Humans you control, including ones you haven’t controlled continuously since the beginning of your most recent turn, to pay the cost of Devout Chaplain’s activated ability. You must have controlled Devout Chaplain continuously since the beginning of your most recent turn, however."
+          "text": "You can tap any two untapped Humans you control, including ones you haven't controlled continuously since the beginning of your most recent turn, to pay the cost of Devout Chaplain's activated ability. You must have controlled Devout Chaplain continuously since the beginning of your most recent turn, however."
         }
       ],
       "subtypes": [
@@ -2055,7 +2055,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Divine Deflection’s only target is the creature or player it may deal damage to. You choose that target as you cast Divine Deflection, not at the time it prevents damage."
+          "text": "Divine Deflection's only target is the creature or player it may deal damage to. You choose that target as you cast Divine Deflection, not at the time it prevents damage."
         },
         {
           "date": "2012-05-01",
@@ -2067,15 +2067,15 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Divine Deflection can prevent damage from multiple sources dealing damage simultaneously (such as during combat). If the chosen value for X won’t prevent all the damage, you choose which sources to prevent damage from."
+          "text": "Divine Deflection can prevent damage from multiple sources dealing damage simultaneously (such as during combat). If the chosen value for X won't prevent all the damage, you choose which sources to prevent damage from."
         },
         {
           "date": "2012-05-01",
-          "text": "If damage is dealt to multiple permanents you control, or is dealt to you and at least one permanent you control, you choose which of that damage to prevent if the chosen value for X won’t prevent all the damage. For example, if 3 damage would be dealt to you and to each of two creatures you control, and Divine Deflection will prevent the next 3 damage, you might choose to prevent the next 2 damage it would deal to you and the next 1 damage it would deal to one of the creatures, among other choices. You don’t decide until the point at which the damage would be dealt."
+          "text": "If damage is dealt to multiple permanents you control, or is dealt to you and at least one permanent you control, you choose which of that damage to prevent if the chosen value for X won't prevent all the damage. For example, if 3 damage would be dealt to you and to each of two creatures you control, and Divine Deflection will prevent the next 3 damage, you might choose to prevent the next 2 damage it would deal to you and the next 1 damage it would deal to one of the creatures, among other choices. You don't decide until the point at which the damage would be dealt."
         },
         {
           "date": "2012-05-01",
-          "text": "Divine Deflection’s effect is not a redirection effect. If it prevents damage, Divine Deflection (not the original source) deals damage to the targeted creature or player as part of that prevention effect. Divine Deflection is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don’t affect this damage. The new damage is not combat damage, even if the prevented damage was. Since you control the source of the new damage, if you targeted an opponent with Divine Deflection, you may have Divine Deflection deal its damage to a planeswalker that opponent controls."
+          "text": "Divine Deflection's effect is not a redirection effect. If it prevents damage, Divine Deflection (not the original source) deals damage to the targeted creature or player as part of that prevention effect. Divine Deflection is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don't affect this damage. The new damage is not combat damage, even if the prevented damage was. Since you control the source of the new damage, if you targeted an opponent with Divine Deflection, you may have Divine Deflection deal its damage to a planeswalker that opponent controls."
         },
         {
           "date": "2012-05-01",
@@ -2087,7 +2087,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If Divine Deflection can’t deal damage to the targeted creature or player (because the creature has gained protection from white, is no longer on the battlefield, or is no longer a creature, or the player is no longer in the game, for example), it will still prevent damage. It just won’t deal any damage itself."
+          "text": "If Divine Deflection can't deal damage to the targeted creature or player (because the creature has gained protection from white, is no longer on the battlefield, or is no longer a creature, or the player is no longer in the game, for example), it will still prevent damage. It just won't deal any damage itself."
         }
       ],
       "text": "Prevent the next X damage that would be dealt to you and/or permanents you control this turn. If damage is prevented this way, Divine Deflection deals that much damage to target creature or player.",
@@ -2199,7 +2199,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The triggered ability doesn’t target a permanent. You choose which one to return to its owner’s hand as the ability resolves. No one can respond to the choice."
+          "text": "The triggered ability doesn't target a permanent. You choose which one to return to its owner's hand as the ability resolves. No one can respond to the choice."
         },
         {
           "date": "2012-05-01",
@@ -2322,7 +2322,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Entreat the Angels’s converted mana cost is based on its mana cost of {X}{X}{W}{W}{W}, even if you’re casting it for its miracle cost. For example, if you cast Entreat the Angels for its miracle cost and choose 4 for X, its converted mana cost is 11."
+          "text": "Entreat the Angels's converted mana cost is based on its mana cost of {X}{X}{W}{W}{W}, even if you're casting it for its miracle cost. For example, if you cast Entreat the Angels for its miracle cost and choose 4 for X, its converted mana cost is 11."
         }
       ],
       "text": "Create X 4/4 white Angel creature tokens with flying.\nMiracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
@@ -2543,7 +2543,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The creature that entered the battlefield will also get +1/+1 until end of turn if it’s still on the battlefield when the ability resolves."
+          "text": "The creature that entered the battlefield will also get +1/+1 until end of turn if it's still on the battlefield when the ability resolves."
         }
       ],
       "subtypes": [
@@ -2787,7 +2787,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "A creature spell that’s both an Angel and a Human will cost {1} less to cast for each +1/+1 counter on Herald of War."
+          "text": "A creature spell that's both an Angel and a Human will cost {1} less to cast for each +1/+1 counter on Herald of War."
         }
       ],
       "subtypes": [
@@ -3780,7 +3780,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You must choose an existing _Magic_ creature type, such as Zombie or Warrior. Card types such as artifact can’t be chosen."
+          "text": "You must choose an existing _Magic_ creature type, such as Zombie or Warrior. Card types such as artifact can't be chosen."
         }
       ],
       "subtypes": [
@@ -4330,7 +4330,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Each player chooses the order that creatures he or she owns are put onto the bottom of his or her library. This order isn’t revealed to other players."
+          "text": "Each player chooses the order that creatures he or she owns are put onto the bottom of his or her library. This order isn't revealed to other players."
         }
       ],
       "text": "Put all creatures on the bottom of their owners' libraries.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
@@ -4876,7 +4876,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If you cast Amass the Components with fewer than three cards in your library, you’ll draw the remaining cards in your library, put a card from your hand on the bottom of your library, then lose the game for drawing a card from a library with no cards in it the next time state-based actions are performed."
+          "text": "If you cast Amass the Components with fewer than three cards in your library, you'll draw the remaining cards in your library, put a card from your hand on the bottom of your library, then lose the game for drawing a card from a library with no cards in it the next time state-based actions are performed."
         }
       ],
       "text": "Draw three cards, then put a card from your hand on the bottom of your library.",
@@ -4987,11 +4987,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Arcane Melee can’t reduce the colored mana requirement of an instant or sorcery spell."
+          "text": "Arcane Melee can't reduce the colored mana requirement of an instant or sorcery spell."
         },
         {
           "date": "2012-05-01",
-          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as Thalia, Guardian of Thraben’s ability), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as Thalia, Guardian of Thraben's ability), apply those increases before applying cost reductions."
         },
         {
           "date": "2012-05-01",
@@ -5226,7 +5226,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Crippling Chill can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Crippling Chill can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         }
       ],
       "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
@@ -5337,11 +5337,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If you activate the ability granted by Deadeye Navigator, the creature will be exiled, the pair will immediately be broken, and then the card will be returned to the battlefield. Deadeye Navigator’s soulbond ability triggers when that card enters the battlefield and the pair can then be reunited."
+          "text": "If you activate the ability granted by Deadeye Navigator, the creature will be exiled, the pair will immediately be broken, and then the card will be returned to the battlefield. Deadeye Navigator's soulbond ability triggers when that card enters the battlefield and the pair can then be reunited."
         },
         {
           "date": "2017-03-14",
-          "text": "Once Deadeye Navigator or the creature it’s paired with is exiled, the other creature will no longer have the activated ability. However, you can activate the ability of one creature in response to activating the ability of the other creature."
+          "text": "Once Deadeye Navigator or the creature it's paired with is exiled, the other creature will no longer have the activated ability. However, you can activate the ability of one creature in response to activating the ability of the other creature."
         }
       ],
       "subtypes": [
@@ -6007,11 +6007,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Fleeting Distraction resolves, the spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target by the time Fleeting Distraction resolves, the spell is countered. You won't draw a card."
         },
         {
           "date": "2012-05-01",
-          "text": "If the targeted creature is an illegal target when Fleeting Distraction tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target when Fleeting Distraction tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
@@ -6230,11 +6230,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If the target creature spell is an illegal target when Geist Snatch tries to resolve, Geist Snatch will be countered and none of its effects will happen. You won’t put a Spirit token onto the battlefield."
+          "text": "If the target creature spell is an illegal target when Geist Snatch tries to resolve, Geist Snatch will be countered and none of its effects will happen. You won't put a Spirit token onto the battlefield."
         },
         {
           "date": "2012-05-01",
-          "text": "If Geist Snatch resolves but the creature spell can’t be countered, you’ll still put the Spirit token onto the battlefield."
+          "text": "If Geist Snatch resolves but the creature spell can't be countered, you'll still put the Spirit token onto the battlefield."
         }
       ],
       "text": "Counter target creature spell. Create a 1/1 blue Spirit creature token with flying.",
@@ -6252,7 +6252,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"There's no such thing as ‘impenetrable.'\"",
+      "flavor": "\"There's no such thing as 'impenetrable.'\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -6778,7 +6778,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If you don’t control any other creatures, the ability won’t do anything."
+          "text": "If you don't control any other creatures, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -6909,11 +6909,11 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Creatures you control don’t copy whether the enchanted creature is tapped or untapped, whether it has any counters on it, whether it has any Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Creatures you control don't copy whether the enchanted creature is tapped or untapped, whether it has any counters on it, whether it has any Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-05-01",
-          "text": "Because creatures you control enter the battlefield as a copy of the enchanted creature, any enters-the-battlefield triggered abilities printed on such creatures won’t trigger. However, if the enchanted creature has any enters-the-battlefield triggered abilities, those will trigger."
+          "text": "Because creatures you control enter the battlefield as a copy of the enchanted creature, any enters-the-battlefield triggered abilities printed on such creatures won't trigger. However, if the enchanted creature has any enters-the-battlefield triggered abilities, those will trigger."
         },
         {
           "date": "2012-05-01",
@@ -6921,15 +6921,15 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If a creature such as Clone is entering the battlefield under your control, there will be two copy effects to apply: the creature’s own and Infinite Reflection’s. No matter what order these effects are applied, the creature will be a copy of the enchanted creature when it enters the battlefield."
+          "text": "If a creature such as Clone is entering the battlefield under your control, there will be two copy effects to apply: the creature's own and Infinite Reflection's. No matter what order these effects are applied, the creature will be a copy of the enchanted creature when it enters the battlefield."
         },
         {
           "date": "2012-05-01",
-          "text": "Other enters-the-battlefield replacement abilities printed on the creature entering the battlefield won’t be applied because the creature will already be a copy of the enchanted creature at that point (and therefore it won’t have those abilities). For example, if the enchanted creature is Serra Angel, a creature that normally enters the battlefield tapped will enter the battlefield as an untapped copy of Serra Angel, and a creature that would normally enter the battlefield with counters on it will enter the battlefield as a copy of Serra Angel with no counters."
+          "text": "Other enters-the-battlefield replacement abilities printed on the creature entering the battlefield won't be applied because the creature will already be a copy of the enchanted creature at that point (and therefore it won't have those abilities). For example, if the enchanted creature is Serra Angel, a creature that normally enters the battlefield tapped will enter the battlefield as an untapped copy of Serra Angel, and a creature that would normally enter the battlefield with counters on it will enter the battlefield as a copy of Serra Angel with no counters."
         },
         {
           "date": "2012-05-01",
-          "text": "External abilities may still affect how a creature enters the battlefield. For example, if your opponent controls Urabrask the Hidden, which reads, in part, “Creatures your opponents control enter the battlefield tapped,” a creature entering the battlefield under your control will be a tapped copy of the enchanted creature."
+          "text": "External abilities may still affect how a creature enters the battlefield. For example, if your opponent controls Urabrask the Hidden, which reads, in part, \"Creatures your opponents control enter the battlefield tapped,\" a creature entering the battlefield under your control will be a tapped copy of the enchanted creature."
         },
         {
           "date": "2012-05-01",
@@ -6954,7 +6954,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"The cathars have their swords, the inquisitors their axes. I prefer the ‘diplomatic' approach.\"\n—Terhold, archmage of Drunau",
+      "flavor": "\"The cathars have their swords, the inquisitors their axes. I prefer the 'diplomatic' approach.\"\n—Terhold, archmage of Drunau",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -7264,19 +7264,19 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You must put one of the cards into your hand, even if you’d rather put all four on the bottom of your library."
+          "text": "You must put one of the cards into your hand, even if you'd rather put all four on the bottom of your library."
         },
         {
           "date": "2012-05-01",
-          "text": "If you control Lone Revenant and any other creature (including another Lone Revenant), its ability won’t trigger."
+          "text": "If you control Lone Revenant and any other creature (including another Lone Revenant), its ability won't trigger."
         },
         {
           "date": "2012-05-01",
-          "text": "Check whether Lone Revenant’s ability triggers after combat damage is dealt but before any creatures that are destroyed due to combat damage leave the battlefield. For example, if you control Lone Revenant and another creature, and that other creature takes lethal damage in the same combat damage step that Lone Revenant deals damage to a player, Lone Revenant’s ability won’t trigger."
+          "text": "Check whether Lone Revenant's ability triggers after combat damage is dealt but before any creatures that are destroyed due to combat damage leave the battlefield. For example, if you control Lone Revenant and another creature, and that other creature takes lethal damage in the same combat damage step that Lone Revenant deals damage to a player, Lone Revenant's ability won't trigger."
         },
         {
           "date": "2012-05-01",
-          "text": "If you control no creatures when Lone Revenant’s ability resolves, you’ll still look at the top four cards and put one into your hand."
+          "text": "If you control no creatures when Lone Revenant's ability resolves, you'll still look at the top four cards and put one into your hand."
         }
       ],
       "subtypes": [
@@ -7395,7 +7395,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "The decision to pay {1} is made when the triggered ability resolves. It’s not an additional cost of the instant spell."
+          "text": "The decision to pay {1} is made when the triggered ability resolves. It's not an additional cost of the instant spell."
         }
       ],
       "subtypes": [
@@ -7623,7 +7623,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Mist Raven’s ability is mandatory. If Mist Raven is the only creature on the battlefield when its ability triggers, you must choose it as the target."
+          "text": "Mist Raven's ability is mandatory. If Mist Raven is the only creature on the battlefield when its ability triggers, you must choose it as the target."
         }
       ],
       "subtypes": [
@@ -7738,19 +7738,19 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Misthollow Griffin can also be cast from a player’s hand."
+          "text": "Misthollow Griffin can also be cast from a player's hand."
         },
         {
           "date": "2012-05-01",
-          "text": "Misthollow Griffin doesn’t have an ability that exiles itself. Some other effect will be needed to get the card into exile."
+          "text": "Misthollow Griffin doesn't have an ability that exiles itself. Some other effect will be needed to get the card into exile."
         },
         {
           "date": "2012-05-01",
-          "text": "You must still pay Misthollow Griffin’s mana cost when you cast it from exile."
+          "text": "You must still pay Misthollow Griffin's mana cost when you cast it from exile."
         },
         {
           "date": "2012-05-01",
-          "text": "Misthollow Griffin’s ability doesn’t change when you can cast creature spells: when you have priority during your main phase when the stack is empty."
+          "text": "Misthollow Griffin's ability doesn't change when you can cast creature spells: when you have priority during your main phase when the stack is empty."
         }
       ],
       "subtypes": [
@@ -8417,15 +8417,15 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Second Guess can’t be cast unless the spell it targets is the second spell cast this turn."
+          "text": "Second Guess can't be cast unless the spell it targets is the second spell cast this turn."
         },
         {
           "date": "2012-05-01",
-          "text": "It doesn’t matter if the first spell cast that turn has resolved yet or not. It also doesn’t matter how many spells have been cast after the second one, as long as the second spell cast is still on the stack."
+          "text": "It doesn't matter if the first spell cast that turn has resolved yet or not. It also doesn't matter how many spells have been cast after the second one, as long as the second spell cast is still on the stack."
         },
         {
           "date": "2012-05-01",
-          "text": "Most spells and abilities that copy a spell create that copy on the stack. These copies are not cast and won’t count toward the number of spells cast that turn. However, a few (like Isochron Scepter’s ability) instruct you to copy a spell and “cast the copy.” These spells are cast and will count toward the number of spells cast that turn."
+          "text": "Most spells and abilities that copy a spell create that copy on the stack. These copies are not cast and won't count toward the number of spells cast that turn. However, a few (like Isochron Scepter's ability) instruct you to copy a spell and \"cast the copy.\" These spells are cast and will count toward the number of spells cast that turn."
         }
       ],
       "text": "Counter target spell that's the second spell cast this turn.",
@@ -8861,7 +8861,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If you can’t cast the nonland card (perhaps because there are no legal targets available) or if you choose not to cast it, it will remain exiled."
+          "text": "If you can't cast the nonland card (perhaps because there are no legal targets available) or if you choose not to cast it, it will remain exiled."
         },
         {
           "date": "2012-05-01",
@@ -8869,7 +8869,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs, such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs, such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-05-01",
@@ -8987,27 +8987,27 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Tamiyo’s first ability tracks the permanent, but not its controller. If the permanent changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "Tamiyo's first ability tracks the permanent, but not its controller. If the permanent changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2012-05-01",
-          "text": "The number of tapped creatures the player controls is determined when Tamiyo’s second ability resolves."
+          "text": "The number of tapped creatures the player controls is determined when Tamiyo's second ability resolves."
         },
         {
           "date": "2012-05-01",
-          "text": "Tamiyo’s third ability creates one emblem with two abilities."
+          "text": "Tamiyo's third ability creates one emblem with two abilities."
         },
         {
           "date": "2012-05-01",
-          "text": "If you activate Tamiyo’s third ability when she has eight loyalty counters on her, she’ll be put into your graveyard before the emblem is created. She won’t return to your hand."
+          "text": "If you activate Tamiyo's third ability when she has eight loyalty counters on her, she'll be put into your graveyard before the emblem is created. She won't return to your hand."
         },
         {
           "date": "2012-05-01",
-          "text": "Cards that are put into your graveyard can be returned to your hand by the emblem’s ability even if they were never in your hand."
+          "text": "Cards that are put into your graveyard can be returned to your hand by the emblem's ability even if they were never in your hand."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability can target a tapped permanent. If the targeted permanent is already tapped when it resolves, that permanent just remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "The ability can target a tapped permanent. If the targeted permanent is already tapped when it resolves, that permanent just remains tapped and doesn't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -9122,7 +9122,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Tandem Lookout or the creature it’s paired with is dealt lethal damage at the same time that either deals damage to an opponent, its ability triggers. You’ll draw a card even though that creature no longer has the ability."
+          "text": "If Tandem Lookout or the creature it's paired with is dealt lethal damage at the same time that either deals damage to an opponent, its ability triggers. You'll draw a card even though that creature no longer has the ability."
         }
       ],
       "subtypes": [
@@ -9556,7 +9556,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If a card in a player’s hand has {X} in its mana cost, X is 0."
+          "text": "If a card in a player's hand has {X} in its mana cost, X is 0."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose a card from it with converted mana cost 4 or greater and exile that card.",
@@ -9684,7 +9684,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Barter in Blood doesn’t target any creatures and may be cast even if a player controls fewer than two creatures."
+          "text": "Barter in Blood doesn't target any creatures and may be cast even if a player controls fewer than two creatures."
         }
       ],
       "text": "Each player sacrifices two creatures.",
@@ -10036,11 +10036,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You must sacrifice exactly one creature to cast this spell; you can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast this spell; you can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "Once you begin to cast Bone Splinters, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast Bone Splinters, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         },
         {
           "date": "2017-03-14",
@@ -10270,7 +10270,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -10391,7 +10391,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You must be able to target a card in a graveyard to activate Crypt Creeper’s ability. It can’t target itself."
+          "text": "You must be able to target a card in a graveyard to activate Crypt Creeper's ability. It can't target itself."
         }
       ],
       "subtypes": [
@@ -10506,15 +10506,15 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Dark Impostor gains only activated abilities. It doesn’t gain triggered abilities or static abilities. Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities; they have colons in their reminder text."
+          "text": "Dark Impostor gains only activated abilities. It doesn't gain triggered abilities or static abilities. Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities; they have colons in their reminder text."
         },
         {
           "date": "2012-05-01",
-          "text": "If an activated ability of a card in exile references the card it’s printed on by name, treat Dark Impostor’s version of that ability as though it referenced Dark Impostor by name instead. For example, if Marrow Bats (which says “Pay 4 life: Regenerate Marrow Bats”) is exiled with Dark Impostor, Dark Impostor has the ability “Pay 4 life: Regenerate Dark Impostor.”"
+          "text": "If an activated ability of a card in exile references the card it's printed on by name, treat Dark Impostor's version of that ability as though it referenced Dark Impostor by name instead. For example, if Marrow Bats (which says \"Pay 4 life: Regenerate Marrow Bats\") is exiled with Dark Impostor, Dark Impostor has the ability \"Pay 4 life: Regenerate Dark Impostor.\""
         },
         {
           "date": "2012-05-01",
-          "text": "Dark Impostor can target and exile a permanent that’s only a creature temporarily, like an animated land. However, because that card isn’t a creature card, Dark Impostor won’t have any of that card’s activated abilities."
+          "text": "Dark Impostor can target and exile a permanent that's only a creature temporarily, like an animated land. However, because that card isn't a creature card, Dark Impostor won't have any of that card's activated abilities."
         },
         {
           "date": "2012-05-01",
@@ -10747,11 +10747,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If you control zero creatures or more than one creature at the beginning of your end step, the ability won’t trigger. If you control zero creatures or more than one creature when the ability resolves, it will do nothing."
+          "text": "If you control zero creatures or more than one creature at the beginning of your end step, the ability won't trigger. If you control zero creatures or more than one creature when the ability resolves, it will do nothing."
         },
         {
           "date": "2012-05-01",
-          "text": "Although you must control exactly one creature both when the ability would trigger and when it would resolve in order for the ability to create the Demon token, that creature doesn’t have to be the same one both times. For example, if the ability triggers, then you lose control of your one creature before it resolves, you can cast a creature with flash to make sure you control exactly one creature when the ability resolves."
+          "text": "Although you must control exactly one creature both when the ability would trigger and when it would resolve in order for the ability to create the Demon token, that creature doesn't have to be the same one both times. For example, if the ability triggers, then you lose control of your one creature before it resolves, you can cast a creature with flash to make sure you control exactly one creature when the ability resolves."
         }
       ],
       "text": "At the beginning of your end step, if you control exactly one creature, create a 5/5 black Demon creature token with flying.",
@@ -10862,11 +10862,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If you control no other creatures, you won’t sacrifice anything."
+          "text": "If you control no other creatures, you won't sacrifice anything."
         },
         {
           "date": "2012-05-01",
-          "text": "If Demonic Taskmaster leaves the battlefield after its ability triggers but before it resolves, you’ll still have to sacrifice a creature. Notably, if you control two Demonic Taskmasters and no other creatures, each one will force you to sacrifice the other."
+          "text": "If Demonic Taskmaster leaves the battlefield after its ability triggers but before it resolves, you'll still have to sacrifice a creature. Notably, if you control two Demonic Taskmasters and no other creatures, each one will force you to sacrifice the other."
         }
       ],
       "subtypes": [
@@ -10980,11 +10980,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Demonlord of Ashmouth’s enters-the-battlefield ability will trigger no matter how it entered the battlefield, including because of its undying ability."
+          "text": "Demonlord of Ashmouth's enters-the-battlefield ability will trigger no matter how it entered the battlefield, including because of its undying ability."
         },
         {
           "date": "2012-05-01",
-          "text": "You don’t have to sacrifice another creature, even if you control one. You may choose to exile Demonlord of Ashmouth."
+          "text": "You don't have to sacrifice another creature, even if you control one. You may choose to exile Demonlord of Ashmouth."
         }
       ],
       "subtypes": [
@@ -11098,19 +11098,19 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "For each despair counter on Descent into Madness, you’ll exile a permanent you control or exile a card from your hand, not both."
+          "text": "For each despair counter on Descent into Madness, you'll exile a permanent you control or exile a card from your hand, not both."
         },
         {
           "date": "2012-05-01",
-          "text": "First you choose the permanents and/or cards from your hand that will be exiled. Then each other player in turn order does the same. Then all the chosen permanents and cards are exiled simultaneously. Players who choose after you will know what permanents you’ll be exiling when they choose. They’ll know how many cards you’ll be exiling from your hand, but they won’t see those cards."
+          "text": "First you choose the permanents and/or cards from your hand that will be exiled. Then each other player in turn order does the same. Then all the chosen permanents and cards are exiled simultaneously. Players who choose after you will know what permanents you'll be exiling when they choose. They'll know how many cards you'll be exiling from your hand, but they won't see those cards."
         },
         {
           "date": "2012-05-01",
-          "text": "If there are more counters on Descent into Madness than the total number of permanents you control plus the number of cards in your hand, you’ll exile all permanents you control (including Descent into Madness) and all cards from your hand."
+          "text": "If there are more counters on Descent into Madness than the total number of permanents you control plus the number of cards in your hand, you'll exile all permanents you control (including Descent into Madness) and all cards from your hand."
         },
         {
           "date": "2012-05-01",
-          "text": "If Descent into Madness isn’t on the battlefield when its ability resolves, use the number of counters on it when it left the battlefield to determine how many permanents and/or cards from hands to exile."
+          "text": "If Descent into Madness isn't on the battlefield when its ability resolves, use the number of counters on it when it left the battlefield to determine how many permanents and/or cards from hands to exile."
         }
       ],
       "text": "At the beginning of your upkeep, put a despair counter on Descent into Madness, then each player exiles X permanents he or she controls and/or cards from his or her hand, where X is the number of despair counters on Descent into Madness.",
@@ -11221,11 +11221,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Each time a creature dies, check whether Dread Slaver had dealt any damage to it at any time during that turn. If so, Dread Slaver’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature dies, check whether Dread Slaver had dealt any damage to it at any time during that turn. If so, Dread Slaver's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2012-05-01",
-          "text": "If Dread Slaver and a creature it was blocking or blocked by both die in combat, Dread Slaver’s ability will trigger."
+          "text": "If Dread Slaver and a creature it was blocking or blocked by both die in combat, Dread Slaver's ability will trigger."
         },
         {
           "date": "2012-05-01",
@@ -11233,7 +11233,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "The card will return to the battlefield under your control only if it’s still in the graveyard when the ability resolves. If it’s not (perhaps because an ability like undying has already returned it to the battlefield), nothing happens."
+          "text": "The card will return to the battlefield under your control only if it's still in the graveyard when the ability resolves. If it's not (perhaps because an ability like undying has already returned it to the battlefield), nothing happens."
         }
       ],
       "subtypes": [
@@ -11469,7 +11469,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Essence Harvest targets only the player. It doesn’t target any creatures. If that player is an illegal target when Essence Harvest tries to resolve, it will be countered and none of its effects will happen. No life will be lost or gained."
+          "text": "Essence Harvest targets only the player. It doesn't target any creatures. If that player is an illegal target when Essence Harvest tries to resolve, it will be countered and none of its effects will happen. No life will be lost or gained."
         }
       ],
       "text": "Target player loses X life and you gain X life, where X is the greatest power among creatures you control.",
@@ -11580,7 +11580,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Evernight Shade’s ability doesn’t put +1/+1 counters on it; it just gives Evernight Shade +1/+1 until end of turn. If Evernight Shade has no +1/+1 counters on it and dies after its ability has resolved, undying will still return it to the battlefield."
+          "text": "Evernight Shade's ability doesn't put +1/+1 counters on it; it just gives Evernight Shade +1/+1 until end of turn. If Evernight Shade has no +1/+1 counters on it and dies after its ability has resolved, undying will still return it to the battlefield."
         }
       ],
       "subtypes": [
@@ -11698,7 +11698,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If you and an opponent both lose life simultaneously, and this causes your life total to become 0 or less, you’ll lose the game before Exquisite Blood’s triggered ability can resolve."
+          "text": "If you and an opponent both lose life simultaneously, and this causes your life total to become 0 or less, you'll lose the game before Exquisite Blood's triggered ability can resolve."
         }
       ],
       "text": "Whenever an opponent loses life, you gain that much life.",
@@ -11922,11 +11922,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Combat damage that would be dealt to Gloom Surgeon will be prevented even if you can’t exile that many cards from the top of your library."
+          "text": "Combat damage that would be dealt to Gloom Surgeon will be prevented even if you can't exile that many cards from the top of your library."
         },
         {
           "date": "2012-05-01",
-          "text": "If damage that can’t be prevented (such as the damage Malignus deals) is dealt to Gloom Surgeon, you’ll still exile cards from your library."
+          "text": "If damage that can't be prevented (such as the damage Malignus deals) is dealt to Gloom Surgeon, you'll still exile cards from your library."
         }
       ],
       "subtypes": [
@@ -12040,7 +12040,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Grave Exchange targets both a creature card in your graveyard and a player. You can’t cast it unless there is a legal target to choose for both. You can target a player who controls no creatures."
+          "text": "Grave Exchange targets both a creature card in your graveyard and a player. You can't cast it unless there is a legal target to choose for both. You can target a player who controls no creatures."
         },
         {
           "date": "2012-05-01",
@@ -12157,7 +12157,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You can’t activate Griselbrand’s ability if you have 6 or less life."
+          "text": "You can't activate Griselbrand's ability if you have 6 or less life."
         }
       ],
       "subtypes": [
@@ -12709,15 +12709,15 @@
         },
         {
           "date": "2012-05-01",
-          "text": "A player may choose to pay life for some creatures and sacrifice the rest. It’s not an all-or-nothing decision."
+          "text": "A player may choose to pay life for some creatures and sacrifice the rest. It's not an all-or-nothing decision."
         },
         {
           "date": "2012-05-01",
-          "text": "You can’t pay more life than you have."
+          "text": "You can't pay more life than you have."
         },
         {
           "date": "2012-05-01",
-          "text": "If you can’t sacrifice a creature (perhaps because of Sigarda, Host of Herons), you can choose not to pay life and nothing will happen."
+          "text": "If you can't sacrifice a creature (perhaps because of Sigarda, Host of Herons), you can choose not to pay life and nothing will happen."
         }
       ],
       "text": "For each creature, its controller sacrifices it unless he or she pays X life.",
@@ -13916,7 +13916,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Triumph of Cruelty’s ability will trigger at the beginning of each of your upkeeps regardless of who controls the creature with the greatest power. The ability checks whether the opponent will discard a card when it resolves."
+          "text": "Triumph of Cruelty's ability will trigger at the beginning of each of your upkeeps regardless of who controls the creature with the greatest power. The ability checks whether the opponent will discard a card when it resolves."
         }
       ],
       "text": "At the beginning of your upkeep, target opponent discards a card if you control the creature with the greatest power or tied for the greatest power.",
@@ -14137,11 +14137,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The card will return to the battlefield under your control only if it’s still in the graveyard when Unhallowed Pact’s ability resolves. If it’s not (perhaps because an ability like undying has already returned it to the battlefield), nothing happens."
+          "text": "The card will return to the battlefield under your control only if it's still in the graveyard when Unhallowed Pact's ability resolves. If it's not (perhaps because an ability like undying has already returned it to the battlefield), nothing happens."
         },
         {
           "date": "2012-05-01",
-          "text": "If Unhallowed Pact is enchanting a token creature, that creature can’t return to the battlefield."
+          "text": "If Unhallowed Pact is enchanting a token creature, that creature can't return to the battlefield."
         }
       ],
       "subtypes": [
@@ -14262,7 +14262,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "text": "Aggravate deals 1 damage to each creature target player controls. Each creature dealt damage this way attacks this turn if able.",
@@ -14373,7 +14373,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Archwing Dragon is only returned to its owner’s hand if it’s on the battlefield."
+          "text": "Archwing Dragon is only returned to its owner's hand if it's on the battlefield."
         }
       ],
       "subtypes": [
@@ -14715,7 +14715,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Bonfire of the Damned’s converted mana cost is based on its mana cost of {X}{X}{R}, even if you’re casting it for its miracle cost. For example, if you cast Bonfire of the Damned for its miracle cost and choose 4 for X, its converted mana cost is 9."
+          "text": "Bonfire of the Damned's converted mana cost is based on its mana cost of {X}{X}{R}, even if you're casting it for its miracle cost. For example, if you cast Bonfire of the Damned for its miracle cost and choose 4 for X, its converted mana cost is 9."
         },
         {
           "date": "2017-03-14",
@@ -14723,7 +14723,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Preventing some or all of the damage dealt to the player won’t affect the amount of damage dealt to each creature that player controls. The same is true for any effect that increases or decreases the amount of damage dealt to the player."
+          "text": "Preventing some or all of the damage dealt to the player won't affect the amount of damage dealt to each creature that player controls. The same is true for any effect that increases or decreases the amount of damage dealt to the player."
         }
       ],
       "text": "Bonfire of the Damned deals X damage to target player and each creature he or she controls.\nMiracle {X}{R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
@@ -14836,7 +14836,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "The amount of damage Burn at the Stake deals won’t change if any creatures tapped to cast it become untapped or leave the battlefield before it resolves."
+          "text": "The amount of damage Burn at the Stake deals won't change if any creatures tapped to cast it become untapped or leave the battlefield before it resolves."
         },
         {
           "date": "2012-05-01",
@@ -14950,7 +14950,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If you have no cards in hand when Dangerous Wager resolves, you’ll simply draw two cards."
+          "text": "If you have no cards in hand when Dangerous Wager resolves, you'll simply draw two cards."
         }
       ],
       "text": "Discard your hand, then draw two cards.",
@@ -15198,15 +15198,15 @@
         },
         {
           "date": "2012-05-01",
-          "text": "The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2012-05-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2012-05-01",
-          "text": "If the spell being copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode(s). You can’t choose different ones."
+          "text": "If the spell being copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode(s). You can't choose different ones."
         },
         {
           "date": "2012-05-01",
@@ -15214,7 +15214,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you sacrifice a 3/3 creature to cast Fling and then copy it with the ability granted by Dual Casting, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you sacrifice a 3/3 creature to cast Fling and then copy it with the ability granted by Dual Casting, the copy of Fling will also deal 3 damage to its target."
         }
       ],
       "subtypes": [
@@ -15438,7 +15438,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The targeted creature can’t block any creatures this turn. The effect doesn’t merely restrict whether it can block Fervent Cathar."
+          "text": "The targeted creature can't block any creatures this turn. The effect doesn't merely restrict whether it can block Fervent Cathar."
         }
       ],
       "subtypes": [
@@ -15556,7 +15556,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You divide the damage as you put Gang of Devils’s triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
+          "text": "You divide the damage as you put Gang of Devils's triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
         }
       ],
       "subtypes": [
@@ -15674,7 +15674,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If, during its controller’s declare attackers step, the enchanted creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during its controller's declare attackers step, the enchanted creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -16451,7 +16451,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "A creature that loses haste after it’s been declared as an attacking creature doesn’t stop attacking."
+          "text": "A creature that loses haste after it's been declared as an attacking creature doesn't stop attacking."
         }
       ],
       "subtypes": [
@@ -16474,7 +16474,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Undead flesh is dry and papery. A single spark and ‘poof.' No more ghoul.\"",
+      "flavor": "\"Undead flesh is dry and papery. A single spark and 'poof.' No more ghoul.\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -16684,7 +16684,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Discarding a card is part of the ability’s activation cost. You can’t activate the ability if you have no cards in hand."
+          "text": "Discarding a card is part of the ability's activation cost. You can't activate the ability if you have no cards in hand."
         }
       ],
       "subtypes": [
@@ -16913,7 +16913,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If Malignus becomes blocked by a creature with protection from red, the damage Malignus deals to that creature won’t be prevented."
+          "text": "If Malignus becomes blocked by a creature with protection from red, the damage Malignus deals to that creature won't be prevented."
         }
       ],
       "subtypes": [
@@ -17029,7 +17029,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "A creature dealt damage by Pillar of Flame that dies that turn will be exiled even if it wasn’t the target of Pillar of Flame (because the damage was redirected somehow)."
+          "text": "A creature dealt damage by Pillar of Flame that dies that turn will be exiled even if it wasn't the target of Pillar of Flame (because the damage was redirected somehow)."
         },
         {
           "date": "2012-05-01",
@@ -17469,7 +17469,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Permanents sacrificed for one card type won’t be on the battlefield to be chosen for subsequent card types."
+          "text": "Permanents sacrificed for one card type won't be on the battlefield to be chosen for subsequent card types."
         },
         {
           "date": "2012-05-01",
@@ -17583,11 +17583,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The value of X is determined when Rush of Blood resolves. The bonus won’t change later in the turn if the creature’s power changes."
-        },
-        {
-          "date": "2012-05-01",
-          "text": "If the creature has power less than 0, the “bonus” will be negative. For example, a creature that’s somehow become -1/3 would get -1/+0 and become -2/3."
+          "text": "The value of X is determined when Rush of Blood resolves. The bonus won't change later in the turn if the creature's power changes."
         }
       ],
       "text": "Target creature gets +X/+0 until end of turn, where X is its power.",
@@ -17808,7 +17804,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Somberwald Vigilante’s ability will trigger for each creature it becomes blocked by."
+          "text": "Somberwald Vigilante's ability will trigger for each creature it becomes blocked by."
         },
         {
           "date": "2012-05-01",
@@ -18356,11 +18352,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The number of cards in the target player’s hand is determined when Tibalt’s second ability resolves."
+          "text": "The number of cards in the target player's hand is determined when Tibalt's second ability resolves."
         },
         {
           "date": "2012-05-01",
-          "text": "When Tibalt’s third ability resolves, all creatures will become untapped and gain haste, including ones you controlled before the ability resolved."
+          "text": "When Tibalt's third ability resolves, all creatures will become untapped and gain haste, including ones you controlled before the ability resolved."
         }
       ],
       "subtypes": [
@@ -18481,11 +18477,11 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If any abilities trigger while Tyrant of Discord’s enters-the-battlefield ability is resolving, those abilities will wait until the enters-the-battlefield ability finishes resolving before going on the stack. Starting with the active player, each player puts his or her abilities on the stack in any order."
+          "text": "If any abilities trigger while Tyrant of Discord's enters-the-battlefield ability is resolving, those abilities will wait until the enters-the-battlefield ability finishes resolving before going on the stack. Starting with the active player, each player puts his or her abilities on the stack in any order."
         },
         {
           "date": "2012-05-01",
-          "text": "If the target opponent can’t sacrifice permanents (perhaps because of Sigarda, Host of Herons), the opponent will choose a permanent at random but not sacrifice it. The ability will then finish resolving."
+          "text": "If the target opponent can't sacrifice permanents (perhaps because of Sigarda, Host of Herons), the opponent will choose a permanent at random but not sacrifice it. The ability will then finish resolving."
         }
       ],
       "subtypes": [
@@ -18923,7 +18919,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The enters-the-battlefield ability can target any permanent, including one that’s untapped or one that you already control."
+          "text": "The enters-the-battlefield ability can target any permanent, including one that's untapped or one that you already control."
         }
       ],
       "subtypes": [
@@ -19038,7 +19034,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The enchanted land retains any other abilities it has. Activating one of the land’s activated abilities won’t cause the other(s) to be activated."
+          "text": "The enchanted land retains any other abilities it has. Activating one of the land's activated abilities won't cause the other(s) to be activated."
         }
       ],
       "subtypes": [
@@ -19371,7 +19367,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Bower Passage won’t affect a blocking creature that gains flying after blockers are declared."
+          "text": "Bower Passage won't affect a blocking creature that gains flying after blockers are declared."
         },
         {
           "date": "2012-05-01",
@@ -19486,15 +19482,15 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Creatures with power less than Champion of Lambholt can’t block any creature you control, not just Champion of Lambholt."
+          "text": "Creatures with power less than Champion of Lambholt can't block any creature you control, not just Champion of Lambholt."
         },
         {
           "date": "2012-05-01",
-          "text": "Champion of Lambholt’s ability works even if it isn’t attacking."
+          "text": "Champion of Lambholt's ability works even if it isn't attacking."
         },
         {
           "date": "2012-05-01",
-          "text": "The comparison of power is only done when blockers are declared. Increasing the power of a blocking creature (or decreasing the power of Champion of Lambholt) after this point won’t cause any creature to stop blocking or become unblocked."
+          "text": "The comparison of power is only done when blockers are declared. Increasing the power of a blocking creature (or decreasing the power of Champion of Lambholt) after this point won't cause any creature to stop blocking or become unblocked."
         }
       ],
       "subtypes": [
@@ -19611,11 +19607,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The value of X is determined only as Craterhoof Behemoth’s triggered ability resolves, potentially including Craterhoof Behemoth itself. It won’t change later in the turn if the number of creatures you control changes."
+          "text": "The value of X is determined only as Craterhoof Behemoth's triggered ability resolves, potentially including Craterhoof Behemoth itself. It won't change later in the turn if the number of creatures you control changes."
         },
         {
           "date": "2017-03-14",
-          "text": "Craterhoof Behemoth’s triggered ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Craterhoof Behemoth's triggered ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -19728,7 +19724,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs, such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs, such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-05-01",
@@ -19736,7 +19732,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If the revealed card is a creature card that shares a creature type with a creature you control, but you choose not to cast it, it’s put on the bottom of your library. (This is a recent change.)"
+          "text": "If the revealed card is a creature card that shares a creature type with a creature you control, but you choose not to cast it, it's put on the bottom of your library. (This is a recent change.)"
         }
       ],
       "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a creature card that shares a creature type with a creature you control, you may cast that card without paying its mana cost. Otherwise, put that card on the bottom of your library.",
@@ -19961,7 +19957,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If Druid’s Familiar becomes unpaired, it will immediately lose the +2/+2 bonus. If this causes it to have damage marked on it equal to it or greater than its new toughness, it will be destroyed. The same is true for the creature it was paired with."
+          "text": "If Druid's Familiar becomes unpaired, it will immediately lose the +2/+2 bonus. If this causes it to have damage marked on it equal to it or greater than its new toughness, it will be destroyed. The same is true for the creature it was paired with."
         }
       ],
       "subtypes": [
@@ -20074,11 +20070,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The first ability of Druids’ Repository will trigger once for each creature you control that attacks."
+          "text": "The first ability of Druids' Repository will trigger once for each creature you control that attacks."
         },
         {
           "date": "2012-05-01",
-          "text": "You can activate the second ability of Druids’ Repository multiple times in the same turn. It’s a mana ability, doesn’t use the stack, and can’t be responded to."
+          "text": "You can activate the second ability of Druids' Repository multiple times in the same turn. It's a mana ability, doesn't use the stack, and can't be responded to."
         }
       ],
       "text": "Whenever a creature you control attacks, put a charge counter on Druids' Repository.\nRemove a charge counter from Druids' Repository: Add one mana of any color to your mana pool.",
@@ -20293,11 +20289,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Whether Flowering Lumberknot is paired is checked only when attackers or blockers are declared. After that point, Flowering Lumberknot becoming unpaired won’t cause it to stop attacking or blocking."
+          "text": "Whether Flowering Lumberknot is paired is checked only when attackers or blockers are declared. After that point, Flowering Lumberknot becoming unpaired won't cause it to stop attacking or blocking."
         },
         {
           "date": "2012-05-01",
-          "text": "If the creature Flowering Lumberknot is paired with loses soulbond, Flowering Lumberknot will remain paired but won’t be able to attack or block."
+          "text": "If the creature Flowering Lumberknot is paired with loses soulbond, Flowering Lumberknot will remain paired but won't be able to attack or block."
         }
       ],
       "subtypes": [
@@ -20643,7 +20639,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The creature can later gain flying from another effect. That will override Grounded’s effect."
+          "text": "The creature can later gain flying from another effect. That will override Grounded's effect."
         }
       ],
       "subtypes": [
@@ -20756,7 +20752,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The comparison of power is performed only when blockers are declared. Increasing the power of a blocking creature (or decreasing the power of Howlgeist) after this point won’t cause any creature to stop blocking or become unblocked."
+          "text": "The comparison of power is performed only when blockers are declared. Increasing the power of a blocking creature (or decreasing the power of Howlgeist) after this point won't cause any creature to stop blocking or become unblocked."
         }
       ],
       "subtypes": [
@@ -20875,7 +20871,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Joint Assault checks whether the target creature is paired only when it resolves. If it becomes unpaired later in the turn, neither creature will lose the bonus. Similarly, if it becomes paired later in the turn, the creature it’s paired with won’t gain the bonus."
+          "text": "Joint Assault checks whether the target creature is paired only when it resolves. If it becomes unpaired later in the turn, neither creature will lose the bonus. Similarly, if it becomes paired later in the turn, the creature it's paired with won't gain the bonus."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn. If it's paired with a creature, that creature also gets +2/+2 until end of turn.",
@@ -21089,7 +21085,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If the artifact or enchantment is an illegal target when Natural End tries to resolve, Natural End will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "If the artifact or enchantment is an illegal target when Natural End tries to resolve, Natural End will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "text": "Destroy target artifact or enchantment. You gain 3 life.",
@@ -21527,11 +21523,11 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Repeating the process includes the instruction to repeat the process. That is, you’ll keep exiling cards and putting them onto the battlefield until you fail to put a permanent card onto the battlefield."
+          "text": "Repeating the process includes the instruction to repeat the process. That is, you'll keep exiling cards and putting them onto the battlefield until you fail to put a permanent card onto the battlefield."
         },
         {
           "date": "2012-05-01",
-          "text": "If you exile a permanent card that you can’t put onto the battlefield (such as an Aura with nothing legal to enchant) or one you don’t want to put onto the battlefield, Primal Surge finishes resolving."
+          "text": "If you exile a permanent card that you can't put onto the battlefield (such as an Aura with nothing legal to enchant) or one you don't want to put onto the battlefield, Primal Surge finishes resolving."
         },
         {
           "date": "2012-05-01",
@@ -22073,15 +22069,15 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Mana produced by Somberwald Sage can be spent on any part of a creature spell’s total cost. This includes additional costs (such as kicker) and alternative costs (such as evoke costs)."
+          "text": "Mana produced by Somberwald Sage can be spent on any part of a creature spell's total cost. This includes additional costs (such as kicker) and alternative costs (such as evoke costs)."
         },
         {
           "date": "2012-05-01",
-          "text": "Mana produced by Somberwald Sage can’t be spent on activated abilities, even ones that put a creature card directly onto the battlefield, such as unearth or ninjutsu."
+          "text": "Mana produced by Somberwald Sage can't be spent on activated abilities, even ones that put a creature card directly onto the battlefield, such as unearth or ninjutsu."
         },
         {
           "date": "2012-05-01",
-          "text": "Mana produced by Somberwald Sage can’t be spent on noncreature spells that would put creature tokens onto the battlefield."
+          "text": "Mana produced by Somberwald Sage can't be spent on noncreature spells that would put creature tokens onto the battlefield."
         }
       ],
       "subtypes": [
@@ -22204,7 +22200,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "A creature card that enters the battlefield as a copy of a token creature is still a nontoken creature. You’ll be able to draw a card."
+          "text": "A creature card that enters the battlefield as a copy of a token creature is still a nontoken creature. You'll be able to draw a card."
         }
       ],
       "subtypes": [
@@ -22319,7 +22315,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Although Terrifying Presence doesn’t affect the target creature, if that creature is an illegal target when Terrifying Presence tries to resolve, it will be countered and none of its effects will happen. No damage will be prevented."
+          "text": "Although Terrifying Presence doesn't affect the target creature, if that creature is an illegal target when Terrifying Presence tries to resolve, it will be countered and none of its effects will happen. No damage will be prevented."
         }
       ],
       "text": "Prevent all combat damage that would be dealt by creatures other than target creature this turn.",
@@ -22545,7 +22541,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Triumph of Ferocity’s ability will trigger at the beginning of each of your upkeeps regardless of who controls the creature with the greatest power. The ability checks whether you’ll draw a card when it resolves."
+          "text": "Triumph of Ferocity's ability will trigger at the beginning of each of your upkeeps regardless of who controls the creature with the greatest power. The ability checks whether you'll draw a card when it resolves."
         }
       ],
       "text": "At the beginning of your upkeep, draw a card if you control the creature with the greatest power or tied for the greatest power.",
@@ -22766,11 +22762,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The second target of Ulvenwald Tracker’s ability can be another creature you control, but it can’t be the same creature as the first target."
+          "text": "The second target of Ulvenwald Tracker's ability can be another creature you control, but it can't be the same creature as the first target."
         },
         {
           "date": "2017-03-14",
-          "text": "If either target of Ulvenwald Tracker’s ability is an illegal target when the ability tries to resolve, neither creature will deal or be dealt damage."
+          "text": "If either target of Ulvenwald Tracker's ability is an illegal target when the ability tries to resolve, neither creature will deal or be dealt damage."
         }
       ],
       "subtypes": [
@@ -22994,7 +22990,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The comparison of power is only done when blockers are declared. Increasing the power of a blocking creature (or decreasing the power of Wandering Wolf) after this point won’t cause any creature to stop blocking or become unblocked."
+          "text": "The comparison of power is only done when blockers are declared. Increasing the power of a blocking creature (or decreasing the power of Wandering Wolf) after this point won't cause any creature to stop blocking or become unblocked."
         }
       ],
       "subtypes": [
@@ -23108,7 +23104,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Wild Defiance’s ability will resolve before that instant or sorcery spell."
+          "text": "Wild Defiance's ability will resolve before that instant or sorcery spell."
         },
         {
           "date": "2012-05-01",
@@ -23551,11 +23547,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The value of X is determined when the ability resolves. The bonus won’t change later in the turn if the creature’s power changes."
+          "text": "The value of X is determined when the ability resolves. The bonus won't change later in the turn if the creature's power changes."
         },
         {
-          "date": "2012-05-01",
-          "text": "If Yew Spirit has power less than 0, the “bonus” will be negative. For example, if it’s somehow become -10/3, it would get -10/-10 and become -20/-7."
+          "date": "2017-06-27",
+          "text": "If this creature's power is negative as its ability resolves, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -23672,7 +23668,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Only Auras that could legally enchant Bruna may be attached to it, whether they’re being moved from other permanents or being put onto the battlefield. An Aura with “enchant land,” for example, could not be attached to Bruna this way."
+          "text": "Only Auras that could legally enchant Bruna may be attached to it, whether they're being moved from other permanents or being put onto the battlefield. An Aura with \"enchant land,\" for example, could not be attached to Bruna this way."
         },
         {
           "date": "2012-05-01",
@@ -23804,7 +23800,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If damage dealt by a source you control is being divided among multiple permanents an opponent controls or among an opponent and one or more permanents he or she controls simultaneously, divide the original amount and double the results. For example, if you attack with a 5/5 creature with trample and your opponent blocks with a 2/2 creature, you can assign 2 damage to the blocker and 3 damage to the defending player. These amounts are then doubled to 4 and 6 damage, respectively. You can’t double the damage to 10 first and then assign 2 to the creature and 8 to the player."
+          "text": "If damage dealt by a source you control is being divided among multiple permanents an opponent controls or among an opponent and one or more permanents he or she controls simultaneously, divide the original amount and double the results. For example, if you attack with a 5/5 creature with trample and your opponent blocks with a 2/2 creature, you can assign 2 damage to the blocker and 3 damage to the defending player. These amounts are then doubled to 4 and 6 damage, respectively. You can't double the damage to 10 first and then assign 2 to the creature and 8 to the player."
         }
       ],
       "subtypes": [
@@ -23924,11 +23920,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "As a spell or ability an opponent controls resolves, if it would force you to sacrifice a permanent, you just don’t. That part of the effect does nothing. If that spell or ability gives you the option to sacrifice a permanent (as Brain Gorger’s ability does), you can’t take that option."
+          "text": "As a spell or ability an opponent controls resolves, if it would force you to sacrifice a permanent, you just don't. That part of the effect does nothing. If that spell or ability gives you the option to sacrifice a permanent (as Brain Gorger's ability does), you can't take that option."
         },
         {
           "date": "2012-05-01",
-          "text": "If a spell or ability an opponent controls instructs you to perform an action unless you sacrifice a permanent (as Ogre Marauder does), you can’t choose to sacrifice a permanent. You must perform the action. On the other hand, if a spell or ability an opponent controls instructs you to sacrifice a permanent unless you perform an action (as Killing Wave does), you can choose whether or not to perform the action. If you don’t perform the action, nothing happens, since you can’t sacrifice any permanents."
+          "text": "If a spell or ability an opponent controls instructs you to perform an action unless you sacrifice a permanent (as Ogre Marauder does), you can't choose to sacrifice a permanent. You must perform the action. On the other hand, if a spell or ability an opponent controls instructs you to sacrifice a permanent unless you perform an action (as Killing Wave does), you can choose whether or not to perform the action. If you don't perform the action, nothing happens, since you can't sacrifice any permanents."
         },
         {
           "date": "2012-05-01",
@@ -23940,11 +23936,11 @@
         },
         {
           "date": "2012-05-01",
-          "text": "You may sacrifice a permanent as a special action, even if the effect that allows you to do so comes from an opponent’s permanent (such as Damping Engine or Volrath’s Curse). No one controls special actions."
+          "text": "You may sacrifice a permanent as a special action, even if the effect that allows you to do so comes from an opponent's permanent (such as Damping Engine or Volrath's Curse). No one controls special actions."
         },
         {
           "date": "2012-05-01",
-          "text": "This ability affects only sacrifices. It won’t stop a creature from being put into the graveyard due to lethal damage or having 0 toughness, and it won’t stop a permanent from being put into the graveyard due to the “legend rule” or the “planeswalker uniqueness rule.” None of these are sacrifices; they’re the result of game rules."
+          "text": "This ability affects only sacrifices. It won't stop a creature from being put into the graveyard due to lethal damage or having 0 toughness, and it won't stop a permanent from being put into the graveyard due to the \"legend rule\" or the \"planeswalker uniqueness rule.\" None of these are sacrifices; they're the result of game rules."
         }
       ],
       "subtypes": [
@@ -24056,11 +24052,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If Angel’s Tomb is already a creature when a creature enters the battlefield under your control, its ability will override any effects that set its base power and toughness to specific values, but other changes to its power and toughness (such as the one created by Titanic Growth) will still apply."
+          "text": "If Angel's Tomb is already a creature when a creature enters the battlefield under your control, its ability will override any effects that set its base power and toughness to specific values, but other changes to its power and toughness (such as the one created by Titanic Growth) will still apply."
         },
         {
           "date": "2015-06-22",
-          "text": "Effects setting Angel’s Tomb’s base power and toughness to specific values that begin to apply after Angel’s Tomb has become a creature will override the effect of Angel’s Tomb. For example, if an effect causes a 3/3 Angel’s Tomb to become 0/1, it will remain 0/1 until another effect (such as triggering the ability of Angel’s Tomb a second time or targeting it with Titanic Growth) causes those values to change."
+          "text": "Effects setting Angel's Tomb's base power and toughness to specific values that begin to apply after Angel's Tomb has become a creature will override the effect of Angel's Tomb. For example, if an effect causes a 3/3 Angel's Tomb to become 0/1, it will remain 0/1 until another effect (such as triggering the ability of Angel's Tomb a second time or targeting it with Titanic Growth) causes those values to change."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, you may have Angel's Tomb become a 3/3 white Angel artifact creature with flying until end of turn.",
@@ -24465,11 +24461,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You can tap any three untapped Humans you control, including ones you haven’t controlled continuously since the beginning of your most recent turn, to pay the cost of the activated ability."
+          "text": "You can tap any three untapped Humans you control, including ones you haven't controlled continuously since the beginning of your most recent turn, to pay the cost of the activated ability."
         },
         {
           "date": "2012-05-01",
-          "text": "If the targeted creature is an illegal target when the ability tries to resolve, the ability will be countered and none of its effects will happen. The creature’s controller won’t put a Spirit token onto the battlefield."
+          "text": "If the targeted creature is an illegal target when the ability tries to resolve, the ability will be countered and none of its effects will happen. The creature's controller won't put a Spirit token onto the battlefield."
         }
       ],
       "text": "{3}, {T}, Tap three untapped Humans you control: Destroy target creature. Its controller creates a 1/1 white Spirit creature token with flying.",
@@ -25193,7 +25189,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If, during your declare attackers step, the equipped creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under your control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, you’re not forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, the equipped creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under your control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, you're not forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -25612,11 +25608,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You must choose an existing creature type, such as Zombie or Warrior. Card types such as artifact can’t be chosen."
+          "text": "You must choose an existing creature type, such as Zombie or Warrior. Card types such as artifact can't be chosen."
         },
         {
           "date": "2017-03-14",
-          "text": "The spell can’t be countered if the mana produced by Cavern of Souls is spent to cover any cost of the spell, even an additional cost such as a kicker cost. This is true even if you use the mana to pay an additional cost while casting a spell “without paying its mana cost.”"
+          "text": "The spell can't be countered if the mana produced by Cavern of Souls is spent to cover any cost of the spell, even an additional cost such as a kicker cost. This is true even if you use the mana to pay an additional cost while casting a spell \"without paying its mana cost.\""
         }
       ],
       "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
@@ -26338,6 +26334,11 @@
           "multiverseid": 295218
         },
         {
+          "language": "French",
+          "name": "Plaine",
+          "multiverseid": 295706
+        },
+        {
           "language": "German",
           "name": "Ebene",
           "multiverseid": 340750
@@ -26388,6 +26389,16 @@
           "multiverseid": 294970
         },
         {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 294973
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 294974
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Planície",
           "multiverseid": 295458
@@ -26416,21 +26427,6 @@
           "language": "Russian",
           "name": "Равнина",
           "multiverseid": 295950
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 296190
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 296193
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 296194
         }
       ],
       "id": "3d7f393fe040a449f8a8fd350653a0d374be2081",
@@ -26718,6 +26714,11 @@
           "multiverseid": 295218
         },
         {
+          "language": "French",
+          "name": "Plaine",
+          "multiverseid": 295706
+        },
+        {
           "language": "German",
           "name": "Ebene",
           "multiverseid": 340750
@@ -26768,6 +26769,16 @@
           "multiverseid": 294970
         },
         {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 294973
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 294974
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Planície",
           "multiverseid": 295458
@@ -26796,21 +26807,6 @@
           "language": "Russian",
           "name": "Равнина",
           "multiverseid": 295950
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 296190
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 296193
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 296194
         }
       ],
       "id": "c13ffde1f1da1dd8056337f2162a3b00a0cd982f",
@@ -29381,6 +29377,11 @@
           "multiverseid": 295212
         },
         {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 295698
+        },
+        {
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 340759
@@ -29428,7 +29429,17 @@
         {
           "language": "Korean",
           "name": "산",
+          "multiverseid": 294962
+        },
+        {
+          "language": "Korean",
+          "name": "산",
           "multiverseid": 294966
+        },
+        {
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 294968
         },
         {
           "language": "Portuguese (Brazil)",
@@ -29459,21 +29470,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 295944
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 296182
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 296186
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 296188
         }
       ],
       "id": "290838d38d59d511e87628407f9f660cc391c84a",
@@ -30533,6 +30529,11 @@
           "multiverseid": 295216
         },
         {
+          "language": "French",
+          "name": "Forêt",
+          "multiverseid": 295704
+        },
+        {
           "language": "German",
           "name": "Wald",
           "multiverseid": 340762
@@ -30580,6 +30581,16 @@
         {
           "language": "Korean",
           "name": "숲",
+          "multiverseid": 294965
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 294971
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
           "multiverseid": 294972
         },
         {
@@ -30611,21 +30622,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 295948
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 296185
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 296191
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 296192
         }
       ],
       "id": "06ddfebd57215cac5cdeb476c37e50ce81015de4",
@@ -30915,6 +30911,11 @@
           "multiverseid": 295216
         },
         {
+          "language": "French",
+          "name": "Forêt",
+          "multiverseid": 295704
+        },
+        {
           "language": "German",
           "name": "Wald",
           "multiverseid": 340762
@@ -30962,6 +30963,16 @@
         {
           "language": "Korean",
           "name": "숲",
+          "multiverseid": 294965
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 294971
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
           "multiverseid": 294972
         },
         {
@@ -30993,21 +31004,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 295948
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 296185
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 296191
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 296192
         }
       ],
       "id": "ae2a2a3d73ae478e9f7236110ca5afb63e97a7f4",
@@ -31297,6 +31293,11 @@
           "multiverseid": 295216
         },
         {
+          "language": "French",
+          "name": "Forêt",
+          "multiverseid": 295704
+        },
+        {
           "language": "German",
           "name": "Wald",
           "multiverseid": 340762
@@ -31344,6 +31345,16 @@
         {
           "language": "Korean",
           "name": "숲",
+          "multiverseid": 294965
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 294971
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
           "multiverseid": 294972
         },
         {
@@ -31375,21 +31386,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 295948
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 296185
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 296191
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 296192
         }
       ],
       "id": "bca4a91d609bdf3c215d070f91b9f26b0c16a7f8",

--- a/json/BFZ.json
+++ b/json/BFZ.json
@@ -143,11 +143,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If Bane of Bala Ged attacks a planeswalker, the defending player may exile that planeswalker. Bane of Bala Ged will still be attacking and may be blocked as normal. If it’s not blocked, it won’t deal combat damage."
+          "text": "If Bane of Bala Ged attacks a planeswalker, the defending player may exile that planeswalker. Bane of Bala Ged will still be attacking and may be blocked as normal. If it's not blocked, it won't deal combat damage."
         },
         {
           "date": "2015-08-25",
-          "text": "In a Two-Headed Giant game, you choose which of your opponents will exile permanents. You can’t have each of them exile one permanent."
+          "text": "In a Two-Headed Giant game, you choose which of your opponents will exile permanents. You can't have each of them exile one permanent."
         },
         {
           "date": "2015-08-25",
@@ -262,25 +262,26 @@
       "power": "4",
       "printings": [
         "pPRE",
+        "pLPA",
         "BFZ"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         },
         {
           "date": "2015-08-25",
@@ -292,11 +293,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -410,11 +411,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If, during its controller’s declare blockers step, a creature the defending player controls is tapped or is affected by a spell or ability that says it can’t block, then it doesn’t block. If there’s a cost associated with having it block, its controller isn’t forced to pay that cost. If he or she doesn’t, the creature doesn’t have to block."
+          "text": "If, during its controller's declare blockers step, a creature the defending player controls is tapped or is affected by a spell or ability that says it can't block, then it doesn't block. If there's a cost associated with having it block, its controller isn't forced to pay that cost. If he or she doesn't, the creature doesn't have to block."
         },
         {
           "date": "2015-08-25",
-          "text": "If a creature can’t legally block Breaker of Armies but could block another attacking creature, it may do so. Likewise, if a creature the defending player controls can’t block Breaker of Armies unless its controller pays a cost, its controller may decline to pay that cost and block a different attacking creature."
+          "text": "If a creature can't legally block Breaker of Armies but could block another attacking creature, it may do so. Likewise, if a creature the defending player controls can't block Breaker of Armies unless its controller pays a cost, its controller may decline to pay that cost and block a different attacking creature."
         },
         {
           "date": "2015-08-25",
@@ -531,15 +532,15 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Conduit of Ruin’s last ability doesn’t change the mana cost or converted mana cost of any spell. It changes only the total cost you actually pay."
+          "text": "Conduit of Ruin's last ability doesn't change the mana cost or converted mana cost of any spell. It changes only the total cost you actually pay."
         },
         {
           "date": "2015-08-25",
-          "text": "Conduit of Ruin’s last ability will look at the entire turn, even if Conduit of Ruin wasn’t on the battlefield for some of it. Notably, if you cast Conduit of Ruin in a turn, then no other creature spell you cast that turn can be your first."
+          "text": "Conduit of Ruin's last ability will look at the entire turn, even if Conduit of Ruin wasn't on the battlefield for some of it. Notably, if you cast Conduit of Ruin in a turn, then no other creature spell you cast that turn can be your first."
         },
         {
           "date": "2015-08-25",
-          "text": "Conduit of Ruin’s last ability can’t reduce the amount of colored mana you pay for a spell. It reduces only the generic component of that mana cost."
+          "text": "Conduit of Ruin's last ability can't reduce the amount of colored mana you pay for a spell. It reduces only the generic component of that mana cost."
         },
         {
           "date": "2015-08-25",
@@ -547,7 +548,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "The first creature spell you cast each turn doesn’t necessarily have to be the first spell you cast. You could cast a sorcery spell and then cast a creature spell that would get the discount."
+          "text": "The first creature spell you cast each turn doesn't necessarily have to be the first spell you cast. You could cast a sorcery spell and then cast a creature spell that would get the discount."
         },
         {
           "date": "2015-08-25",
@@ -559,11 +560,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the first creature spell you cast in a turn has {X} in its mana cost, you choose the value of X before calculating the spell’s total cost. For example, if the first creature spell you cast in a turn has a mana cost of {X}{G}, you could choose 2 as the value of X and pay {G} to cast the spell."
+          "text": "If the first creature spell you cast in a turn has {X} in its mana cost, you choose the value of X before calculating the spell's total cost. For example, if the first creature spell you cast in a turn has a mana cost of {X}{G}, you could choose 2 as the value of X and pay {G} to cast the spell."
         },
         {
           "date": "2015-08-25",
-          "text": "If the first creature spell you cast in a turn has converge, you can’t ignore the cost reduction of Conduit of Ruin’s last ability in order to spend more colors of mana."
+          "text": "If the first creature spell you cast in a turn has converge, you can't ignore the cost reduction of Conduit of Ruin's last ability in order to spend more colors of mana."
         }
       ],
       "subtypes": [
@@ -684,11 +685,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -1336,11 +1337,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Oblivion Sower’s ability allows you to put any land cards the player owns from exile onto the battlefield, regardless of how those cards were exiled."
+          "text": "Oblivion Sower's ability allows you to put any land cards the player owns from exile onto the battlefield, regardless of how those cards were exiled."
         },
         {
           "date": "2015-08-25",
-          "text": "Cards that are face down in exile have no characteristics. Such cards can’t be put onto the battlefield with Oblivion Sower’s ability."
+          "text": "Cards that are face down in exile have no characteristics. Such cards can't be put onto the battlefield with Oblivion Sower's ability."
         }
       ],
       "subtypes": [
@@ -1453,19 +1454,19 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "subtypes": [
@@ -1680,15 +1681,15 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The colorless creature card stays revealed until Titan’s Presence leaves the stack."
+          "text": "The colorless creature card stays revealed until Titan's Presence leaves the stack."
         },
         {
           "date": "2015-08-25",
-          "text": "The colorless creature card you reveal doesn’t have to still be in your hand as Titan’s Presence resolves. If it’s not, use its power as it last existed in your hand."
+          "text": "The colorless creature card you reveal doesn't have to still be in your hand as Titan's Presence resolves. If it's not, use its power as it last existed in your hand."
         },
         {
           "date": "2015-08-25",
-          "text": "Check the target creature’s power as Titan’s Presence resolves to see if it’s less than or equal to revealed creature card’s power. If it’s greater, Titan’s Presence will finish resolving with no effect."
+          "text": "Check the target creature's power as Titan's Presence resolves to see if it's less than or equal to revealed creature card's power. If it's greater, Titan's Presence will finish resolving with no effect."
         }
       ],
       "text": "As an additional cost to cast Titan's Presence, reveal a colorless creature card from your hand.\nExile target creature if its power is less than or equal to the revealed card's power.",
@@ -1798,15 +1799,15 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Ulamog’s first ability resolves independently of Ulamog once they’ve both been put on the stack. If Ulamog is countered, that triggered ability will still resolve. That triggered ability will always resolve before Ulamog does."
+          "text": "Ulamog's first ability resolves independently of Ulamog once they've both been put on the stack. If Ulamog is countered, that triggered ability will still resolve. That triggered ability will always resolve before Ulamog does."
         },
         {
           "date": "2015-08-25",
-          "text": "Cards exiled by Ulamog’s first and third abilities are exiled face up."
+          "text": "Cards exiled by Ulamog's first and third abilities are exiled face up."
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has less than twenty cards in his or her library, exile all of them. That player won’t lose the game until he or she has to draw a card from an empty library."
+          "text": "If the player has less than twenty cards in his or her library, exile all of them. That player won't lose the game until he or she has to draw a card from an empty library."
         }
       ],
       "subtypes": [
@@ -1921,19 +1922,19 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "subtypes": [
@@ -2048,11 +2049,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Effects that increase or reduce the cost to cast a spell don’t affect that spell’s converted mana cost."
+          "text": "Effects that increase or reduce the cost to cast a spell don't affect that spell's converted mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell’s converted mana cost is even or not. For example, your opponent could cast Endless One (with mana cost {X}) with X equal to 5, but not with X equal to 6."
+          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell's converted mana cost is even or not. For example, your opponent could cast Endless One (with mana cost {X}) with X equal to 5, but not with X equal to 6."
         },
         {
           "date": "2015-08-25",
@@ -2064,7 +2065,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Yes, your opponent can’t even. We know."
+          "text": "Yes, your opponent can't even. We know."
         }
       ],
       "subtypes": [
@@ -2183,7 +2184,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Count the number of creatures you control as the ability resolves to determine how much life you gain. Angel of Renewal will count toward this number if it’s still on the battlefield."
+          "text": "Count the number of creatures you control as the ability resolves to determine how much life you gain. Angel of Renewal will count toward this number if it's still on the battlefield."
         }
       ],
       "subtypes": [
@@ -2302,7 +2303,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If the target of an Aura becomes illegal before the spell resolves, the Aura will be countered and put into its owner’s graveyard. It won’t enter the battlefield and you won’t draw a card."
+          "text": "If the target of an Aura becomes illegal before the spell resolves, the Aura will be countered and put into its owner's graveyard. It won't enter the battlefield and you won't draw a card."
         }
       ],
       "subtypes": [
@@ -2648,11 +2649,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "A “nonland permanent card” is an artifact, creature, enchantment, or planeswalker card."
+          "text": "A \"nonland permanent card\" is an artifact, creature, enchantment, or planeswalker card."
         },
         {
           "date": "2015-08-25",
-          "text": "If you return an Aura to the battlefield this way, you choose what it will enchant as it enters the battlefield. This doesn’t target any player or permanent, so you could attach an Aura to a permanent with hexproof controlled by an opponent, for example. If there’s nothing the Aura can legally enchant, it stays in the graveyard."
+          "text": "If you return an Aura to the battlefield this way, you choose what it will enchant as it enters the battlefield. This doesn't target any player or permanent, so you could attach an Aura to a permanent with hexproof controlled by an opponent, for example. If there's nothing the Aura can legally enchant, it stays in the graveyard."
         },
         {
           "date": "2015-08-25",
@@ -2664,7 +2665,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -2781,31 +2782,31 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Encircling Fissure prevents all combat damage that would be dealt by any creature controlled by the target opponent, even if that creature wasn’t on the battlefield or wasn’t a creature as Encircling Fissure resolved."
+          "text": "Encircling Fissure prevents all combat damage that would be dealt by any creature controlled by the target opponent, even if that creature wasn't on the battlefield or wasn't a creature as Encircling Fissure resolved."
         },
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Prevent all combat damage that would be dealt this turn by creatures target opponent controls.\nAwaken 2—{4}{W} (If you cast this spell for {4}{W}, also put two +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -3153,11 +3154,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Felidar Sovereign’s triggered ability checks to see if you have 40 or more life as your upkeep begins. If you don’t, the ability won’t trigger at all. If you do, the ability will check again as it tries to resolve. If you don’t have 40 or more life at that time, the ability won’t do anything."
+          "text": "Felidar Sovereign's triggered ability checks to see if you have 40 or more life as your upkeep begins. If you don't, the ability won't trigger at all. If you do, the ability will check again as it tries to resolve. If you don't have 40 or more life at that time, the ability won't do anything."
         },
         {
           "date": "2015-08-25",
-          "text": "In a Two-Headed Giant game, your life total is the same as your team’s life total. As such, the ability triggers if your team has 40 or more life."
+          "text": "In a Two-Headed Giant game, your life total is the same as your team's life total. As such, the ability triggers if your team has 40 or more life."
         }
       ],
       "subtypes": [
@@ -3504,19 +3505,19 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Gideon’s first ability doesn’t count as a creature entering the battlefield. Gideon was already on the battlefield; he only changed his types. Specifically, your rally abilities won’t trigger. (Of course, Gideon’s second ability will cause rally abilities to trigger.)"
+          "text": "Gideon's first ability doesn't count as a creature entering the battlefield. Gideon was already on the battlefield; he only changed his types. Specifically, your rally abilities won't trigger. (Of course, Gideon's second ability will cause rally abilities to trigger.)"
         },
         {
           "date": "2015-08-25",
-          "text": "If Gideon becomes a creature the same turn he enters the battlefield, you can’t attack with him or use any of his {T} abilities (if he gains any)."
+          "text": "If Gideon becomes a creature the same turn he enters the battlefield, you can't attack with him or use any of his {T} abilities (if he gains any)."
         },
         {
           "date": "2015-08-25",
-          "text": "Gideon’s first ability causes him to become a creature with the creature types Human, Soldier, and Ally. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: planeswalker is only a type (not a creature type), and Human, Soldier, and Ally are just creature types (not planeswalker types)."
+          "text": "Gideon's first ability causes him to become a creature with the creature types Human, Soldier, and Ally. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: planeswalker is only a type (not a creature type), and Human, Soldier, and Ally are just creature types (not planeswalker types)."
         },
         {
           "date": "2015-08-25",
-          "text": "If damage that can’t be prevented is dealt to Gideon after his first ability has resolved, that damage will have all applicable results: specifically, the damage is marked on Gideon (since he’s a creature) and that damage causes that many loyalty counters to be removed from him (since he’s a planeswalker). Even though he has indestructible, if Gideon has no loyalty counters on him, he’s put into his owner’s graveyard."
+          "text": "If damage that can't be prevented is dealt to Gideon after his first ability has resolved, that damage will have all applicable results: specifically, the damage is marked on Gideon (since he's a creature) and that damage causes that many loyalty counters to be removed from him (since he's a planeswalker). Even though he has indestructible, if Gideon has no loyalty counters on him, he's put into his owner's graveyard."
         }
       ],
       "subtypes": [
@@ -3879,7 +3880,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The set of creatures affected by Inspired Charge is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won’t get +2/+1."
+          "text": "The set of creatures affected by Inspired Charge is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get +2/+1."
         }
       ],
       "text": "Creatures you control get +2/+1 until end of turn.",
@@ -4233,7 +4234,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "A creature that’s an Eldrazi but not a Scion (or vice versa) can block Kor Castigator."
+          "text": "A creature that's an Eldrazi but not a Scion (or vice versa) can block Kor Castigator."
         }
       ],
       "subtypes": [
@@ -4480,7 +4481,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Multiple instances of lifelink are redundant. There usually isn’t much benefit in having the rally ability resolve more than once in a turn, other than that new creatures will be affected by the ability resolving an additional time."
+          "text": "multiple instances of lifelink on the same creature are redundant. There usually isn't much benefit in having the rally ability resolve more than once in a turn, other than that new creatures will be affected by the ability resolving an additional time."
         },
         {
           "date": "2015-08-25",
@@ -4608,7 +4609,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Lithomancer’s Focus will prevent damage to the creature from any colorless source that turn, even if that source didn’t exist or wasn’t colorless as Lithomancer’s Focus resolved."
+          "text": "Lithomancer's Focus will prevent damage to the creature from any colorless source that turn, even if that source didn't exist or wasn't colorless as Lithomancer's Focus resolved."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn. Prevent all damage that would be dealt to that creature this turn by colorless sources.",
@@ -4723,7 +4724,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Vigilance matters only as attackers are declared. Giving a creature vigilance after that point won’t untap it, even if it’s attacking."
+          "text": "Vigilance matters only as attackers are declared. Giving a creature vigilance after that point won't untap it, even if it's attacking."
         },
         {
           "date": "2015-08-25",
@@ -4860,7 +4861,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -4977,31 +4978,31 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Ondu Rising creates a delayed triggered ability. Any creature that attacks that turn will cause that ability to trigger, including creatures controlled by a teammate and creatures you didn’t control or that didn’t exist as Ondu Rising resolved. Notably, this includes the land creature created if Ondu Rising is cast for its awaken cost."
+          "text": "Ondu Rising creates a delayed triggered ability. Any creature that attacks that turn will cause that ability to trigger, including creatures controlled by a teammate and creatures you didn't control or that didn't exist as Ondu Rising resolved. Notably, this includes the land creature created if Ondu Rising is cast for its awaken cost."
         },
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Whenever a creature attacks this turn, it gains lifelink until end of turn.\nAwaken 4—{4}{W} (If you cast this spell for {4}{W}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -5115,31 +5116,31 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "A “nonland creature” is a creature that isn’t also a land."
+          "text": "A \"nonland creature\" is a creature that isn't also a land."
         },
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Destroy all nonland creatures.\nAwaken 4—{5}{W}{W}{W} (If you cast this spell for {5}{W}{W}{W}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -5253,7 +5254,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Use the number of isolation counters on Quarantine Field as its triggered ability is put on the stack to determine how many targets you may choose. Once the targets are chosen, the number of targets the ability has is locked in. Changing the number of isolation counters on Quarantine Field won’t change how many nonland permanents are exiled."
+          "text": "Use the number of isolation counters on Quarantine Field as its triggered ability is put on the stack to determine how many targets you may choose. Once the targets are chosen, the number of targets the ability has is locked in. Changing the number of isolation counters on Quarantine Field won't change how many nonland permanents are exiled."
         },
         {
           "date": "2015-08-25",
@@ -5265,11 +5266,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Auras attached to the exiled permanents will be put into their owners’ graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled permanents will cease to exist."
+          "text": "Auras attached to the exiled permanents will be put into their owners' graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled permanents will cease to exist."
         },
         {
           "date": "2015-08-25",
-          "text": "If a token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2015-08-25",
@@ -5277,7 +5278,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "In a multiplayer game, if Quarantine Field’s owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Quarantine Field's owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "Quarantine Field enters the battlefield with X isolation counters on it.\nWhen Quarantine Field enters the battlefield, for each isolation counter on it, exile up to one target nonland permanent an opponent controls until Quarantine Field leaves the battlefield.",
@@ -5398,7 +5399,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "text": "Landfall — Whenever a land enters the battlefield under your control, choose one —\n• Create a 1/1 white Kor Ally creature token.\n• Creatures you control get +1/+1 until end of turn.",
@@ -5512,11 +5513,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You choose how many targets Roil’s Retribution has and how the damage is divided as you cast the spell. Each target must receive at least 1 damage."
+          "text": "You choose how many targets Roil's Retribution has and how the damage is divided as you cast the spell. Each target must receive at least 1 damage."
         },
         {
           "date": "2015-08-25",
-          "text": "If some, but not all, of the targets become illegal by the time Roil’s Retribution tries to resolve, the original division of damage still applies, but no damage is dealt to illegal targets. If all the targets are illegal, the spell will be countered."
+          "text": "If some, but not all, of the targets become illegal by the time Roil's Retribution tries to resolve, the original division of damage still applies, but no damage is dealt to illegal targets. If all the targets are illegal, the spell will be countered."
         }
       ],
       "text": "Roil's Retribution deals 5 damage divided as you choose among any number of target attacking or blocking creatures.",
@@ -5631,7 +5632,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Drana’s Emissary or 7 life from Nissa’s Renewal."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Drana's Emissary or 7 life from Nissa's Renewal."
         },
         {
           "date": "2015-08-25",
@@ -5639,7 +5640,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -5873,27 +5874,27 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Destroy target tapped creature.\nAwaken 3—{5}{W} (If you cast this spell for {5}{W}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -6127,15 +6128,15 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If Stasis Snare leaves the battlefield before its triggered ability resolves, the target creature won’t be exiled."
+          "text": "If Stasis Snare leaves the battlefield before its triggered ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2015-08-25",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2015-08-25",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2015-08-25",
@@ -6143,7 +6144,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "In a multiplayer game, if Stasis Snare’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Stasis Snare's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Stasis Snare enters the battlefield, exile target creature an opponent controls until Stasis Snare leaves the battlefield. (That creature returns under its owner's control.)",
@@ -6371,7 +6372,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast Tandem Tactics with no targets. When it resolves, you’ll gain 2 life. However, if you cast Tandem Tactics with any targets and all of those targets are illegal as it tries to resolve, it will be countered and none of its effects will happen. You won’t gain 2 life in that case."
+          "text": "You can cast Tandem Tactics with no targets. When it resolves, you'll gain 2 life. However, if you cast Tandem Tactics with any targets and all of those targets are illegal as it tries to resolve, it will be countered and none of its effects will happen. You won't gain 2 life in that case."
         }
       ],
       "text": "Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.",
@@ -6489,7 +6490,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -6611,11 +6612,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast Adverse Conditions with no targets. When it resolves, you’ll get an Eldrazi Scion. However, if you cast Adverse Conditions with any targets and all of those targets are illegal as it tries to resolve, it will be countered and none of its effects will happen. You won’t get the Eldrazi Scion in that case."
+          "text": "You can cast Adverse Conditions with no targets. When it resolves, you'll get an Eldrazi Scion. However, if you cast Adverse Conditions with any targets and all of those targets are illegal as it tries to resolve, it will be countered and none of its effects will happen. You won't get the Eldrazi Scion in that case."
         },
         {
           "date": "2015-08-25",
-          "text": "Adverse Conditions tracks the creatures, but not their controller. If either of the creatures changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "Adverse Conditions tracks the creatures, but not their controller. If either of the creatures changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2015-08-25",
@@ -6623,11 +6624,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -6635,7 +6636,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -6647,11 +6648,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "text": "Devoid (This card has no color.)\nTap up to two target creatures. Those creatures don't untap during their controller's next untap step. Create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C} to your mana pool.\"",
@@ -6766,11 +6767,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -6778,7 +6779,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -6786,7 +6787,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -6907,11 +6908,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -6919,23 +6920,23 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "subtypes": [
@@ -7053,11 +7054,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can sacrifice any Eldrazi Scion to activate Drowner of Hope’s last ability, not just one created by Drowner of Hope."
+          "text": "You can sacrifice any Eldrazi Scion to activate Drowner of Hope's last ability, not just one created by Drowner of Hope."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t sacrifice the same permanent to pay two different costs. Notably, if you sacrifice an Eldrazi Scion to activate the last ability of Drowner of Hope, you won’t add {C} to your mana pool."
+          "text": "You can't sacrifice the same permanent to pay two different costs. Notably, if you sacrifice an Eldrazi Scion to activate the last ability of Drowner of Hope, you won't add {C} to your mana pool."
         },
         {
           "date": "2015-08-25",
@@ -7065,11 +7066,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -7077,7 +7078,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -7089,11 +7090,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -7212,11 +7213,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -7224,7 +7225,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -7236,11 +7237,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -7356,7 +7357,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The converted mana cost of a spell doesn’t change if its controller paid an alternative cost (such as an evoke cost) to cast it."
+          "text": "The converted mana cost of a spell doesn't change if its controller paid an alternative cost (such as an evoke cost) to cast it."
         },
         {
           "date": "2015-08-25",
@@ -7364,11 +7365,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -7376,7 +7377,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nCounter target creature spell with converted mana cost 4 or less. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
@@ -7492,11 +7493,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -7504,7 +7505,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -7516,11 +7517,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -7641,11 +7642,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -7653,7 +7654,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -7661,7 +7662,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -7778,11 +7779,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If the target creature becomes illegal before the triggered ability resolves, it will be countered and none of its effects will happen. You won’t “process” a card in exile."
+          "text": "If the target creature becomes illegal before the triggered ability resolves, it will be countered and none of its effects will happen. You won't \"process\" a card in exile."
         },
         {
           "date": "2015-08-25",
-          "text": "Players can respond to the triggered ability, but once it starts resolving and you decide whether to put a card from exile into the player’s graveyard, it’s too late for anyone to respond."
+          "text": "Players can respond to the triggered ability, but once it starts resolving and you decide whether to put a card from exile into the player's graveyard, it's too late for anyone to respond."
         },
         {
           "date": "2015-08-25",
@@ -7790,11 +7791,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -7802,23 +7803,23 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "subtypes": [
@@ -7939,11 +7940,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -7951,23 +7952,23 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "subtypes": [
@@ -8087,11 +8088,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -8099,7 +8100,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -8107,7 +8108,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -8227,11 +8228,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -8239,7 +8240,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -8247,7 +8248,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -8366,11 +8367,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -8378,7 +8379,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nCounter target spell unless its controller pays {4}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
@@ -8494,11 +8495,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -8506,7 +8507,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -8626,11 +8627,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -8638,23 +8639,23 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "subtypes": [
@@ -8891,7 +8892,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -9129,27 +9130,27 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Return target creature to its owner's hand.\nAwaken 3—{4}{U} (If you cast this spell for {4}{U}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -9262,27 +9263,27 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Draw two cards.\nAwaken 4—{5}{U} (If you cast this spell for {5}{U}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -9397,7 +9398,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Once an attacking creature has been legally blocked, making it so it can’t be blocked won’t change or undo that block."
+          "text": "Once an attacking creature has been legally blocked, making it so it can't be blocked won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -9744,11 +9745,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Check the creature’s power as Exert Influence resolves to see if it’s less than or equal to the number of colors spent to cast Exert Influence. If it’s greater, Exert Influence will finish resolving with no effect."
+          "text": "Check the creature's power as Exert Influence resolves to see if it's less than or equal to the number of colors spent to cast Exert Influence. If it's greater, Exert Influence will finish resolving with no effect."
         },
         {
           "date": "2015-08-25",
-          "text": "Once you’ve gained control of a creature with Exert Influence, it doesn’t matter what happens to its power. Raising it won’t cause the control-changing effect to end."
+          "text": "Once you've gained control of a creature with Exert Influence, it doesn't matter what happens to its power. Raising it won't cause the control-changing effect to end."
         },
         {
           "date": "2015-08-25",
@@ -9756,7 +9757,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -9883,11 +9884,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Guardian of Tazeem’s landfall ability can target a creature that’s already tapped. If the land that caused it to trigger was an Island, that creature won’t untap during its controller’s next untap step."
+          "text": "Guardian of Tazeem's landfall ability can target a creature that's already tapped. If the land that caused it to trigger was an Island, that creature won't untap during its controller's next untap step."
         },
         {
           "date": "2015-08-25",
-          "text": "The ability tracks the creature, but not its controller. If the creature changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "The ability tracks the creature, but not its controller. If the creature changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2015-08-25",
@@ -9899,7 +9900,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -10132,31 +10133,31 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Exiling Part the Waterveil is part of its effect. If Part the Waterveil is countered, including if it was cast for its awaken cost and the land you control became an illegal target, it will be put into its owner’s graveyard."
+          "text": "Exiling Part the Waterveil is part of its effect. If Part the Waterveil is countered, including if it was cast for its awaken cost and the land you control became an illegal target, it will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Take an extra turn after this one. Exile Part the Waterveil.\nAwaken 6—{6}{U}{U}{U} (If you cast this spell for {6}{U}{U}{U}, also put six +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -10278,7 +10279,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -10411,7 +10412,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "text": "Landfall — Whenever a land enters the battlefield under your control, choose one —\n• You may tap or untap target creature.\n• Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -10525,7 +10526,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast Roilmage’s Trick even if your opponents control no creatures. You’ll simply draw a card."
+          "text": "You can cast Roilmage's Trick even if your opponents control no creatures. You'll simply draw a card."
         },
         {
           "date": "2015-08-25",
@@ -10533,7 +10534,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -10658,35 +10659,35 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Rush of Ice can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Rush of Ice can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         },
         {
           "date": "2015-08-25",
-          "text": "Rush of Ice tracks the creature, but not its controller. If the creature changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "Rush of Ice tracks the creature, but not its controller. If the creature changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nAwaken 3—{4}{U} (If you cast this spell for {4}{U}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -10800,27 +10801,27 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Counter target spell.\nAwaken 3—{4}{U}{U} (If you cast this spell for {4}{U}{U}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -11052,11 +11053,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Use the highest converted mana cost among permanents you control as Ugin’s Insight resolves to determine how many cards you scry."
+          "text": "Use the highest converted mana cost among permanents you control as Ugin's Insight resolves to determine how many cards you scry."
         },
         {
           "date": "2015-08-25",
-          "text": "If X is 0, you won’t scry at all. Any abilities that trigger whenever you scry won’t trigger."
+          "text": "If X is 0, you won't scry at all. Any abilities that trigger whenever you scry won't trigger."
         }
       ],
       "text": "Scry X, where X is the highest converted mana cost among permanents you control, then draw three cards.",
@@ -11179,7 +11180,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -11411,11 +11412,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -11423,7 +11424,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nExile target creature with power 3 or less.",
@@ -11539,11 +11540,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -11551,7 +11552,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -11559,7 +11560,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -11676,7 +11677,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Dominator Drone’s last ability checks to see if you control another colorless creature at the moment it enters the battlefield. If you don’t, the ability won’t trigger at all. If you do, the ability will check again as it tries to resolve. If you no longer control another colorless creature, the ability will be removed from the stack and have no effect."
+          "text": "Dominator Drone's last ability checks to see if you control another colorless creature at the moment it enters the battlefield. If you don't, the ability won't trigger at all. If you do, the ability will check again as it tries to resolve. If you no longer control another colorless creature, the ability will be removed from the stack and have no effect."
         },
         {
           "date": "2015-08-25",
@@ -11684,11 +11685,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -11696,7 +11697,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -11704,7 +11705,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -11823,7 +11824,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "You can cast Grave Birthing targeting an opponent with an empty graveyard. Even though that player won’t exile a card from his or her graveyard, you’ll still get an Eldrazi Scion and draw a card."
+          "text": "You can cast Grave Birthing targeting an opponent with an empty graveyard. Even though that player won't exile a card from his or her graveyard, you'll still get an Eldrazi Scion and draw a card."
         },
         {
           "date": "2015-08-25",
@@ -11831,11 +11832,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -11843,7 +11844,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -11855,11 +11856,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "text": "Devoid (This card has no color.)\nTarget opponent exiles a card from his or her graveyard. You create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C} to your mana pool.\"\nDraw a card.",
@@ -11970,7 +11971,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You must target a creature and a land in order to cast Grip of Desolation. A permanent that’s both a land and a creature can be chosen for both targets."
+          "text": "You must target a creature and a land in order to cast Grip of Desolation. A permanent that's both a land and a creature can be chosen for both targets."
         },
         {
           "date": "2015-08-25",
@@ -11978,11 +11979,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -11990,7 +11991,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nExile target creature and target land.",
@@ -12106,11 +12107,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -12118,23 +12119,23 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "subtypes": [
@@ -12255,11 +12256,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -12267,7 +12268,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -12383,11 +12384,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Once you legally activate the ability, it doesn’t matter what happens to the other colorless creature. The ability will resolve and create a regeneration shield even if you don’t control another colorless creature at that time."
+          "text": "Once you legally activate the ability, it doesn't matter what happens to the other colorless creature. The ability will resolve and create a regeneration shield even if you don't control another colorless creature at that time."
         },
         {
           "date": "2015-08-25",
-          "text": "Skitterskin’s activated ability doesn’t depend on Skitterskin being colorless. If it gains one or more colors, you can still activate the ability if you control another creature that’s colorless."
+          "text": "Skitterskin's activated ability doesn't depend on Skitterskin being colorless. If it gains one or more colors, you can still activate the ability if you control another creature that's colorless."
         },
         {
           "date": "2015-08-25",
@@ -12395,11 +12396,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -12407,7 +12408,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -12527,11 +12528,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -12539,7 +12540,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -12547,7 +12548,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -12664,7 +12665,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You choose which creature you control to sacrifice as the first triggered ability resolves. Players can respond to this ability triggering, but once you choose a creature to sacrifice, it’s too late for anyone to respond."
+          "text": "You choose which creature you control to sacrifice as the first triggered ability resolves. Players can respond to this ability triggering, but once you choose a creature to sacrifice, it's too late for anyone to respond."
         },
         {
           "date": "2015-08-25",
@@ -12680,11 +12681,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -12692,7 +12693,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -12807,7 +12808,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "A colorless creature given first strike by Swarm Surge won’t lose first strike if it stops being colorless later in the turn."
+          "text": "A colorless creature given first strike by Swarm Surge won't lose first strike if it stops being colorless later in the turn."
         },
         {
           "date": "2015-08-25",
@@ -12815,11 +12816,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -12827,7 +12828,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nCreatures you control get +2/+0 until end of turn. Colorless creatures you control also gain first strike until end of turn.",
@@ -12942,11 +12943,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -12954,7 +12955,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nTarget player reveals his or her hand. You choose a card from it with converted mana cost 3 or greater and exile that card.",
@@ -13070,11 +13071,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -13082,23 +13083,23 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "subtypes": [
@@ -13347,7 +13348,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Drana’s Emissary or 7 life from Nissa’s Renewal."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Drana's Emissary or 7 life from Nissa's Renewal."
         },
         {
           "date": "2015-08-25",
@@ -13355,7 +13356,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -13488,11 +13489,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You must sacrifice exactly one creature to cast this spell; you can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast this spell; you can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "Once you begin to cast Bone Splinters, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast Bone Splinters, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         },
         {
           "date": "2017-03-14",
@@ -13620,11 +13621,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -13745,7 +13746,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Drana’s Emissary or 7 life from Nissa’s Renewal."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Drana's Emissary or 7 life from Nissa's Renewal."
         },
         {
           "date": "2015-08-25",
@@ -13753,7 +13754,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -13982,11 +13983,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Drana’s last ability triggers after combat damage has been dealt, so only attacking creatures that survive the combat damage step in which Drana deals combat damage will have +1/+1 counters put on them."
+          "text": "Drana's last ability triggers after combat damage has been dealt, so only attacking creatures that survive the combat damage step in which Drana deals combat damage will have +1/+1 counters put on them."
         },
         {
           "date": "2015-08-25",
-          "text": "The +1/+1 counter won’t change how much damage Drana or any other attacking creature with first strike or double strike deals during that combat damage step. However, the +1/+1 counters that are put on attacking creatures without first strike will affect the damage those creatures deal during the regular combat damage step."
+          "text": "The +1/+1 counter won't change how much damage Drana or any other attacking creature with first strike or double strike deals during that combat damage step. However, the +1/+1 counters that are put on attacking creatures without first strike will affect the damage those creatures deal during the regular combat damage step."
         }
       ],
       "subtypes": [
@@ -14229,7 +14230,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -14356,7 +14357,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -14475,7 +14476,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "An effect that gives a creature -1/-1 is different from putting a -1/-1 counter on that creature. Notably, if the target of Hagra Sharpshooter’s ability has any +1/+1 counters on it, those counters will remain."
+          "text": "An effect that gives a creature -1/-1 is different from putting a -1/-1 counter on that creature. Notably, if the target of Hagra Sharpshooter's ability has any +1/+1 counters on it, those counters will remain."
         }
       ],
       "subtypes": [
@@ -14721,7 +14722,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Drana’s Emissary or 7 life from Nissa’s Renewal."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Drana's Emissary or 7 life from Nissa's Renewal."
         },
         {
           "date": "2015-08-25",
@@ -14729,7 +14730,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -14850,7 +14851,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Drana’s Emissary or 7 life from Nissa’s Renewal."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Drana's Emissary or 7 life from Nissa's Renewal."
         },
         {
           "date": "2015-08-25",
@@ -14858,7 +14859,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -14975,27 +14976,27 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Target opponent discards two cards.\nAwaken 3—{5}{B} (If you cast this spell for {5}{B}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -15110,7 +15111,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Drana’s Emissary or 7 life from Nissa’s Renewal."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Drana's Emissary or 7 life from Nissa's Renewal."
         },
         {
           "date": "2015-08-25",
@@ -15118,7 +15119,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -15240,7 +15241,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The emblem created by Ob Nixilis Reignited’s last ability is both owned and controlled by the target opponent. In a multiplayer game, if you own Ob Nixilis Reignited and use him to give one of your opponents an emblem, the emblem remains even if you leave the game."
+          "text": "The emblem created by Ob Nixilis Reignited's last ability is both owned and controlled by the target opponent. In a multiplayer game, if you own Ob Nixilis Reignited and use him to give one of your opponents an emblem, the emblem remains even if you leave the game."
         }
       ],
       "subtypes": [
@@ -15362,7 +15363,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -15495,7 +15496,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "text": "Landfall — Whenever a land enters the battlefield under your control, choose one —\n• Target creature gets +1/+0 and gains deathtouch until end of turn.\n• Each opponent loses 1 life and you gain 1 life.",
@@ -15608,31 +15609,31 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If you cast Rising Miasma for its awaken cost, creatures will get -2/-2 before the land you targeted is turned into a creature. Unless it was already a land creature before Rising Miasma started resolving, it won’t get -2/-2."
+          "text": "If you cast Rising Miasma for its awaken cost, creatures will get -2/-2 before the land you targeted is turned into a creature. Unless it was already a land creature before Rising Miasma started resolving, it won't get -2/-2."
         },
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "All creatures get -2/-2 until end of turn.\nAwaken 3—{5}{B}{B} (If you cast this spell for {5}{B}{B}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -15747,27 +15748,27 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Destroy target creature or planeswalker.\nAwaken 4—{5}{B}{B} (If you cast this spell for {5}{B}{B}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -16217,7 +16218,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Barrage Tyrant deals the damage, not the sacrificed creature. For example, if the sacrificed creature had lifelink, you won’t gain life."
+          "text": "Barrage Tyrant deals the damage, not the sacrificed creature. For example, if the sacrificed creature had lifelink, you won't gain life."
         },
         {
           "date": "2015-08-25",
@@ -16225,11 +16226,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -16237,7 +16238,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -16351,7 +16352,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You may leave any cards with that name in the player’s graveyard, hand, or library. You don’t have to exile them."
+          "text": "You may leave any cards with that name in the player's graveyard, hand, or library. You don't have to exile them."
         },
         {
           "date": "2015-08-25",
@@ -16359,11 +16360,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -16371,7 +16372,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nExile target nonbasic land. Search its controller's graveyard, hand, and library for any number of cards with the same name as that land and exile them. Then that player shuffles his or her library.",
@@ -16487,11 +16488,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -16499,7 +16500,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -16619,11 +16620,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -16631,7 +16632,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nWhenever you cast a colorless spell, Molten Nursery deals 1 damage to target creature or player.",
@@ -16746,11 +16747,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -16758,7 +16759,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -16874,11 +16875,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You must put exactly one card an opponent owns from exile into that player’s graveyard to cast Processor Assault. You can’t cast it without doing so, and you can’t put multiple exiled cards into their owners’ graveyards this way."
+          "text": "You must put exactly one card an opponent owns from exile into that player's graveyard to cast Processor Assault. You can't cast it without doing so, and you can't put multiple exiled cards into their owners' graveyards this way."
         },
         {
           "date": "2015-08-25",
-          "text": "Players can respond to Processor Assault only after it’s been cast and all of its costs have been paid. No one can try to remove the card from exile to stop you from casting the spell."
+          "text": "Players can respond to Processor Assault only after it's been cast and all of its costs have been paid. No one can try to remove the card from exile to stop you from casting the spell."
         },
         {
           "date": "2015-08-25",
@@ -16886,11 +16887,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -16898,23 +16899,23 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "text": "Devoid (This card has no color.)\nAs an additional cost to cast Processor Assault, put a card an opponent owns from exile into that player's graveyard.\nProcessor Assault deals 5 damage to target creature.",
@@ -17025,15 +17026,15 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Each target must be a different creature. You can’t cast Serpentine Spike without three different creatures available."
+          "text": "Each target must be a different creature. You can't cast Serpentine Spike without three different creatures available."
         },
         {
           "date": "2015-08-25",
-          "text": "If one or two of those targets become illegal by the time Serpentine Spike resolves, you can’t change how much damage will be dealt to the remaining legal targets."
+          "text": "If one or two of those targets become illegal by the time Serpentine Spike resolves, you can't change how much damage will be dealt to the remaining legal targets."
         },
         {
           "date": "2015-08-25",
-          "text": "A creature doesn’t necessarily have to be dealt lethal damage by Serpentine Spike to be exiled. After being dealt damage, if it would die for any reason that turn, it’ll be exiled instead."
+          "text": "A creature doesn't necessarily have to be dealt lethal damage by Serpentine Spike to be exiled. After being dealt damage, if it would die for any reason that turn, it'll be exiled instead."
         },
         {
           "date": "2015-08-25",
@@ -17041,11 +17042,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -17053,7 +17054,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nSerpentine Spike deals 2 damage to target creature, 3 damage to another target creature, and 4 damage to a third target creature. If a creature dealt damage this way would die this turn, exile it instead.",
@@ -17164,7 +17165,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "A creature doesn’t necessarily have to be dealt lethal damage by Touch of the Void to be exiled. After being dealt damage, if it would die for any reason that turn, it’ll be exiled instead."
+          "text": "A creature doesn't necessarily have to be dealt lethal damage by Touch of the Void to be exiled. After being dealt damage, if it would die for any reason that turn, it'll be exiled instead."
         },
         {
           "date": "2015-08-25",
@@ -17172,11 +17173,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -17184,7 +17185,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nTouch of the Void deals 3 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
@@ -17295,11 +17296,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Turn Against can target any creature, even one that’s untapped or one you already control."
+          "text": "Turn Against can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2015-08-25",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2015-08-25",
@@ -17307,11 +17308,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -17319,7 +17320,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
@@ -17435,11 +17436,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -17447,7 +17448,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -17563,7 +17564,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The ability that defines Vile Aggregate’s power works in all zones, not just the battlefield. If Vile Aggregate is on the battlefield, it will count itself."
+          "text": "The ability that defines Vile Aggregate's power works in all zones, not just the battlefield. If Vile Aggregate is on the battlefield, it will count itself."
         },
         {
           "date": "2015-08-25",
@@ -17571,11 +17572,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -17583,7 +17584,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -17591,7 +17592,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -17711,7 +17712,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If, during its controller’s declare attackers step, Akoum Firebird is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having it attack, its controller isn’t forced to pay that cost. If he or she doesn’t, Akoum Firebird doesn’t have to attack."
+          "text": "If, during its controller's declare attackers step, Akoum Firebird is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having it attack, its controller isn't forced to pay that cost. If he or she doesn't, Akoum Firebird doesn't have to attack."
         },
         {
           "date": "2015-08-25",
@@ -17719,7 +17720,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Players can respond to the triggered ability, but once it starts resolving and you decide whether to pay {4}{R}{R}, it’s too late for anyone to respond."
+          "text": "Players can respond to the triggered ability, but once it starts resolving and you decide whether to pay {4}{R}{R}, it's too late for anyone to respond."
         },
         {
           "date": "2015-08-25",
@@ -17731,7 +17732,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -17858,7 +17859,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -17984,7 +17985,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -18112,7 +18113,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -18229,27 +18230,27 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Boiling Earth deals 1 damage to each creature your opponents control.\nAwaken 4—{6}{R} (If you cast this spell for {6}{R}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -18978,7 +18979,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -19341,7 +19342,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -19468,15 +19469,15 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Reckless Cohort can attack if you control another Ally. It just isn’t forced to."
+          "text": "Reckless Cohort can attack if you control another Ally. It just isn't forced to."
         },
         {
           "date": "2015-08-25",
-          "text": "Reckless Cohort checks whether you control another Ally as attacking creatures are declared. At that time, if you don’t, Reckless Cohort attacks if able."
+          "text": "Reckless Cohort checks whether you control another Ally as attacking creatures are declared. At that time, if you don't, Reckless Cohort attacks if able."
         },
         {
           "date": "2015-08-25",
-          "text": "If, during its controller’s declare attackers step, that player doesn’t control another Ally but Reckless Cohort is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having Reckless Cohort attack, its controller isn’t forced to pay that cost. If he or she doesn’t, Reckless Cohort doesn’t have to attack."
+          "text": "If, during its controller's declare attackers step, that player doesn't control another Ally but Reckless Cohort is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having Reckless Cohort attack, its controller isn't forced to pay that cost. If he or she doesn't, Reckless Cohort doesn't have to attack."
         }
       ],
       "subtypes": [
@@ -19603,7 +19604,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "text": "Landfall — Whenever a land enters the battlefield under your control, choose one —\n• Target creature gets +2/+0 until end of turn.\n• Target creature can't block this turn.",
@@ -19725,7 +19726,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If X is greater than 0, you can’t choose zero targets. You must choose between one and X targets. If X is 0, you can’t choose any targets."
+          "text": "If X is greater than 0, you can't choose zero targets. You must choose between one and X targets. If X is 0, you can't choose any targets."
         },
         {
           "date": "2015-08-25",
@@ -19737,7 +19738,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can’t change the way damage is divided."
+          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can't change the way damage is divided."
         }
       ],
       "text": "Rolling Thunder deals X damage divided as you choose among any number of target creatures and/or players.",
@@ -20197,7 +20198,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -20438,7 +20439,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -20670,11 +20671,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If you cast an instant or sorcery spell that has multiple targets, but it’s targeting only Zada with all of them, Zada’s ability will trigger. The copies will similarly each be targeting only one of your other creatures. You can’t change any of the copy’s targets to other creatures."
+          "text": "If you cast an instant or sorcery spell that has multiple targets, but it's targeting only Zada with all of them, Zada's ability will trigger. The copies will similarly each be targeting only one of your other creatures. You can't change any of the copy's targets to other creatures."
         },
         {
           "date": "2015-08-25",
-          "text": "Any creature you control that couldn’t be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Zada’s ability."
+          "text": "Any creature you control that couldn't be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Zada's ability."
         },
         {
           "date": "2015-08-25",
@@ -20682,19 +20683,19 @@
         },
         {
           "date": "2015-08-25",
-          "text": "The copies that the ability creates are created on the stack, so they’re not cast. Abilities that trigger when a player casts a spell (like Zada’s ability itself) won’t trigger."
+          "text": "The copies that the ability creates are created on the stack, so they're not cast. Abilities that trigger when a player casts a spell (like Zada's ability itself) won't trigger."
         },
         {
           "date": "2015-08-25",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copies will have the same mode. You can’t choose a different one."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copies will have the same mode. You can't choose a different one."
         },
         {
           "date": "2015-08-25",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Rolling Thunder does), the copies have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Rolling Thunder does), the copies have the same value of X."
         },
         {
           "date": "2015-08-25",
-          "text": "The controller of a copy can’t choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
+          "text": "The controller of a copy can't choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
         }
       ],
       "subtypes": [
@@ -20818,11 +20819,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -20830,7 +20831,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -20842,11 +20843,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -20967,11 +20968,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -20979,7 +20980,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -20991,11 +20992,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -21115,11 +21116,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -21127,7 +21128,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -21139,11 +21140,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "text": "Devoid (This card has no color.)\nCreate two 1/1 colorless Eldrazi Scion creature tokens. They have \"Sacrifice this creature: Add {C} to your mana pool.\"",
@@ -21259,11 +21260,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -21271,7 +21272,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -21283,11 +21284,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -21403,7 +21404,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "An Eldrazi card is one with the creature type Eldrazi. Just having “Eldrazi” in its name or being an Eldrazi-themed card doesn’t count."
+          "text": "An Eldrazi card is one with the creature type Eldrazi. Just having \"Eldrazi\" in its name or being an Eldrazi-themed card doesn't count."
         },
         {
           "date": "2015-08-25",
@@ -21411,11 +21412,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -21423,7 +21424,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -21435,11 +21436,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "text": "Devoid (This card has no color.)\nAt the beginning of your upkeep, create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C} to your mana pool.\"\n{1}{G}, Sacrifice From Beyond: Search your library for an Eldrazi card, reveal it, put it into your hand, then shuffle your library.",
@@ -21562,11 +21563,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -21574,7 +21575,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nTarget creature you control fights target creature an opponent controls. If the creature an opponent controls would die this turn, exile it instead.",
@@ -21686,7 +21687,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Once you announce that you’re activating this ability, players can’t respond until after you have paid its costs and completed activating it. Specifically, no one can try to remove the card from exile to stop you from activating the ability."
+          "text": "Once you announce that you're activating this ability, players can't respond until after you have paid its costs and completed activating it. Specifically, no one can try to remove the card from exile to stop you from activating the ability."
         },
         {
           "date": "2015-08-25",
@@ -21694,11 +21695,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -21706,23 +21707,23 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         },
         {
           "date": "2015-08-25",
@@ -21734,11 +21735,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -21859,11 +21860,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Mana produced by Beastcaller Savant can be spent on any part of a creature spell’s total cost, including additional costs (such as kicker costs) and alternative costs (such as dash costs). It can’t be spent to pay the costs of abilities of creatures you control."
+          "text": "Mana produced by Beastcaller Savant can be spent on any part of a creature spell's total cost, including additional costs (such as kicker costs) and alternative costs (such as dash costs). It can't be spent to pay the costs of abilities of creatures you control."
         },
         {
           "date": "2015-08-25",
-          "text": "Mana produced by Beastcaller Savant can’t be used to activate an ability or cast an instant or sorcery spell that creates creature tokens."
+          "text": "Mana produced by Beastcaller Savant can't be used to activate an ability or cast an instant or sorcery spell that creates creature tokens."
         }
       ],
       "subtypes": [
@@ -22093,7 +22094,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Any permanent can have a +1/+1 counter put on it. Those counters won’t have any effect unless that permanent is or becomes a creature."
+          "text": "Any permanent can have a +1/+1 counter put on it. Those counters won't have any effect unless that permanent is or becomes a creature."
         },
         {
           "date": "2015-08-25",
@@ -22101,27 +22102,27 @@
         },
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Put two +1/+1 counters on target permanent.\nAwaken 4—{6}{G} (If you cast this spell for {6}{G}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -22355,11 +22356,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You decide whether to exile Greenwarden of Murasa as the last ability resolves. Players can respond to this ability triggering, but once it starts resolving and you decide to exile Greenwarden of Murasa, it’s too late for anyone to respond."
+          "text": "You decide whether to exile Greenwarden of Murasa as the last ability resolves. Players can respond to this ability triggering, but once it starts resolving and you decide to exile Greenwarden of Murasa, it's too late for anyone to respond."
         },
         {
           "date": "2015-08-25",
-          "text": "If the target card becomes illegal before the last ability resolves, it will be countered. You can’t exile Greenwarden of Murasa in that case, even if you want to."
+          "text": "If the target card becomes illegal before the last ability resolves, it will be countered. You can't exile Greenwarden of Murasa in that case, even if you want to."
         }
       ],
       "subtypes": [
@@ -22481,7 +22482,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -22616,7 +22617,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -22857,7 +22858,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -23206,7 +23207,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -23787,7 +23788,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "text": "Landfall — Whenever a land enters the battlefield under your control, choose one —\n• Put a +1/+1 counter on target creature.\n• You gain 2 life.",
@@ -24025,7 +24026,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -24260,7 +24261,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -24378,7 +24379,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Putting a land onto the battlefield this way is not the same as playing a land. Swell of Growth doesn’t affect how many lands you can play from your hand during your turn."
+          "text": "Putting a land onto the battlefield this way is not the same as playing a land. Swell of Growth doesn't affect how many lands you can play from your hand during your turn."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn. You may put a land card from your hand onto the battlefield.",
@@ -24736,7 +24737,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -25000,7 +25001,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -25016,7 +25017,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -25135,11 +25136,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If Undergrowth Champion is dealt damage from multiple sources at the same time (for example, if it’s blocked by multiple creatures), its prevention effect will apply once to all that damage. You’ll remove only one +1/+1 counter."
+          "text": "If Undergrowth Champion is dealt damage from multiple sources at the same time (for example, if it's blocked by multiple creatures), its prevention effect will apply once to all that damage. You'll remove only one +1/+1 counter."
         },
         {
           "date": "2015-08-25",
-          "text": "If damage that can’t be prevented is dealt to Undergrowth Champion while it has a +1/+1 counter on it, you’ll still remove a +1/+1 counter on it."
+          "text": "If damage that can't be prevented is dealt to Undergrowth Champion while it has a +1/+1 counter on it, you'll still remove a +1/+1 counter on it."
         },
         {
           "date": "2015-08-25",
@@ -25151,7 +25152,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -25275,7 +25276,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -25408,11 +25409,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -25420,7 +25421,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -25432,11 +25433,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -25553,7 +25554,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If a spell is returned to its owner’s hand, it’s removed from the stack. The spell isn’t countered, but it won’t resolve. If a copy of a spell is returned to a hand this way, the copy will cease to exist the next time state-based actions are performed."
+          "text": "If a spell is returned to its owner's hand, it's removed from the stack. The spell isn't countered, but it won't resolve. If a copy of a spell is returned to a hand this way, the copy will cease to exist the next time state-based actions are performed."
         },
         {
           "date": "2015-08-25",
@@ -25565,11 +25566,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -25577,7 +25578,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "text": "Devoid (This card has no color.)\nChoose one or both —\n• Return target spell or creature to its owner's hand.\n• Brutal Expulsion deals 2 damage to target creature or planeswalker. If that permanent would be put into a graveyard this turn, exile it instead.",
@@ -25693,11 +25694,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -25705,7 +25706,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -25717,11 +25718,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -25840,15 +25841,15 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Dust Stalker’s last ability checks to see if you control another colorless creature as the end step begins. If you do, the ability won’t trigger. If you don’t, the ability will check again as it tries to resolve. If you somehow control another colorless creature at that time, the ability won’t do anything. You won’t return Dust Stalker to its owner’s hand."
+          "text": "Dust Stalker's last ability checks to see if you control another colorless creature as the end step begins. If you do, the ability won't trigger. If you don't, the ability will check again as it tries to resolve. If you somehow control another colorless creature at that time, the ability won't do anything. You won't return Dust Stalker to its owner's hand."
         },
         {
           "date": "2015-08-25",
-          "text": "Dust Stalker’s last ability doesn’t depend on Dust Stalker being colorless. If it gains one or more colors, the ability will still look for another creature you control that’s colorless."
+          "text": "Dust Stalker's last ability doesn't depend on Dust Stalker being colorless. If it gains one or more colors, the ability will still look for another creature you control that's colorless."
         },
         {
           "date": "2015-08-25",
-          "text": "Like most abilities, Dust Stalker’s last ability functions only while Dust Stalker is on the battlefield."
+          "text": "Like most abilities, Dust Stalker's last ability functions only while Dust Stalker is on the battlefield."
         },
         {
           "date": "2015-08-25",
@@ -25856,11 +25857,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -25868,7 +25869,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -25989,11 +25990,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -26001,7 +26002,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -26009,7 +26010,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -26132,11 +26133,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -26144,7 +26145,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -26262,11 +26263,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Herald of Kozilek’s last ability doesn’t change the mana cost or converted mana cost of any spell. It changes only the total cost you actually pay."
+          "text": "Herald of Kozilek's last ability doesn't change the mana cost or converted mana cost of any spell. It changes only the total cost you actually pay."
         },
         {
           "date": "2015-08-25",
-          "text": "Herald of Kozilek’s last ability can’t reduce the amount of colored mana you pay for a spell. It reduces only the generic component of that mana cost."
+          "text": "Herald of Kozilek's last ability can't reduce the amount of colored mana you pay for a spell. It reduces only the generic component of that mana cost."
         },
         {
           "date": "2015-08-25",
@@ -26278,7 +26279,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a colorless spell you cast has {X} in its mana cost, you choose the value of X before calculating the spell’s total cost. For example, if that spell’s mana cost is {X}, you could choose 5 as the value of X and pay {4} to cast the spell."
+          "text": "If a colorless spell you cast has {X} in its mana cost, you choose the value of X before calculating the spell's total cost. For example, if that spell's mana cost is {X}, you could choose 5 as the value of X and pay {4} to cast the spell."
         },
         {
           "date": "2015-08-25",
@@ -26286,11 +26287,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -26298,7 +26299,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -26421,7 +26422,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If that player has one card in his or her library when Sire of Stagnation’s triggered ability resolves, that card will be exiled. If his or her library has zero cards, no cards are exiled. In both cases, you’ll still draw two cards. That player won’t lose the game (until he or she attempts to draw a card from an empty library)."
+          "text": "If that player has one card in his or her library when Sire of Stagnation's triggered ability resolves, that card will be exiled. If his or her library has zero cards, no cards are exiled. In both cases, you'll still draw two cards. That player won't lose the game (until he or she attempts to draw a card from an empty library)."
         },
         {
           "date": "2015-08-25",
@@ -26429,11 +26430,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -26441,7 +26442,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -26561,11 +26562,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -26573,23 +26574,23 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner’s graveyard."
+          "text": "If a spell or ability requires that you put more than one exiled card into the graveyard, you may choose cards owned by different opponents. Each card chosen will be put into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent’s graveyard. The card becomes a new object and remains in exile. In this situation, you can’t use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner’s graveyard."
+          "text": "If a replacement effect will cause cards that would be put into a graveyard from anywhere to be exiled instead (such as the one created by Anafenza, the Foremost), you can still put an exiled card into its opponent's graveyard. The card becomes a new object and remains in exile. In this situation, you can't use a single exiled card if required to put more than one exiled card into the graveyard. Conversely, you could use the same card in this situation if two separate spells or abilities each required you to put a single exiled card into its owner's graveyard."
         },
         {
           "date": "2015-08-25",
-          "text": "You can’t look at face-down cards in exile unless an effect allows you to."
+          "text": "You can't look at face-down cards in exile unless an effect allows you to."
         },
         {
           "date": "2015-08-25",
-          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner’s graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
+          "text": "Face-down cards in exile are grouped using two criteria: what caused them to be exiled face down and when they were exiled face down. If you want to put a face-down card in exile into its owner's graveyard, you must first choose one of these groups and then choose a card from within that group at random. For example, say an artifact causes your opponent to exile his or her hand of three cards face down. Then on a later turn, that artifact causes your opponent to exile another two cards face down. If you use Wasteland Strangler to put one of those cards into his or her graveyard, you would pick the first or second pile and put a card chosen at random from that pile into the graveyard."
         }
       ],
       "subtypes": [
@@ -26716,7 +26717,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Once the ability resolves, the bonus won’t change later in the turn, even if the number of other attacking Allies does."
+          "text": "Once the ability resolves, the bonus won't change later in the turn, even if the number of other attacking Allies does."
         }
       ],
       "subtypes": [
@@ -26837,11 +26838,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If you cast the exiled card, you do so as part of the resolution of Bring to Light. You can’t wait to cast it later in the turn. Timing restrictions based on the card’s type are ignored, but other restrictions (such as “Cast [this card] only during combat”) are not."
+          "text": "If you cast the exiled card, you do so as part of the resolution of Bring to Light. You can't wait to cast it later in the turn. Timing restrictions based on the card's type are ignored, but other restrictions (such as \"Cast [this card] only during combat\") are not."
         },
         {
           "date": "2015-08-25",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as awaken costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as awaken costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those to cast the card."
         },
         {
           "date": "2015-08-25",
@@ -26849,11 +26850,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If you cast an instant or sorcery card this way, it goes to your graveyard as normal. It doesn’t return to exile."
+          "text": "If you cast an instant or sorcery card this way, it goes to your graveyard as normal. It doesn't return to exile."
         },
         {
           "date": "2015-08-25",
-          "text": "If you don’t cast the card, it remains exiled."
+          "text": "If you don't cast the card, it remains exiled."
         },
         {
           "date": "2015-08-25",
@@ -26861,7 +26862,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -27115,7 +27116,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -27363,15 +27364,15 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can activate Kiora’s first ability with no targets just to put a loyalty counter on her."
+          "text": "You can activate Kiora's first ability with no targets just to put a loyalty counter on her."
         },
         {
           "date": "2015-08-25",
-          "text": "With Kiora’s second ability, you could put no cards, a creature card, a land card, or a creature card and a land card into your hand."
+          "text": "With Kiora's second ability, you could put no cards, a creature card, a land card, or a creature card and a land card into your hand."
         },
         {
           "date": "2015-08-25",
-          "text": "You will have the emblem by the time the Octopus creature tokens enter the battlefield—they’ll be looking to fight!"
+          "text": "You will have the emblem by the time the Octopus creature tokens enter the battlefield—they'll be looking to fight!"
         }
       ],
       "subtypes": [
@@ -27732,7 +27733,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Although Noyan Dar’s ability is very similar to awaken, it is not the same ability. Any card that refers to a “card with awaken” doesn’t include Noyan Dar."
+          "text": "Although Noyan Dar's ability is very similar to awaken, it is not the same ability. Any card that refers to a \"card with awaken\" doesn't include Noyan Dar."
         },
         {
           "date": "2015-08-25",
@@ -27861,11 +27862,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "If Omnath dies at the same time as any other Elementals you control, Omnath’s last ability will trigger for each of them (and once for itself)."
+          "text": "If Omnath dies at the same time as any other Elementals you control, Omnath's last ability will trigger for each of them (and once for itself)."
         },
         {
           "date": "2015-08-25",
-          "text": "Omanth doesn’t have the land type Locus."
+          "text": "Omanth doesn't have the land type Locus."
         },
         {
           "date": "2015-08-25",
@@ -27877,7 +27878,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -28126,27 +28127,27 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Put target creature on top of its owner's library.\nAwaken 4—{4}{W}{U} (If you cast this spell for {4}{W}{U}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -28263,7 +28264,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can choose any value for X. The value chosen for X doesn’t directly affect the number of +1/+1 counters Skyrider Elf enters the battlefield with, but it does let you pay more mana and thus spend more colors of mana to cast it. For example, you can choose 0 for the value of X and pay {G}{U} to cast Skyrider Elf for two +1/+1 counters. You can also choose 3 for the value of X, making its mana cost {3}{G}{U}, and pay {W}{U}{B}{R}{G} for five +1/+1 counters."
+          "text": "You can choose any value for X. The value chosen for X doesn't directly affect the number of +1/+1 counters Skyrider Elf enters the battlefield with, but it does let you pay more mana and thus spend more colors of mana to cast it. For example, you can choose 0 for the value of X and pay {G}{U} to cast Skyrider Elf for two +1/+1 counters. You can also choose 3 for the value of X, making its mana cost {3}{G}{U}, and pay {W}{U}{B}{R}{G} for five +1/+1 counters."
         },
         {
           "date": "2015-08-25",
@@ -28271,7 +28272,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2015-08-25",
@@ -28407,11 +28408,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The ability that defines Veteran Warleader’s power and toughness works in all zones, not just the battlefield. If Veteran Warleader is on the battlefield, it will count itself."
+          "text": "The ability that defines Veteran Warleader's power and toughness works in all zones, not just the battlefield. If Veteran Warleader is on the battlefield, it will count itself."
         },
         {
           "date": "2015-08-25",
-          "text": "To activate the last ability, you can tap any other untapped Ally you control, including one that hasn’t been under your control since the beginning of your most recent turn. (Note that ability doesn’t use the tap symbol.)"
+          "text": "To activate the last ability, you can tap any other untapped Ally you control, including one that hasn't been under your control since the beginning of your most recent turn. (Note that ability doesn't use the tap symbol.)"
         },
         {
           "date": "2015-08-25",
@@ -28419,7 +28420,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Vigilance matters only as attackers are declared. Giving a creature vigilance after that point won’t untap it, even if it’s attacking."
+          "text": "Vigilance matters only as attackers are declared. Giving a creature vigilance after that point won't untap it, even if it's attacking."
         }
       ],
       "subtypes": [
@@ -28534,7 +28535,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Check the power of each creature as Aligned Hedron Network’s ability resolves to determine if it’s exiled. It doesn’t matter who controls the creature."
+          "text": "Check the power of each creature as Aligned Hedron Network's ability resolves to determine if it's exiled. It doesn't matter who controls the creature."
         },
         {
           "date": "2015-08-25",
@@ -28546,11 +28547,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Auras attached to the exiled creatures will be put into their owners’ graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled creatures will cease to exist."
+          "text": "Auras attached to the exiled creatures will be put into their owners' graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled creatures will cease to exist."
         },
         {
           "date": "2015-08-25",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2015-08-25",
@@ -28558,7 +28559,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "In a multiplayer game, if Aligned Hedron Network’s owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Aligned Hedron Network's owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         },
         {
           "date": "2015-08-25",
@@ -29202,7 +29203,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "An “Ally spell” is any spell with the subtype Ally. Mana produced by the second ability can’t be spent to pay the costs of abilities of Allies you control."
+          "text": "An \"Ally spell\" is any spell with the subtype Ally. Mana produced by the second ability can't be spent to pay the costs of abilities of Allies you control."
         },
         {
           "date": "2015-08-25",
@@ -29839,11 +29840,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -29963,11 +29964,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -30043,6 +30044,10 @@
       "imageName": "evolving wilds",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Battle for Zendikar Block",
           "legality": "Legal"
@@ -30218,7 +30223,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You don’t have to reveal a basic land card from among the five cards you look at, even if one is there. If you don’t, you won’t put a card on top of your library."
+          "text": "You don't have to reveal a basic land card from among the five cards you look at, even if one is there. If you don't, you won't put a card on top of your library."
         }
       ],
       "text": "Fertile Thicket enters the battlefield tapped.\nWhen Fertile Thicket enters the battlefield, you may look at the top five cards of your library. If you do, reveal up to one basic land card from among them, then put that card on top of your library and the rest on the bottom in any order.\n{T}: Add {G} to your mana pool.",
@@ -30430,7 +30435,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
         },
         {
           "date": "2015-08-25",
@@ -30438,11 +30443,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2015-08-25",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Lumbering Falls has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 6/6 creature that’s still a land."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Lumbering Falls has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 6/6 creature that's still a land."
         }
       ],
       "text": "Lumbering Falls enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.\n{2}{G}{U}: Lumbering Falls becomes a 3/3 green and blue Elemental creature with hexproof until end of turn. It's still a land.",
@@ -30656,11 +30661,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -30980,11 +30985,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Multiple instances of lifelink are redundant. Activating the last ability more than once won’t cause you to gain additional life if Shambling Vent deals damage."
+          "text": "multiple instances of lifelink on the same creature are redundant. Activating the last ability more than once won't cause you to gain additional life if Shambling Vent deals damage."
         },
         {
           "date": "2015-08-25",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
         },
         {
           "date": "2015-08-25",
@@ -30992,11 +30997,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2015-08-25",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Shambling Vent has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 5/6 creature that’s still a land."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Shambling Vent has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 5/6 creature that's still a land."
         }
       ],
       "text": "Shambling Vent enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.\n{1}{W}{B}: Shambling Vent becomes a 2/3 white and black Elemental creature with lifelink until end of turn. It's still a land.",
@@ -31205,11 +31210,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Skyline Cascade’s triggered ability doesn’t tap the creature. It can target any creature, tapped or untapped. If that creature is already untapped at the beginning of its controller’s next untap step, the effect won’t do anything."
+          "text": "Skyline Cascade's triggered ability doesn't tap the creature. It can target any creature, tapped or untapped. If that creature is already untapped at the beginning of its controller's next untap step, the effect won't do anything."
         },
         {
           "date": "2015-08-25",
-          "text": "The triggered ability tracks the creature, but not its controller. If the creature changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "The triggered ability tracks the creature, but not its controller. If the creature changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         }
       ],
       "text": "Skyline Cascade enters the battlefield tapped.\nWhen Skyline Cascade enters the battlefield, target creature an opponent controls doesn't untap during its controller's next untap step.\n{T}: Add {U} to your mana pool.",
@@ -31321,11 +31326,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -31447,11 +31452,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{6}, {T}, Sacrifice Spawning Bed: Create three 1/1 colorless Eldrazi Scion creature tokens. They have \"Sacrifice this creature: Add {C} to your mana pool.\"",
@@ -31563,11 +31568,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -31614,31 +31619,6 @@
           "language": "Chinese Traditional",
           "name": "平原",
           "multiverseid": 402587
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402588
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402589
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402590
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402591
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402592
         },
         {
           "language": "German",
@@ -31691,29 +31671,54 @@
           "multiverseid": 402891
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403480
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404975
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403481
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404976
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403482
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404977
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403483
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404978
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403484
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404979
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404980
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404981
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404982
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404983
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404984
         }
       ],
       "id": "db17ba1d9144fc8b6cc3f2ef4ed963920f66a923",
@@ -32004,31 +32009,6 @@
           "multiverseid": 402587
         },
         {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402588
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402589
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402590
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402591
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402592
-        },
-        {
           "language": "German",
           "name": "Ebene",
           "multiverseid": 402882
@@ -32079,29 +32059,54 @@
           "multiverseid": 402891
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403480
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404975
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403481
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404976
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403482
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404977
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403483
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404978
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403484
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404979
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404980
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404981
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404982
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404983
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404984
         }
       ],
       "id": "5b1ffbc4d920c9a13da19538ff783bf504226b09",
@@ -32392,31 +32397,6 @@
           "multiverseid": 402587
         },
         {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402588
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402589
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402590
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402591
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402592
-        },
-        {
           "language": "German",
           "name": "Ebene",
           "multiverseid": 402882
@@ -32467,29 +32447,54 @@
           "multiverseid": 402891
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403480
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404975
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403481
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404976
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403482
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404977
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403483
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404978
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403484
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404979
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404980
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404981
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404982
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404983
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404984
         }
       ],
       "id": "ca94ccde4ca7eecc43f42fd9cf78661a434352c5",
@@ -32780,31 +32785,6 @@
           "multiverseid": 402587
         },
         {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402588
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402589
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402590
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402591
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402592
-        },
-        {
           "language": "German",
           "name": "Ebene",
           "multiverseid": 402882
@@ -32855,29 +32835,54 @@
           "multiverseid": 402891
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403480
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404975
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403481
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404976
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403482
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404977
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403483
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404978
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403484
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404979
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404980
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404981
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404982
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404983
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404984
         }
       ],
       "id": "f6206ce0535a1d8bd544af837803290a40b9cae7",
@@ -33556,31 +33561,6 @@
           "multiverseid": 402587
         },
         {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402588
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402589
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402590
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402591
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402592
-        },
-        {
           "language": "German",
           "name": "Ebene",
           "multiverseid": 402882
@@ -33631,29 +33611,54 @@
           "multiverseid": 402891
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403480
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404975
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403481
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404976
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403482
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404977
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403483
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404978
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403484
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404979
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404980
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404981
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404982
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404983
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404984
         }
       ],
       "id": "e135b8efff5966d946be62a30927b747146854e2",
@@ -33944,31 +33949,6 @@
           "multiverseid": 402587
         },
         {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402588
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402589
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402590
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402591
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402592
-        },
-        {
           "language": "German",
           "name": "Ebene",
           "multiverseid": 402882
@@ -34019,29 +33999,54 @@
           "multiverseid": 402891
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403480
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404975
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403481
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404976
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403482
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404977
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403483
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404978
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403484
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404979
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404980
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404981
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404982
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404983
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404984
         }
       ],
       "id": "195b8fc538ea14a553aea36b353a8cc108a80d3f",
@@ -34332,31 +34337,6 @@
           "multiverseid": 402587
         },
         {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402588
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402589
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402590
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402591
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原",
-          "multiverseid": 402592
-        },
-        {
           "language": "German",
           "name": "Ebene",
           "multiverseid": 402882
@@ -34407,29 +34387,54 @@
           "multiverseid": 402891
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403480
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404975
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403481
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404976
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403482
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404977
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403483
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404978
         },
         {
-          "language": "Italian",
-          "name": "Pianura",
-          "multiverseid": 403484
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404979
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404980
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404981
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404982
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404983
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 404984
         }
       ],
       "id": "81eedccfa15fdb6dced8b5fb7c088f198b6aa892",
@@ -37426,31 +37431,6 @@
           "multiverseid": 402520
         },
         {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402521
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402522
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402523
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402524
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402525
-        },
-        {
           "language": "German",
           "name": "Insel",
           "multiverseid": 402815
@@ -37501,29 +37481,54 @@
           "multiverseid": 402824
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403712
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404908
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403713
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404909
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403714
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404910
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403715
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404911
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403716
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404912
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404913
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404914
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404915
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404916
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404917
         }
       ],
       "id": "a562400f9c6bd08827bf31675ae75bff794b5aaa",
@@ -38584,31 +38589,6 @@
           "multiverseid": 402520
         },
         {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402521
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402522
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402523
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402524
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "海島",
-          "multiverseid": 402525
-        },
-        {
           "language": "German",
           "name": "Insel",
           "multiverseid": 402815
@@ -38659,29 +38639,54 @@
           "multiverseid": 402824
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403712
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404908
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403713
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404909
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403714
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404910
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403715
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404911
         },
         {
-          "language": "Japanese",
-          "name": "島",
-          "multiverseid": 403716
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404912
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404913
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404914
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404915
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404916
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 404917
         }
       ],
       "id": "790a79180cc46bdb8b4c9969f574894f8867dda4",
@@ -43658,6 +43663,31 @@
           "multiverseid": 402555
         },
         {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402556
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402557
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402558
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402559
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402560
+        },
+        {
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 402850
@@ -43708,54 +43738,29 @@
           "multiverseid": 402859
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404943
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404046
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404944
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404047
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404945
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404048
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404946
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404049
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404947
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404948
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404949
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404950
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404951
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404952
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404050
         }
       ],
       "id": "362eec441e6a2b062067d1ceb1ac23433d5be825",
@@ -44442,6 +44447,31 @@
           "multiverseid": 402555
         },
         {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402556
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402557
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402558
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402559
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈",
+          "multiverseid": 402560
+        },
+        {
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 402850
@@ -44492,54 +44522,29 @@
           "multiverseid": 402859
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404943
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404046
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404944
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404047
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404945
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404048
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404946
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404049
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404947
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404948
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404949
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404950
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404951
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 404952
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 404050
         }
       ],
       "id": "b28fcb59175adfed2cd6a273f027b581f9d3c724",
@@ -49136,31 +49141,6 @@
           "multiverseid": 402484
         },
         {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402485
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402486
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402487
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402488
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402489
-        },
-        {
           "language": "German",
           "name": "Wald",
           "multiverseid": 402779
@@ -49211,29 +49191,54 @@
           "multiverseid": 402788
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403377
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404872
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403378
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404873
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403379
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404874
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403380
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404875
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403381
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404876
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404877
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404878
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404879
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404880
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404881
         }
       ],
       "id": "18484b19bce8888c0c4a52b691b21c204852ffb5",
@@ -49916,31 +49921,6 @@
           "multiverseid": 402484
         },
         {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402485
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402486
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402487
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402488
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402489
-        },
-        {
           "language": "German",
           "name": "Wald",
           "multiverseid": 402779
@@ -49991,29 +49971,54 @@
           "multiverseid": 402788
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403377
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404872
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403378
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404873
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403379
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404874
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403380
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404875
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403381
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404876
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404877
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404878
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404879
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404880
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404881
         }
       ],
       "id": "48bde29840dd6911477ec1f730e8b49dc5cfdd5f",
@@ -50306,31 +50311,6 @@
           "multiverseid": 402484
         },
         {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402485
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402486
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402487
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402488
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402489
-        },
-        {
           "language": "German",
           "name": "Wald",
           "multiverseid": 402779
@@ -50381,29 +50361,54 @@
           "multiverseid": 402788
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403377
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404872
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403378
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404873
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403379
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404874
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403380
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404875
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403381
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404876
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404877
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404878
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404879
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404880
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404881
         }
       ],
       "id": "fd2483a84a73b88a0c349e6a870c05cdf0dfe0f1",
@@ -50696,31 +50701,6 @@
           "multiverseid": 402484
         },
         {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402485
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402486
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402487
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402488
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "樹林",
-          "multiverseid": 402489
-        },
-        {
           "language": "German",
           "name": "Wald",
           "multiverseid": 402779
@@ -50771,29 +50751,54 @@
           "multiverseid": 402788
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403377
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404872
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403378
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404873
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403379
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404874
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403380
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404875
         },
         {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 403381
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404876
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404877
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404878
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404879
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404880
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 404881
         }
       ],
       "id": "d29542aef05d72eb98496610fa613ad129d9b147",

--- a/json/BNG.json
+++ b/json/BNG.json
@@ -142,11 +142,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -154,47 +154,47 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2014-02-01",
-          "text": "Acolyte’s Reward has two targets: the creature that would be dealt damage and the creature or player that Acolyte’s Reward will deal damage to. These targets are chosen as you cast Acolyte’s Reward."
+          "text": "Acolyte's Reward has two targets: the creature that would be dealt damage and the creature or player that Acolyte's Reward will deal damage to. These targets are chosen as you cast Acolyte's Reward."
         },
         {
           "date": "2014-02-01",
-          "text": "The amount of damage the prevention shield will prevent is based on your devotion to white as Acolyte’s Reward resolves. That amount won’t change later in the turn, even if your devotion to white does."
+          "text": "The amount of damage the prevention shield will prevent is based on your devotion to white as Acolyte's Reward resolves. That amount won't change later in the turn, even if your devotion to white does."
         },
         {
           "date": "2014-02-01",
-          "text": "You don’t choose a source of damage. The prevention shield will apply to the next X damage that would be dealt to the first target, no matter where that damage comes from. It also doesn’t matter whether the damage is dealt at the same time. For example, if the shield prevents the next 5 damage to the first target, and that creature would be dealt 3 damage by Lightning Strike, that 3 damage is prevented and Acolyte’s Reward deals 3 damage to the second target. The prevention effect will still apply to the next 2 damage the first target would be dealt that turn."
+          "text": "You don't choose a source of damage. The prevention shield will apply to the next X damage that would be dealt to the first target, no matter where that damage comes from. It also doesn't matter whether the damage is dealt at the same time. For example, if the shield prevents the next 5 damage to the first target, and that creature would be dealt 3 damage by Lightning Strike, that 3 damage is prevented and Acolyte's Reward deals 3 damage to the second target. The prevention effect will still apply to the next 2 damage the first target would be dealt that turn."
         },
         {
           "date": "2014-02-01",
-          "text": "The effect of Acolyte’s Reward isn’t a redirection effect. If it prevents damage, Acolyte’s Reward (not the source of that damage) deals damage to the second target as part of that prevention effect. Acolyte’s Reward is the source of the new damage, so the characteristics of the original source (such as its color or whether it had lifelink) don’t apply. The new damage isn’t combat damage, even if the prevented damage was. Since you control the source of the new damage, if the second target is an opponent, you may have Acolyte’s Reward deal its damage to a planeswalker that opponent controls."
+          "text": "The effect of Acolyte's Reward isn't a redirection effect. If it prevents damage, Acolyte's Reward (not the source of that damage) deals damage to the second target as part of that prevention effect. Acolyte's Reward is the source of the new damage, so the characteristics of the original source (such as its color or whether it had lifelink) don't apply. The new damage isn't combat damage, even if the prevented damage was. Since you control the source of the new damage, if the second target is an opponent, you may have Acolyte's Reward deal its damage to a planeswalker that opponent controls."
         },
         {
           "date": "2014-02-01",
-          "text": "As Acolyte’s Reward tries to resolve, if only the first target is illegal, Acolyte’s Reward won’t prevent any damage that would be dealt to that creature and, because of this, Acolyte’s Reward won’t deal damage to the second target. If only the second target is illegal, damage that would be dealt to the first target will be prevented, but Acolyte’s Reward won’t deal damage. If both targets are illegal, Acolyte’s Reward will be countered."
+          "text": "As Acolyte's Reward tries to resolve, if only the first target is illegal, Acolyte's Reward won't prevent any damage that would be dealt to that creature and, because of this, Acolyte's Reward won't deal damage to the second target. If only the second target is illegal, damage that would be dealt to the first target will be prevented, but Acolyte's Reward won't deal damage. If both targets are illegal, Acolyte's Reward will be countered."
         },
         {
           "date": "2014-02-01",
-          "text": "After Acolyte’s Reward resolves, it no longer matters whether either target is still legal. For example, if the second target is a creature controlled by an opponent, and it gains hexproof after Acolyte’s Reward resolves but before it prevents damage, Acolyte’s Reward will still deal damage to that creature. If Acolyte’s Reward can’t deal damage to the second target (perhaps because it’s a creature that has left the battlefield), Acolyte’s Reward will still prevent damage; it just won’t deal any damage itself."
+          "text": "After Acolyte's Reward resolves, it no longer matters whether either target is still legal. For example, if the second target is a creature controlled by an opponent, and it gains hexproof after Acolyte's Reward resolves but before it prevents damage, Acolyte's Reward will still deal damage to that creature. If Acolyte's Reward can't deal damage to the second target (perhaps because it's a creature that has left the battlefield), Acolyte's Reward will still prevent damage; it just won't deal any damage itself."
         },
         {
           "date": "2014-02-01",
-          "text": "If Acolyte’s Reward prevents damage, it deals its damage immediately afterward as part of that same prevention effect. This happens before state-based actions are performed, and before any player can cast spells or activate abilities. If the source of the original damage was a spell or ability, this happens before that spell or ability resumes its resolution."
+          "text": "If Acolyte's Reward prevents damage, it deals its damage immediately afterward as part of that same prevention effect. This happens before state-based actions are performed, and before any player can cast spells or activate abilities. If the source of the original damage was a spell or ability, this happens before that spell or ability resumes its resolution."
         },
         {
           "date": "2014-02-01",
-          "text": "If the amount of damage that would be dealt to the first target is in excess of the amount of damage that Acolyte’s Reward would prevent, the source deals its excess damage to the first target at the same time that the rest of it is prevented. Then Acolyte’s Reward deals its damage."
+          "text": "If the amount of damage that would be dealt to the first target is in excess of the amount of damage that Acolyte's Reward would prevent, the source deals its excess damage to the first target at the same time that the rest of it is prevented. Then Acolyte's Reward deals its damage."
         },
         {
           "date": "2014-02-01",
-          "text": "The damage will be dealt by Acolyte’s Reward as it existed on the stack, not as it exists when the damage is dealt. That is, it’s an instant spell that’s dealing the damage, in case an ability cares about that (such as Satyr Firedancer’s, which includes the phrase “Whenever an instant or sorcery spell you control deals damage to an opponent”)."
+          "text": "The damage will be dealt by Acolyte's Reward as it existed on the stack, not as it exists when the damage is dealt. That is, it's an instant spell that's dealing the damage, in case an ability cares about that (such as Satyr Firedancer's, which includes the phrase \"Whenever an instant or sorcery spell you control deals damage to an opponent\")."
         },
         {
           "date": "2014-02-01",
-          "text": "If the first target would be dealt combat damage by multiple creatures, you choose which of that damage to prevent. (For example, if one of those creatures has deathtouch, you could choose to prevent the damage from that creature specifically.) You don’t decide until the point at which the creatures would deal their damage."
+          "text": "If the first target would be dealt combat damage by multiple creatures, you choose which of that damage to prevent. (For example, if one of those creatures has deathtouch, you could choose to prevent the damage from that creature specifically.) You don't decide until the point at which the creatures would deal their damage."
         }
       ],
       "text": "Prevent the next X damage that would be dealt to target creature this turn, where X is your devotion to white. If damage is prevented this way, Acolyte's Reward deals that much damage to target creature or player. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)",
@@ -424,7 +424,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -540,11 +540,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The Archetype’s second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
+          "text": "The Archetype's second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
         },
         {
           "date": "2014-02-01",
-          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren’t created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn’t cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
+          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren't created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn't cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
         },
         {
           "date": "2014-02-01",
@@ -668,15 +668,15 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "For the first triggered ability, you declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Brimaz is attacking."
+          "text": "For the first triggered ability, you declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Brimaz is attacking."
         },
         {
           "date": "2014-02-01",
-          "text": "If Brimaz somehow blocks two or more creatures (note it can’t naturally do this), its last ability will trigger that many times."
+          "text": "If Brimaz somehow blocks two or more creatures (note it can't naturally do this), its last ability will trigger that many times."
         },
         {
           "date": "2014-02-01",
-          "text": "Although the tokens enter the battlefield attacking or blocking, they were never declared as attacking or blocking creatures. Abilities that trigger whenever a creature attacks or blocks won’t trigger."
+          "text": "Although the tokens enter the battlefield attacking or blocking, they were never declared as attacking or blocking creatures. Abilities that trigger whenever a creature attacks or blocks won't trigger."
         }
       ],
       "subtypes": [
@@ -795,11 +795,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You choose which mode you’re using—or that you’re using both modes—as you’re casting the spell. Once this choice is made, it can’t be changed later while the spell is on the stack."
+          "text": "You choose which mode you're using—or that you're using both modes—as you're casting the spell. Once this choice is made, it can't be changed later while the spell is on the stack."
         },
         {
           "date": "2014-02-01",
-          "text": "Dawn to Dusk won’t affect any target that is illegal when it tries to resolve. If you chose to use both modes and both targets are illegal at that time, Dawn to Dusk will be countered."
+          "text": "Dawn to Dusk won't affect any target that is illegal when it tries to resolve. If you chose to use both modes and both targets are illegal at that time, Dawn to Dusk will be countered."
         }
       ],
       "text": "Choose one or both —\n• Return target enchantment card from your graveyard to your hand.\n• Destroy target enchantment.",
@@ -909,39 +909,39 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-02-01",
-          "text": "Eidolon of Countless Battles’s last ability functions only on the battlefield. In other zones, it is a 0/0 enchantment creature card."
+          "text": "Eidolon of Countless Battles's last ability functions only on the battlefield. In other zones, it is a 0/0 enchantment creature card."
         },
         {
           "date": "2014-02-01",
-          "text": "A permanent with bestow is either a creature or an Aura, not both (although it’s an enchantment either way). It will contribute just +1/+1 toward the bonus given by Eidolon of Countless Battles."
+          "text": "A permanent with bestow is either a creature or an Aura, not both (although it's an enchantment either way). It will contribute just +1/+1 toward the bonus given by Eidolon of Countless Battles."
         }
       ],
       "subtypes": [
@@ -1065,7 +1065,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -1399,11 +1399,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Destroy all creatures and planeswalkers. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -1514,31 +1514,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -1661,15 +1661,15 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         },
         {
           "date": "2014-02-01",
-          "text": "If you choose zero targets, you’ll just scry 1 when the spell resolves. However, if you choose at least one target and all of Glimpse the Sun God’s targets are illegal as it tries to resolve, the spell will be countered and none of its effects will happen. You won’t scry in that case."
+          "text": "If you choose zero targets, you'll just scry 1 when the spell resolves. However, if you choose at least one target and all of Glimpse the Sun God's targets are illegal as it tries to resolve, the spell will be countered and none of its effects will happen. You won't scry in that case."
         }
       ],
       "text": "Tap X target creatures. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -1784,11 +1784,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -2132,11 +2132,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         },
         {
           "date": "2014-02-01",
-          "text": "Hero of Iroas’s first ability will apply if you cast a card for its bestow cost."
+          "text": "Hero of Iroas's first ability will apply if you cast a card for its bestow cost."
         }
       ],
       "subtypes": [
@@ -2364,7 +2364,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Although Loyal Pegasus can’t attack alone, other attacking creatures don’t have to attack the same player or planeswalker. For example, Loyal Pegasus could attack an opponent and another creature could attack a planeswalker that opponent controls."
+          "text": "Although Loyal Pegasus can't attack alone, other attacking creatures don't have to attack the same player or planeswalker. For example, Loyal Pegasus could attack an opponent and another creature could attack a planeswalker that opponent controls."
         },
         {
           "date": "2014-02-01",
@@ -2588,31 +2588,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -2733,11 +2733,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -2856,11 +2856,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -2868,15 +2868,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -3207,11 +3207,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If you return an enchantment creature card with bestow to the battlefield, you can’t pay its bestow cost. It won’t be an Aura and can’t be attached to a creature."
+          "text": "If you return an enchantment creature card with bestow to the battlefield, you can't pay its bestow cost. It won't be an Aura and can't be attached to a creature."
         },
         {
           "date": "2014-02-01",
-          "text": "If the enchantment card is an Aura, you choose a legal player or object for that Aura to enchant as it enters the battlefield. This doesn’t target the player or object, so it’s possible to enchant an opposing creature with hexproof this way, for example. If there’s no player or object the Aura can legally enchant, it stays in the graveyard."
+          "text": "If the enchantment card is an Aura, you choose a legal player or object for that Aura to enchant as it enters the battlefield. This doesn't target the player or object, so it's possible to enchant an opposing creature with hexproof this way, for example. If there's no player or object the Aura can legally enchant, it stays in the graveyard."
         }
       ],
       "subtypes": [
@@ -3326,19 +3326,19 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You can draw a maximum of one card on each player’s turn. Subsequent card draws are ignored."
+          "text": "You can draw a maximum of one card on each player's turn. Subsequent card draws are ignored."
         },
         {
           "date": "2014-02-01",
-          "text": "If you haven’t drawn any cards in a turn, and a spell or ability would cause you to draw multiple cards, you’ll just draw one card."
+          "text": "If you haven't drawn any cards in a turn, and a spell or ability would cause you to draw multiple cards, you'll just draw one card."
         },
         {
           "date": "2014-02-01",
-          "text": "If you draw a card, and then Spirit of the Labyrinth enters the battlefield, you won’t be able to draw more cards that turn."
+          "text": "If you draw a card, and then Spirit of the Labyrinth enters the battlefield, you won't be able to draw more cards that turn."
         },
         {
           "date": "2014-02-01",
-          "text": "If a replacement effect would try to replace a card that you can’t draw, that effect can’t apply."
+          "text": "If a replacement effect would try to replace a card that you can't draw, that effect can't apply."
         }
       ],
       "subtypes": [
@@ -3453,11 +3453,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "In some unusual cases, you can gain life even though your life total actually decreases. For example, if you are being attacked by two 3/3 creatures and you block one with a 2/2 creature with lifelink, your life total will decrease by 1 even though you’ve gained 2 life. You’ll put two +1/+1 counters on the enchanted creature."
+          "text": "In some unusual cases, you can gain life even though your life total actually decreases. For example, if you are being attacked by two 3/3 creatures and you block one with a 2/2 creature with lifelink, your life total will decrease by 1 even though you've gained 2 life. You'll put two +1/+1 counters on the enchanted creature."
         },
         {
           "date": "2014-02-01",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -3579,7 +3579,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -3699,11 +3699,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -3827,7 +3827,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If you choose to not put the card onto the battlefield, or if the card isn’t one of the listed types, it will remain on top of your library. (Note that revealing the card is not optional.)"
+          "text": "If you choose to not put the card onto the battlefield, or if the card isn't one of the listed types, it will remain on top of your library. (Note that revealing the card is not optional.)"
         },
         {
           "date": "2014-02-01",
@@ -3839,11 +3839,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -3962,11 +3962,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The Archetype’s second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
+          "text": "The Archetype's second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
         },
         {
           "date": "2014-02-01",
-          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren’t created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn’t cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
+          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren't created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn't cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
         },
         {
           "date": "2014-02-01",
@@ -4098,7 +4098,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         },
         {
           "date": "2013-09-15",
@@ -4110,11 +4110,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -4228,7 +4228,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Abilities of creature cards not on the battlefield owned by an opponent can’t target that creature, and damage those cards would deal to the creature is prevented."
+          "text": "Abilities of creature cards not on the battlefield owned by an opponent can't target that creature, and damage those cards would deal to the creature is prevented."
         },
         {
           "date": "2014-02-01",
@@ -4347,11 +4347,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -4810,15 +4810,15 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         },
         {
           "date": "2014-02-01",
-          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2014-02-01",
@@ -4834,7 +4834,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         }
       ],
       "text": "Create a token that's a copy of target creature you control. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -4944,31 +4944,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -5084,7 +5084,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You must return an enchantment you control to its owner’s hand during each combat in which you attack with Floodtide Serpent."
+          "text": "You must return an enchantment you control to its owner's hand during each combat in which you attack with Floodtide Serpent."
         }
       ],
       "subtypes": [
@@ -5199,7 +5199,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The number of Islands you control is counted as blockers are declared. Creatures with power less than that number at that time can’t block Kraken of the Straits. Once blockers have been declared, the power of the blocking creatures and the number of Islands you control don’t matter."
+          "text": "The number of Islands you control is counted as blockers are declared. Creatures with power less than that number at that time can't block Kraken of the Straits. Once blockers have been declared, the power of the blocking creatures and the number of Islands you control don't matter."
         }
       ],
       "subtypes": [
@@ -5321,7 +5321,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -5444,7 +5444,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         },
         {
           "date": "2014-02-01",
@@ -5452,7 +5452,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If Mindreaver leaves the battlefield, and later another Mindreaver enters the battlefield, it is a new object (even if the two were represented by the same card). The last ability of the second Mindreaver doesn’t refer to any cards exiled with the first one."
+          "text": "If Mindreaver leaves the battlefield, and later another Mindreaver enters the battlefield, it is a new object (even if the two were represented by the same card). The last ability of the second Mindreaver doesn't refer to any cards exiled with the first one."
         }
       ],
       "subtypes": [
@@ -5672,31 +5672,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -5818,11 +5818,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -5943,7 +5943,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If Perplexing Chimera leaves the battlefield or the spell leaves the stack before the triggered ability resolves, you can’t make the exchange."
+          "text": "If Perplexing Chimera leaves the battlefield or the spell leaves the stack before the triggered ability resolves, you can't make the exchange."
         },
         {
           "date": "2014-02-01",
@@ -5951,23 +5951,23 @@
         },
         {
           "date": "2014-02-01",
-          "text": "After the ability resolves, you control the spell. Any instance of “you” in that spell’s text now refers to you, “an opponent” refers to one of your opponents, and so on. The change of control happens before new targets are chosen, so any targeting restrictions such as “target opponent” or “target creature you control” are now made in reference to you, not the spell’s original controller. You may change those targets to be legal in reference to you, or, if those are the spell’s only targets, the spell will be countered on resolution for having illegal targets. When the spell resolves, any illegal targets are unaffected by it and you make all decisions the spell’s effect calls for."
+          "text": "After the ability resolves, you control the spell. Any instance of \"you\" in that spell's text now refers to you, \"an opponent\" refers to one of your opponents, and so on. The change of control happens before new targets are chosen, so any targeting restrictions such as \"target opponent\" or \"target creature you control\" are now made in reference to you, not the spell's original controller. You may change those targets to be legal in reference to you, or, if those are the spell's only targets, the spell will be countered on resolution for having illegal targets. When the spell resolves, any illegal targets are unaffected by it and you make all decisions the spell's effect calls for."
         },
         {
           "date": "2014-02-01",
-          "text": "You may change any of the spell’s targets. If you change a target, you must choose a legal target for the spell. If you can’t, you must leave the target the same (even if that target is now illegal)."
+          "text": "You may change any of the spell's targets. If you change a target, you must choose a legal target for the spell. If you can't, you must leave the target the same (even if that target is now illegal)."
         },
         {
           "date": "2014-02-01",
-          "text": "Gaining control of a spell and changing its targets won’t cause any heroic abilities of the new targets to trigger."
+          "text": "Gaining control of a spell and changing its targets won't cause any heroic abilities of the new targets to trigger."
         },
         {
           "date": "2014-02-01",
-          "text": "If you gain control of an instant or sorcery spell, it will be put into its owner’s graveyard as it resolves or is countered."
+          "text": "If you gain control of an instant or sorcery spell, it will be put into its owner's graveyard as it resolves or is countered."
         },
         {
           "date": "2014-02-01",
-          "text": "In some unusual cases, you may not control Perplexing Chimera when its triggered ability resolves (perhaps because the triggered ability triggered again and resolved while the original ability was on the stack). In these cases, you can exchange control of Perplexing Chimera and the spell that causes the ability to trigger, even if you control neither of them. If you do, you’ll be able to change targets of the spell, not the spell’s new controller."
+          "text": "In some unusual cases, you may not control Perplexing Chimera when its triggered ability resolves (perhaps because the triggered ability triggered again and resolved while the original ability was on the stack). In these cases, you can exchange control of Perplexing Chimera and the spell that causes the ability to trigger, even if you control neither of them. If you do, you'll be able to change targets of the spell, not the spell's new controller."
         }
       ],
       "subtypes": [
@@ -6186,11 +6186,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -6198,15 +6198,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -6325,11 +6325,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -6563,27 +6563,27 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         },
         {
           "date": "2014-02-01",
-          "text": "If a creature affected by Sudden Storm changes controllers before its old controller’s next untap step, Sudden Storm will prevent it from becoming untapped during its new controller’s next untap step."
+          "text": "If a creature affected by Sudden Storm changes controllers before its old controller's next untap step, Sudden Storm will prevent it from becoming untapped during its new controller's next untap step."
         },
         {
           "date": "2014-02-01",
-          "text": "This spell can target tapped creatures. If a targeted creature is already tapped when the spell resolves, that creature remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "This spell can target tapped creatures. If a targeted creature is already tapped when the spell resolves, that creature remains tapped and doesn't untap during its controller's next untap step."
         },
         {
           "date": "2014-02-01",
-          "text": "If you chose two targets and one is an illegal target when Sudden Storm resolves, that creature won’t become tapped and it won’t be stopped from untapping during its controller’s next untap step. It won’t be affected by Sudden Storm in any way."
+          "text": "If you chose two targets and one is an illegal target when Sudden Storm resolves, that creature won't become tapped and it won't be stopped from untapping during its controller's next untap step. It won't be affected by Sudden Storm in any way."
         },
         {
           "date": "2014-02-01",
-          "text": "If you choose zero targets, you’ll just scry 1 when the ability resolves. However, if you choose at least one target and all of Sudden Storm’s targets are illegal as it tries to resolve, the spell will be countered and none of its effects will happen. You won’t scry in that case."
+          "text": "If you choose zero targets, you'll just scry 1 when the ability resolves. However, if you choose at least one target and all of Sudden Storm's targets are illegal as it tries to resolve, the spell will be countered and none of its effects will happen. You won't scry in that case."
         }
       ],
       "text": "Tap up to two target creatures. Those creatures don't untap during their controllers' next untap steps. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -6798,7 +6798,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The defending player may block Tromokratis with each creature he or she controls. If that player can’t, perhaps because one of those creatures is tapped, or chooses not to, Tromokratis can’t be blocked."
+          "text": "The defending player may block Tromokratis with each creature he or she controls. If that player can't, perhaps because one of those creatures is tapped, or chooses not to, Tromokratis can't be blocked."
         },
         {
           "date": "2014-02-01",
@@ -6920,15 +6920,15 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If no creature is blocking or being blocked by Vortex Elemental as its first ability resolves, it alone will be put on top of its owner’s library, and that library will be shuffled. You can activate the first ability outside of combat."
+          "text": "If no creature is blocking or being blocked by Vortex Elemental as its first ability resolves, it alone will be put on top of its owner's library, and that library will be shuffled. You can activate the first ability outside of combat."
         },
         {
           "date": "2014-02-01",
-          "text": "If Vortex Elemental isn’t on the battlefield when its first ability resolves, any creatures blocking or blocked by it when it left the battlefield will be put on top of their owners’ libraries and those libraries will be shuffled."
+          "text": "If Vortex Elemental isn't on the battlefield when its first ability resolves, any creatures blocking or blocked by it when it left the battlefield will be put on top of their owners' libraries and those libraries will be shuffled."
         },
         {
           "date": "2014-02-01",
-          "text": "The creature blocks Vortex Elemental only if it’s able to do so as the declare blockers step begins. If, at that time, the creature is tapped, it’s affected by a spell or ability that says it can’t block, or Vortex Elemental isn’t attacking its controller or a planeswalker controlled by that player, then it doesn’t block. If there’s a cost associated with having the creature block, the player isn’t forced to pay that cost. If that cost isn’t paid, the creature won’t block."
+          "text": "The creature blocks Vortex Elemental only if it's able to do so as the declare blockers step begins. If, at that time, the creature is tapped, it's affected by a spell or ability that says it can't block, or Vortex Elemental isn't attacking its controller or a planeswalker controlled by that player, then it doesn't block. If there's a cost associated with having the creature block, the player isn't forced to pay that cost. If that cost isn't paid, the creature won't block."
         }
       ],
       "subtypes": [
@@ -7148,11 +7148,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The Archetype’s second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
+          "text": "The Archetype's second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
         },
         {
           "date": "2014-02-01",
-          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren’t created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn’t cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
+          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren't created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn't cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
         },
         {
           "date": "2014-02-01",
@@ -7284,7 +7284,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -7512,7 +7512,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "The name of a creature token is the same as its creature types, unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 1/1 Cat Soldier creature token is named “Cat Soldier.”"
+          "text": "The name of a creature token is the same as its creature types, unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 1/1 Cat Soldier creature token is named \"Cat Soldier.\""
         }
       ],
       "text": "Target creature and all other creatures with the same name as that creature get -3/-3 until end of turn.",
@@ -7623,7 +7623,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You can tap a creature that hasn’t been under your control since your most recent turn began to activate the last ability."
+          "text": "You can tap a creature that hasn't been under your control since your most recent turn began to activate the last ability."
         }
       ],
       "subtypes": [
@@ -7740,7 +7740,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You choose the targets of the first ability as you activate that ability, before you pay any costs. You can’t target any of the creatures you sacrifice."
+          "text": "You choose the targets of the first ability as you activate that ability, before you pay any costs. You can't target any of the creatures you sacrifice."
         },
         {
           "date": "2014-02-01",
@@ -7974,11 +7974,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         },
         {
           "date": "2014-02-01",
@@ -8204,7 +8204,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the target creature is a Cyclops, it will get -1/-1 before it’s destroyed."
+          "text": "If the target creature is a Cyclops, it will get -1/-1 before it's destroyed."
         }
       ],
       "text": "Target creature gets -1/-1 until end of turn. If it's a Cyclops, destroy it.",
@@ -8432,19 +8432,19 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         },
         {
           "date": "2014-02-01",
-          "text": "The effect that causes the creature to gain indestructible doesn’t have a duration. It lasts until the creature leaves the battlefield."
+          "text": "The effect that causes the creature to gain indestructible doesn't have a duration. It lasts until the creature leaves the battlefield."
         },
         {
           "date": "2014-02-01",
-          "text": "The indestructible granted by Fated Return isn’t part of the creature’s copiable values. If the creature is copied, the copy won’t have indestructible (unless the creature otherwise has indestructible)."
+          "text": "The indestructible granted by Fated Return isn't part of the creature's copiable values. If the creature is copied, the copy won't have indestructible (unless the creature otherwise has indestructible)."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. It gains indestructible. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -8555,7 +8555,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Whether you control another Minotaur is checked only as you declare blockers. The other Minotaur doesn’t have to block."
+          "text": "Whether you control another Minotaur is checked only as you declare blockers. The other Minotaur doesn't have to block."
         }
       ],
       "subtypes": [
@@ -8674,11 +8674,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -8910,7 +8910,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If the creature isn’t a legal target as Gild tries to resolve, the spell will be countered and none of its effects will happen. No token will be created."
+          "text": "If the creature isn't a legal target as Gild tries to resolve, the spell will be countered and none of its effects will happen. No token will be created."
         }
       ],
       "text": "Exile target creature. Create a colorless artifact token named Gold. It has \"Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
@@ -9126,35 +9126,35 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability that causes you to lose life applies whether Herald of Torment is a creature or an Aura. The “you” in that ability refers to Herald of Torment’s controller. If you control Herald of Torment as an Aura enchanting a creature another player controls, that ability will trigger at the beginning of your upkeep and cause you to lose 1 life."
+          "text": "The triggered ability that causes you to lose life applies whether Herald of Torment is a creature or an Aura. The \"you\" in that ability refers to Herald of Torment's controller. If you control Herald of Torment as an Aura enchanting a creature another player controls, that ability will trigger at the beginning of your upkeep and cause you to lose 1 life."
         }
       ],
       "subtypes": [
@@ -9270,11 +9270,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -9282,11 +9282,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Your devotion to black is calculated when you determine Marshmist Titan’s total cost, and that cost is locked in before any costs are paid. For example, if you control a creature with black mana symbols in its mana cost that can be sacrificed for mana, those mana symbols will count toward your devotion to black. You can then sacrifice that creature for mana to pay the reduced total cost."
+          "text": "Your devotion to black is calculated when you determine Marshmist Titan's total cost, and that cost is locked in before any costs are paid. For example, if you control a creature with black mana symbols in its mana cost that can be sacrificed for mana, those mana symbols will count toward your devotion to black. You can then sacrifice that creature for mana to pay the reduced total cost."
         },
         {
           "date": "2014-02-01",
-          "text": "If your devotion to black is greater than six, Marshmist Titan will cost {B} to cast. The colored mana requirement isn’t reduced."
+          "text": "If your devotion to black is greater than six, Marshmist Titan will cost {B} to cast. The colored mana requirement isn't reduced."
         }
       ],
       "subtypes": [
@@ -9511,31 +9511,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -9765,7 +9765,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If the revealed card doesn’t have a mana cost (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If the revealed card doesn't have a mana cost (because it's a land card, for example), its converted mana cost is 0."
         },
         {
           "date": "2014-02-01",
@@ -9773,11 +9773,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -9895,11 +9895,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -9907,7 +9907,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "text": "You draw X cards and you lose X life, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
@@ -10018,7 +10018,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "A creature taps when its regeneration shield is used, not when the shield is created. Notably, you won’t be able to use Servant of Tymaret’s last ability to tap it so that its inspired ability will trigger unless Servant of Tymaret would be destroyed."
+          "text": "A creature taps when its regeneration shield is used, not when the shield is created. Notably, you won't be able to use Servant of Tymaret's last ability to tap it so that its inspired ability will trigger unless Servant of Tymaret would be destroyed."
         },
         {
           "date": "2014-02-01",
@@ -10026,11 +10026,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -10148,15 +10148,15 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The opponent you target with the triggered ability doesn’t have to be the same opponent you chose to pay tribute or not."
+          "text": "The opponent you target with the triggered ability doesn't have to be the same opponent you chose to pay tribute or not."
         },
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -10164,15 +10164,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -10286,31 +10286,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -10429,11 +10429,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -10669,19 +10669,19 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         },
         {
           "date": "2014-02-01",
-          "text": "The ability can target any creature except Akroan Conscriptor, including one that’s untapped or one you already control."
+          "text": "The ability can target any creature except Akroan Conscriptor, including one that's untapped or one you already control."
         },
         {
           "date": "2014-02-01",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it. Notably, if that creature is enchanted by an Aura with bestow and dies while under your control, the Aura’s controller will continue to control the creature that Aura becomes."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it. Notably, if that creature is enchanted by an Aura with bestow and dies while under your control, the Aura's controller will continue to control the creature that Aura becomes."
         },
         {
           "date": "2014-02-01",
-          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you’ll choose one to remain on the battlefield and put the other into its owner’s graveyard."
+          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you'll choose one to remain on the battlefield and put the other into its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -10797,11 +10797,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The Archetype’s second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
+          "text": "The Archetype's second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
         },
         {
           "date": "2014-02-01",
-          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren’t created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn’t cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
+          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren't created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn't cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
         },
         {
           "date": "2014-02-01",
@@ -10933,11 +10933,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Bolt of Keranos deals 3 damage to target creature or player. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -11261,35 +11261,35 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-02-01",
-          "text": "As Everflame Eidolon’s ability resolves, the bonus is applied to either Everflame Eidolon (if it’s a creature) or to the enchanted creature (if it’s an Aura). If the bonus is applied to the enchanted creature, that bonus won’t apply to Everflame Eidolon, even if it becomes a creature later that turn."
+          "text": "As Everflame Eidolon's ability resolves, the bonus is applied to either Everflame Eidolon (if it's a creature) or to the enchanted creature (if it's an Aura). If the bonus is applied to the enchanted creature, that bonus won't apply to Everflame Eidolon, even if it becomes a creature later that turn."
         }
       ],
       "subtypes": [
@@ -11405,11 +11405,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "As Fall of the Hammer tries to resolve, if only one of the targets is legal, Fall of the Hammer will still resolve but will have no effect: If the first target creature is illegal, it can’t deal damage to anything. If the second target creature is illegal, it can’t be dealt damage."
+          "text": "As Fall of the Hammer tries to resolve, if only one of the targets is legal, Fall of the Hammer will still resolve but will have no effect: If the first target creature is illegal, it can't deal damage to anything. If the second target creature is illegal, it can't be dealt damage."
         },
         {
           "date": "2014-02-01",
-          "text": "The amount of damage dealt is based on the first target creature’s power as Fall of the Hammer resolves."
+          "text": "The amount of damage dealt is based on the first target creature's power as Fall of the Hammer resolves."
         }
       ],
       "text": "Target creature you control deals damage equal to its power to another target creature.",
@@ -11527,11 +11527,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Fated Conflagration deals 5 damage to target creature or planeswalker. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -11641,7 +11641,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The activated ability granted by Fearsome Temper can’t change or undo a block that’s already happened. For it to have an effect, you must activate it no later than the declare attackers step."
+          "text": "The activated ability granted by Fearsome Temper can't change or undo a block that's already happened. For it to have an effect, you must activate it no later than the declare attackers step."
         },
         {
           "date": "2014-02-01",
@@ -11758,7 +11758,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The token copies exactly what was printed on the original creature (except that the copy is also an enchantment) and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "The token copies exactly what was printed on the original creature (except that the copy is also an enchantment) and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2014-02-01",
@@ -11774,11 +11774,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2014-02-01",
-          "text": "If another creature becomes or enters the battlefield as a copy of the token, that creature won’t have haste and you won’t exile it. However, if Felhide Spiritbinder creates multiple tokens due to a replacement effect (like the one Doubling Season creates), each of those tokens will have haste and you’ll exile each of them."
+          "text": "If another creature becomes or enters the battlefield as a copy of the token, that creature won't have haste and you won't exile it. However, if Felhide Spiritbinder creates multiple tokens due to a replacement effect (like the one Doubling Season creates), each of those tokens will have haste and you'll exile each of them."
         },
         {
           "date": "2014-02-01",
@@ -11786,11 +11786,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -11909,11 +11909,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -11921,15 +11921,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -12045,11 +12045,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Forgestoker Dragon’s activated ability can target any creature, not just creatures controlled by the defending player or ones that could block."
+          "text": "Forgestoker Dragon's activated ability can target any creature, not just creatures controlled by the defending player or ones that could block."
         },
         {
           "date": "2014-02-01",
-          "text": "If you don’t want the target creature to be able to block, Forgestoker Dragon’s activated ability must be activated during the declare attackers step."
+          "text": "If you don't want the target creature to be able to block, Forgestoker Dragon's activated ability must be activated during the declare attackers step."
         }
       ],
       "subtypes": [
@@ -12164,7 +12164,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Impetuous Sunchaser attacks only if it’s able to do so as the declare attackers step begins. If, at that time, it’s tapped or affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having it attack, you’re not forced to pay that cost. If that cost isn’t paid, Impetuous Sunchaser won’t attack."
+          "text": "Impetuous Sunchaser attacks only if it's able to do so as the declare attackers step begins. If, at that time, it's tapped or affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having it attack, you're not forced to pay that cost. If that cost isn't paid, Impetuous Sunchaser won't attack."
         },
         {
           "date": "2014-02-01",
@@ -12288,11 +12288,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -12515,31 +12515,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -12654,7 +12654,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If you want to cast a card this way, you cast it as part of the resolution of the triggered ability. Timing restrictions based on the card’s type (such as sorcery) are ignored. Other casting restrictions (such as “Cast [this card] only before attackers are declared”) are not."
+          "text": "If you want to cast a card this way, you cast it as part of the resolution of the triggered ability. Timing restrictions based on the card's type (such as sorcery) are ignored. Other casting restrictions (such as \"Cast [this card] only before attackers are declared\") are not."
         },
         {
           "date": "2014-02-01",
@@ -12662,7 +12662,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay alternative costs such as overload costs. You can, however, pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can, however, pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2014-02-01",
@@ -12670,11 +12670,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -12682,15 +12682,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -12805,11 +12805,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -12817,15 +12817,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -12943,7 +12943,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If one of the targets is a player, you can redirect the damage dealt by Pinnacle of Rage to a planeswalker that player controls. However, Pinnacle of Rage can’t be used to deal damage to both a player and a planeswalker he or she controls."
+          "text": "If one of the targets is a player, you can redirect the damage dealt by Pinnacle of Rage to a planeswalker that player controls. However, Pinnacle of Rage can't be used to deal damage to both a player and a planeswalker he or she controls."
         }
       ],
       "text": "Pinnacle of Rage deals 3 damage to each of two target creatures and/or players.",
@@ -13380,11 +13380,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -13511,11 +13511,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Scouring Sands deals 1 damage to each creature your opponents control. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -13625,7 +13625,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the target creature dies that turn, Searing Blood will deal 3 damage to whoever controls the creature when it dies, who isn’t necessarily the player who controlled it when Searing Blood resolved. It doesn’t matter what causes the creature to die."
+          "text": "If the target creature dies that turn, Searing Blood will deal 3 damage to whoever controls the creature when it dies, who isn't necessarily the player who controlled it when Searing Blood resolved. It doesn't matter what causes the creature to die."
         }
       ],
       "text": "Searing Blood deals 2 damage to target creature. When that creature dies this turn, Searing Blood deals 3 damage to the creature's controller.",
@@ -13745,11 +13745,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -13864,11 +13864,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -13876,15 +13876,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -13997,11 +13997,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -14009,7 +14009,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -14130,7 +14130,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If you put all permanents you control into one pile, you’ll have a two-thirds chance of not having to sacrifice any permanents, but a one-third chance of having to sacrifice all of them."
+          "text": "If you put all permanents you control into one pile, you'll have a two-thirds chance of not having to sacrifice any permanents, but a one-third chance of having to sacrifice all of them."
         }
       ],
       "text": "Starting with you, each player separates all permanents he or she controls into three piles. Then each player chooses one of his or her piles at random and sacrifices those permanents. (Piles can be empty.)",
@@ -14241,11 +14241,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The Archetype’s second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
+          "text": "The Archetype's second ability applies to each creature controlled by any of your opponents, no matter when it entered the battlefield."
         },
         {
           "date": "2014-02-01",
-          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren’t created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn’t cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
+          "text": "While you control an Archetype, continuous effects generated by the resolution of spells and abilities that would give the specified ability to creatures your opponents control aren't created. For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures he or she controls first strike wouldn't cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield. (If the spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
         },
         {
           "date": "2014-02-01",
@@ -14368,11 +14368,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -14380,11 +14380,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2014-02-01",
-          "text": "The value of X is calculated as Aspect of Hydra resolves. The bonus won’t change later in the turn, even if your devotion to green does."
+          "text": "The value of X is calculated as Aspect of Hydra resolves. The bonus won't change later in the turn, even if your devotion to green does."
         }
       ],
       "text": "Target creature gets +X/+X until end of turn, where X is your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
@@ -14604,15 +14604,15 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Courser of Kruphix doesn’t change when you can play lands. You can do so only during your main phase when you have priority and the stack is empty."
+          "text": "Courser of Kruphix doesn't change when you can play lands. You can do so only during your main phase when you have priority and the stack is empty."
         },
         {
           "date": "2014-02-01",
-          "text": "Playing a land with the second ability counts as your land play for the turn. If you play a land from your hand during your turn, you won’t be able to play an additional land from the top of your library unless another effect allows you to."
+          "text": "Playing a land with the second ability counts as your land play for the turn. If you play a land from your hand during your turn, you won't be able to play an additional land from the top of your library unless another effect allows you to."
         },
         {
           "date": "2014-02-01",
-          "text": "The last ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The last ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2014-02-01",
@@ -14731,7 +14731,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The creature blocks only if it’s able to do so as the declare blockers step begins. If, at that time, the creature is tapped, it’s affected by a spell or ability that says it can’t block, or no creatures are attacking its controller or a planeswalker controlled by that player, then it doesn’t block. If there’s a cost associated with having the creature block, the player isn’t forced to pay that cost. If that cost isn’t paid, the creature won’t block."
+          "text": "The creature blocks only if it's able to do so as the declare blockers step begins. If, at that time, the creature is tapped, it's affected by a spell or ability that says it can't block, or no creatures are attacking its controller or a planeswalker controlled by that player, then it doesn't block. If there's a cost associated with having the creature block, the player isn't forced to pay that cost. If that cost isn't paid, the creature won't block."
         },
         {
           "date": "2014-02-01",
@@ -14739,7 +14739,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If there are multiple combat phases in a turn, the creature must block only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, the creature must block only in the first one in which it's able to."
         }
       ],
       "text": "Target creature blocks this turn if able.",
@@ -14857,11 +14857,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Create two 3/3 green Centaur enchantment creature tokens. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -14973,7 +14973,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The number of creature cards in your graveyard is counted only as the ability resolves. Once the ability resolves, the bonus won’t change, even if the number of creature cards in your graveyard changes later in the turn."
+          "text": "The number of creature cards in your graveyard is counted only as the ability resolves. Once the ability resolves, the bonus won't change, even if the number of creature cards in your graveyard changes later in the turn."
         }
       ],
       "subtypes": [
@@ -15096,7 +15096,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         },
         {
           "date": "2014-02-01",
@@ -15635,11 +15635,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -15647,15 +15647,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -15770,11 +15770,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -15782,15 +15782,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -15905,31 +15905,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -16044,31 +16044,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -16190,15 +16190,15 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         },
         {
           "date": "2014-02-01",
-          "text": "You can choose to search for only one basic land card with Peregrination. If you do, you’ll put that card onto the battlefield tapped."
+          "text": "You can choose to search for only one basic land card with Peregrination. If you do, you'll put that card onto the battlefield tapped."
         }
       ],
       "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle your library, then scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -16313,11 +16313,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -16441,11 +16441,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -16906,7 +16906,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -17130,11 +17130,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -17142,7 +17142,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "text": "Skyreaping deals damage to each creature with flying equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
@@ -17253,11 +17253,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -17265,15 +17265,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -17498,7 +17498,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If the artifact or enchantment is a token, it will be shuffled into its owner’s library when Unravel the Aether resolves, then will cease to exist. For practical purposes, whatever item is representing the token should not actually be put into the library, though the library is still shuffled."
+          "text": "If the artifact or enchantment is a token, it will be shuffled into its owner's library when Unravel the Aether resolves, then will cease to exist. For practical purposes, whatever item is representing the token should not actually be put into the library, though the library is still shuffled."
         }
       ],
       "text": "Choose target artifact or enchantment. Its owner shuffles it into his or her library.",
@@ -17616,31 +17616,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -17757,11 +17757,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -17769,11 +17769,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -17785,7 +17785,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -17793,19 +17793,19 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-02-01",
-          "text": "Ephara’s last ability checks at the beginning of each upkeep whether another creature entered the battlefield under your control last turn. If one did, it will trigger; otherwise, it won’t. The ability will trigger only once no matter how many creatures entered the battlefield under your control that turn, as long as at least one did."
+          "text": "Ephara's last ability checks at the beginning of each upkeep whether another creature entered the battlefield under your control last turn. If one did, it will trigger; otherwise, it won't. The ability will trigger only once no matter how many creatures entered the battlefield under your control that turn, as long as at least one did."
         },
         {
           "date": "2014-02-01",
-          "text": "The last ability will trigger regardless of what has happened to the creature that entered the battlefield on the previous turn. It doesn’t matter whether it’s still under your control or whether it’s still on the battlefield."
+          "text": "The last ability will trigger regardless of what has happened to the creature that entered the battlefield on the previous turn. It doesn't matter whether it's still under your control or whether it's still on the battlefield."
         },
         {
           "date": "2014-02-01",
-          "text": "If a noncreature permanent you control (such as an Aura with bestow) becomes a creature, it will not cause Ephara’s last ability to trigger the following turn. This is true even if that noncreature permanent became a creature the same turn it entered the battlefield."
+          "text": "If a noncreature permanent you control (such as an Aura with bestow) becomes a creature, it will not cause Ephara's last ability to trigger the following turn. This is true even if that noncreature permanent became a creature the same turn it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -17924,11 +17924,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The last ability of Ephara’s Enlightenment will trigger only if it’s on the battlefield when the creature enters the battlefield under your control. You may return it to its owner’s hand only if it’s still on the battlefield when that ability resolves."
+          "text": "The last ability of Ephara's Enlightenment will trigger only if it's on the battlefield when the creature enters the battlefield under your control. You may return it to its owner's hand only if it's still on the battlefield when that ability resolves."
         },
         {
           "date": "2014-02-01",
-          "text": "If Ephara’s Enlightenment isn’t on the battlefield when its enters-the-battlefield ability resolves, put a +1/+1 counter on the creature it was enchanting when it left the battlefield."
+          "text": "If Ephara's Enlightenment isn't on the battlefield when its enters-the-battlefield ability resolves, put a +1/+1 counter on the creature it was enchanting when it left the battlefield."
         }
       ],
       "subtypes": [
@@ -18044,11 +18044,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won’t enter the battlefield and then have the +1/+1 counters placed on it."
+          "text": "If the opponent pays tribute, the creature will enter the battlefield with the specified number of +1/+1 counters on it. It won't enter the battlefield and then have the +1/+1 counters placed on it."
         },
         {
           "date": "2014-02-01",
-          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it’s too late to respond to the creature spell. For example, in a multiplayer game, opponents won’t know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
+          "text": "The choice of whether to pay tribute is made as the creature with tribute is entering the battlefield. At that point, it's too late to respond to the creature spell. For example, in a multiplayer game, opponents won't know whether tribute will be paid or which opponent will be chosen to pay tribute or not when deciding whether to counter the creature spell."
         },
         {
           "date": "2014-02-01",
@@ -18056,15 +18056,15 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Players can’t respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn’t pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
+          "text": "Players can't respond to the tribute decision before the creature enters the battlefield. That is, if the opponent doesn't pay tribute, the triggered ability will trigger before any player has a chance to remove the creature."
         },
         {
           "date": "2014-02-01",
-          "text": "The triggered ability will resolve even if the creature with tribute isn’t on the battlefield at that time."
+          "text": "The triggered ability will resolve even if the creature with tribute isn't on the battlefield at that time."
         },
         {
           "date": "2017-04-18",
-          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature’s controller."
+          "text": "For effects that check which player put counters on the entering creature, the player chosen to pay tribute puts those counters on it, not the creature's controller."
         }
       ],
       "subtypes": [
@@ -18181,11 +18181,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -18193,11 +18193,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -18209,7 +18209,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -18217,11 +18217,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-02-01",
-          "text": "If you cast a creature card with bestow for its bestow cost, it becomes an Aura spell and not a creature spell. Karametra’s last ability won’t trigger."
+          "text": "If you cast a creature card with bestow for its bestow cost, it becomes an Aura spell and not a creature spell. Karametra's last ability won't trigger."
         },
         {
           "date": "2014-02-01",
@@ -18346,7 +18346,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Kiora’s first ability can target any permanent an opponent controls, not just one that can deal or be dealt damage."
+          "text": "Kiora's first ability can target any permanent an opponent controls, not just one that can deal or be dealt damage."
         },
         {
           "date": "2014-02-01",
@@ -18354,7 +18354,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Kiora’s second ability allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you won’t play a land as that ability resolves. The ability will fully resolve (and you’ll draw a card, perhaps a land you’ll play later) first."
+          "text": "Kiora's second ability allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you won't play a land as that ability resolves. The ability will fully resolve (and you'll draw a card, perhaps a land you'll play later) first."
         },
         {
           "date": "2014-02-01",
@@ -18362,7 +18362,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If Kiora leaves the battlefield after her second ability is activated but before it resolves, you’ll still be able to play an additional land after the ability resolves."
+          "text": "If Kiora leaves the battlefield after her second ability is activated but before it resolves, you'll still be able to play an additional land after the ability resolves."
         }
       ],
       "subtypes": [
@@ -18590,11 +18590,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -18602,11 +18602,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -18618,7 +18618,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -18626,11 +18626,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-02-01",
-          "text": "If the player can’t sacrifice a creature (usually because he or she doesn’t control one), Mogis will deal 2 damage to him or her."
+          "text": "If the player can't sacrifice a creature (usually because he or she doesn't control one), Mogis will deal 2 damage to him or her."
         }
       ],
       "subtypes": [
@@ -18750,11 +18750,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -18762,11 +18762,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -18778,7 +18778,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -18786,7 +18786,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-02-01",
@@ -18798,7 +18798,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If you tap Phenax to activate the ability it grants itself, and Phenax is no longer a creature but still on the battlefield as that ability resolves, no cards will be put into the target player’s graveyard. Similarly, if Phenax isn’t on the battlefield as the ability resolves and wasn’t a creature when it left the battlefield, no cards will be put into the graveyard."
+          "text": "If you tap Phenax to activate the ability it grants itself, and Phenax is no longer a creature but still on the battlefield as that ability resolves, no cards will be put into the target player's graveyard. Similarly, if Phenax isn't on the battlefield as the ability resolves and wasn't a creature when it left the battlefield, no cards will be put into the graveyard."
         }
       ],
       "subtypes": [
@@ -19043,7 +19043,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Reap What Is Sown can’t target the same creature multiple times. It will put only one +1/+1 counter on each of its targets."
+          "text": "Reap What Is Sown can't target the same creature multiple times. It will put only one +1/+1 counter on each of its targets."
         }
       ],
       "text": "Put a +1/+1 counter on each of up to three target creatures.",
@@ -19159,11 +19159,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-02-01",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -19284,11 +19284,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -19296,11 +19296,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -19312,7 +19312,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -19320,7 +19320,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-02-01",
@@ -19440,7 +19440,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "The last ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The last ability is a mana ability. It doesn't use the stack and can't be responded to."
         }
       ],
       "text": "Astral Cornucopia enters the battlefield with X charge counters on it.\n{T}: Choose a color. Add one mana of that color to your mana pool for each charge counter on Astral Cornucopia.",
@@ -19644,11 +19644,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The bonus given by Heroes’ Podium counts only legendary creatures. It won’t count itself unless some other effect causes it to be a creature in addition to being a land (in which case it will also get the bonus)."
+          "text": "The bonus given by Heroes' Podium counts only legendary creatures. It won't count itself unless some other effect causes it to be a creature in addition to being a land (in which case it will also get the bonus)."
         },
         {
           "date": "2014-02-01",
-          "text": "Heroes’ Podium will give a bonus to each legendary creature you control, even if gaining control of one causes the “legend rule” to apply. For example, if you control Brimaz, King of Oreskos (a 3/4 legendary creature), and gain control of another one, they’ll each be 4/5 when you put one into its owner’s graveyard. Then the remaining one will return to being 3/4."
+          "text": "Heroes' Podium will give a bonus to each legendary creature you control, even if gaining control of one causes the \"legend rule\" to apply. For example, if you control Brimaz, King of Oreskos (a 3/4 legendary creature), and gain control of another one, they'll each be 4/5 when you put one into its owner's graveyard. Then the remaining one will return to being 3/4."
         }
       ],
       "supertypes": [
@@ -19756,7 +19756,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Defender only matters when Pillar of War could be declared as an attacking creature. If Pillar of War is already attacking, it becoming not enchanted doesn’t cause it to be removed from combat."
+          "text": "Defender only matters when Pillar of War could be declared as an attacking creature. If Pillar of War is already attacking, it becoming not enchanted doesn't cause it to be removed from combat."
         }
       ],
       "subtypes": [
@@ -19971,7 +19971,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You can tap a creature that hasn’t been under your control since your most recent turn began to activate the ability."
+          "text": "You can tap a creature that hasn't been under your control since your most recent turn began to activate the ability."
         }
       ],
       "text": "{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
@@ -20084,11 +20084,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {W} or {U} to your mana pool.",
@@ -20201,11 +20201,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Temple of Malice enters the battlefield tapped.\nWhen Temple of Malice enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {B} or {R} to your mana pool.",
@@ -20318,11 +20318,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {G} or {W} to your mana pool.",

--- a/json/BOK.json
+++ b/json/BOK.json
@@ -594,15 +594,15 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "When activated multiple times, it will have the triggered ability multiple times. When the animated Plains deals damage, the ability will trigger once for each copy of the ability. If, for example, you activate the ability three times, the Plains will deal two damage, and you’ll gain six life."
+          "text": "When activated multiple times, it will have the triggered ability multiple times. When the animated Plains deals damage, the ability will trigger once for each copy of the ability. If, for example, you activate the ability three times, the Plains will deal two damage, and you'll gain six life."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -898,15 +898,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -1381,11 +1381,11 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Kentaro doesn’t change when you can cast Samurai. It just makes Samurai castable for generic mana."
+          "text": "Kentaro doesn't change when you can cast Samurai. It just makes Samurai castable for generic mana."
         },
         {
           "date": "2005-02-01",
-          "text": "Kentaro’s ability only applies while Kentaro is on the battlefield. You have to pay for Kentaro normally. It still costs {1}{W}."
+          "text": "Kentaro's ability only applies while Kentaro is on the battlefield. You have to pay for Kentaro normally. It still costs {1}{W}."
         }
       ],
       "subtypes": [
@@ -1489,7 +1489,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Kitsune Palliator’s ability creates prevention shields for every creature and player when it resolves. It doesn’t affect creatures that enter the battlefield (or become creatures) later."
+          "text": "Kitsune Palliator's ability creates prevention shields for every creature and player when it resolves. It doesn't affect creatures that enter the battlefield (or become creatures) later."
         }
       ],
       "subtypes": [
@@ -2081,7 +2081,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "Scour can target and exile cards that aren’t always enchantments, but are enchantments when Scour is cast and resolves (such as creatures turned into enchantments by Soul Sculptor). Scour’s exile effect only looks for cards by name, not type."
+          "text": "Scour can target and exile cards that aren't always enchantments, but are enchantments when Scour is cast and resolves (such as creatures turned into enchantments by Soul Sculptor). Scour's exile effect only looks for cards by name, not type."
         },
         {
           "date": "2005-02-01",
@@ -2179,7 +2179,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "If the player or creature that was targeted is no longer playing or on the battlefield when the damage would occur, the damage isn’t redirected."
+          "text": "If the player or creature that was targeted is no longer playing or on the battlefield when the damage would occur, the damage isn't redirected."
         },
         {
           "date": "2005-02-01",
@@ -2846,7 +2846,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Redirected damage retains its information. For example, your opponent attacks you with Slith Firewalker (which reads, in part, “Whenever Slith Firewalker deals combat damage to a player, put a +1/+1 counter on it.”) and you block with a creature enchanted with Ward of Piety. If you activate Ward of Piety, targeting your opponent, the Slith’s ability triggers during the combat damage step and it gets a +1/+1 counter. It’s still combat damage."
+          "text": "Redirected damage retains its information. For example, your opponent attacks you with Slith Firewalker (which reads, in part, \"Whenever Slith Firewalker deals combat damage to a player, put a +1/+1 counter on it.\") and you block with a creature enchanted with Ward of Piety. If you activate Ward of Piety, targeting your opponent, the Slith's ability triggers during the combat damage step and it gets a +1/+1 counter. It's still combat damage."
         }
       ],
       "subtypes": [
@@ -3039,11 +3039,11 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Yomiji’s ability triggers whenever any legendary permanent is put into a graveyard from the battlefield, not just legendary creatures."
+          "text": "Yomiji's ability triggers whenever any legendary permanent is put into a graveyard from the battlefield, not just legendary creatures."
         },
         {
           "date": "2005-02-01",
-          "text": "Yomiji’s ability triggers even if Yomiji is going to the graveyard at the same time as the other legendary permanent."
+          "text": "Yomiji's ability triggers even if Yomiji is going to the graveyard at the same time as the other legendary permanent."
         }
       ],
       "subtypes": [
@@ -3538,7 +3538,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Disrupting Shoal can target any spell, but does nothing unless that spell’s converted mana cost is X."
+          "text": "Disrupting Shoal can target any spell, but does nothing unless that spell's converted mana cost is X."
         }
       ],
       "subtypes": [
@@ -3637,7 +3637,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "The land Floodbringer returns to its owner’s hand can be the targeted land."
+          "text": "The land Floodbringer returns to its owner's hand can be the targeted land."
         }
       ],
       "subtypes": [
@@ -3736,11 +3736,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -3932,7 +3932,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "If Higure deals regular combat damage and you use its ability to search for another Ninja, that card won’t be in your hand in time to activate its ninjutsu ability to put it onto the battlefield and deal damage. However, the card you searched for could still be swapped for an unblocked creature, including Higure, as long as you activate its ninjutsu ability before the end of combat."
+          "text": "If Higure deals regular combat damage and you use its ability to search for another Ninja, that card won't be in your hand in time to activate its ninjutsu ability to put it onto the battlefield and deal damage. However, the card you searched for could still be swapped for an unblocked creature, including Higure, as long as you activate its ninjutsu ability before the end of combat."
         },
         {
           "date": "2005-02-01",
@@ -4705,7 +4705,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "You may put zero, one, or two lands onto the battlefield with Patron of the Moon’s ability. The number is determined as the ability resolves. You don’t need lands in hand to activate the ability."
+          "text": "You may put zero, one, or two lands onto the battlefield with Patron of the Moon's ability. The number is determined as the ability resolves. You don't need lands in hand to activate the ability."
         }
       ],
       "subtypes": [
@@ -4912,7 +4912,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then it does not get exiled but all the other copies in the graveyard, hand, and library are exiled."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then it does not get exiled but all the other copies in the graveyard, hand, and library are exiled."
         },
         {
           "date": "2005-02-01",
@@ -4920,7 +4920,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "If Quash counters a spell that has had text spliced onto it, only the base spell may be exiled. For example, if you use Quash to counter a Kodama’s Might with a Glacial Ray spliced onto it, you may search for and exile only Kodama’s Might."
+          "text": "If Quash counters a spell that has had text spliced onto it, only the base spell may be exiled. For example, if you use Quash to counter a Kodama's Might with a Glacial Ray spliced onto it, you may search for and exile only Kodama's Might."
         },
         {
           "date": "2005-02-01",
@@ -5586,11 +5586,11 @@
         },
         {
           "date": "2005-02-01",
-          "text": "Tokens are included in the effect but shouldn’t actually be included in the shuffle. Tokens will cease to exist immediately after the spell resolves."
+          "text": "Tokens are included in the effect but shouldn't actually be included in the shuffle. Tokens will cease to exist immediately after the spell resolves."
         },
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Each player shuffles his or her hand, graveyard, and permanents he or she owns into his or her library, then draws seven cards. Each player's life total becomes 7.",
@@ -5773,13 +5773,14 @@
       "originalText": "Threads of Disloyalty can enchant only a creature with converted mana cost 2 or less.\nYou control enchanted creature.",
       "originalType": "Enchant Creature",
       "printings": [
-        "BOK"
+        "BOK",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Threads of Disloyalty can’t target a creature with converted mana cost 3 or greater. If it somehow enchants a creature with converted mana cost 3 or greater, Threads of Disloyalty is put into the graveyard the next time state-based actions are checked."
+          "text": "Threads of Disloyalty can't target a creature with converted mana cost 3 or greater. If it somehow enchants a creature with converted mana cost 3 or greater, Threads of Disloyalty is put into the graveyard the next time state-based actions are checked."
         },
         {
           "date": "2005-02-01",
@@ -5983,7 +5984,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Tomorrow’s ability makes you look at the top three cards, not draw them. Therefore it won’t trigger abilities that trigger when cards are drawn."
+          "text": "Tomorrow's ability makes you look at the top three cards, not draw them. Therefore it won't trigger abilities that trigger when cards are drawn."
         },
         {
           "date": "2005-02-01",
@@ -5999,7 +6000,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "Since Tomorrow replaces all your card drawing with looking at cards, you can’t lose the game by being required to draw more cards than are in your library with Tomorrow on the battlefield."
+          "text": "Since Tomorrow replaces all your card drawing with looking at cards, you can't lose the game by being required to draw more cards than are in your library with Tomorrow on the battlefield."
         }
       ],
       "subtypes": [
@@ -6104,15 +6105,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -6490,7 +6491,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Uses last known information for the sacrificed creature’s power."
+          "text": "Uses last known information for the sacrificed creature's power."
         },
         {
           "date": "2005-02-01",
@@ -6709,7 +6710,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "If you manage to turn a land (such as a Forest or Stalking Stones) into a creature, you can indeed use this effect on that basic land type. Eradicate’s exile effect only looks for cards by name, not type."
+          "text": "If you manage to turn a land (such as a Forest or Stalking Stones) into a creature, you can indeed use this effect on that basic land type. Eradicate's exile effect only looks for cards by name, not type."
         },
         {
           "date": "2005-02-01",
@@ -6717,7 +6718,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "A face-down creature has no name, so no card can possibly share a name with it (not even other cards with no name). If you Eradicate a face-down creature you will still search its controller’s library, but you won’t be able to exile any cards from that library."
+          "text": "A face-down creature has no name, so no card can possibly share a name with it (not even other cards with no name). If you Eradicate a face-down creature you will still search its controller's library, but you won't be able to exile any cards from that library."
         }
       ],
       "text": "Exile target nonblack creature. Search its controller's graveyard, hand, and library for all cards with the same name as that creature and exile them. Then that player shuffles his or her library.",
@@ -6813,11 +6814,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -6918,15 +6919,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -7411,7 +7412,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Horobi’s Whisper can target a creature even if you don’t control a Swamp, but the spell does nothing."
+          "text": "Horobi's Whisper can target a creature even if you don't control a Swamp, but the spell does nothing."
         },
         {
           "date": "2013-06-07",
@@ -7419,15 +7420,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -7529,7 +7530,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "If, during the combat damage step, a creature is destroyed during combat and Ink-Eyes also deals combat damage to a player, the destroyed creature can be a legal target for Ink-Eyes’s ability."
+          "text": "If, during the combat damage step, a creature is destroyed during combat and Ink-Eyes also deals combat damage to a player, the destroyed creature can be a legal target for Ink-Eyes's ability."
         }
       ],
       "subtypes": [
@@ -7633,11 +7634,11 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Cards exiled by Kyoki’s ability are exiled face up."
+          "text": "Cards exiled by Kyoki's ability are exiled face up."
         },
         {
           "date": "2005-02-01",
-          "text": "Cards exiled by Kyoki’s ability stay exiled even if Kyoki leaves the battlefield."
+          "text": "Cards exiled by Kyoki's ability stay exiled even if Kyoki leaves the battlefield."
         }
       ],
       "subtypes": [
@@ -7928,11 +7929,11 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Ogre Marauder’s ability requires the defending player to sacrifice a creature as the ability resolves, or Ogre Marauder can’t be blocked for the rest of the turn."
+          "text": "Ogre Marauder's ability requires the defending player to sacrifice a creature as the ability resolves, or Ogre Marauder can't be blocked for the rest of the turn."
         },
         {
           "date": "2005-02-01",
-          "text": "Attacking with Ogre Marauder a second time would cause a second trigger. If no creature was previously sacrificed, the Marauder already can’t be blocked. Sacrificing a creature for the second trigger will not nullify the first."
+          "text": "Attacking with Ogre Marauder a second time would cause a second trigger. If no creature was previously sacrificed, the Marauder already can't be blocked. Sacrificing a creature for the second trigger will not nullify the first."
         }
       ],
       "subtypes": [
@@ -8135,7 +8136,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Patron of the Nezumi’s ability triggers even if an event puts this and multiple other permanents into the graveyard at the same time (Wrath of God, gang blocks, etc.)"
+          "text": "Patron of the Nezumi's ability triggers even if an event puts this and multiple other permanents into the graveyard at the same time (Wrath of God, gang blocks, etc.)"
         }
       ],
       "subtypes": [
@@ -8520,15 +8521,15 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Shirei’s ability only triggers if the creature’s power immediately before leaving the battlefield is 1 or less."
+          "text": "Shirei's ability only triggers if the creature's power immediately before leaving the battlefield is 1 or less."
         },
         {
           "date": "2005-02-01",
-          "text": "If Shirei leaves the battlefield and returns to the battlefield after a creature with power 1 or less is put into your graveyard, it won’t return that creature to the battlefield under your control."
+          "text": "If Shirei leaves the battlefield and returns to the battlefield after a creature with power 1 or less is put into your graveyard, it won't return that creature to the battlefield under your control."
         },
         {
           "date": "2005-02-01",
-          "text": "Shirei’s ability doesn’t affect creatures put into your graveyard before Shirei enters the battlefield. The “if” clause modifies the conditions on which creatures are returned."
+          "text": "Shirei's ability doesn't affect creatures put into your graveyard before Shirei enters the battlefield. The \"if\" clause modifies the conditions on which creatures are returned."
         }
       ],
       "subtypes": [
@@ -8816,7 +8817,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Skullsnatcher’s ability can target zero, one, or two cards in that player’s graveyard."
+          "text": "Skullsnatcher's ability can target zero, one, or two cards in that player's graveyard."
         }
       ],
       "subtypes": [
@@ -9288,11 +9289,11 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "You must still pay the mana cost of the target instant in your graveyard to cast it using Toshiro’s ability."
+          "text": "You must still pay the mana cost of the target instant in your graveyard to cast it using Toshiro's ability."
         },
         {
           "date": "2011-01-01",
-          "text": "Creatures destroyed by an instant that you cast normally can cause a trigger that allows the instant to be cast again. For example, cast Terror on an opponent’s creature. The creature is destroyed, triggering Toshiro’s ability, and then the Terror is put into your graveyard. You can put Toshiro’s ability on the stack targeting the Terror and then recast it when the ability resolves."
+          "text": "Creatures destroyed by an instant that you cast normally can cause a trigger that allows the instant to be cast again. For example, cast Terror on an opponent's creature. The creature is destroyed, triggering Toshiro's ability, and then the Terror is put into your graveyard. You can put Toshiro's ability on the stack targeting the Terror and then recast it when the ability resolves."
         }
       ],
       "subtypes": [
@@ -10057,7 +10058,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Clash of Realities’s abilities apply as each creature enters the battlefield and gives them a enters-the-battlefield triggered ability."
+          "text": "Clash of Realities's abilities apply as each creature enters the battlefield and gives them a enters-the-battlefield triggered ability."
         },
         {
           "date": "2005-02-01",
@@ -10539,7 +10540,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "The damage is unpreventable, and the targeted player’s life gain that turn is replaced with nothing."
+          "text": "The damage is unpreventable, and the targeted player's life gain that turn is replaced with nothing."
         },
         {
           "date": "2005-02-01",
@@ -10826,15 +10827,15 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "X is variable. The bushido bonus is calculated each time Fumiko’s bushido trigger resolves, based on the number of attackers at that time."
+          "text": "X is variable. The bushido bonus is calculated each time Fumiko's bushido trigger resolves, based on the number of attackers at that time."
         },
         {
           "date": "2005-02-01",
-          "text": "Fumiko’s ability doesn’t force an opponent to pay for effects in order to be able to attack with his or her creatures (such as Ghostly Prison, for example)."
+          "text": "Fumiko's ability doesn't force an opponent to pay for effects in order to be able to attack with his or her creatures (such as Ghostly Prison, for example)."
         },
         {
           "date": "2005-02-01",
-          "text": "Fumiko’s ability doesn’t force tapped creatures or creatures with summoning sickness to attack."
+          "text": "Fumiko's ability doesn't force tapped creatures or creatures with summoning sickness to attack."
         }
       ],
       "subtypes": [
@@ -10937,7 +10938,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -11231,7 +11232,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "In the Web of War doesn’t affect creatures you take control of which are already on the battlefield."
+          "text": "In the Web of War doesn't affect creatures you take control of which are already on the battlefield."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, it gets +2/+0 and gains haste until end of turn.",
@@ -11612,7 +11613,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -11812,15 +11813,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -12314,15 +12315,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -12724,7 +12725,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"The soratami scoff at the perils of Jukai, calling the forest an ‘unruly garden.' Perhaps we should send them a rose such as this.\"\n—Dokai, Weaver of Life",
+      "flavor": "\"The soratami scoff at the perils of Jukai, calling the forest an 'unruly garden.' Perhaps we should send them a rose such as this.\"\n—Dokai, Weaver of Life",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -13088,11 +13089,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -13574,7 +13575,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "Kodama of the Center Tree can return itself to its owner’s hand if you control five or more Spirits when it is put into a graveyard from the battlefield."
+          "text": "Kodama of the Center Tree can return itself to its owner's hand if you control five or more Spirits when it is put into a graveyard from the battlefield."
         }
       ],
       "subtypes": [
@@ -14230,11 +14231,11 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Patron of the Orochi’s ability untaps nonbasic lands that are also Forests (such as some of the Revised dual lands) and multicolored creatures that are also green."
+          "text": "Patron of the Orochi's ability untaps nonbasic lands that are also Forests (such as some of the Revised dual lands) and multicolored creatures that are also green."
         },
         {
           "date": "2005-02-01",
-          "text": "The Patron’s ability can be activated only once per turn, even if control of Patron of the Orochi changes."
+          "text": "The Patron's ability can be activated only once per turn, even if control of Patron of the Orochi changes."
         }
       ],
       "subtypes": [
@@ -14428,7 +14429,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Roar of Jukai can be cast even if you don’t control a Forest or there are no blocked creatures. If you control no Forests or if there are no blocked creatures, the spell does nothing."
+          "text": "Roar of Jukai can be cast even if you don't control a Forest or there are no blocked creatures. If you control no Forests or if there are no blocked creatures, the spell does nothing."
         },
         {
           "date": "2013-06-07",
@@ -14436,15 +14437,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -14656,7 +14657,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"Say, what rhymes with ‘run for your lives'?\"\n—Ku-Ku, akki poet",
+      "flavor": "\"Say, what rhymes with 'run for your lives'?\"\n—Ku-Ku, akki poet",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -15020,7 +15021,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "Splinter can target and exile cards that aren’t always artifacts, but are artifacts when Splinter is cast and resolves (such as an animated Stalking Stones). Splinter’s exile effect only looks for cards by name, not type."
+          "text": "Splinter can target and exile cards that aren't always artifacts, but are artifacts when Splinter is cast and resolves (such as an animated Stalking Stones). Splinter's exile effect only looks for cards by name, not type."
         },
         {
           "date": "2005-02-01",
@@ -15399,15 +15400,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -15512,11 +15513,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -15778,7 +15779,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Mirror Gallery removes the “Legend rule” while it’s on the battlefield. If all Mirror Galleries leave the battlefield, the “Legend rule” will apply the next time state-based actions are performed."
+          "text": "Mirror Gallery removes the \"Legend rule\" while it's on the battlefield. If all Mirror Galleries leave the battlefield, the \"Legend rule\" will apply the next time state-based actions are performed."
         }
       ],
       "text": "The \"legend rule\" doesn't apply.",
@@ -16035,11 +16036,11 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Normal restrictions apply to cards exiled by Ornate Kanzashi (you can’t cast an instant unless you have priority, etc.)."
+          "text": "Normal restrictions apply to cards exiled by Ornate Kanzashi (you can't cast an instant unless you have priority, etc.)."
         },
         {
           "date": "2005-02-01",
-          "text": "Cards exiled by Ornate Kanzashi’s ability are exiled face up."
+          "text": "Cards exiled by Ornate Kanzashi's ability are exiled face up."
         },
         {
           "date": "2005-02-01",
@@ -16047,11 +16048,11 @@
         },
         {
           "date": "2005-02-01",
-          "text": "You can’t play cards you exiled with Ornate Kanzashi on previous turns."
+          "text": "You can't play cards you exiled with Ornate Kanzashi on previous turns."
         },
         {
           "date": "2005-02-01",
-          "text": "Cards exiled by Ornate Kanzashi’s ability stay exiled even if the Kanzashi leaves the battlefield."
+          "text": "Cards exiled by Ornate Kanzashi's ability stay exiled even if the Kanzashi leaves the battlefield."
         }
       ],
       "text": "{2}, {T}: Target opponent exiles the top card of his or her library. You may play that card this turn.",
@@ -16139,11 +16140,11 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "The triggered ability can attach Ronin Warclub to an untargetable creature because the ability doesn’t target."
+          "text": "The triggered ability can attach Ronin Warclub to an untargetable creature because the ability doesn't target."
         },
         {
           "date": "2005-02-01",
-          "text": "The triggered ability won’t attach Ronin Warclub to a creature that can’t be equipped (such as Goblin Brawler)."
+          "text": "The triggered ability won't attach Ronin Warclub to a creature that can't be equipped (such as Goblin Brawler)."
         }
       ],
       "subtypes": [
@@ -16235,7 +16236,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You may activate this card’s equip ability targeting the creature that it is currently attached to, even if it’s the only creature you control. Since the equip ability costs zero, you can do this as many times as you like during your main phases, though it generally won’t do anything."
+          "text": "You may activate this card's equip ability targeting the creature that it is currently attached to, even if it's the only creature you control. Since the equip ability costs zero, you can do this as many times as you like during your main phases, though it generally won't do anything."
         }
       ],
       "subtypes": [
@@ -16411,7 +16412,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{2}, Discard a Spirit or Arcane card: Slumbering Tora becomes an X/X Cat artifact creature until end of turn, where X is the discarded card's converted mana cost.",
@@ -16601,23 +16602,23 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Umezawa’s Jitte’s activated ability generates a modal choice. The choice is made when the ability is activated."
+          "text": "Umezawa's Jitte's activated ability generates a modal choice. The choice is made when the ability is activated."
         },
         {
           "date": "2005-02-01",
-          "text": "If the “target creature gets -1/-1 until end of turn” mode is chosen, the target creature must also be announced."
+          "text": "If the \"target creature gets -1/-1 until end of turn\" mode is chosen, the target creature must also be announced."
         },
         {
           "date": "2005-02-01",
-          "text": "The ability can be used any time Umezawa’s Jitte’s controller has priority — only the “target creature” choice has additional requirements. Choosing the “Equipped creature gets +2/+2 until end of turn” mode does nothing if the Jitte isn’t equipped to a creature when the ability resolves."
+          "text": "The ability can be used any time Umezawa's Jitte's controller has priority — only the \"target creature\" choice has additional requirements. Choosing the \"Equipped creature gets +2/+2 until end of turn\" mode does nothing if the Jitte isn't equipped to a creature when the ability resolves."
         },
         {
           "date": "2005-02-01",
-          "text": "If the Jitte is moved after the “+2/+2” mode is announced but before it resolves, the bonus is given to the creature that is equipped when the ability resolves."
+          "text": "If the Jitte is moved after the \"+2/+2\" mode is announced but before it resolves, the bonus is given to the creature that is equipped when the ability resolves."
         },
         {
           "date": "2005-02-01",
-          "text": "If the Jitte leaves the battlefield after the “+2/+2” mode is announced but before it resolves, the bonus is given to the creature that was most recently equipped once the ability resolves."
+          "text": "If the Jitte leaves the battlefield after the \"+2/+2\" mode is announced but before it resolves, the bonus is given to the creature that was most recently equipped once the ability resolves."
         }
       ],
       "subtypes": [

--- a/json/BRB.json
+++ b/json/BRB.json
@@ -385,7 +385,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The ability must target two different lands. It can’t be activated if there is just one land to target."
+          "text": "The ability must target two different lands. It can't be activated if there is just one land to target."
         }
       ],
       "subtypes": [
@@ -831,7 +831,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -1162,7 +1162,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A spell or ability that tells a player to “put a land onto the battlefield” does not count as playing a land."
+          "text": "A spell or ability that tells a player to \"put a land onto the battlefield\" does not count as playing a land."
         }
       ],
       "subtypes": [
@@ -4453,7 +4453,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         }
       ],
       "subtypes": [
@@ -5770,15 +5770,15 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "You can fetch any of the “Snow-Covered” lands, since they all also have the supertype basic."
+          "text": "You can fetch any of the \"Snow-Covered\" lands, since they all also have the supertype basic."
         },
         {
           "date": "2009-10-01",
-          "text": "This ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
+          "text": "This ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "You shuffle your library if you search, even if you don’t put any basic land cards into your hand."
+          "text": "You shuffle your library if you search, even if you don't put any basic land cards into your hand."
         }
       ],
       "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, and put them into your hand. If you do, shuffle your library.",
@@ -5841,7 +5841,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -5968,7 +5968,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures which are sacrificed can’t be regenerated."
+          "text": "The creatures which are sacrificed can't be regenerated."
         },
         {
           "date": "2004-10-04",
@@ -5976,7 +5976,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
+          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
         }
       ],
       "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -6117,7 +6117,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are no other creatures on the battlefield when Man-o’-War enters the battlefield, its ability must target itself."
+          "text": "If there are no other creatures on the battlefield when Man-o'-War enters the battlefield, its ability must target itself."
         }
       ],
       "subtypes": [
@@ -8830,7 +8830,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it’s a creature you control."
+          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it's a creature you control."
         }
       ],
       "subtypes": [
@@ -9047,7 +9047,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -11541,7 +11541,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -11811,11 +11811,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The creature returns to the opponent when the “until end of turn” effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
+          "text": "The creature returns to the opponent when the \"until end of turn\" effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command's effect ends, or because a spell or ability causes another player to gain control of it."
         }
       ],
       "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature gains haste until end of turn. When you lose control of the creature, tap it.",
@@ -11874,7 +11874,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You lose life equal to the converted mana cost of the card you’re bringing back, so if you Reanimate Volrath’s Shapeshifter, you lose three life, regardless of what the next card down is."
+          "text": "You lose life equal to the converted mana cost of the card you're bringing back, so if you Reanimate Volrath's Shapeshifter, you lose three life, regardless of what the next card down is."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
@@ -12059,7 +12059,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If X is greater than 0, you can’t choose zero targets. You must choose between one and X targets. If X is 0, you can’t choose any targets."
+          "text": "If X is greater than 0, you can't choose zero targets. You must choose between one and X targets. If X is 0, you can't choose any targets."
         },
         {
           "date": "2015-08-25",
@@ -12071,7 +12071,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can’t change the way damage is divided."
+          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can't change the way damage is divided."
         }
       ],
       "text": "Rolling Thunder deals X damage divided as you choose among any number of target creatures and/or players.",
@@ -12616,15 +12616,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -13026,7 +13026,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other’s ability to trigger."
+          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other's ability to trigger."
         },
         {
           "date": "2005-08-01",
@@ -13364,7 +13364,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This is loss of life, not damage. It can’t be prevented."
+          "text": "This is loss of life, not damage. It can't be prevented."
         }
       ],
       "text": "At the beginning of your upkeep, each opponent loses 1 life. You gain life equal to the life lost this way.",
@@ -14515,7 +14515,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",

--- a/json/BTD.json
+++ b/json/BTD.json
@@ -755,7 +755,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
+          "text": "You don't have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
         }
       ],
       "subtypes": [
@@ -912,7 +912,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -1459,7 +1459,8 @@
         "pARL",
         "TMP",
         "BTD",
-        "TPR"
+        "TPR",
+        "MPS_AKH"
       ],
       "rarity": "Common",
       "text": "Target player sacrifices a creature.",
@@ -1677,6 +1678,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -1690,6 +1695,10 @@
         },
         {
           "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -1735,7 +1744,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -1889,15 +1898,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -2022,7 +2031,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -2342,7 +2351,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "There is no penalty if it can’t attack."
+          "text": "There is no penalty if it can't attack."
         }
       ],
       "subtypes": [
@@ -2427,7 +2436,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -2439,7 +2448,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -3030,7 +3039,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t discard more than once to target more than one creature (or player) or to do multiple amounts of damage to a single creature (or player)."
+          "text": "You can't discard more than once to target more than one creature (or player) or to do multiple amounts of damage to a single creature (or player)."
         },
         {
           "date": "2004-10-04",
@@ -3503,7 +3512,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different player’s creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
+          "text": "In multiplayer games you can choose a different player's creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
         },
         {
           "date": "2004-10-04",
@@ -4018,7 +4027,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -4557,7 +4566,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Clockwork Beast’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "Clockwork Beast's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         }
       ],
       "subtypes": [

--- a/json/C13.json
+++ b/json/C13.json
@@ -86,7 +86,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "If you choose to not exile a permanent with the second ability, you’ll retain control of Act of Authority."
+          "text": "If you choose to not exile a permanent with the second ability, you'll retain control of Act of Authority."
         }
       ],
       "text": "When Act of Authority enters the battlefield, you may exile target artifact or enchantment.\nAt the beginning of your upkeep, you may exile target artifact or enchantment. If you do, its controller gains control of Act of Authority.",
@@ -260,11 +260,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Soulmender or 8 life from Meditation Puzzle."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Soulmender or 8 life from Meditation Puzzle."
         },
         {
           "date": "2014-07-18",
-          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Ajani’s Pridemate’s ability will trigger twice. However, if a single creature you control with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
+          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Ajani's Pridemate's ability will trigger twice. However, if a single creature you control with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
         }
       ],
       "subtypes": [
@@ -528,7 +528,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -618,11 +618,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You choose a target when the ability triggers. You don’t choose whether to pay {1}{W} until the ability resolves."
+          "text": "You choose a target when the ability triggers. You don't choose whether to pay {1}{W} until the ability resolves."
         },
         {
           "date": "2008-10-01",
-          "text": "Cradle of Vitality triggers just once for each life-gaining event, whether it’s 1 life from Deathgreeter or 8 life from Soul’s Grace. You pay the cost just once, but the targeted creature will get a number of counters equal to the amount of life you gained."
+          "text": "Cradle of Vitality triggers just once for each life-gaining event, whether it's 1 life from Deathgreeter or 8 life from Soul's Grace. You pay the cost just once, but the targeted creature will get a number of counters equal to the amount of life you gained."
         },
         {
           "date": "2014-02-01",
@@ -704,7 +704,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse’s color (or any other characteristic the Curse has), the Curse will be put into its owner’s graveyard."
+          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse's color (or any other characteristic the Curse has), the Curse will be put into its owner's graveyard."
         },
         {
           "date": "2013-10-17",
@@ -716,7 +716,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "The ability won’t trigger when a creature attacks a planeswalker controlled by the enchanted player."
+          "text": "The ability won't trigger when a creature attacks a planeswalker controlled by the enchanted player."
         },
         {
           "date": "2013-10-17",
@@ -810,11 +810,11 @@
         },
         {
           "date": "2013-10-17",
-          "text": "Darksteel Mutation overwrites any previous effects that set the enchanted creature’s power or toughness to a specific value. Any such effects that start to apply after Darksteel Mutation entered the battlefield will work normally."
+          "text": "Darksteel Mutation overwrites any previous effects that set the enchanted creature's power or toughness to a specific value. Any such effects that start to apply after Darksteel Mutation entered the battlefield will work normally."
         },
         {
           "date": "2013-10-17",
-          "text": "However, Darksteel Mutation does not overwrite effects that change the enchanted creature’s power or toughness without setting it to a specific value (such as the ones created by Giant Growth or Glorious Anthem). It also won’t overwrite the effect of counters."
+          "text": "However, Darksteel Mutation does not overwrite effects that change the enchanted creature's power or toughness without setting it to a specific value (such as the ones created by Giant Growth or Glorious Anthem). It also won't overwrite the effect of counters."
         },
         {
           "date": "2013-10-17",
@@ -822,15 +822,15 @@
         },
         {
           "date": "2013-10-17",
-          "text": "In some rare cases, the creature may have subtypes other than creature types before becoming enchanted with Darksteel Mutation. If it had any other artifact subtypes (such as Equipment), it will retain those. If it had any subtypes other than artifact types and creature types (such as Shrine), it won’t retain those."
+          "text": "In some rare cases, the creature may have subtypes other than creature types before becoming enchanted with Darksteel Mutation. If it had any other artifact subtypes (such as Equipment), it will retain those. If it had any subtypes other than artifact types and creature types (such as Shrine), it won't retain those."
         },
         {
           "date": "2013-10-17",
-          "text": "The creature will keep any supertypes it previously had. Notably, if Darksteel Mutation is enchanting a legendary creature, that creature will continue to be legendary. Also, if it’s enchanting a commander, that creature will continue to be a commander."
+          "text": "The creature will keep any supertypes it previously had. Notably, if Darksteel Mutation is enchanting a legendary creature, that creature will continue to be legendary. Also, if it's enchanting a commander, that creature will continue to be a commander."
         },
         {
           "date": "2013-10-17",
-          "text": "Darksteel Mutation doesn’t affect the enchanted creature’s colors, if any. It will continue to be whatever color or colors it was before Darksteel Mutation entered the battlefield."
+          "text": "Darksteel Mutation doesn't affect the enchanted creature's colors, if any. It will continue to be whatever color or colors it was before Darksteel Mutation entered the battlefield."
         },
         {
           "date": "2013-10-17",
@@ -921,7 +921,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Plainscycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Plains card. After you find a Plains card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Plainscycling doesn't allow you to draw a card. Instead, it lets you search your library for a Plains card. After you find a Plains card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -1118,7 +1118,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The card that was enchanted comes back onto the battlefield first, regardless of whether it’s still a creature. Then any Auras exiled that can legally enchant that card come back. Any Auras that can’t enchant that permanent remain exiled."
+          "text": "The card that was enchanted comes back onto the battlefield first, regardless of whether it's still a creature. Then any Auras exiled that can legally enchant that card come back. Any Auras that can't enchant that permanent remain exiled."
         },
         {
           "date": "2005-10-01",
@@ -1126,7 +1126,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the enchanted creature was also enchanted by Copy Enchantment, Copy Enchantment will return to the battlefield attached to that permanent. As Copy Enchantment returns to the battlefield, its controller may choose any enchantment on the battlefield for it to copy. It can’t copy Flickerform or any other Aura returning to the battlefield at the same time. If it copies a non-Aura enchantment, it returns to the battlefield unattached instead."
+          "text": "If the enchanted creature was also enchanted by Copy Enchantment, Copy Enchantment will return to the battlefield attached to that permanent. As Copy Enchantment returns to the battlefield, its controller may choose any enchantment on the battlefield for it to copy. It can't copy Flickerform or any other Aura returning to the battlefield at the same time. If it copies a non-Aura enchantment, it returns to the battlefield unattached instead."
         },
         {
           "date": "2014-02-01",
@@ -1229,7 +1229,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won’t trigger that turn."
+          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won't trigger that turn."
         }
       ],
       "subtypes": [
@@ -1575,7 +1575,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         },
         {
           "date": "2013-07-01",
@@ -1659,11 +1659,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Mystic Barrier affects only what players and planeswalkers each player may attack with creatures he or she controls. It doesn’t affect what players may be targeted by spells or abilities or other interactions."
+          "text": "Mystic Barrier affects only what players and planeswalkers each player may attack with creatures he or she controls. It doesn't affect what players may be targeted by spells or abilities or other interactions."
         },
         {
           "date": "2013-10-17",
-          "text": "Mystic Barrier doesn’t affect creatures that enter the battlefield attacking."
+          "text": "Mystic Barrier doesn't affect creatures that enter the battlefield attacking."
         },
         {
           "date": "2013-10-17",
@@ -1758,7 +1758,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If the artifact card in your graveyard is an illegal target by the time the ability resolves, the ability will be countered. You won’t gain any life."
+          "text": "If the artifact card in your graveyard is an illegal target by the time the ability resolves, the ability will be countered. You won't gain any life."
         },
         {
           "date": "2011-01-01",
@@ -1844,11 +1844,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "When Serene Master’s ability resolves, its power becomes equal to the former power of the target creature. At the same time, that creature’s power will become equal to Serene Master’s former power."
+          "text": "When Serene Master's ability resolves, its power becomes equal to the former power of the target creature. At the same time, that creature's power will become equal to Serene Master's former power."
         },
         {
           "date": "2013-10-17",
-          "text": "Any power-modifying effects, counters, Auras, or Equipment will apply to the creatures’ new powers. For example, say Serene Master is enchanted with Lightning Talons, which gives it +3/+0, and it blocks a 5/5 creature. After the exchange, Serene Master would be an 8/2 creature (its power became 5, which was then modified by Lightning Talons), and the other creature would be 3/5."
+          "text": "Any power-modifying effects, counters, Auras, or Equipment will apply to the creatures' new powers. For example, say Serene Master is enchanted with Lightning Talons, which gives it +3/+0, and it blocks a 5/5 creature. After the exchange, Serene Master would be an 8/2 creature (its power became 5, which was then modified by Lightning Talons), and the other creature would be 3/5."
         },
         {
           "date": "2013-10-17",
@@ -1856,7 +1856,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "If Serene Master blocks multiple creatures, its ability will trigger only once, and it will exchange power with only the target creature. (Note that Serene Master can’t block multiple creatures normally.)"
+          "text": "If Serene Master blocks multiple creatures, its ability will trigger only once, and it will exchange power with only the target creature. (Note that Serene Master can't block multiple creatures normally.)"
         }
       ],
       "subtypes": [
@@ -1952,19 +1952,19 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Whether or not the ability triggers depends on if the Avatar has the ability while in the graveyard. If it doesn’t (thanks to Yixlid Jailer, for instance), then the ability won’t trigger. It doesn’t matter whether the Avatar had the ability in its previous zone (it will trigger even if it had been on the battlefield with Humility)."
+          "text": "Whether or not the ability triggers depends on if the Avatar has the ability while in the graveyard. If it doesn't (thanks to Yixlid Jailer, for instance), then the ability won't trigger. It doesn't matter whether the Avatar had the ability in its previous zone (it will trigger even if it had been on the battlefield with Humility)."
         },
         {
           "date": "2012-07-01",
-          "text": "Serra Avatar’s power and toughness are constantly updated as your life total changes."
+          "text": "Serra Avatar's power and toughness are constantly updated as your life total changes."
         },
         {
           "date": "2012-07-01",
-          "text": "The ability that defines Serra Avatar’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Serra Avatar's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2012-07-01",
-          "text": "If Serra Avatar is no longer in your graveyard when its triggered ability resolves, you won’t shuffle your library."
+          "text": "If Serra Avatar is no longer in your graveyard when its triggered ability resolves, you won't shuffle your library."
         }
       ],
       "subtypes": [
@@ -2060,11 +2060,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -2153,11 +2153,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -2165,27 +2165,27 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, anything that cares about your life total checks the life total of your team. For example, say that your team has 10 life and your opponent’s team has 11 life when you cast Survival Cache. You’ll gain 2 life, so your team’s life total becomes 12. Since your life total (12) is greater than an opponent’s life total (11), you’ll draw a card."
+          "text": "In a Two-Headed Giant game, anything that cares about your life total checks the life total of your team. For example, say that your team has 10 life and your opponent's team has 11 life when you cast Survival Cache. You'll gain 2 life, so your team's life total becomes 12. Since your life total (12) is greater than an opponent's life total (11), you'll draw a card."
         }
       ],
       "text": "You gain 2 life. Then if you have more life than an opponent, draw a card.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -2345,11 +2345,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are fewer than X cards in that player’s library, put that permanent on the bottom of that library."
+          "text": "If there are fewer than X cards in that player's library, put that permanent on the bottom of that library."
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose 0 as the value for X, put that permanent on top of its owner’s library."
+          "text": "If you choose 0 as the value for X, put that permanent on top of its owner's library."
         }
       ],
       "text": "Put target nonland permanent into its owner's library just beneath the top X cards of that library.",
@@ -2436,7 +2436,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "This ability triggers and resolves before “until end of turn” effects have worn off."
+          "text": "This ability triggers and resolves before \"until end of turn\" effects have worn off."
         }
       ],
       "subtypes": [
@@ -2618,7 +2618,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "The controller of the countered spell doesn’t choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
+          "text": "The controller of the countered spell doesn't choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
         }
       ],
       "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
@@ -2704,11 +2704,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Arcane Melee can’t reduce the colored mana requirement of an instant or sorcery spell."
+          "text": "Arcane Melee can't reduce the colored mana requirement of an instant or sorcery spell."
         },
         {
           "date": "2012-05-01",
-          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as Thalia, Guardian of Thraben’s ability), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as Thalia, Guardian of Thraben's ability), apply those increases before applying cost reductions."
         },
         {
           "date": "2012-05-01",
@@ -2799,11 +2799,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You don’t reveal the other two cards, nor do you reveal their order on the bottom of the library."
+          "text": "You don't reveal the other two cards, nor do you reveal their order on the bottom of the library."
         },
         {
           "date": "2012-07-01",
-          "text": "If there are fewer than three cards in your library when Augur of Bolas’s ability resolves, you’ll look at the remaining cards. This won’t cause you to lose the game as you haven’t drawn from an empty library."
+          "text": "If there are fewer than three cards in your library when Augur of Bolas's ability resolves, you'll look at the remaining cards. This won't cause you to lose the game as you haven't drawn from an empty library."
         }
       ],
       "subtypes": [
@@ -2986,11 +2986,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         },
         {
           "date": "2011-06-01",
-          "text": "You follow the instructions in order. You won’t be able to draw the same Blue Sun’s Zenith that you cast."
+          "text": "You follow the instructions in order. You won't be able to draw the same Blue Sun's Zenith that you cast."
         }
       ],
       "text": "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.",
@@ -3227,7 +3227,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -3308,7 +3308,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse’s color (or any other characteristic the Curse has), the Curse will be put into its owner’s graveyard."
+          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse's color (or any other characteristic the Curse has), the Curse will be put into its owner's graveyard."
         },
         {
           "date": "2013-10-17",
@@ -3320,7 +3320,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "The ability won’t trigger when a creature attacks a planeswalker controlled by the enchanted player."
+          "text": "The ability won't trigger when a creature attacks a planeswalker controlled by the enchanted player."
         },
         {
           "date": "2013-10-17",
@@ -3328,7 +3328,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "Curse of Inertia’s ability will trigger only once per attacking player per combat phase, no matter how many creatures that player attacks with."
+          "text": "Curse of Inertia's ability will trigger only once per attacking player per combat phase, no matter how many creatures that player attacks with."
         },
         {
           "date": "2013-10-17",
@@ -3744,7 +3744,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "You don’t have to control either target."
+          "text": "You don't have to control either target."
         },
         {
           "date": "2013-10-17",
@@ -3752,7 +3752,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "If one of the creatures is an illegal target when the ability resolves, the exchange won’t happen. If both creatures are illegal targets, the ability will be countered."
+          "text": "If one of the creatures is an illegal target when the ability resolves, the exchange won't happen. If both creatures are illegal targets, the ability will be countered."
         }
       ],
       "subtypes": [
@@ -3847,11 +3847,11 @@
         },
         {
           "date": "2011-01-22",
-          "text": "If you gain control of the creature that’s being prevented from untapping, that creature won’t untap during your untap step for as long as you control Dungeon Geists."
+          "text": "If you gain control of the creature that's being prevented from untapping, that creature won't untap during your untap step for as long as you control Dungeon Geists."
         },
         {
           "date": "2013-04-15",
-          "text": "The ability can target a tapped creature. If the targeted creature is already tapped when it resolves, that creature just remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "The ability can target a tapped creature. If the targeted creature is already tapped when it resolves, that creature just remains tapped and doesn't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -3941,43 +3941,43 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         },
         {
           "date": "2010-06-15",
-          "text": "Echo Mage’s last two activated abilities can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Echo Mage's last two activated abilities can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2010-06-15",
-          "text": "When either ability resolves, it creates a copy (or two) of a spell. The copies are created on the stack, so they’re not “cast.” Abilities that trigger when a player casts a spell won’t trigger. Each copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. Each copy resolves before the original spell does."
+          "text": "When either ability resolves, it creates a copy (or two) of a spell. The copies are created on the stack, so they're not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. Each copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. Each copy resolves before the original spell does."
         },
         {
           "date": "2010-06-15",
-          "text": "Each copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "Each copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you activate Echo Mage’s last ability to copy a spell twice, you may choose new targets for each copy independently. They don’t have to have the same targets as one another. Be sure to specify which of the copies will resolve first."
+          "text": "If you activate Echo Mage's last ability to copy a spell twice, you may choose new targets for each copy independently. They don't have to have the same targets as one another. Be sure to specify which of the copies will resolve first."
         },
         {
           "date": "2010-06-15",
-          "text": "If the spell the ability copies is modal (that is, it says “Choose one —” or the like), each copy will have the same mode as the original spell. You can’t choose a different one."
+          "text": "If the spell the ability copies is modal (that is, it says \"Choose one —\" or the like), each copy will have the same mode as the original spell. You can't choose a different one."
         },
         {
           "date": "2010-06-15",
@@ -3985,11 +3985,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "You can’t choose to pay any additional costs for a copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for each copy too."
+          "text": "You can't choose to pay any additional costs for a copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for each copy too."
         },
         {
           "date": "2010-06-15",
-          "text": "If a copy says that it affects “you,” it affects the controller of that copy, not the controller of the original spell. Similarly, if a copy says that it affects an “opponent,” it affects an opponent of that copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If a copy says that it affects \"you,\" it affects the controller of that copy, not the controller of the original spell. Similarly, if a copy says that it affects an \"opponent,\" it affects an opponent of that copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "subtypes": [
@@ -4084,7 +4084,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If Fog Bank blocks a creature with trample, that creature’s controller must assign 2 damage to Fog Bank (assuming it’s blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
+          "text": "If Fog Bank blocks a creature with trample, that creature's controller must assign 2 damage to Fog Bank (assuming it's blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
         }
       ],
       "subtypes": [
@@ -4263,23 +4263,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -4357,6 +4357,20 @@
         "C13"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-10-17",
+          "text": "Creatures that didn't attack during the combat phase when Illusionist's Gambit resolved aren't required to attack in the additional combat phase, although they may. Those creatures can attack you or a planeswalker you control."
+        },
+        {
+          "date": "2013-10-17",
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack."
+        },
+        {
+          "date": "2013-10-17",
+          "text": "If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack."
+        }
+      ],
       "text": "Cast Illusionist's Gambit only during the declare blockers step on an opponent's turn.\nRemove all attacking creatures from combat and untap them. After this phase, there is an additional combat phase. Each of those creatures attacks that combat if able. They can't attack you or a planeswalker you control that combat.",
       "type": "Instant",
       "types": [
@@ -4523,11 +4537,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "Lu Xun’s second ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Lu Xun's second ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -4787,11 +4801,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Order of Succession doesn’t target any players or creatures. You can choose and gain control of a creature with protection from blue, for example."
+          "text": "Order of Succession doesn't target any players or creatures. You can choose and gain control of a creature with protection from blue, for example."
         },
         {
           "date": "2013-10-17",
-          "text": "It doesn’t matter whether the next player is a teammate or an opponent."
+          "text": "It doesn't matter whether the next player is a teammate or an opponent."
         },
         {
           "date": "2013-10-17",
@@ -4799,7 +4813,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "If the next player in the chosen direction controls no creatures, you won’t gain control of anything."
+          "text": "If the next player in the chosen direction controls no creatures, you won't gain control of anything."
         }
       ],
       "text": "Choose left or right. Starting with you and proceeding in the chosen direction, each player chooses a creature controlled by the next player in that direction. Each player gains control of the creature he or she chose.",
@@ -4903,7 +4917,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -5164,7 +5178,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If combat damage is dealt to players by multiple artifact creatures you control (including, perhaps, Sharding Sphinx itself), Sharding Sphinx’s ability will trigger that many times. You’ll get that many Thopter tokens. You’ll get just one token per creature, no matter how much combat damage that creature dealt."
+          "text": "If combat damage is dealt to players by multiple artifact creatures you control (including, perhaps, Sharding Sphinx itself), Sharding Sphinx's ability will trigger that many times. You'll get that many Thopter tokens. You'll get just one token per creature, no matter how much combat damage that creature dealt."
         }
       ],
       "subtypes": [
@@ -5384,11 +5398,19 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
           "legality": "Legal"
         },
         {
@@ -5509,7 +5531,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "The tokens copy exactly what was printed on the original creature and nothing else (unless that creature is copying something else or is a token; see below). They don’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "The tokens copy exactly what was printed on the original creature and nothing else (unless that creature is copying something else or is a token; see below). They don't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2013-10-17",
@@ -5525,7 +5547,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the copied creature will also work."
         }
       ],
       "text": "Tempting offer — Choose target creature you control. Create a token that's a copy of that creature. Each opponent may create a token that's a copy of that creature. For each opponent who does, create a token that's a copy of that creature.",
@@ -5760,7 +5782,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Protection from a player is a new variant of the protection ability. It means the following: — True-Name Nemesis can’t be the target of spells or abilities controlled by the chosen player. — True-Name Nemesis can’t be enchanted by Auras or equipped by Equipment controlled by the chosen player. (The same is true for Fortifications controlled by the chosen player, if True-Name Nemesis becomes a land.) — True-Name Nemesis can’t be blocked by creatures controlled by the chosen player. — All damage that would be dealt to True-Name Nemesis by sources controlled by the chosen player is prevented. (The same is true for sources owned by the chosen player that don’t have controllers.)"
+          "text": "Protection from a player is a new variant of the protection ability. It means the following: — True-Name Nemesis can't be the target of spells or abilities controlled by the chosen player. — True-Name Nemesis can't be enchanted by Auras or equipped by Equipment controlled by the chosen player. (The same is true for Fortifications controlled by the chosen player, if True-Name Nemesis becomes a land.) — True-Name Nemesis can't be blocked by creatures controlled by the chosen player. — All damage that would be dealt to True-Name Nemesis by sources controlled by the chosen player is prevented. (The same is true for sources owned by the chosen player that don't have controllers.)"
         }
       ],
       "subtypes": [
@@ -5851,7 +5873,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If you copy an Arcane spell that has cards spliced onto it, you’ll copy the spliced text as well as the original spell text."
+          "text": "If you copy an Arcane spell that has cards spliced onto it, you'll copy the spliced text as well as the original spell text."
         }
       ],
       "subtypes": [
@@ -6188,7 +6210,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature is an illegal target when Annihilate tries to resolve, the entire spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target when Annihilate tries to resolve, the entire spell is countered. You won't draw a card."
         }
       ],
       "text": "Destroy target nonblack creature. It can't be regenerated.\nDraw a card.",
@@ -6422,7 +6444,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse’s color (or any other characteristic the Curse has), the Curse will be put into its owner’s graveyard."
+          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse's color (or any other characteristic the Curse has), the Curse will be put into its owner's graveyard."
         },
         {
           "date": "2013-10-17",
@@ -6434,7 +6456,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "The ability won’t trigger when a creature attacks a planeswalker controlled by the enchanted player."
+          "text": "The ability won't trigger when a creature attacks a planeswalker controlled by the enchanted player."
         },
         {
           "date": "2013-10-17",
@@ -6532,7 +6554,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way.\nCycling {3}{B}{B} ({3}{B}{B}, Discard this card: Draw a card.)\nWhen you cycle Decree of Pain, all creatures get -2/-2 until end of turn.",
@@ -6621,11 +6643,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "All creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)\nWhen you cycle Dirge of Dread, you may have target creature gain fear until end of turn.",
@@ -6881,11 +6903,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The second ability is a state trigger. Once it triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "The second ability is a state trigger. Once it triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         },
         {
           "date": "2006-09-25",
-          "text": "When the second ability resolves, Endrek Sahr will be sacrificed regardless of how many Thrulls you control at that time, even if it’s less than seven."
+          "text": "When the second ability resolves, Endrek Sahr will be sacrificed regardless of how many Thrulls you control at that time, even if it's less than seven."
         },
         {
           "date": "2006-09-25",
@@ -7048,7 +7070,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Creature cards that were put into your graveyard from any zone other than the battlefield, such as a card that was discarded, won’t return to your hand."
+          "text": "Creature cards that were put into your graveyard from any zone other than the battlefield, such as a card that was discarded, won't return to your hand."
         },
         {
           "date": "2013-10-17",
@@ -7213,11 +7235,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "The number of creatures each player controls is evaluated only as blocking creatures are declared. If, at that time, the defending player doesn’t control the most creatures or isn’t tied for the most, Hooded Horror can be blocked."
+          "text": "The number of creatures each player controls is evaluated only as blocking creatures are declared. If, at that time, the defending player doesn't control the most creatures or isn't tied for the most, Hooded Horror can be blocked."
         },
         {
           "date": "2013-10-17",
-          "text": "Once Hooded Horror is blocked, it doesn’t matter if the defending player controls the most creatures. The block won’t be undone."
+          "text": "Once Hooded Horror is blocked, it doesn't matter if the defending player controls the most creatures. The block won't be undone."
         }
       ],
       "subtypes": [
@@ -7485,7 +7507,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -7505,7 +7527,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -7587,7 +7609,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Ophiomancer’s ability checks if you control a Snake at the beginning of each upkeep. If you do, the ability won’t trigger."
+          "text": "Ophiomancer's ability checks if you control a Snake at the beginning of each upkeep. If you do, the ability won't trigger."
         },
         {
           "date": "2013-10-17",
@@ -7595,7 +7617,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "Ophiomancer’s ability considers any creature you control with the creature type Snake, not just the tokens Ophiomancer creates."
+          "text": "Ophiomancer's ability considers any creature you control with the creature type Snake, not just the tokens Ophiomancer creates."
         }
       ],
       "subtypes": [
@@ -7686,39 +7708,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -7726,7 +7748,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If the creature’s power is less than 0, use its actual value to determine the total life loss. However, if this total is 0 or less, no life is lost. For example, if Phthisis destroys a -2/3 creature, its controller would lose 1 life. If it destroys a -4/3 creature, its controller would lose no life."
+          "text": "If the creature's power is less than 0, use its actual value to determine the total life loss. However, if this total is 0 or less, no life is lost. For example, if Phthisis destroys a -2/3 creature, its controller would lose 1 life. If it destroys a -4/3 creature, its controller would lose no life."
         }
       ],
       "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5—{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
@@ -7979,7 +8001,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "{1}{B}, Pay 2 life: Return target creature card from your graveyard to your hand.",
@@ -8055,7 +8077,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Count the number of cards in that opponent’s hand when the ability resolves to determine how much damage is dealt."
+          "text": "Count the number of cards in that opponent's hand when the ability resolves to determine how much damage is dealt."
         }
       ],
       "text": "Players have no maximum hand size.\nAt the beginning of each opponent's upkeep, Price of Knowledge deals damage to that player equal to the number of cards in that player's hand.",
@@ -8304,7 +8326,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Sanguine Bond’s ability triggers just once for each life-gaining event, whether it’s 1 life from Soul Warden or 8 life from Tendrils of Corruption."
+          "text": "Sanguine Bond's ability triggers just once for each life-gaining event, whether it's 1 life from Soul Warden or 8 life from Tendrils of Corruption."
         }
       ],
       "text": "Whenever you gain life, target opponent loses that much life.",
@@ -8474,11 +8496,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Sudden Spoiling doesn’t counter abilities that have already triggered or been activated. In particular, you can’t cast this fast enough to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering."
+          "text": "Sudden Spoiling doesn't counter abilities that have already triggered or been activated. In particular, you can't cast this fast enough to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering."
         },
         {
           "date": "2006-09-25",
-          "text": "Sudden Spoiling affects only permanents that are creatures on the battlefield under the targeted player’s control at the time Sudden Spoiling resolves. It won’t affect creatures that enter the battlefield later or noncreature permanents that later become creatures."
+          "text": "Sudden Spoiling affects only permanents that are creatures on the battlefield under the targeted player's control at the time Sudden Spoiling resolves. It won't affect creatures that enter the battlefield later or noncreature permanents that later become creatures."
         },
         {
           "date": "2006-09-25",
@@ -8486,7 +8508,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a face-down creature is affected by Sudden Spoiling, it won’t be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/2 creature with no abilities until the turn ends. Its “When this creature turns face up” or “As this creature turns face up” abilities won’t work."
+          "text": "If a face-down creature is affected by Sudden Spoiling, it won't be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/2 creature with no abilities until the turn ends. Its \"When this creature turns face up\" or \"As this creature turns face up\" abilities won't work."
         },
         {
           "date": "2013-06-07",
@@ -8494,23 +8516,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntil end of turn, creatures target player controls lose all abilities and have base power and toughness 0/2.",
@@ -8676,7 +8698,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you cast Toxic Deluge without paying its mana cost, you’ll still choose a value for X and pay X life. This is because it doesn’t have {X} in its mana cost."
+          "text": "If you cast Toxic Deluge without paying its mana cost, you'll still choose a value for X and pay X life. This is because it doesn't have {X} in its mana cost."
         },
         {
           "date": "2016-06-08",
@@ -8940,7 +8962,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -9034,7 +9056,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Wight of Precinct Six’s ability applies only if Wight of Precinct Six is on the battlefield."
+          "text": "Wight of Precinct Six's ability applies only if Wight of Precinct Six is on the battlefield."
         }
       ],
       "subtypes": [
@@ -9201,19 +9223,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If Capricious Efreet is the only nonland permanent you control when its ability triggers, you’ll have to target it."
+          "text": "If Capricious Efreet is the only nonland permanent you control when its ability triggers, you'll have to target it."
         },
         {
           "date": "2009-10-01",
-          "text": "You may target zero, one, or two nonland permanents you don’t control."
+          "text": "You may target zero, one, or two nonland permanents you don't control."
         },
         {
           "date": "2009-10-01",
-          "text": "You target between one and three permanents as you put the ability on the stack. You don’t randomly choose which one will be destroyed until the ability resolves. If one of those permanents has become an illegal target by then, you randomly choose between the remaining ones."
+          "text": "You target between one and three permanents as you put the ability on the stack. You don't randomly choose which one will be destroyed until the ability resolves. If one of those permanents has become an illegal target by then, you randomly choose between the remaining ones."
         },
         {
           "date": "2009-10-01",
-          "text": "As the ability resolves, there is no time to react between the time a permanent is chosen at random and the time it’s destroyed. If you want to put a regeneration shield on one of those permanents, or sacrifice it for some effect, or anything else, you must do so before the ability resolves (and before you know which one of the permanents will be chosen at random)."
+          "text": "As the ability resolves, there is no time to react between the time a permanent is chosen at random and the time it's destroyed. If you want to put a regeneration shield on one of those permanents, or sacrifice it for some effect, or anything else, you must do so before the ability resolves (and before you know which one of the permanents will be chosen at random)."
         },
         {
           "date": "2013-07-01",
@@ -9309,11 +9331,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The instant or sorcery card returned to your hand is chosen at random as the triggered ability resolves. If any player responds to the ability, that player won’t yet know what card will be returned."
+          "text": "The instant or sorcery card returned to your hand is chosen at random as the triggered ability resolves. If any player responds to the ability, that player won't yet know what card will be returned."
         },
         {
           "date": "2011-09-22",
-          "text": "Because the first ability doesn’t target the instant or sorcery card, any instants or sorceries put into your graveyard in response to that ability may be returned to your hand."
+          "text": "Because the first ability doesn't target the instant or sorcery card, any instants or sorceries put into your graveyard in response to that ability may be returned to your hand."
         }
       ],
       "subtypes": [
@@ -9478,7 +9500,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse’s color (or any other characteristic the Curse has), the Curse will be put into its owner’s graveyard."
+          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse's color (or any other characteristic the Curse has), the Curse will be put into its owner's graveyard."
         },
         {
           "date": "2013-10-17",
@@ -9490,7 +9512,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "The ability won’t trigger when a creature attacks a planeswalker controlled by the enchanted player."
+          "text": "The ability won't trigger when a creature attacks a planeswalker controlled by the enchanted player."
         },
         {
           "date": "2013-10-17",
@@ -9498,7 +9520,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "Curse of Chaos’s ability will trigger only once per attacking player per combat phase, no matter how many creatures that player attacks with."
+          "text": "Curse of Chaos's ability will trigger only once per attacking player per combat phase, no matter how many creatures that player attacks with."
         }
       ],
       "subtypes": [
@@ -9610,7 +9632,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -9622,7 +9644,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -9712,7 +9734,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may choose just the first mode (targeting an artifact), just the second mode (targeting a nonbasic land), or both modes (targeting an artifact and a nonbasic land). You can’t choose a mode unless there’s a legal target for it."
+          "text": "You may choose just the first mode (targeting an artifact), just the second mode (targeting a nonbasic land), or both modes (targeting an artifact and a nonbasic land). You can't choose a mode unless there's a legal target for it."
         }
       ],
       "text": "Choose one or both —\n• Destroy target artifact.\n• Destroy target nonbasic land.",
@@ -9868,15 +9890,15 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Furnace Celebration itself doesn’t allow you to sacrifice any permanents. Its ability triggers whenever you sacrifice a permanent because some other spell, ability, or cost instructed you to."
+          "text": "Furnace Celebration itself doesn't allow you to sacrifice any permanents. Its ability triggers whenever you sacrifice a permanent because some other spell, ability, or cost instructed you to."
         },
         {
           "date": "2011-01-01",
-          "text": "You choose the target when the ability triggers. You choose whether or not to pay {2} as the ability resolves. You can’t pay {2} more than once for a single sacrificed permanent."
+          "text": "You choose the target when the ability triggers. You choose whether or not to pay {2} as the ability resolves. You can't pay {2} more than once for a single sacrificed permanent."
         },
         {
           "date": "2011-01-01",
-          "text": "Although players may respond to the ability, once it starts to resolve and you decide to pay {2}, it’s too late for players to respond."
+          "text": "Although players may respond to the ability, once it starts to resolve and you decide to pay {2}, it's too late for players to respond."
         },
         {
           "date": "2011-01-01",
@@ -10128,7 +10150,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Guttersnipe’s ability resolves and Guttersnipe deals damage before the instant or sorcery spell resolves."
+          "text": "Guttersnipe's ability resolves and Guttersnipe deals damage before the instant or sorcery spell resolves."
         }
       ],
       "subtypes": [
@@ -10298,7 +10320,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You divide the damage as you put Inferno Titan’s triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
+          "text": "You divide the damage as you put Inferno Titan's triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
         }
       ],
       "subtypes": [
@@ -10393,15 +10415,15 @@
         },
         {
           "date": "2007-02-01",
-          "text": "Magus of the Arena’s controller always chooses his or her creature first."
+          "text": "Magus of the Arena's controller always chooses his or her creature first."
         },
         {
           "date": "2007-02-01",
-          "text": "Tapped creatures can be targeted. Tapping them again will do nothing, but they’ll still deal damage."
+          "text": "Tapped creatures can be targeted. Tapping them again will do nothing, but they'll still deal damage."
         },
         {
           "date": "2007-02-01",
-          "text": "If an effect changes the targets of this ability, the second target can be changed to any creature the chosen opponent controls. The choice of opponent can’t be changed."
+          "text": "If an effect changes the targets of this ability, the second target can be changed to any creature the chosen opponent controls. The choice of opponent can't be changed."
         }
       ],
       "subtypes": [
@@ -10485,11 +10507,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "The phrase “up to one” was inadvertently omitted from Mass Mutiny’s rules text. The card has received errata to correct this."
+          "text": "The phrase \"up to one\" was inadvertently omitted from Mass Mutiny's rules text. The card has received errata to correct this."
         },
         {
           "date": "2012-06-01",
-          "text": "You can cast Mass Mutiny even if an opponent doesn’t control any creatures. You simply won’t choose a target for that opponent."
+          "text": "You can cast Mass Mutiny even if an opponent doesn't control any creatures. You simply won't choose a target for that opponent."
         },
         {
           "date": "2012-06-01",
@@ -10497,7 +10519,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it. However, if you gain control of a creature enchanted by an Aura with totem armor and that creature would be destroyed that turn, instead the Aura will be destroyed and the creature will survive."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it. However, if you gain control of a creature enchanted by an Aura with totem armor and that creature would be destroyed that turn, instead the Aura will be destroyed and the creature will survive."
         }
       ],
       "text": "For each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn.",
@@ -10583,7 +10605,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Molten Disaster was kicked, Molten Disaster has split second as long as it’s on the stack."
+          "text": "If Molten Disaster was kicked, Molten Disaster has split second as long as it's on the stack."
         },
         {
           "date": "2013-06-07",
@@ -10591,23 +10613,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nIf Molten Disaster was kicked, it has split second. (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nMolten Disaster deals X damage to each creature without flying and each player.",
@@ -10863,7 +10885,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Slice and Dice deals 4 damage to each creature.\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle Slice and Dice, you may have it deal 1 damage to each creature.",
@@ -10953,7 +10975,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -10961,19 +10983,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -11233,23 +11255,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -11257,7 +11279,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Street Spasm deals X damage to target creature without flying you don't control.\nOverload {X}{X}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -11335,7 +11357,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "You choose the value for X as you cast Sudden Demise. You don’t choose the color until it resolves."
+          "text": "You choose the value for X as you cast Sudden Demise. You don't choose the color until it resolves."
         },
         {
           "date": "2013-10-17",
@@ -11661,7 +11683,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can choose X=0. This doesn’t have an effect most of the time, but it does mean that creatures can’t block unless the controller chooses to pay the cost (a cost of zero is not automatically paid). You can use this to make your creatures unable to block an attacker."
+          "text": "You can choose X=0. This doesn't have an effect most of the time, but it does mean that creatures can't block unless the controller chooses to pay the cost (a cost of zero is not automatically paid). You can use this to make your creatures unable to block an attacker."
         },
         {
           "date": "2004-10-04",
@@ -11750,11 +11772,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it’s no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
+          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it's no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2011-09-22",
-          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn’t target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
+          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn't target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to target creature or player.",
@@ -11840,7 +11862,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability checks that creature’s power only once: when that creature enters the battlefield. The trigger checks a creature’s initial power upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it’s on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, boosting its power with a spell (such as Giant Growth), activated ability, or triggered ability won’t allow this ability to trigger; it’s too late by then. Once the ability triggers, it will resolve no matter what the creature’s power may become while the ability is on the stack."
+          "text": "The ability checks that creature's power only once: when that creature enters the battlefield. The trigger checks a creature's initial power upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it's on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, boosting its power with a spell (such as Giant Growth), activated ability, or triggered ability won't allow this ability to trigger; it's too late by then. Once the ability triggers, it will resolve no matter what the creature's power may become while the ability is on the stack."
         }
       ],
       "text": "Whenever a creature with power 5 or greater enters the battlefield under your control, you may have Where Ancients Tread deal 5 damage to target creature or player.",
@@ -11917,7 +11939,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Widespread Panic’s ability is put onto the stack after the library is shuffled."
+          "text": "Widespread Panic's ability is put onto the stack after the library is shuffled."
         }
       ],
       "text": "Whenever a spell or ability causes its controller to shuffle his or her library, that player puts a card from his or her hand on top of his or her library.",
@@ -12005,19 +12027,19 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Wild Ricochet can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Wild Ricochet can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2013-07-01",
-          "text": "When Wild Ricochet resolves, it creates a copy of a spell. You control the copy. The controller of the original spell retains control of that spell. The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. The copy resolves before the original spell."
+          "text": "When Wild Ricochet resolves, it creates a copy of a spell. You control the copy. The controller of the original spell retains control of that spell. The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. The copy resolves before the original spell."
         },
         {
           "date": "2013-07-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2013-07-01",
-          "text": "If the spell Wild Ricochet copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Wild Ricochet copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2013-07-01",
@@ -12025,11 +12047,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Wild Ricochet, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Wild Ricochet, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2013-07-01",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
@@ -12110,11 +12132,11 @@
         },
         {
           "date": "2013-10-17",
-          "text": "Abilities that trigger whenever a player gains life can’t trigger and effects that would replace gaining life with another effect won’t apply because it’s impossible for players to gain life."
+          "text": "Abilities that trigger whenever a player gains life can't trigger and effects that would replace gaining life with another effect won't apply because it's impossible for players to gain life."
         },
         {
           "date": "2013-10-17",
-          "text": "If an effect sets a player’s life total to a specific number and that number is higher than the player’s current life total, that part of the effect won’t do anything. (If the number is lower than the player’s current life total, the effect will work as normal.)"
+          "text": "If an effect sets a player's life total to a specific number and that number is higher than the player's current life total, that part of the effect won't do anything. (If the number is lower than the player's current life total, the effect will work as normal.)"
         },
         {
           "date": "2013-10-17",
@@ -12301,7 +12323,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -12397,7 +12419,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -12485,11 +12507,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Bane of Progress’s ability destroys all artifacts and enchantments, including those you control."
+          "text": "Bane of Progress's ability destroys all artifacts and enchantments, including those you control."
         },
         {
           "date": "2013-10-17",
-          "text": "If an artifact or enchantment isn’t destroyed (perhaps because it has indestructible or it regenerated), it won’t count toward the number of +1/+1 counters put on Bane of Progress. However, if an artifact or enchantment is destroyed but doesn’t go to its owner’s graveyard due to a replacement effect (like the one Rest in Peace creates), it will count."
+          "text": "If an artifact or enchantment isn't destroyed (perhaps because it has indestructible or it regenerated), it won't count toward the number of +1/+1 counters put on Bane of Progress. However, if an artifact or enchantment is destroyed but doesn't go to its owner's graveyard due to a replacement effect (like the one Rest in Peace creates), it will count."
         }
       ],
       "subtypes": [
@@ -12580,7 +12602,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If a permanent is enchanted with an Aura such as Confiscate when Brooding Saurian’s ability resolves, the enchanted permanent’s owner will regain control of it. The Aura will not be removed. The Aura will still be controlled by its owner, but its effect will be overridden."
+          "text": "If a permanent is enchanted with an Aura such as Confiscate when Brooding Saurian's ability resolves, the enchanted permanent's owner will regain control of it. The Aura will not be removed. The Aura will still be controlled by its owner, but its effect will be overridden."
         }
       ],
       "subtypes": [
@@ -12750,7 +12772,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse’s color (or any other characteristic the Curse has), the Curse will be put into its owner’s graveyard."
+          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse's color (or any other characteristic the Curse has), the Curse will be put into its owner's graveyard."
         },
         {
           "date": "2013-10-17",
@@ -12762,7 +12784,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "The ability won’t trigger when a creature attacks a planeswalker controlled by the enchanted player."
+          "text": "The ability won't trigger when a creature attacks a planeswalker controlled by the enchanted player."
         },
         {
           "date": "2013-10-17",
@@ -12942,7 +12964,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The first ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control a creature with power 5 or greater as your end step begins, and (2) the ability will do nothing if you don’t control a creature with power 5 or greater by the time it resolves. (It doesn’t have to be the same creature as the one that allowed the ability to trigger.) Power-boosting effects that last “until end of turn” will still be in effect when this kind of ability triggers and resolves. An ability like this will trigger a maximum of once per turn, no matter how many applicable creatures you control."
+          "text": "The first ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control a creature with power 5 or greater as your end step begins, and (2) the ability will do nothing if you don't control a creature with power 5 or greater by the time it resolves. (It doesn't have to be the same creature as the one that allowed the ability to trigger.) Power-boosting effects that last \"until end of turn\" will still be in effect when this kind of ability triggers and resolves. An ability like this will trigger a maximum of once per turn, no matter how many applicable creatures you control."
         }
       ],
       "subtypes": [
@@ -13371,7 +13393,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -13816,23 +13838,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -13931,23 +13953,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
@@ -14044,7 +14066,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -14295,7 +14317,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Naya Soulbeast’s last ability triggers while Naya Soulbeast is on the stack. After that ability resolves, players will be able to cast spells and activate abilities knowing how many counters Naya Soulbeast will enter the battlefield with if it resolves."
+          "text": "Naya Soulbeast's last ability triggers while Naya Soulbeast is on the stack. After that ability resolves, players will be able to cast spells and activate abilities knowing how many counters Naya Soulbeast will enter the battlefield with if it resolves."
         }
       ],
       "subtypes": [
@@ -14378,11 +14400,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-10-01",
-          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can’t be paid."
+          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can't be paid."
         }
       ],
       "text": "{1}, Exile two creature cards from a single graveyard: Create a 1/1 green Saproling creature token.",
@@ -14648,7 +14670,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The creature’s controller, not Presence of Gond’s controller, is the one who can activate the ability, so that’s the player who will get the token."
+          "text": "The creature's controller, not Presence of Gond's controller, is the one who can activate the ability, so that's the player who will get the token."
         }
       ],
       "subtypes": [
@@ -14727,11 +14749,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "It doesn’t matter who controls the tokens or the creature that the +1/+1 counters are being placed on."
+          "text": "It doesn't matter who controls the tokens or the creature that the +1/+1 counters are being placed on."
         },
         {
           "date": "2013-10-17",
-          "text": "Primal Vigor affects permanents that “enter the battlefield with” a certain number of counters. For example, if a creature would normally enter the battlefield with three +1/+1 counters on it, it will enter with six +1/+1 counters on it."
+          "text": "Primal Vigor affects permanents that \"enter the battlefield with\" a certain number of counters. For example, if a creature would normally enter the battlefield with three +1/+1 counters on it, it will enter with six +1/+1 counters on it."
         },
         {
           "date": "2013-10-17",
@@ -14912,7 +14934,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -15083,19 +15105,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "All Reincarnation does when it resolves is set up a delayed triggered ability. If the targeted creature isn’t put into a graveyard this turn, that ability never triggers. If the targeted creature is put into a graveyard this turn, that ability triggers and resolves like any other triggered ability."
+          "text": "All Reincarnation does when it resolves is set up a delayed triggered ability. If the targeted creature isn't put into a graveyard this turn, that ability never triggers. If the targeted creature is put into a graveyard this turn, that ability triggers and resolves like any other triggered ability."
         },
         {
           "date": "2009-10-01",
-          "text": "The creature card that will be returned to the battlefield isn’t chosen until the delayed triggered ability resolves. The player who chooses is the player who controlled Reincarnation. The player under whose control the chosen creature card enters the battlefield is the player who owned the targeted creature (in other words, the player into whose graveyard it went), not necessarily the controller of that creature."
+          "text": "The creature card that will be returned to the battlefield isn't chosen until the delayed triggered ability resolves. The player who chooses is the player who controlled Reincarnation. The player under whose control the chosen creature card enters the battlefield is the player who owned the targeted creature (in other words, the player into whose graveyard it went), not necessarily the controller of that creature."
         },
         {
           "date": "2009-10-01",
-          "text": "The creature that’s returned to the battlefield may be the same one that was put into the graveyard (assuming it’s still in the graveyard when the delayed triggered ability resolves). If so, it returns to the battlefield as a brand-new creature."
+          "text": "The creature that's returned to the battlefield may be the same one that was put into the graveyard (assuming it's still in the graveyard when the delayed triggered ability resolves). If so, it returns to the battlefield as a brand-new creature."
         }
       ],
       "text": "Choose target creature. When that creature dies this turn, return a creature card from its owner's graveyard to the battlefield under the control of that creature's owner.",
@@ -15368,7 +15390,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"The hypocrisy of these elves is thicker than steel—destroying ‘unnatural metal' with their own enchanted swords.\"\n—Kara Vrist, Neurok agent",
+      "flavor": "\"The hypocrisy of these elves is thicker than steel—destroying 'unnatural metal' with their own enchanted swords.\"\n—Kara Vrist, Neurok agent",
       "foreignNames": [
         {
           "language": "French",
@@ -15582,7 +15604,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2009-10-01",
@@ -15667,15 +15689,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -15848,7 +15870,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -15856,19 +15878,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -15960,19 +15982,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If you don’t reveal any creature cards, or if you choose not to put a revealed creature card onto the battlefield, all the revealed cards go on the bottom of your library."
+          "text": "If you don't reveal any creature cards, or if you choose not to put a revealed creature card onto the battlefield, all the revealed cards go on the bottom of your library."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature that you put onto the battlefield leaves the battlefield before your next end step, it won’t be returned to your hand at the beginning of your next end step."
+          "text": "If the creature that you put onto the battlefield leaves the battlefield before your next end step, it won't be returned to your hand at the beginning of your next end step."
         },
         {
           "date": "2017-03-14",
-          "text": "If you put a creature onto the battlefield this way during your end step, it won’t be returned to your hand until your next end step."
+          "text": "If you put a creature onto the battlefield this way during your end step, it won't be returned to your hand until your next end step."
         },
         {
           "date": "2017-03-14",
-          "text": "The triggered ability that the creature gains won’t be copied if an effect creates a token that’s a copy of that creature or causes another object to become a copy of that creature."
+          "text": "The triggered ability that the creature gains won't be copied if an effect creates a token that's a copy of that creature or causes another object to become a copy of that creature."
         }
       ],
       "text": "Reveal the top four cards of your library. You may put a creature card from among them onto the battlefield. It gains \"At the beginning of your end step, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
@@ -16146,7 +16168,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Multiple instances of lifelink are redundant. If a creature with multiple instances of lifelink deals damage, its controller still only gains life equal to the damage dealt."
+          "text": "multiple instances of lifelink on the same creature are redundant. If a creature with multiple instances of lifelink deals damage, its controller still only gains life equal to the damage dealt."
         }
       ],
       "subtypes": [
@@ -16242,7 +16264,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Planeswalkers with indestructible will still have loyalty counters removed from them as they are dealt damage. If planeswalker with indestructible has no loyalty counters, it will still be put into its owner’s graveyard, as the rule that does this doesn’t destroy the planeswalker."
+          "text": "Planeswalkers with indestructible will still have loyalty counters removed from them as they are dealt damage. If planeswalker with indestructible has no loyalty counters, it will still be put into its owner's graveyard, as the rule that does this doesn't destroy the planeswalker."
         }
       ],
       "text": "Choose one —\n• Boros Charm deals 4 damage to target player.\n• Permanents you control gain indestructible until end of turn.\n• Target creature gains double strike until end of turn.",
@@ -16511,7 +16533,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Cruel Ultimatum’s only target is an opponent. You don’t choose which creature card in your graveyard you’ll return to your hand until Cruel Ultimatum resolves."
+          "text": "Cruel Ultimatum's only target is an opponent. You don't choose which creature card in your graveyard you'll return to your hand until Cruel Ultimatum resolves."
         },
         {
           "date": "2017-03-14",
@@ -16519,7 +16541,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If, as Cruel Ultimatum begins to resolve, your opponent’s life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent’s life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You’ll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
+          "text": "If, as Cruel Ultimatum begins to resolve, your opponent's life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent's life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You'll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
         }
       ],
       "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
@@ -16872,11 +16894,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "You can activate Derevi’s last ability only when it is in the command zone."
+          "text": "You can activate Derevi's last ability only when it is in the command zone."
         },
         {
           "date": "2013-10-17",
-          "text": "When you activate Derevi’s last ability, you’re not casting Derevi as a spell. The ability can’t be countered by something that counters only spells. The ability isn’t subject to the additional cost of casting commanders from the command zone."
+          "text": "When you activate Derevi's last ability, you're not casting Derevi as a spell. The ability can't be countered by something that counters only spells. The ability isn't subject to the additional cost of casting commanders from the command zone."
         }
       ],
       "subtypes": [
@@ -17068,7 +17090,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The target opponent for the life-gaining effect may also be a target for the damage-dealing effect. If this happens and the damage brings that player’s life total to 0 or less, the life-gaining effect will raise his or her life total above 0 again before the player would lose the game."
+          "text": "The target opponent for the life-gaining effect may also be a target for the damage-dealing effect. If this happens and the damage brings that player's life total to 0 or less, the life-gaining effect will raise his or her life total above 0 again before the player would lose the game."
         }
       ],
       "text": "Fiery Justice deals 5 damage divided as you choose among any number of target creatures and/or players. Target opponent gains 5 life.",
@@ -17158,7 +17180,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Filigree Angel’s enters-the-battlefield ability counts Filigree Angel itself, assuming that it’s still on the battlefield and still an artifact by the time the ability resolves."
+          "text": "Filigree Angel's enters-the-battlefield ability counts Filigree Angel itself, assuming that it's still on the battlefield and still an artifact by the time the ability resolves."
         }
       ],
       "subtypes": [
@@ -17422,11 +17444,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -17588,6 +17610,44 @@
         "C13"
       ],
       "rarity": "Mythic Rare",
+      "rulings": [
+        {
+          "date": "2013-10-17",
+          "text": "If Jeleva leaves the battlefield, the exiled cards will remain exiled indefinitely. If Jeleva enters the battlefield again, it won't be associated with the cards the \"other\" Jeleva exiled. The new Jeleva will exile a new set of cards. Only those cards can be cast using Jeleva's last ability."
+        },
+        {
+          "date": "2013-10-17",
+          "text": "If you cast an instant or sorcery card using Jeleva's last ability, you do so while that ability is resolving. If you choose not to (or you can't), you won't get a chance to cast it later unless the ability triggers again."
+        },
+        {
+          "date": "2013-10-17",
+          "text": "When casting an instant or sorcery card this way, ignore all timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
+        },
+        {
+          "date": "2013-10-17",
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. However, you can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+        },
+        {
+          "date": "2013-10-17",
+          "text": "If the card has {X} in its mana cost, you must choose 0 as its value."
+        },
+        {
+          "date": "2013-10-17",
+          "text": "The card is cast before blocking creatures are declared."
+        },
+        {
+          "date": "2014-02-01",
+          "text": "The amount of mana you spent to cast this creature is usually equal to its converted mana cost. However, you also include any additional costs you pay, including the cost imposed for casting your commander from the command zone."
+        },
+        {
+          "date": "2014-02-01",
+          "text": "You can't choose to pay extra mana to cast a creature spell unless something instructs you to."
+        },
+        {
+          "date": "2014-02-01",
+          "text": "If Jeleva enters the battlefield without being cast, then no mana was spent to cast it. This means X will be 0, so no cards will be exiled."
+        }
+      ],
       "subtypes": [
         "Vampire",
         "Wizard"
@@ -17683,11 +17743,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -17861,7 +17921,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "In other words: — Step 1: Look at the top five cards of your library. — Step 2: If you like them, proceed to step 3a. If you don’t like them, proceed to step 3b. — Step 3a: Shuffle the rest of your library, then put those five cards back on top of your library in the order you want. The spell has finished resolving. — Step 3b: Put those five cards on the bottom of your library in the order you want. Pay 1 life. Return to step 1."
+          "text": "In other words: — Step 1: Look at the top five cards of your library. — Step 2: If you like them, proceed to step 3a. If you don't like them, proceed to step 3b. — Step 3a: Shuffle the rest of your library, then put those five cards back on top of your library in the order you want. The spell has finished resolving. — Step 3b: Put those five cards on the bottom of your library in the order you want. Pay 1 life. Return to step 1."
         },
         {
           "date": "2007-09-16",
@@ -17869,7 +17929,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If you have five or fewer cards in your library, you can pay 1 life as many times as you like, but you’ll keep seeing the same cards."
+          "text": "If you have five or fewer cards in your library, you can pay 1 life as many times as you like, but you'll keep seeing the same cards."
         }
       ],
       "text": "Look at the top five cards of your library. As many times as you choose, you may pay 1 life, put those cards on the bottom of your library in any order, then look at the top five cards of your library. Then shuffle your library and put the last cards you looked at this way on top of it in any order.",
@@ -17950,7 +18010,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Marath, Will of the Wild has received minor errata. The text “X can’t be 0” was inadvertently omitted from the card. The correct Oracle wording appears above."
+          "text": "Marath, Will of the Wild has received minor errata. The text \"X can't be 0\" was inadvertently omitted from the card. The correct Oracle wording appears above."
         },
         {
           "date": "2013-10-17",
@@ -17962,11 +18022,11 @@
         },
         {
           "date": "2014-02-01",
-          "text": "You can’t choose to pay extra mana to cast a creature spell unless something instructs you to."
+          "text": "You can't choose to pay extra mana to cast a creature spell unless something instructs you to."
         },
         {
           "date": "2014-02-01",
-          "text": "If Marath enters the battlefield without being cast, then no mana was spent to cast it. It will therefore enter the battlefield without any +1/+1 counters. If no other effects are increasing its toughness at that time, it will subsequently be put into its owner’s graveyard as a state-based action."
+          "text": "If Marath enters the battlefield without being cast, then no mana was spent to cast it. It will therefore enter the battlefield without any +1/+1 counters. If no other effects are increasing its toughness at that time, it will subsequently be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -18159,11 +18219,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -18341,27 +18401,27 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Nivix Guildmage’s second ability can target (and copy) any instant or sorcery spell you control, not just one with targets."
+          "text": "Nivix Guildmage's second ability can target (and copy) any instant or sorcery spell you control, not just one with targets."
         },
         {
           "date": "2012-10-01",
-          "text": "When the second ability resolves, it creates a copy of a spell. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When the second ability resolves, it creates a copy of a spell. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2012-10-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2012-10-01",
-          "text": "If the copied spell is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the copied spell is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2012-10-01",
-          "text": "If the copied spell has an X whose value was determined as it was cast (like Sphinx’s Revelation does), the copy has the same value of X."
+          "text": "If the copied spell has an X whose value was determined as it was cast (like Sphinx's Revelation does), the copy has the same value of X."
         },
         {
           "date": "2012-10-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you copy a spell that you cast by paying its overload cost, the copy will resolve as though its overload cost had been paid as well."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you copy a spell that you cast by paying its overload cost, the copy will resolve as though its overload cost had been paid as well."
         }
       ],
       "subtypes": [
@@ -18448,7 +18508,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Oloro’s first ability works only if Oloro is on the battlefield."
+          "text": "Oloro's first ability works only if Oloro is on the battlefield."
         },
         {
           "date": "2013-10-17",
@@ -18456,23 +18516,23 @@
         },
         {
           "date": "2013-10-17",
-          "text": "Oloro’s second ability triggers just once for each life-gaining event, no matter how much life is gained."
+          "text": "Oloro's second ability triggers just once for each life-gaining event, no matter how much life is gained."
         },
         {
           "date": "2013-10-17",
-          "text": "You decide whether to pay {1} as the second ability resolves. If you do, you’ll draw a card and each opponent will lose 1 life."
+          "text": "You decide whether to pay {1} as the second ability resolves. If you do, you'll draw a card and each opponent will lose 1 life."
         },
         {
           "date": "2013-10-17",
-          "text": "If two creatures you control with lifelink deal combat damage at the same time, Oloro’s ability will trigger twice. However, if a single creature with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
+          "text": "If two creatures you control with lifelink deal combat damage at the same time, Oloro's ability will trigger twice. However, if a single creature with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
         },
         {
           "date": "2013-10-17",
-          "text": "In some unusual cases, you can gain life even though your life total actually decreases. For example, if you are being attacked by two 3/3 creatures and you block one with a 2/2 creature with lifelink, your life total will decrease by 1 even though you’ve gained 2 life. Oloro’s second ability would trigger."
+          "text": "In some unusual cases, you can gain life even though your life total actually decreases. For example, if you are being attacked by two 3/3 creatures and you block one with a 2/2 creature with lifelink, your life total will decrease by 1 even though you've gained 2 life. Oloro's second ability would trigger."
         },
         {
           "date": "2013-10-17",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -18565,7 +18625,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "You can’t choose to pay extra mana to cast a creature spell unless something instructs you to."
+          "text": "You can't choose to pay extra mana to cast a creature spell unless something instructs you to."
         },
         {
           "date": "2014-02-01",
@@ -18667,7 +18727,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability checks the targeted creature’s power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
+          "text": "The ability checks the targeted creature's power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
         }
       ],
       "subtypes": [
@@ -18754,7 +18814,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "If Roon of the Hidden Realm’s ability targets a commander, that card’s owner may choose to have it go to the command zone rather than being exiled. The delayed triggered ability will return it to the battlefield no matter which of the two zones it went to, as long as it’s still in that zone when that triggered ability resolves."
+          "text": "If Roon of the Hidden Realm's ability targets a commander, that card's owner may choose to have it go to the command zone rather than being exiled. The delayed triggered ability will return it to the battlefield no matter which of the two zones it went to, as long as it's still in that zone when that triggered ability resolves."
         }
       ],
       "subtypes": [
@@ -18852,11 +18912,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won’t gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
+          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won't gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the targeted permanent remains a legal target for the ability, only that it’s on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
+          "text": "Once the ability resolves, it doesn't care whether the targeted permanent remains a legal target for the ability, only that it's on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
         }
       ],
       "subtypes": [
@@ -19576,11 +19636,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "You may choose just the first mode (targeting a creature spell), just the second mode (targeting a creature card in your graveyard), or both modes (targeting a creature spell and a creature card in your graveyard). You can’t choose a mode unless there’s a legal target for it."
+          "text": "You may choose just the first mode (targeting a creature spell), just the second mode (targeting a creature card in your graveyard), or both modes (targeting a creature spell and a creature card in your graveyard). You can't choose a mode unless there's a legal target for it."
         },
         {
           "date": "2009-05-01",
-          "text": "If you choose both modes, you choose their targets at the same time. You can’t counter your own creature spell and then return that card from your graveyard to your hand."
+          "text": "If you choose both modes, you choose their targets at the same time. You can't counter your own creature spell and then return that card from your graveyard to your hand."
         }
       ],
       "text": "Choose one or both —\n• Counter target creature spell.\n• Return target creature card from your graveyard to your hand.",
@@ -19669,15 +19729,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Any spells or abilities that would counter Spellbreaker Behemoth or (once it’s on the battlefield) a creature spell you control with power 5 or greater can still be cast or activated and will still resolve. They just won’t counter that spell. Any other effects they have will happen as normal."
+          "text": "Any spells or abilities that would counter Spellbreaker Behemoth or (once it's on the battlefield) a creature spell you control with power 5 or greater can still be cast or activated and will still resolve. They just won't counter that spell. Any other effects they have will happen as normal."
         },
         {
           "date": "2009-05-01",
-          "text": "Effects that affect a creature’s power (such as the one from Glorious Anthem, for example) apply only to creatures on the battlefield, not to creature spells on the stack."
+          "text": "Effects that affect a creature's power (such as the one from Glorious Anthem, for example) apply only to creatures on the battlefield, not to creature spells on the stack."
         },
         {
           "date": "2009-05-01",
-          "text": "If a creature card has “*” in its power, the ability that defines “*” works in all zones, including the stack."
+          "text": "If a creature card has \"*\" in its power, the ability that defines \"*\" works in all zones, including the stack."
         }
       ],
       "subtypes": [
@@ -19856,7 +19916,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice is mandatory. The last “if you do” only fails if for some reason you could not sacrifice."
+          "text": "The sacrifice is mandatory. The last \"if you do\" only fails if for some reason you could not sacrifice."
         }
       ],
       "text": "Cast Spinal Embrace only during combat.\nUntap target creature you don't control and gain control of it. It gains haste until end of turn. At the beginning of the next end step, sacrifice it. If you do, you gain life equal to its toughness.",
@@ -20029,15 +20089,15 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-10-17",
-          "text": "If the noncreature artifact had any other supertypes, types, or subtypes, it will keep those. In most cases, the artifact creature won’t have any creature types."
+          "text": "If the noncreature artifact had any other supertypes, types, or subtypes, it will keep those. In most cases, the artifact creature won't have any creature types."
         },
         {
           "date": "2013-10-17",
-          "text": "If an Equipment attached to a creature becomes a creature, it becomes unattached. An Equipment that is also a creature can’t equip another creature."
+          "text": "If an Equipment attached to a creature becomes a creature, it becomes unattached. An Equipment that is also a creature can't equip another creature."
         },
         {
           "date": "2013-10-17",
@@ -20140,11 +20200,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Thraximundar’s middle ability resolves during the declare attackers step. The defending player sacrifices a creature before it would get a chance to block."
+          "text": "Thraximundar's middle ability resolves during the declare attackers step. The defending player sacrifices a creature before it would get a chance to block."
         },
         {
           "date": "2009-05-01",
-          "text": "Thraximundar’s last ability triggers whenever any player (including you) sacrifices a creature for any reason. It doesn’t trigger only when a creature is sacrificed due to its middle ability. Note that Thraximundar itself doesn’t allow you to sacrifice any creatures."
+          "text": "Thraximundar's last ability triggers whenever any player (including you) sacrifices a creature for any reason. It doesn't trigger only when a creature is sacrificed due to its middle ability. Note that Thraximundar itself doesn't allow you to sacrifice any creatures."
         }
       ],
       "subtypes": [
@@ -20421,7 +20481,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -20433,7 +20493,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -20529,7 +20589,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Multiple instances of lifelink are redundant. Giving the same creature lifelink more than once won’t cause you to gain additional life."
+          "text": "multiple instances of lifelink on the same creature are redundant. Giving the same creature lifelink more than once won't cause you to gain additional life."
         },
         {
           "date": "2013-01-24",
@@ -21075,15 +21135,15 @@
         },
         {
           "date": "2008-08-01",
-          "text": "All your green and/or blue creatures untap during each other player’s untap step. You have no choice about what untaps. Those creatures untap at the same time as the active player’s permanents."
+          "text": "All your green and/or blue creatures untap during each other player's untap step. You have no choice about what untaps. Those creatures untap at the same time as the active player's permanents."
         },
         {
           "date": "2008-08-01",
-          "text": "During each other player’s untap step, effects that would otherwise cause your green and/or blue creatures to stay tapped don’t apply because they only apply during *your* untap step. For example, if you control Nettle Sentinel (a green creature that says “Nettle Sentinel doesn’t untap during your untap step”), you untap it during each other player’s untap step."
+          "text": "During each other player's untap step, effects that would otherwise cause your green and/or blue creatures to stay tapped don't apply because they only apply during *your* untap step. For example, if you control Nettle Sentinel (a green creature that says \"Nettle Sentinel doesn't untap during your untap step\"), you untap it during each other player's untap step."
         },
         {
           "date": "2008-08-01",
-          "text": "Multiple Murkfiend Lieges are redundant when it comes to the untap effect. You can’t untap your permanents more than once in a single untap step."
+          "text": "Multiple Murkfiend Lieges are redundant when it comes to the untap effect. You can't untap your permanents more than once in a single untap step."
         }
       ],
       "subtypes": [
@@ -21267,7 +21327,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Spiteful Visions’s second ability triggers any time any player draws a card, not just when a player draws a card as a result of its first ability."
+          "text": "Spiteful Visions's second ability triggers any time any player draws a card, not just when a player draws a card as a result of its first ability."
         },
         {
           "date": "2013-04-15",
@@ -21531,7 +21591,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {W} or {U} to your mana pool.\n{W}{U}: Azorius Keyrune becomes a 2/2 white and blue Bird artifact creature with flying until end of turn.",
@@ -21990,7 +22050,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the revealed card is both a creature and a land (such as Dryad Arbor), you’ll put a Saproling creature token and that card onto the battlefield."
+          "text": "If the revealed card is both a creature and a land (such as Dryad Arbor), you'll put a Saproling creature token and that card onto the battlefield."
         },
         {
           "date": "2011-09-22",
@@ -22072,7 +22132,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "If a permanent with a doom counter isn’t destroyed by Eye of Doom’s last ability (perhaps because it has indestructible or it regenerated), the doom counter will remain on that permanent."
+          "text": "If a permanent with a doom counter isn't destroyed by Eye of Doom's last ability (perhaps because it has indestructible or it regenerated), the doom counter will remain on that permanent."
         }
       ],
       "text": "When Eye of Doom enters the battlefield, each player chooses a nonland permanent and puts a doom counter on it.\n{2}, {T}, Sacrifice Eye of Doom: Destroy each permanent with a doom counter on it.",
@@ -22317,11 +22377,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It triggers once per spell, so you can’t get multiple copies of a spell using this card. And since this card is legendary, you can’t control more than one."
+          "text": "It triggers once per spell, so you can't get multiple copies of a spell using this card. And since this card is legendary, you can't control more than one."
         },
         {
           "date": "2004-10-04",
-          "text": "The copy is not “cast” so it will not trigger anything that triggers on a spell being cast."
+          "text": "The copy is not \"cast\" so it will not trigger anything that triggers on a spell being cast."
         },
         {
           "date": "2004-10-04",
@@ -22329,7 +22389,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You are not required to choose new targets. If you do choose, then the targets must be legal. If you don’t change them, the spell is placed on the stack whether or not the targets are legal. The legality of the targets is always checked on resolution of the spell, so the spell may be countered at that time if all of its targets are illegal."
+          "text": "You are not required to choose new targets. If you do choose, then the targets must be legal. If you don't change them, the spell is placed on the stack whether or not the targets are legal. The legality of the targets is always checked on resolution of the spell, so the spell may be countered at that time if all of its targets are illegal."
         }
       ],
       "supertypes": [
@@ -22414,11 +22474,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You choose the value for X as the last ability resolves. You can’t choose a value for X that’s greater than the number of untapped Myr you control."
+          "text": "You choose the value for X as the last ability resolves. You can't choose a value for X that's greater than the number of untapped Myr you control."
         },
         {
           "date": "2011-01-01",
-          "text": "You can tap any untapped Myr you control as the last ability resolves, not just the Myr tokens you put onto the battlefield with the first ability. This includes Myr that haven’t been under your control since your most recent turn began."
+          "text": "You can tap any untapped Myr you control as the last ability resolves, not just the Myr tokens you put onto the battlefield with the first ability. This includes Myr that haven't been under your control since your most recent turn began."
         },
         {
           "date": "2011-01-01",
@@ -22426,7 +22486,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "As the last ability resolves, you can tap untapped Myr you control even if Myr Battlesphere is no longer on the battlefield by then. If that has happened, Myr Battlesphere won’t be able to get the +X/+0 bonus, but it will still deal X damage to the defending player."
+          "text": "As the last ability resolves, you can tap untapped Myr you control even if Myr Battlesphere is no longer on the battlefield by then. If that has happened, Myr Battlesphere won't be able to get the +X/+0 bonus, but it will still deal X damage to the defending player."
         }
       ],
       "subtypes": [
@@ -22517,7 +22577,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -22599,7 +22659,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You may activate Nihil Spellbomb’s first ability targeting any player, even one whose graveyard has no cards in it."
+          "text": "You may activate Nihil Spellbomb's first ability targeting any player, even one whose graveyard has no cards in it."
         }
       ],
       "text": "{T}, Sacrifice Nihil Spellbomb: Exile all cards from target player's graveyard.\nWhen Nihil Spellbomb is put into a graveyard from the battlefield, you may pay {B}. If you do, draw a card.",
@@ -23015,11 +23075,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You choose whether to add or remove a counter when the second ability resolves. You can’t choose to remove a counter if there isn’t one there."
+          "text": "You choose whether to add or remove a counter when the second ability resolves. You can't choose to remove a counter if there isn't one there."
         },
         {
           "date": "2005-10-01",
-          "text": "If the third ability triggers, removing a counter in response won’t stop the effect. However, somehow removing Plague Boiler from the battlefield in response would stop the effect because then you wouldn’t be able to sacrifice Plague Boiler."
+          "text": "If the third ability triggers, removing a counter in response won't stop the effect. However, somehow removing Plague Boiler from the battlefield in response would stop the effect because then you wouldn't be able to sacrifice Plague Boiler."
         },
         {
           "date": "2005-10-01",
@@ -23105,7 +23165,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Pristine Talisman has a mana ability. Its ability doesn’t use the stack and can’t be responded to."
+          "text": "Pristine Talisman has a mana ability. Its ability doesn't use the stack and can't be responded to."
         }
       ],
       "text": "{T}: Add {C} to your mana pool. You gain 1 life.",
@@ -23189,7 +23249,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -23522,7 +23582,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Spine of Ish Sah’s last ability doesn’t allow you to sacrifice it. You must find another way to get Spine of Ish Sah into the graveyard."
+          "text": "Spine of Ish Sah's last ability doesn't allow you to sacrifice it. You must find another way to get Spine of Ish Sah into the graveyard."
         }
       ],
       "text": "When Spine of Ish Sah enters the battlefield, destroy target permanent.\nWhen Spine of Ish Sah is put into a graveyard from the battlefield, return Spine of Ish Sah to its owner's hand.",
@@ -23677,7 +23737,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "If no players control at least two more lands than you when the ability resolves, you’ll still search and shuffle your library."
+          "text": "If no players control at least two more lands than you when the ability resolves, you'll still search and shuffle your library."
         }
       ],
       "text": "{T}, Exile Surveyor's Scope: Search your library for up to X basic land cards, where X is the number of players who control at least two more lands than you. Put those cards onto the battlefield, then shuffle your library.",
@@ -23756,7 +23816,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can’t be the target of spells and abilities you control."
+          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can't be the target of spells and abilities you control."
         }
       ],
       "subtypes": [
@@ -23988,7 +24048,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Thousand-Year Elixir doesn’t actually grant haste to creatures you control, nor does it let you attack with them as though they had haste."
+          "text": "Thousand-Year Elixir doesn't actually grant haste to creatures you control, nor does it let you attack with them as though they had haste."
         }
       ],
       "text": "You may activate abilities of creatures you control as though those creatures had haste.\n{1}, {T}: Untap target creature.",
@@ -24070,7 +24130,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If Thunderstaff is untapped, it prevents 1 damage from each creature, each time it would deal combat damage to you. So if three creatures with double strike attack you and aren’t blocked, Thunderstaff will prevent a total of 6 damage."
+          "text": "If Thunderstaff is untapped, it prevents 1 damage from each creature, each time it would deal combat damage to you. So if three creatures with double strike attack you and aren't blocked, Thunderstaff will prevent a total of 6 damage."
         }
       ],
       "text": "As long as Thunderstaff is untapped, if a creature would deal combat damage to you, prevent 1 of that damage.\n{2}, {T}: Attacking creatures get +1/+0 until end of turn.",
@@ -25198,15 +25258,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander's color."
         },
         {
           "date": "2011-09-22",
-          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower’s ability produces no mana."
+          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower's ability produces no mana."
         },
         {
           "date": "2011-09-22",
-          "text": "In formats other than Commander, Command Tower’s ability produces no mana."
+          "text": "In formats other than Commander, Command Tower's ability produces no mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color in your commander's color identity.",
@@ -25651,6 +25711,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Battle for Zendikar Block",
           "legality": "Legal"
         },
@@ -25799,11 +25863,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Faerie Conclave enters the battlefield tapped.\n{T}: Add {U} to your mana pool.\n{1}{U}: Faerie Conclave becomes a 2/1 blue Faerie creature with flying until end of turn. It's still a land.",
@@ -27113,7 +27177,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The +1/+1 counter won’t affect Llanowar Reborn in any way unless another effect turns it into a creature."
+          "text": "The +1/+1 counter won't affect Llanowar Reborn in any way unless another effect turns it into a creature."
         }
       ],
       "text": "Llanowar Reborn enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nGraft 1 (This land enters the battlefield with a +1/+1 counter on it. Whenever a creature enters the battlefield, you may move a +1/+1 counter from this land onto it.)",
@@ -27567,19 +27631,19 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "The “number of times it’s been cast from the command zone” includes the most recent time. For example, the first time you cast your commander from the command zone in a game, if you spent mana from Opal Palace’s last ability to do so, it will enter the battlefield with a +1/+1 counter."
+          "text": "The \"number of times it's been cast from the command zone\" includes the most recent time. For example, the first time you cast your commander from the command zone in a game, if you spent mana from Opal Palace's last ability to do so, it will enter the battlefield with a +1/+1 counter."
         },
         {
           "date": "2013-10-17",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even if your commander is in a hidden zone (like the hand or library) or an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even if your commander is in a hidden zone (like the hand or library) or an effect changes your commander's color."
         },
         {
           "date": "2013-10-17",
-          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Opal Palace’s last ability produces no mana."
+          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Opal Palace's last ability produces no mana."
         },
         {
           "date": "2013-10-17",
-          "text": "In formats other than Commander, Opal Palace’s last ability produces no mana."
+          "text": "In formats other than Commander, Opal Palace's last ability produces no mana."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add to your mana pool one mana of any color in your commander's color identity. If you spend this mana to cast your commander, it enters the battlefield with a number of additional +1/+1 counters on it equal to the number of times it's been cast from the command zone this game.",
@@ -28925,11 +28989,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Springjack Pasture’s last ability is a mana ability. The whole ability — including the life gain — doesn’t use the stack and therefore can’t be responded to."
+          "text": "Springjack Pasture's last ability is a mana ability. The whole ability — including the life gain — doesn't use the stack and therefore can't be responded to."
         },
         {
           "date": "2008-08-01",
-          "text": "If you sacrifice no Goats, you’ll add no mana to your mana pool and you’ll gain no life."
+          "text": "If you sacrifice no Goats, you'll add no mana to your mana pool and you'll gain no life."
         },
         {
           "date": "2008-08-01",
@@ -29331,7 +29395,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Although Urza’s Factory has the Urza’s land type, it doesn’t interact with Urza’s Tower, Urza’s Mine, or Urza’s Power Plant."
+          "text": "Although Urza's Factory has the Urza's land type, it doesn't interact with Urza's Tower, Urza's Mine, or Urza's Power Plant."
         }
       ],
       "subtypes": [

--- a/json/C14.json
+++ b/json/C14.json
@@ -91,7 +91,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Creatures that were declared as attackers or entered the battlefield attacking continue to be attacking creatures until the combat phase ends. It’s possible to exile all attacking creatures after they’ve dealt combat damage if you cast Angel of the Dire Hour during the combat damage step or end of combat step."
+          "text": "Creatures that were declared as attackers or entered the battlefield attacking continue to be attacking creatures until the combat phase ends. It's possible to exile all attacking creatures after they've dealt combat damage if you cast Angel of the Dire Hour during the combat damage step or end of combat step."
         },
         {
           "date": "2014-11-07",
@@ -99,7 +99,7 @@
         },
         {
           "date": "2014-11-07",
-          "text": "If a spell or ability instructs you to put Angel of the Dire Hour onto the battlefield from your hand, that means you won’t have cast it, so its triggered ability won’t trigger."
+          "text": "If a spell or ability instructs you to put Angel of the Dire Hour onto the battlefield from your hand, that means you won't have cast it, so its triggered ability won't trigger."
         }
       ],
       "subtypes": [
@@ -190,15 +190,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player’s commander."
+          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player's commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won’t check whether its owner controls his or her commander."
+          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won't check whether its owner controls his or her commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature’s toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
+          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature's toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
         },
         {
           "date": "2014-11-07",
@@ -287,7 +287,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "In some unusual cases, the Spirit tokens will have a toughness of 0 or less as they enter the battlefield, perhaps because an opponent controls an enchantment that gives your creatures -1/-1. Because state-based actions aren’t performed in the middle of a spell’s resolution, you’ll gain 2 life for each of those Spirit tokens. After Benevolent Offering has finished resolving, the Spirit tokens will die and subsequently cease to exist."
+          "text": "In some unusual cases, the Spirit tokens will have a toughness of 0 or less as they enter the battlefield, perhaps because an opponent controls an enchantment that gives your creatures -1/-1. Because state-based actions aren't performed in the middle of a spell's resolution, you'll gain 2 life for each of those Spirit tokens. After Benevolent Offering has finished resolving, the Spirit tokens will die and subsequently cease to exist."
         },
         {
           "date": "2014-11-07",
@@ -376,7 +376,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Comeuppance’s effect is not a redirection effect. If it prevents damage, Comeuppance (not the original source) deals damage to the creature or player as part of that prevention effect. Comeuppance is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don’t affect the new damage. The new damage is not combat damage, even if the prevented damage was."
+          "text": "Comeuppance's effect is not a redirection effect. If it prevents damage, Comeuppance (not the original source) deals damage to the creature or player as part of that prevention effect. Comeuppance is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don't affect the new damage. The new damage is not combat damage, even if the prevented damage was."
         },
         {
           "date": "2014-11-07",
@@ -464,19 +464,19 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Containment Priest’s last ability won’t affect any nontoken creatures that were cast, including ones cast from unusual zones such as your graveyard."
+          "text": "Containment Priest's last ability won't affect any nontoken creatures that were cast, including ones cast from unusual zones such as your graveyard."
         },
         {
           "date": "2014-11-07",
-          "text": "Containment Priest’s last ability doesn’t stop creature tokens from entering the battlefield. It also doesn’t affect creatures that were already on the battlefield."
+          "text": "Containment Priest's last ability doesn't stop creature tokens from entering the battlefield. It also doesn't affect creatures that were already on the battlefield."
         },
         {
           "date": "2014-11-07",
-          "text": "If Containment Priest enters the battlefield without being cast, it won’t exile itself."
+          "text": "If Containment Priest enters the battlefield without being cast, it won't exile itself."
         },
         {
           "date": "2014-11-07",
-          "text": "If Containment Priest enters the battlefield at the same time as other creatures, its ability won’t affect those creatures."
+          "text": "If Containment Priest enters the battlefield at the same time as other creatures, its ability won't affect those creatures."
         }
       ],
       "subtypes": [
@@ -639,11 +639,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Use the power of the target creature as Fell the Mighty resolves to determine which creatures are destroyed. Fell the Mighty doesn’t target any of those creatures, so a creature with hexproof or protection from white will be destroyed if its power is high enough."
+          "text": "Use the power of the target creature as Fell the Mighty resolves to determine which creatures are destroyed. Fell the Mighty doesn't target any of those creatures, so a creature with hexproof or protection from white will be destroyed if its power is high enough."
         },
         {
           "date": "2014-11-07",
-          "text": "Fell the Mighty won’t destroy the target creature."
+          "text": "Fell the Mighty won't destroy the target creature."
         },
         {
           "date": "2014-11-07",
@@ -729,7 +729,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Count the number of creature cards in your graveyard as the triggered ability resolves, including Hallowed Spiritkeeper itself if it’s still there, to determine how many Spirits are created."
+          "text": "Count the number of creature cards in your graveyard as the triggered ability resolves, including Hallowed Spiritkeeper itself if it's still there, to determine how many Spirits are created."
         }
       ],
       "subtypes": [
@@ -978,7 +978,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "You must choose six different legal targets in order to cast Aether Gale. If some, but not all, of those targets become illegal before Aether Gale resolves, the remaining legal targets will be put into their owners’ hands."
+          "text": "You must choose six different legal targets in order to cast Aether Gale. If some, but not all, of those targets become illegal before Aether Gale resolves, the remaining legal targets will be put into their owners' hands."
         }
       ],
       "text": "Return six target nonland permanents to their owners' hands.",
@@ -1065,7 +1065,7 @@
         },
         {
           "date": "2014-11-07",
-          "text": "The triggered ability tracks the creatures, but not their controllers. If any of the creatures changes controllers before its original controller’s next untap step has come around, that creature won’t untap during its new controller’s next untap step."
+          "text": "The triggered ability tracks the creatures, but not their controllers. If any of the creatures changes controllers before its original controller's next untap step has come around, that creature won't untap during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -1154,11 +1154,11 @@
         },
         {
           "date": "2014-11-07",
-          "text": "Each of those creatures blocks only if it’s able to do so as the declare blockers step begins. If, at that time, one of the creatures is tapped, is affected by a spell or ability that says it can’t block, or no creatures are attacking that creature’s controller or a planeswalker controlled by that player, then it doesn’t block. If there’s a cost associated with having the creature block, the player isn’t forced to pay that cost, so it doesn’t block in that case either."
+          "text": "Each of those creatures blocks only if it's able to do so as the declare blockers step begins. If, at that time, one of the creatures is tapped, is affected by a spell or ability that says it can't block, or no creatures are attacking that creature's controller or a planeswalker controlled by that player, then it doesn't block. If there's a cost associated with having the creature block, the player isn't forced to pay that cost, so it doesn't block in that case either."
         },
         {
           "date": "2014-11-07",
-          "text": "Notably, Domineering Will doesn’t give any of the target creatures haste. Unless they have haste due to some other means, they won’t be able to attack that turn."
+          "text": "Notably, Domineering Will doesn't give any of the target creatures haste. Unless they have haste due to some other means, they won't be able to attack that turn."
         }
       ],
       "text": "Target player gains control of up to three target nonattacking creatures until end of turn. Untap those creatures. They block this turn if able.",
@@ -1241,7 +1241,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "“Target opponent” means one of your opponents. In other words, Dulcet Sirens’s ability can’t make a creature attack you."
+          "text": "\"Target opponent\" means one of your opponents. In other words, Dulcet Sirens's ability can't make a creature attack you."
         },
         {
           "date": "2014-11-07",
@@ -1249,15 +1249,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "If, as attackers are declared, the target creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under its controller’s control continuously since his or her last turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having the creature attack the opponent, its controller isn’t forced to pay that cost, so it doesn’t have to attack that player in that case either."
+          "text": "If, as attackers are declared, the target creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under its controller's control continuously since his or her last turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having the creature attack the opponent, its controller isn't forced to pay that cost, so it doesn't have to attack that player in that case either."
         },
         {
           "date": "2014-11-07",
-          "text": "If the creature can’t attack the player for one of the above reasons but it can still attack elsewhere, its controller may choose to have it attack another player, attack a planeswalker, or not attack at all."
+          "text": "If the creature can't attack the player for one of the above reasons but it can still attack elsewhere, its controller may choose to have it attack another player, attack a planeswalker, or not attack at all."
         },
         {
           "date": "2014-11-07",
-          "text": "If either the target creature or the target player is an illegal target when the activated ability tries to resolve, the ability will have no effect. The creature won’t be forced to attack that opponent, but it still can if able."
+          "text": "If either the target creature or the target player is an illegal target when the activated ability tries to resolve, the ability will have no effect. The creature won't be forced to attack that opponent, but it still can if able."
         }
       ],
       "subtypes": [
@@ -1428,7 +1428,7 @@
       "subtypes": [
         "Worm"
       ],
-      "text": "When Reef Worm dies, create a 3/3 blue Fish creature token with \"When this creature dies, create a 6/6 blue Whale creature token with ‘When this creature dies, create a 9/9 blue Kraken creature token.'\"",
+      "text": "When Reef Worm dies, create a 3/3 blue Fish creature token with \"When this creature dies, create a 6/6 blue Whale creature token with 'When this creature dies, create a 9/9 blue Kraken creature token.'\"",
       "toughness": "1",
       "type": "Creature — Worm",
       "types": [
@@ -1508,7 +1508,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "“Exiled this way” refers to the exile instruction that’s part of the ability’s effect. If the cards each player would put into his or her graveyard are exiled because of a replacement effect, those cards won’t be in the graveyards to be exiled by the next part of the ability. In this case, the value of X will be 0. You’ll put a 0/0 token onto the battlefield, then that token will die and subsequently cease to exist (unless something else raises its toughness above 0)."
+          "text": "\"Exiled this way\" refers to the exile instruction that's part of the ability's effect. If the cards each player would put into his or her graveyard are exiled because of a replacement effect, those cards won't be in the graveyards to be exiled by the next part of the ability. In this case, the value of X will be 0. You'll put a 0/0 token onto the battlefield, then that token will die and subsequently cease to exist (unless something else raises its toughness above 0)."
         }
       ],
       "subtypes": [
@@ -1603,15 +1603,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player’s commander."
+          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player's commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won’t check whether its owner controls his or her commander."
+          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won't check whether its owner controls his or her commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature’s toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
+          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature's toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
         },
         {
           "date": "2014-11-07",
@@ -1701,11 +1701,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "If you control Teferi’s emblem, the rule that says you can activate a loyalty ability only if none of that permanent’s loyalty abilities have been activated that turn still applies. In other words, you could activate a planeswalker’s loyalty ability once on your turn and once on each of your opponents’ turns."
+          "text": "If you control Teferi's emblem, the rule that says you can activate a loyalty ability only if none of that permanent's loyalty abilities have been activated that turn still applies. In other words, you could activate a planeswalker's loyalty ability once on your turn and once on each of your opponents' turns."
         },
         {
           "date": "2014-11-07",
-          "text": "If you control The Chain Veil (from the Magic 2015 core set) and its activated ability has resolved, and you also control Teferi’s emblem, for each planeswalker you control, you can activate one of its loyalty abilities during that turn any time you could cast an instant, and then you may activate a loyalty ability again that turn (choosing the same loyalty ability or a different one) any time you could cast an instant."
+          "text": "If you control The Chain Veil (from the Magic 2015 core set) and its activated ability has resolved, and you also control Teferi's emblem, for each planeswalker you control, you can activate one of its loyalty abilities during that turn any time you could cast an instant, and then you may activate a loyalty ability again that turn (choosing the same loyalty ability or a different one) any time you could cast an instant."
         }
       ],
       "subtypes": [
@@ -1873,15 +1873,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player’s commander."
+          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player's commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won’t check whether its owner controls his or her commander."
+          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won't check whether its owner controls his or her commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature’s toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
+          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature's toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
         },
         {
           "date": "2014-11-07",
@@ -1972,7 +1972,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Use Flesh Carver’s power when it died (including any +1/+1 counters it had) to determine the value of X."
+          "text": "Use Flesh Carver's power when it died (including any +1/+1 counters it had) to determine the value of X."
         }
       ],
       "subtypes": [
@@ -2143,11 +2143,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The sacrifice isn’t optional. If you control at least one creature, you must sacrifice one. If you control no creatures, you won’t sacrifice one and you won’t draw two cards. The same is true for the chosen opponent."
+          "text": "The sacrifice isn't optional. If you control at least one creature, you must sacrifice one. If you control no creatures, you won't sacrifice one and you won't draw two cards. The same is true for the chosen opponent."
         },
         {
           "date": "2014-11-07",
-          "text": "You choose which creature card you’re returning to the battlefield, then the chosen opponent chooses which creature card he or she is returning. These choices aren’t made until Infernal Offering resolves. Neither card is a target of Infernal Offering."
+          "text": "You choose which creature card you're returning to the battlefield, then the chosen opponent chooses which creature card he or she is returning. These choices aren't made until Infernal Offering resolves. Neither card is a target of Infernal Offering."
         },
         {
           "date": "2014-11-07",
@@ -2238,11 +2238,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The copy of Malicious Affliction is created on the stack. It’s not cast, so the copy won’t cause the morbid ability to trigger again."
+          "text": "The copy of Malicious Affliction is created on the stack. It's not cast, so the copy won't cause the morbid ability to trigger again."
         },
         {
           "date": "2016-06-08",
-          "text": "The copy will have the same target as the original spell unless you choose a new one. You don’t have to change this target if you don’t want to or can’t choose a new legal target (perhaps because there are no other nonblack creatures on the battlefield)."
+          "text": "The copy will have the same target as the original spell unless you choose a new one. You don't have to change this target if you don't want to or can't choose a new legal target (perhaps because there are no other nonblack creatures on the battlefield)."
         }
       ],
       "text": "Morbid — When you cast Malicious Affliction, if a creature died this turn, you may copy Malicious Affliction and may choose a new target for the copy.\nDestroy target nonblack creature.",
@@ -2324,11 +2324,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Necromantic Selection doesn’t overwrite any of the creature’s colors or types. Rather, it adds another color and another creature type."
+          "text": "Necromantic Selection doesn't overwrite any of the creature's colors or types. Rather, it adds another color and another creature type."
         },
         {
           "date": "2014-11-07",
-          "text": "If the creature is normally colorless, it will simply become black. It can’t be both black and colorless."
+          "text": "If the creature is normally colorless, it will simply become black. It can't be both black and colorless."
         }
       ],
       "text": "Destroy all creatures, then return a creature card put into a graveyard this way to the battlefield under your control. It's a black Zombie in addition to its other colors and types. Exile Necromantic Selection.",
@@ -2574,15 +2574,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "If, as attackers are declared, Raving Dead is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under your control continuously since your turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having Raving Dead attack the chosen player, you aren’t forced to pay that cost, so it doesn’t have to attack that player in that case either."
+          "text": "If, as attackers are declared, Raving Dead is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under your control continuously since your turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having Raving Dead attack the chosen player, you aren't forced to pay that cost, so it doesn't have to attack that player in that case either."
         },
         {
           "date": "2014-11-07",
-          "text": "If Raving Dead can’t attack the chosen player for one of the above reasons but it can still attack elsewhere, you may choose to have it attack another player, attack a planeswalker, or not attack at all."
+          "text": "If Raving Dead can't attack the chosen player for one of the above reasons but it can still attack elsewhere, you may choose to have it attack another player, attack a planeswalker, or not attack at all."
         },
         {
           "date": "2014-11-07",
-          "text": "If your turn has multiple combat phases, Raving Dead’s ability triggers at the beginning of each of them. Ignore any choices made during previous combat phases that turn."
+          "text": "If your turn has multiple combat phases, Raving Dead's ability triggers at the beginning of each of them. Ignore any choices made during previous combat phases that turn."
         },
         {
           "date": "2014-11-07",
@@ -2753,7 +2753,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The delayed triggered ability that makes you sacrifice the creatures will trigger only once. If you don’t sacrifice one or more of those creatures at that time (perhaps because another player gained control of them), the ability won’t try to make you sacrifice them on future turns."
+          "text": "The delayed triggered ability that makes you sacrifice the creatures will trigger only once. If you don't sacrifice one or more of those creatures at that time (perhaps because another player gained control of them), the ability won't try to make you sacrifice them on future turns."
         }
       ],
       "text": "Cast Wake the Dead only during combat on an opponent's turn.\nReturn X target creature cards from your graveyard to the battlefield. Sacrifice those creatures at the beginning of the next end step.",
@@ -2838,7 +2838,7 @@
         },
         {
           "date": "2014-11-07",
-          "text": "The source of the damage doesn’t change. A spell that deals damage will specify the source of the damage. This is usually the spell itself. An ability that deals damage will specify the source of the damage, although it will never be the ability itself. Usually the source of the ability is also the source of the damage."
+          "text": "The source of the damage doesn't change. A spell that deals damage will specify the source of the damage. This is usually the spell itself. An ability that deals damage will specify the source of the damage, although it will never be the ability itself. Usually the source of the ability is also the source of the damage."
         },
         {
           "date": "2014-11-07",
@@ -2846,7 +2846,7 @@
         },
         {
           "date": "2014-11-07",
-          "text": "If multiple effects modify how damage is dealt, the player being dealt damage, or the controller of the permanent being dealt damage, chooses the order in which to apply the effects. For example, the ability of Decorated Griffin says “{1}{W}: Prevent the next 1 combat damage that would be dealt to you this turn.” Suppose you control a Decorated Griffin, and you and an opponent are the chosen players for a Bitter Feud. If a creature that player controls would deal 3 combat damage to you, and Decorated Griffin’s ability has resolved once, you can choose to either (a) apply the effect from Decorated Griffin first and prevent 1 damage, and then let Bitter Feud’s effect double the remaining 2 damage, for a result 4 damage being dealt to you, or (b) let Bitter Feud’s effect apply first and double the damage to 6, and then apply the effect from Decorated Griffin to prevent 1 damage, for a result of 5 damage being dealt to you."
+          "text": "If multiple effects modify how damage is dealt, the player being dealt damage, or the controller of the permanent being dealt damage, chooses the order in which to apply the effects. For example, the ability of Decorated Griffin says \"{1}{W}: Prevent the next 1 combat damage that would be dealt to you this turn.\" Suppose you control a Decorated Griffin, and you and an opponent are the chosen players for a Bitter Feud. If a creature that player controls would deal 3 combat damage to you, and Decorated Griffin's ability has resolved once, you can choose to either (a) apply the effect from Decorated Griffin first and prevent 1 damage, and then let Bitter Feud's effect double the remaining 2 damage, for a result 4 damage being dealt to you, or (b) let Bitter Feud's effect apply first and double the damage to 6, and then apply the effect from Decorated Griffin to prevent 1 damage, for a result of 5 damage being dealt to you."
         }
       ],
       "text": "As Bitter Feud enters the battlefield, choose two players.\nIf a source controlled by one of the chosen players would deal damage to the other chosen player or a permanent that player controls, that source deals double that damage to that player or permanent instead.",
@@ -2929,7 +2929,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "You may choose to discard zero cards as the first ability resolves. In that case, you won’t draw any cards."
+          "text": "You may choose to discard zero cards as the first ability resolves. In that case, you won't draw any cards."
         },
         {
           "date": "2014-11-07",
@@ -2937,7 +2937,7 @@
         },
         {
           "date": "2014-11-07",
-          "text": "The ability of Daretti’s emblem will return the artifact card only if it’s still in your graveyard when the delayed triggered ability resolves at the beginning of the next end step. If the artifact card left your graveyard before that point (even if it was put back into your graveyard), the ability won’t return it to the battlefield."
+          "text": "The ability of Daretti's emblem will return the artifact card only if it's still in your graveyard when the delayed triggered ability resolves at the beginning of the next end step. If the artifact card left your graveyard before that point (even if it was put back into your graveyard), the ability won't return it to the battlefield."
         }
       ],
       "subtypes": [
@@ -3026,23 +3026,23 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Dualcaster Mage’s triggered ability can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Dualcaster Mage's triggered ability can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2016-06-08",
-          "text": "As Dualcaster Mage’s triggered ability resolves, it creates a copy of a spell on the stack. The copy isn’t cast, so abilities that trigger when a player casts a spell won’t trigger."
+          "text": "As Dualcaster Mage's triggered ability resolves, it creates a copy of a spell on the stack. The copy isn't cast, so abilities that trigger when a player casts a spell won't trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs paid for the targeted spell are copied as though those same costs were paid for the copy."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs paid for the targeted spell are copied as though those same costs were paid for the copy."
         },
         {
           "date": "2016-06-08",
-          "text": "If the spell is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2016-06-08",
@@ -3050,7 +3050,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "subtypes": [
@@ -3147,15 +3147,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "Any enters-the-battlefield abilities of the copied creature card will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature card will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature card will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature card will also work."
         },
         {
           "date": "2014-11-07",
-          "text": "If another creature becomes a copy of, or enters the battlefield as a copy of, the token, that creature will copy the creature card the token is copying, except it will also be an artifact. This is true even if the creature card that was copied by Feldon of the Third Path is no longer in the graveyard at that time. However, the new copy won’t gain haste and you won’t sacrifice it at the beginning of the next end step."
+          "text": "If another creature becomes a copy of, or enters the battlefield as a copy of, the token, that creature will copy the creature card the token is copying, except it will also be an artifact. This is true even if the creature card that was copied by Feldon of the Third Path is no longer in the graveyard at that time. However, the new copy won't gain haste and you won't sacrifice it at the beginning of the next end step."
         },
         {
           "date": "2014-11-07",
-          "text": "If Feldon’s ability creates multiple tokens due to a replacement effect (such as the one Doubling Season creates), each of those tokens will gain haste and you’ll sacrifice each of them."
+          "text": "If Feldon's ability creates multiple tokens due to a replacement effect (such as the one Doubling Season creates), each of those tokens will gain haste and you'll sacrifice each of them."
         }
       ],
       "subtypes": [
@@ -3244,7 +3244,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "You determine the value for X and announce how damage will be divided as you cast Impact Resonance. Each chosen target must receive at least 1 damage. Once the value of X is determined, it won’t change, even if a source deals a greater amount of damage before Impact Resonance resolves. (Most of the time, the value of X in an effect would be determined only as the spell resolves. However, the rules state that if damage needs to be “divided,” that information is checked as the spell is put on the stack.)"
+          "text": "You determine the value for X and announce how damage will be divided as you cast Impact Resonance. Each chosen target must receive at least 1 damage. Once the value of X is determined, it won't change, even if a source deals a greater amount of damage before Impact Resonance resolves. (Most of the time, the value of X in an effect would be determined only as the spell resolves. However, the rules state that if damage needs to be \"divided,\" that information is checked as the spell is put on the stack.)"
         },
         {
           "date": "2014-11-07",
@@ -3416,7 +3416,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "“Exiled this way” refers to the exile instruction that’s part of Scrap Mastery’s effect. If the sacrificed artifacts are instead exiled because of a replacement effect, those cards won’t be put onto the battlefield."
+          "text": "\"Exiled this way\" refers to the exile instruction that's part of Scrap Mastery's effect. If the sacrificed artifacts are instead exiled because of a replacement effect, those cards won't be put onto the battlefield."
         }
       ],
       "text": "Each player exiles all artifact cards from his or her graveyard, then sacrifices all artifacts he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -3503,15 +3503,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player’s commander."
+          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player's commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won’t check whether its owner controls his or her commander."
+          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won't check whether its owner controls his or her commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature’s toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
+          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature's toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
         },
         {
           "date": "2014-11-07",
@@ -3600,11 +3600,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Unlike the other Offerings, you choose the opponents for Volcanic Offering as you cast the spell because those players are involved in choosing the spell’s targets."
+          "text": "Unlike the other Offerings, you choose the opponents for Volcanic Offering as you cast the spell because those players are involved in choosing the spell's targets."
         },
         {
           "date": "2014-11-07",
-          "text": "The chosen opponent for each effect may choose the same target nonbasic land or creature you don’t control that you did."
+          "text": "The chosen opponent for each effect may choose the same target nonbasic land or creature you don't control that you did."
         },
         {
           "date": "2014-11-07",
@@ -3691,19 +3691,19 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Each creature’s controller still chooses which player or planeswalker the creature attacks."
+          "text": "Each creature's controller still chooses which player or planeswalker the creature attacks."
         },
         {
           "date": "2014-11-07",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2014-11-07",
-          "text": "Only creatures that are attacking when the last ability resolves will get +1/+0. That is, activating that ability before attackers have been declared won’t give the bonus to any creatures, including ones that attack later in the turn."
+          "text": "Only creatures that are attacking when the last ability resolves will get +1/+0. That is, activating that ability before attackers have been declared won't give the bonus to any creatures, including ones that attack later in the turn."
         },
         {
           "date": "2014-11-07",
-          "text": "If there are multiple combat phases in a turn, creatures must attack during each combat phase in which they’re able to."
+          "text": "If there are multiple combat phases in a turn, creatures must attack during each combat phase in which they're able to."
         }
       ],
       "subtypes": [
@@ -3791,11 +3791,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The activated ability overwrites all previous effects that set the target creature’s base power and/or toughness to specific values. Other effects that set its base power and/or toughness that start to apply after Creeperhulk’s ability resolves will overwrite Creeperhulk’s effect."
+          "text": "The activated ability overwrites all previous effects that set the target creature's base power and/or toughness to specific values. Other effects that set its base power and/or toughness that start to apply after Creeperhulk's ability resolves will overwrite Creeperhulk's effect."
         },
         {
           "date": "2014-11-07",
-          "text": "Effects that modify the target creature’s power and/or toughness, such as the effect of Giant Growth or Glorious Anthem, will apply to the creature no matter when they started applying. The same is true for counters that affect the target creature’s power and toughness and effects that switch its power and toughness."
+          "text": "Effects that modify the target creature's power and/or toughness, such as the effect of Giant Growth or Glorious Anthem, will apply to the creature no matter when they started applying. The same is true for counters that affect the target creature's power and toughness and effects that switch its power and toughness."
         }
       ],
       "subtypes": [
@@ -3964,7 +3964,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The creature type each player chooses applies only to that player. For example, if another player chose Elf, you wouldn’t return Elf cards to your hand unless you also chose Elf (or if an Elf card in your graveyard also had the creature type you chose)."
+          "text": "The creature type each player chooses applies only to that player. For example, if another player chose Elf, you wouldn't return Elf cards to your hand unless you also chose Elf (or if an Elf card in your graveyard also had the creature type you chose)."
         }
       ],
       "subtypes": [
@@ -4053,7 +4053,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Use Lifeblood Hydra’s power when it died (including any +1/+1 counters it had) to determine how much life to gain and how many cards to draw."
+          "text": "Use Lifeblood Hydra's power when it died (including any +1/+1 counters it had) to determine how much life to gain and how many cards to draw."
         }
       ],
       "subtypes": [
@@ -4141,7 +4141,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "You decide whether to assign a creature’s combat damage as though it weren’t blocked just before it assigns that damage. You may make a different choice for each creature you control—that is, you may have none, some, or all of those creatures assign combat damage as though they weren’t blocked."
+          "text": "You decide whether to assign a creature's combat damage as though it weren't blocked just before it assigns that damage. You may make a different choice for each creature you control—that is, you may have none, some, or all of those creatures assign combat damage as though they weren't blocked."
         }
       ],
       "subtypes": [
@@ -4228,7 +4228,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The enchanted permanent loses any card types, subtypes, and colors it previously had. It keeps any supertypes it had and its name remains unchanged. It gains “{T}: Add {G} to your mana pool” and loses all other abilities from its rules text. It will still have any abilities it gained from other effects."
+          "text": "The enchanted permanent loses any card types, subtypes, and colors it previously had. It keeps any supertypes it had and its name remains unchanged. It gains \"{T}: Add {G} to your mana pool\" and loses all other abilities from its rules text. It will still have any abilities it gained from other effects."
         },
         {
           "date": "2014-11-07",
@@ -4410,15 +4410,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player’s commander."
+          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player's commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won’t check whether its owner controls his or her commander."
+          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won't check whether its owner controls his or her commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature’s toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
+          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature's toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
         },
         {
           "date": "2014-11-07",
@@ -4666,6 +4666,12 @@
         "CMA"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2014-11-07",
+          "text": "Use the number of opponents who have four or more cards in hand as the ability resolves to determine the value of X."
+        }
+      ],
       "text": "At the beginning of your upkeep, create X 2/2 green Wolf creature tokens, where X is the number of your opponents with four or more cards in hand.",
       "type": "Enchantment",
       "types": [
@@ -4740,11 +4746,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The equipped creature can’t be sacrificed for any reason. If an effect instructs you to sacrifice it, you can’t and it remains on the battlefield. You also can’t sacrifice it to pay a cost that requires you to sacrifice a creature."
+          "text": "The equipped creature can't be sacrificed for any reason. If an effect instructs you to sacrifice it, you can't and it remains on the battlefield. You also can't sacrifice it to pay a cost that requires you to sacrifice a creature."
         },
         {
           "date": "2014-11-07",
-          "text": "If an effect instructs you to sacrifice a creature, and you control any creatures other than the creature equipped with Assault Suit, you must sacrifice one of them. You can’t try to sacrifice the equipped creature, fail, and therefore ignore the effect."
+          "text": "If an effect instructs you to sacrifice a creature, and you control any creatures other than the creature equipped with Assault Suit, you must sacrifice one of them. You can't try to sacrifice the equipped creature, fail, and therefore ignore the effect."
         }
       ],
       "subtypes": [
@@ -4825,15 +4831,15 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even if your commander is in a hidden zone (such as your hand or your library) or if an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even if your commander is in a hidden zone (such as your hand or your library) or if an effect changes your commander's color."
         },
         {
           "date": "2014-11-07",
-          "text": "If your commander has no colors in its color identity, Commander’s Sphere produces no mana."
+          "text": "If your commander has no colors in its color identity, Commander's Sphere produces no mana."
         },
         {
           "date": "2014-11-07",
-          "text": "In formats other than Commander, Commander’s Sphere produces no mana."
+          "text": "In formats other than Commander, Commander's Sphere produces no mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
@@ -4909,7 +4915,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "You are Crown of Doom’s owner if it started the game in your deck. Therefore, once you hand off the Crown, your opponents cannot give it back to you by activating its ability (although other effects, such as the one Zedruu the Greathearted’s ability creates, may do this)."
+          "text": "You are Crown of Doom's owner if it started the game in your deck. Therefore, once you hand off the Crown, your opponents cannot give it back to you by activating its ability (although other effects, such as the one Zedruu the Greathearted's ability creates, may do this)."
         }
       ],
       "text": "Whenever a creature attacks you or a planeswalker you control, it gets +2/+0 until end of turn.\n{2}: Target player other than Crown of Doom's owner gains control of it. Activate this ability only during your turn.",
@@ -5062,11 +5068,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Although Masterwork of Ingenuity doesn’t have an equip ability, it will have the equip ability of the Equipment it copies."
+          "text": "Although Masterwork of Ingenuity doesn't have an equip ability, it will have the equip ability of the Equipment it copies."
         },
         {
           "date": "2014-11-07",
-          "text": "Any enters-the-battlefield abilities of the chosen Equipment will trigger. Any “as [this permanent] enters the battlefield or “[this permanent] enters the battlefield with” abilities of the chosen Equipment will also work."
+          "text": "Any enters-the-battlefield abilities of the chosen Equipment will trigger. Any \"as [this permanent] enters the battlefield or \"[this permanent] enters the battlefield with\" abilities of the chosen Equipment will also work."
         }
       ],
       "subtypes": [
@@ -5212,11 +5218,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The second ability applies only to creatures controlled by your opponents when it resolves. Creatures that enter the battlefield or come under an opponent’s control later in the turn won’t be affected."
+          "text": "The second ability applies only to creatures controlled by your opponents when it resolves. Creatures that enter the battlefield or come under an opponent's control later in the turn won't be affected."
         },
         {
           "date": "2014-11-07",
-          "text": "After the second ability resolves, continuous effects generated by the resolution of spells and abilities that would give hexproof or shroud to one of the affected creatures aren’t created. For example, after the second ability resolves, a spell cast by an opponent that gives creatures he or she controls hexproof wouldn’t cause the creatures to have hexproof. (If that spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
+          "text": "After the second ability resolves, continuous effects generated by the resolution of spells and abilities that would give hexproof or shroud to one of the affected creatures aren't created. For example, after the second ability resolves, a spell cast by an opponent that gives creatures he or she controls hexproof wouldn't cause the creatures to have hexproof. (If that spell has additional effects, such as raising the power of the creatures, those effects will apply as normal.)"
         },
         {
           "date": "2014-11-07",
@@ -5455,15 +5461,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -5560,7 +5566,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Adarkar Valkyrie’s ability can target a token creature, but since token creatures cease to exist when they leave the battlefield, it won’t be returned to the battlefield."
+          "text": "Adarkar Valkyrie's ability can target a token creature, but since token creatures cease to exist when they leave the battlefield, it won't be returned to the battlefield."
         }
       ],
       "subtypes": [
@@ -5828,11 +5834,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You choose a color as Brave the Elements resolves. Once the color is chosen, it’s too late for players to respond."
+          "text": "You choose a color as Brave the Elements resolves. Once the color is chosen, it's too late for players to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "Only white creatures you control at the time Brave the Elements resolves gain the protection ability. Creatures that come under your control later in the turn, or that turn white later in the turn, won’t have it."
+          "text": "Only white creatures you control at the time Brave the Elements resolves gain the protection ability. Creatures that come under your control later in the turn, or that turn white later in the turn, won't have it."
         }
       ],
       "text": "Choose a color. White creatures you control gain protection from the chosen color until end of turn.",
@@ -5924,7 +5930,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The creature that entered the battlefield and caused the ability to trigger will also get a +1/+1 counter, provided it’s still on the battlefield when the ability resolves."
+          "text": "The creature that entered the battlefield and caused the ability to trigger will also get a +1/+1 counter, provided it's still on the battlefield when the ability resolves."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
@@ -6020,23 +6026,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -6135,7 +6141,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The affected creature’s last known existence on the battlefield is checked to determine its toughness."
+          "text": "The affected creature's last known existence on the battlefield is checked to determine its toughness."
         }
       ],
       "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
@@ -6224,7 +6230,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two X’s in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
+          "text": "The two X's in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
         },
         {
           "date": "2004-10-04",
@@ -6244,7 +6250,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
@@ -6345,7 +6351,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won’t trigger that turn."
+          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won't trigger that turn."
         }
       ],
       "subtypes": [
@@ -6440,7 +6446,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The ability that defines Geist-Honored Monk’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Geist-Honored Monk's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2011-09-22",
@@ -6629,11 +6635,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Grand Abolisher doesn’t stop your opponents from activating abilities of artifact, creature, or enchantment cards in zones other than the battlefield (like cycling abilities, for example)."
+          "text": "Grand Abolisher doesn't stop your opponents from activating abilities of artifact, creature, or enchantment cards in zones other than the battlefield (like cycling abilities, for example)."
         },
         {
           "date": "2011-09-22",
-          "text": "Grand Abolisher doesn’t affect triggered abilities or static abilities."
+          "text": "Grand Abolisher doesn't affect triggered abilities or static abilities."
         }
       ],
       "subtypes": [
@@ -7012,11 +7018,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "You do what the spell says in order. If X is 5 or more, you’ll put the Soldier tokens onto the battlefield, then you’ll destroy all other creatures."
+          "text": "You do what the spell says in order. If X is 5 or more, you'll put the Soldier tokens onto the battlefield, then you'll destroy all other creatures."
         },
         {
           "date": "2009-02-01",
-          "text": "No one can cast spells or activate abilities between the time the Soldier tokens are put onto the battlefield and the time all other creatures are destroyed. For example, you can’t sacrifice one of those Soldier tokens to regenerate a Skeletal Kathari."
+          "text": "No one can cast spells or activate abilities between the time the Soldier tokens are put onto the battlefield and the time all other creatures are destroyed. For example, you can't sacrifice one of those Soldier tokens to regenerate a Skeletal Kathari."
         }
       ],
       "text": "Create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures.",
@@ -7114,7 +7120,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Apply power bonuses from counters the creature enters the battlefield with and continuous effects like Mayor of Avabruck’s when checking to see if Mentor of the Meek’s ability will trigger."
+          "text": "Apply power bonuses from counters the creature enters the battlefield with and continuous effects like Mayor of Avabruck's when checking to see if Mentor of the Meek's ability will trigger."
         },
         {
           "date": "2011-09-22",
@@ -7384,11 +7390,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -7396,23 +7402,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Create a 1/1 white Kor Soldier creature token for each creature you control.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -7678,7 +7684,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there’s only one legal target. If it’s cast at a time other than its controller’s main phase and a second target is chosen, nothing will happen to that target."
+          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there's only one legal target. If it's cast at a time other than its controller's main phase and a second target is chosen, nothing will happen to that target."
         }
       ],
       "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
@@ -7870,19 +7876,19 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Whether or not the ability triggers depends on if the Avatar has the ability while in the graveyard. If it doesn’t (thanks to Yixlid Jailer, for instance), then the ability won’t trigger. It doesn’t matter whether the Avatar had the ability in its previous zone (it will trigger even if it had been on the battlefield with Humility)."
+          "text": "Whether or not the ability triggers depends on if the Avatar has the ability while in the graveyard. If it doesn't (thanks to Yixlid Jailer, for instance), then the ability won't trigger. It doesn't matter whether the Avatar had the ability in its previous zone (it will trigger even if it had been on the battlefield with Humility)."
         },
         {
           "date": "2012-07-01",
-          "text": "Serra Avatar’s power and toughness are constantly updated as your life total changes."
+          "text": "Serra Avatar's power and toughness are constantly updated as your life total changes."
         },
         {
           "date": "2012-07-01",
-          "text": "The ability that defines Serra Avatar’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Serra Avatar's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2012-07-01",
-          "text": "If Serra Avatar is no longer in your graveyard when its triggered ability resolves, you won’t shuffle your library."
+          "text": "If Serra Avatar is no longer in your graveyard when its triggered ability resolves, you won't shuffle your library."
         }
       ],
       "subtypes": [
@@ -8164,7 +8170,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -8281,7 +8287,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         }
       ],
       "subtypes": [
@@ -8379,7 +8385,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The second ability destroys each creature that’s tapped at the time it resolves, including creatures you control. If Sunblast Angel has become tapped by the time its ability resolves, it will be destroyed too."
+          "text": "The second ability destroys each creature that's tapped at the time it resolves, including creatures you control. If Sunblast Angel has become tapped by the time its ability resolves, it will be destroyed too."
         }
       ],
       "subtypes": [
@@ -8569,23 +8575,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -8680,7 +8686,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         }
       ],
       "text": "Create X 2/2 white Cat creature tokens. Shuffle White Sun's Zenith into its owner's library.",
@@ -8774,11 +8780,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -8869,15 +8875,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -9067,7 +9073,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Skipping the “next” step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player’s opponents will each skip their next two untap steps."
+          "text": "Skipping the \"next\" step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player's opponents will each skip their next two untap steps."
         }
       ],
       "subtypes": [
@@ -9162,7 +9168,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2017-03-14",
@@ -9170,7 +9176,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If the copied creature is a token, the token that’s created copies the original characteristics of that token as stated by the effect that created the token."
+          "text": "If the copied creature is a token, the token that's created copies the original characteristics of that token as stated by the effect that created the token."
         },
         {
           "date": "2017-03-14",
@@ -9178,7 +9184,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         }
       ],
       "text": "Create a token that's a copy of target creature you control.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -9533,23 +9539,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -9557,7 +9563,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -9649,39 +9655,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -10123,7 +10129,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If Fog Bank blocks a creature with trample, that creature’s controller must assign 2 damage to Fog Bank (assuming it’s blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
+          "text": "If Fog Bank blocks a creature with trample, that creature's controller must assign 2 damage to Fog Bank (assuming it's blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
         }
       ],
       "subtypes": [
@@ -10217,7 +10223,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Fool’s Demise and the enchanted creature go to the graveyard from the battlefield at the same time, both abilities will trigger."
+          "text": "If Fool's Demise and the enchanted creature go to the graveyard from the battlefield at the same time, both abilities will trigger."
         }
       ],
       "subtypes": [
@@ -10309,19 +10315,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Frost Titan’s first ability affects each spell (including Aura spells), activated ability, and triggered ability that’s controlled by an opponent and that Frost Titan becomes a target of."
+          "text": "Frost Titan's first ability affects each spell (including Aura spells), activated ability, and triggered ability that's controlled by an opponent and that Frost Titan becomes a target of."
         },
         {
           "date": "2010-08-15",
-          "text": "You may target any permanent with Frost Titan’s second ability. It’s okay if that permanent is already tapped."
+          "text": "You may target any permanent with Frost Titan's second ability. It's okay if that permanent is already tapped."
         },
         {
           "date": "2010-08-15",
-          "text": "If the permanent affected by Frost Titan’s second ability is untapped at the time that permanent’s controller’s next untap step begins, the last part of Frost Titan’s second ability has no effect."
+          "text": "If the permanent affected by Frost Titan's second ability is untapped at the time that permanent's controller's next untap step begins, the last part of Frost Titan's second ability has no effect."
         },
         {
           "date": "2010-08-15",
-          "text": "If the permanent affected by Frost Titan’s second ability changes controllers before its old controller’s next untap step, Frost Titan’s second ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "If the permanent affected by Frost Titan's second ability changes controllers before its old controller's next untap step, Frost Titan's second ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -10521,11 +10527,11 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Creatures you control don’t copy whether the enchanted creature is tapped or untapped, whether it has any counters on it, whether it has any Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Creatures you control don't copy whether the enchanted creature is tapped or untapped, whether it has any counters on it, whether it has any Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-05-01",
-          "text": "Because creatures you control enter the battlefield as a copy of the enchanted creature, any enters-the-battlefield triggered abilities printed on such creatures won’t trigger. However, if the enchanted creature has any enters-the-battlefield triggered abilities, those will trigger."
+          "text": "Because creatures you control enter the battlefield as a copy of the enchanted creature, any enters-the-battlefield triggered abilities printed on such creatures won't trigger. However, if the enchanted creature has any enters-the-battlefield triggered abilities, those will trigger."
         },
         {
           "date": "2012-05-01",
@@ -10533,15 +10539,15 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If a creature such as Clone is entering the battlefield under your control, there will be two copy effects to apply: the creature’s own and Infinite Reflection’s. No matter what order these effects are applied, the creature will be a copy of the enchanted creature when it enters the battlefield."
+          "text": "If a creature such as Clone is entering the battlefield under your control, there will be two copy effects to apply: the creature's own and Infinite Reflection's. No matter what order these effects are applied, the creature will be a copy of the enchanted creature when it enters the battlefield."
         },
         {
           "date": "2012-05-01",
-          "text": "Other enters-the-battlefield replacement abilities printed on the creature entering the battlefield won’t be applied because the creature will already be a copy of the enchanted creature at that point (and therefore it won’t have those abilities). For example, if the enchanted creature is Serra Angel, a creature that normally enters the battlefield tapped will enter the battlefield as an untapped copy of Serra Angel, and a creature that would normally enter the battlefield with counters on it will enter the battlefield as a copy of Serra Angel with no counters."
+          "text": "Other enters-the-battlefield replacement abilities printed on the creature entering the battlefield won't be applied because the creature will already be a copy of the enchanted creature at that point (and therefore it won't have those abilities). For example, if the enchanted creature is Serra Angel, a creature that normally enters the battlefield tapped will enter the battlefield as an untapped copy of Serra Angel, and a creature that would normally enter the battlefield with counters on it will enter the battlefield as a copy of Serra Angel with no counters."
         },
         {
           "date": "2012-05-01",
-          "text": "External abilities may still affect how a creature enters the battlefield. For example, if your opponent controls Urabrask the Hidden, which reads, in part, “Creatures your opponents control enter the battlefield tapped,” a creature entering the battlefield under your control will be a tapped copy of the enchanted creature."
+          "text": "External abilities may still affect how a creature enters the battlefield. For example, if your opponent controls Urabrask the Hidden, which reads, in part, \"Creatures your opponents control enter the battlefield tapped,\" a creature entering the battlefield under your control will be a tapped copy of the enchanted creature."
         },
         {
           "date": "2012-05-01",
@@ -10640,7 +10646,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted permanent is an illegal target by the time Into the Roil resolves, the entire spell is countered. You don’t draw a card."
+          "text": "If the targeted permanent is an illegal target by the time Into the Roil resolves, the entire spell is countered. You don't draw a card."
         }
       ],
       "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If Into the Roil was kicked, draw a card.",
@@ -10739,15 +10745,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "The controller of a face-down creature can look at it at any time, even if it doesn’t have morph. Other players can’t, but the rules for face-down permanents state that “you must ensure at all times that your face-down spells and permanents can be easily differentiated from each other.” As a result, all players must be able to figure out what each of the creatures Ixidron turned face down is."
+          "text": "The controller of a face-down creature can look at it at any time, even if it doesn't have morph. Other players can't, but the rules for face-down permanents state that \"you must ensure at all times that your face-down spells and permanents can be easily differentiated from each other.\" As a result, all players must be able to figure out what each of the creatures Ixidron turned face down is."
         },
         {
           "date": "2006-09-25",
-          "text": "You turn the creatures face-down *as* Ixidron enters the battlefield. There is never a moment when Ixidron is on the battlefield and the creatures are face-up. If a creature on the battlefield has a “whenever another creature enters the battlefield” ability, it won’t trigger because that creature will be face down before Ixidron enters the battlefield."
+          "text": "You turn the creatures face-down *as* Ixidron enters the battlefield. There is never a moment when Ixidron is on the battlefield and the creatures are face-up. If a creature on the battlefield has a \"whenever another creature enters the battlefield\" ability, it won't trigger because that creature will be face down before Ixidron enters the battlefield."
         },
         {
           "date": "2006-09-25",
-          "text": "Turning a face-down creature face-down typically has no effect; the creature’s status is unchanged."
+          "text": "Turning a face-down creature face-down typically has no effect; the creature's status is unchanged."
         }
       ],
       "subtypes": [
@@ -10843,15 +10849,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target any eight (or fewer) permanents. It’s okay if any of them are already tapped, and it’s okay if any of them are controlled by someone other than the defending player."
+          "text": "You may target any eight (or fewer) permanents. It's okay if any of them are already tapped, and it's okay if any of them are controlled by someone other than the defending player."
         },
         {
           "date": "2009-10-01",
-          "text": "If a targeted permanent is untapped at the time its controller’s next untap step begins, this ability has no effect on it. It won’t apply at some later time when the targeted permanent is tapped."
+          "text": "If a targeted permanent is untapped at the time its controller's next untap step begins, this ability has no effect on it. It won't apply at some later time when the targeted permanent is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "If an affected permanent changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "If an affected permanent changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -11046,15 +11052,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Phyrexian Ingester will get bonuses based on the card’s power and toughness in exile. Counters, Auras, and Equipment it had on it before it was exiled won’t add to those numbers."
+          "text": "Phyrexian Ingester will get bonuses based on the card's power and toughness in exile. Counters, Auras, and Equipment it had on it before it was exiled won't add to those numbers."
         },
         {
           "date": "2016-06-08",
-          "text": "Abilities that define a creature’s power and toughness apply while that card is in exile, but abilities that add or subtract from it don’t. For example, the ability of Battle Squadron applies to determine Phyrexian Ingester’s power and toughness, but the ability of Werebear doesn’t. Phyrexian Ingester’s power and toughness are constantly updated if the exiled card’s power and/or toughness change."
+          "text": "Abilities that define a creature's power and toughness apply while that card is in exile, but abilities that add or subtract from it don't. For example, the ability of Battle Squadron applies to determine Phyrexian Ingester's power and toughness, but the ability of Werebear doesn't. Phyrexian Ingester's power and toughness are constantly updated if the exiled card's power and/or toughness change."
         },
         {
           "date": "2016-06-08",
-          "text": "If the card in exile isn’t a creature card (perhaps because it was a land that was temporarily a creature while on the battlefield), Phyrexian Ingester doesn’t get a bonus."
+          "text": "If the card in exile isn't a creature card (perhaps because it was a land that was temporarily a creature while on the battlefield), Phyrexian Ingester doesn't get a bonus."
         }
       ],
       "subtypes": [
@@ -11149,7 +11155,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The creature’s controller gets the Ape token even if the creature isn’t actually destroyed."
+          "text": "The creature's controller gets the Ape token even if the creature isn't actually destroyed."
         }
       ],
       "text": "Destroy target creature. It can't be regenerated. Its controller creates a 3/3 green Ape creature token.",
@@ -11332,15 +11338,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Rite of Replication resolves, the entire spell is countered. You won’t get any tokens."
+          "text": "If the targeted creature is an illegal target by the time Rite of Replication resolves, the entire spell is countered. You won't get any tokens."
         },
         {
           "date": "2009-10-01",
-          "text": "As the token or tokens are created, they check the printed values of the creature they’re copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "As the token or tokens are created, they check the printed values of the creature they're copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, or so on."
         },
         {
           "date": "2009-10-01",
-          "text": "The tokens see each other enter the battlefield. If they have a triggered ability that triggers when a creature enters the battlefield, they’ll all trigger for one another."
+          "text": "The tokens see each other enter the battlefield. If they have a triggered ability that triggers when a creature enters the battlefield, they'll all trigger for one another."
         }
       ],
       "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nCreate a token that's a copy of target creature. If Rite of Replication was kicked, create five of those tokens instead.",
@@ -11515,7 +11521,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If there’s only one card in your library as Sea Gate Oracle’s ability resolves, you’ll put it into your hand."
+          "text": "If there's only one card in your library as Sea Gate Oracle's ability resolves, you'll put it into your hand."
         }
       ],
       "subtypes": [
@@ -11707,11 +11713,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Essentially, Sphinx of Jwar Isle lets you play with the top card of your library revealed only to you. Knowing what that card is becomes part of the information you have access to, just like you can look at the cards in your hand. You may look at the top card of your library whenever you want, even if you don’t have priority. This action doesn’t use the stack."
+          "text": "Essentially, Sphinx of Jwar Isle lets you play with the top card of your library revealed only to you. Knowing what that card is becomes part of the information you have access to, just like you can look at the cards in your hand. You may look at the top card of your library whenever you want, even if you don't have priority. This action doesn't use the stack."
         },
         {
           "date": "2009-10-01",
-          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, you can’t look at the new top card until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
+          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, you can't look at the new top card until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
         }
       ],
       "subtypes": [
@@ -11906,7 +11912,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "A pile can have no cards in it. In this case, you’ll choose whether to put all the revealed cards into your hand or into your graveyard."
+          "text": "A pile can have no cards in it. In this case, you'll choose whether to put all the revealed cards into your hand or into your graveyard."
         },
         {
           "date": "2011-09-22",
@@ -11914,7 +11920,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn’t target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
+          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn't target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
         }
       ],
       "subtypes": [
@@ -12095,11 +12101,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Turn to Frog overwrites all previous effects that set the creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Turn to Frog resolves will overwrite this effect."
+          "text": "Turn to Frog overwrites all previous effects that set the creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Turn to Frog resolves will overwrite this effect."
         },
         {
           "date": "2014-07-18",
-          "text": "Turn to Frog doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature’s ability that says “At the beginning of your upkeep,” “When this creature enters the battlefield,” or similar from triggering."
+          "text": "Turn to Frog doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature's ability that says \"At the beginning of your upkeep,\" \"When this creature enters the battlefield,\" or similar from triggering."
         },
         {
           "date": "2014-07-18",
@@ -12107,11 +12113,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
         },
         {
           "date": "2014-07-18",
-          "text": "If one of the Theros block Gods is affected by Turn to Frog, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God’s type-changing ability is applied before the effect that removes that ability is applied."
+          "text": "If one of the Theros block Gods is affected by Turn to Frog, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God's type-changing ability is applied before the effect that removes that ability is applied."
         }
       ],
       "text": "Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
@@ -12312,11 +12318,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "No game effect can cause you to win the game or cause any opponent to lose the game while you control Abyssal Persecutor. It doesn’t matter whether an opponent has 0 or less life, an opponent is forced to draw a card while his or her library is empty, an opponent has ten or more poison counters, an opponent is dealt combat damage by Phage the Untouchable, you control Felidar Sovereign and have 40 or more life, or so on. You keep playing."
+          "text": "No game effect can cause you to win the game or cause any opponent to lose the game while you control Abyssal Persecutor. It doesn't matter whether an opponent has 0 or less life, an opponent is forced to draw a card while his or her library is empty, an opponent has ten or more poison counters, an opponent is dealt combat damage by Phage the Untouchable, you control Felidar Sovereign and have 40 or more life, or so on. You keep playing."
         },
         {
           "date": "2010-03-01",
-          "text": "Other circumstances can still cause an opponent to lose the game, however. An opponent will lose a game if he or she concedes, if that player is penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if that player’s _Magic Online_(R) game clock runs out of time."
+          "text": "Other circumstances can still cause an opponent to lose the game, however. An opponent will lose a game if he or she concedes, if that player is penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if that player's _Magic Online_(R) game clock runs out of time."
         },
         {
           "date": "2010-03-01",
@@ -12324,7 +12330,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "Abyssal Persecutor won’t preclude an opponent’s life total from reaching 0 or less. It will just preclude that player from losing the game as a result."
+          "text": "Abyssal Persecutor won't preclude an opponent's life total from reaching 0 or less. It will just preclude that player from losing the game as a result."
         },
         {
           "date": "2010-03-01",
@@ -12332,11 +12338,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "Even though your opponents can’t lose the game, a player can’t pay an amount of life that’s greater than his or her life total. If a player’s life total is 0 or less, that player can’t pay life at all, with one exception: a player may always pay 0 life."
+          "text": "Even though your opponents can't lose the game, a player can't pay an amount of life that's greater than his or her life total. If a player's life total is 0 or less, that player can't pay life at all, with one exception: a player may always pay 0 life."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control Abyssal Persecutor in a Two-Headed Giant game, your team can’t win the game and the opposing team can’t lose the game."
+          "text": "If you control Abyssal Persecutor in a Two-Headed Giant game, your team can't win the game and the opposing team can't lose the game."
         }
       ],
       "subtypes": [
@@ -12434,7 +12440,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Counters on objects that aren’t permanents, such as time counters on a suspended card or poison counters on a player, are unaffected by Aether Snap."
+          "text": "Counters on objects that aren't permanents, such as time counters on a suspended card or poison counters on a player, are unaffected by Aether Snap."
         }
       ],
       "text": "Remove all counters from all permanents and exile all tokens.",
@@ -12523,7 +12529,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature is an illegal target when Annihilate tries to resolve, the entire spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target when Annihilate tries to resolve, the entire spell is countered. You won't draw a card."
         }
       ],
       "text": "Destroy target nonblack creature. It can't be regenerated.\nDraw a card.",
@@ -12709,7 +12715,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         }
       ],
       "text": "Put X -1/-1 counters on each creature. Shuffle Black Sun's Zenith into its owner's library.",
@@ -12900,15 +12906,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners’ graveyards at the same time, Butcher of Malakir’s triggered ability will trigger that many times."
+          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners' graveyards at the same time, Butcher of Malakir's triggered ability will trigger that many times."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers’ abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
+          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers' abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player’s Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player’s Butcher to trigger, and so on."
+          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player's Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player's Butcher to trigger, and so on."
         }
       ],
       "subtypes": [
@@ -13008,11 +13014,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -13104,19 +13110,19 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can’t sacrifice Disciple of Bolas to its own ability, because it says “another.”"
+          "text": "You can't sacrifice Disciple of Bolas to its own ability, because it says \"another.\""
         },
         {
           "date": "2012-07-01",
-          "text": "You can’t sacrifice more than one creature this way."
+          "text": "You can't sacrifice more than one creature this way."
         },
         {
           "date": "2012-07-01",
-          "text": "The ability is mandatory. If you control at least one other creature when the ability resolves, you must sacrifice one. If you don’t control any other creatures at that time, the ability won’t do anything."
+          "text": "The ability is mandatory. If you control at least one other creature when the ability resolves, you must sacrifice one. If you don't control any other creatures at that time, the ability won't do anything."
         },
         {
           "date": "2012-07-01",
-          "text": "The creature’s power when it was last on the battlefield is the amount of life you gain and the number of cards you draw."
+          "text": "The creature's power when it was last on the battlefield is the amount of life you gain and the number of cards you draw."
         }
       ],
       "subtypes": [
@@ -13213,11 +13219,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The value of X may exceed the targeted creature’s toughness. Drana’s bonus is based on the value of X, regardless of what the targeted creature’s toughness was."
+          "text": "The value of X may exceed the targeted creature's toughness. Drana's bonus is based on the value of X, regardless of what the targeted creature's toughness was."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time the ability resolves, the ability is countered. Drana won’t get the bonus."
+          "text": "If the targeted creature is an illegal target by the time the ability resolves, the ability is countered. Drana won't get the bonus."
         },
         {
           "date": "2010-06-15",
@@ -13495,7 +13501,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Evernight Shade’s ability doesn’t put +1/+1 counters on it; it just gives Evernight Shade +1/+1 until end of turn. If Evernight Shade has no +1/+1 counters on it and dies after its ability has resolved, undying will still return it to the battlefield."
+          "text": "Evernight Shade's ability doesn't put +1/+1 counters on it; it just gives Evernight Shade +1/+1 until end of turn. If Evernight Shade has no +1/+1 counters on it and dies after its ability has resolved, undying will still return it to the battlefield."
         }
       ],
       "subtypes": [
@@ -13678,11 +13684,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -13690,7 +13696,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -13778,6 +13784,12 @@
         "C14"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-07-01",
+          "text": "If the player's hand is empty when the triggered ability resolves, you'll still put a Zombie token onto the battlefield."
+        }
+      ],
       "subtypes": [
         "Zombie"
       ],
@@ -14061,7 +14073,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won’t change later in the turn, even if the number of Swamps you control changes."
+          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won't change later in the turn, even if the number of Swamps you control changes."
         }
       ],
       "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
@@ -14251,7 +14263,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it’s a creature you control."
+          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it's a creature you control."
         }
       ],
       "subtypes": [
@@ -14542,11 +14554,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -14644,10 +14656,10 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The value chosen for X applies to each X in the spell’s effect. You pay {X} only once."
+          "text": "The value chosen for X applies to each X in the spell's effect. You pay {X} only once."
         }
       ],
-      "text": "Choose two —\n• Target player loses X life. \n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
+      "text": "Choose two —\n• Target player loses X life.\n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -14740,11 +14752,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The power and toughness of the Demon token are set when Promise of Power resolves. They’re unaffected if the number of cards in your hand changes later."
+          "text": "The power and toughness of the Demon token are set when Promise of Power resolves. They're unaffected if the number of cards in your hand changes later."
         },
         {
           "date": "2004-12-01",
-          "text": "If you pay the entwine cost, you draw five cards, then lose five life, then put the Demon token onto the battlefield. The five cards you draw count toward the Demon’s power and toughness."
+          "text": "If you pay the entwine cost, you draw five cards, then lose five life, then put the Demon token onto the battlefield. The five cards you draw count toward the Demon's power and toughness."
         }
       ],
       "text": "Choose one —\n• You draw five cards and you lose 5 life.\n• Create an X/X black Demon creature token with flying, where X is the number of cards in your hand.\nEntwine {4} (Choose both if you pay the entwine cost.)",
@@ -14837,7 +14849,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The loss of life is part of the spell’s effect. It’s not an additional cost. If Read the Bones is countered, you won’t lose life."
+          "text": "The loss of life is part of the spell's effect. It's not an additional cost. If Read the Bones is countered, you won't lose life."
         },
         {
           "date": "2013-09-15",
@@ -14849,11 +14861,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -15313,7 +15325,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Unlike Skirsdag High Priest itself, the two other creatures you tap to activate the ability aren’t required to have been under your control continuously since the beginning of your most recent turn."
+          "text": "Unlike Skirsdag High Priest itself, the two other creatures you tap to activate the ability aren't required to have been under your control continuously since the beginning of your most recent turn."
         }
       ],
       "subtypes": [
@@ -15409,11 +15421,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Sudden Spoiling doesn’t counter abilities that have already triggered or been activated. In particular, you can’t cast this fast enough to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering."
+          "text": "Sudden Spoiling doesn't counter abilities that have already triggered or been activated. In particular, you can't cast this fast enough to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering."
         },
         {
           "date": "2006-09-25",
-          "text": "Sudden Spoiling affects only permanents that are creatures on the battlefield under the targeted player’s control at the time Sudden Spoiling resolves. It won’t affect creatures that enter the battlefield later or noncreature permanents that later become creatures."
+          "text": "Sudden Spoiling affects only permanents that are creatures on the battlefield under the targeted player's control at the time Sudden Spoiling resolves. It won't affect creatures that enter the battlefield later or noncreature permanents that later become creatures."
         },
         {
           "date": "2006-09-25",
@@ -15421,7 +15433,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a face-down creature is affected by Sudden Spoiling, it won’t be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/2 creature with no abilities until the turn ends. Its “When this creature turns face up” or “As this creature turns face up” abilities won’t work."
+          "text": "If a face-down creature is affected by Sudden Spoiling, it won't be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/2 creature with no abilities until the turn ends. Its \"When this creature turns face up\" or \"As this creature turns face up\" abilities won't work."
         },
         {
           "date": "2013-06-07",
@@ -15429,23 +15441,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntil end of turn, creatures target player controls lose all abilities and have base power and toughness 0/2.",
@@ -15630,7 +15642,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -15815,7 +15827,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If all loyalty counters are removed from a planeswalker, that planeswalker is put into its owner’s graveyard as a state-based action."
+          "text": "If all loyalty counters are removed from a planeswalker, that planeswalker is put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -15911,19 +15923,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You must choose two targets. You can’t cast Victimize targeting only one creature card."
+          "text": "You must choose two targets. You can't cast Victimize targeting only one creature card."
         },
         {
           "date": "2016-06-08",
-          "text": "The creature you sacrifice isn’t chosen until Victimize resolves. You can’t return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
+          "text": "The creature you sacrifice isn't chosen until Victimize resolves. You can't return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
         },
         {
           "date": "2016-06-08",
-          "text": "As Victimize resolves, you must sacrifice a creature if able. You can’t change your mind and choose not to sacrifice anything."
+          "text": "As Victimize resolves, you must sacrifice a creature if able. You can't change your mind and choose not to sacrifice anything."
         },
         {
           "date": "2016-06-08",
-          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you’ll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won’t sacrifice a creature."
+          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you'll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won't sacrifice a creature."
         },
         {
           "date": "2016-06-08",
@@ -16018,7 +16030,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you have two Xathrid Demons, both abilities will trigger at the beginning of your upkeep. When the first Demon’s ability resolves, you can sacrifice the second Demon to satisfy the requirement (“Sacrifice a creature other than Xathrid Demon” really means “Sacrifice a creature other than this creature”). When the second Demon’s ability resolves, you must sacrifice another creature. If you can’t (because the first Demon has somehow left the battlefield and you control no other creatures), you lose 7 life, regardless of whether the second Demon is still on the battlefield at this time."
+          "text": "If you have two Xathrid Demons, both abilities will trigger at the beginning of your upkeep. When the first Demon's ability resolves, you can sacrifice the second Demon to satisfy the requirement (\"Sacrifice a creature other than Xathrid Demon\" really means \"Sacrifice a creature other than this creature\"). When the second Demon's ability resolves, you must sacrifice another creature. If you can't (because the first Demon has somehow left the battlefield and you control no other creatures), you lose 7 life, regardless of whether the second Demon is still on the battlefield at this time."
         }
       ],
       "subtypes": [
@@ -16205,11 +16217,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Blasphemous Act’s ability can’t reduce the total cost to cast the spell below {R}."
+          "text": "Blasphemous Act's ability can't reduce the total cost to cast the spell below {R}."
         },
         {
           "date": "2011-09-22",
-          "text": "Although players may respond to Blasphemous Act once it’s been cast, once it’s announced, they can’t respond before the cost is calculated and paid."
+          "text": "Although players may respond to Blasphemous Act once it's been cast, once it's announced, they can't respond before the cost is calculated and paid."
         }
       ],
       "text": "Blasphemous Act costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
@@ -16392,7 +16404,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player’s library this way, that player shuffles before revealing the top card of that library."
+          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player's library this way, that player shuffles before revealing the top card of that library."
         },
         {
           "date": "2011-09-22",
@@ -16404,7 +16416,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the revealed card is a permanent card but can’t enter the battlefield (perhaps because it’s an Aura with nothing to enchant), it remains on top of that library."
+          "text": "If the revealed card is a permanent card but can't enter the battlefield (perhaps because it's an Aura with nothing to enchant), it remains on top of that library."
         },
         {
           "date": "2011-09-22",
@@ -16788,7 +16800,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If the targeted artifact is an illegal target by the time the activated ability resolves, the ability is countered. Hoard-Smelter Dragon won’t get the bonus."
+          "text": "If the targeted artifact is an illegal target by the time the activated ability resolves, the ability is countered. Hoard-Smelter Dragon won't get the bonus."
         },
         {
           "date": "2011-01-01",
@@ -16796,7 +16808,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the activated ability resolves but the targeted artifact isn’t destroyed (perhaps because it has indestructible or it regenerates), Hoard-Smelter Dragon will still get the bonus."
+          "text": "If the activated ability resolves but the targeted artifact isn't destroyed (perhaps because it has indestructible or it regenerates), Hoard-Smelter Dragon will still get the bonus."
         }
       ],
       "subtypes": [
@@ -16987,7 +16999,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Magmaquake doesn’t target any creature or planeswalker. For example, it will deal damage to a creature without flying that has hexproof."
+          "text": "Magmaquake doesn't target any creature or planeswalker. For example, it will deal damage to a creature without flying that has hexproof."
         }
       ],
       "text": "Magmaquake deals X damage to each creature without flying and each planeswalker.",
@@ -17082,7 +17094,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -17090,19 +17102,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -17287,7 +17299,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Both Tuktuk the Explorer and Tuktuk the Returned are legendary creatures. However, since they have different names, one of each may coexist without being affected by the “legend rule.”"
+          "text": "Both Tuktuk the Explorer and Tuktuk the Returned are legendary creatures. However, since they have different names, one of each may coexist without being affected by the \"legend rule.\""
         }
       ],
       "subtypes": [
@@ -17476,23 +17488,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntap target permanent and gain control of it until end of turn. It gains haste until end of turn.",
@@ -17585,7 +17597,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you attack with multiple creatures, Beastmaster Ascension’s first ability triggers multiple times."
+          "text": "If you attack with multiple creatures, Beastmaster Ascension's first ability triggers multiple times."
         }
       ],
       "text": "Whenever a creature you control attacks, you may put a quest counter on Beastmaster Ascension.\nAs long as Beastmaster Ascension has seven or more quest counters on it, creatures you control get +5/+5.",
@@ -17945,11 +17957,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Elvish Archdruid’s first ability affects only other Elves you control. However, Elvish Archdruid’s second ability counts all Elves you control — including itself."
+          "text": "Elvish Archdruid's first ability affects only other Elves you control. However, Elvish Archdruid's second ability counts all Elves you control — including itself."
         },
         {
           "date": "2011-09-22",
-          "text": "Elvish Archdruid’s activated ability is a mana ability. It doesn’t use the stack and players can’t respond to it."
+          "text": "Elvish Archdruid's activated ability is a mana ability. It doesn't use the stack and players can't respond to it."
         }
       ],
       "subtypes": [
@@ -18436,11 +18448,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Ezuri’s first ability can’t affect itself, but its second ability does."
+          "text": "Ezuri's first ability can't affect itself, but its second ability does."
         },
         {
           "date": "2011-01-01",
-          "text": "Only Elf creatures you control when the last ability resolves will get +3/+3 and gain trample until end of turn. Non-Elf creatures that become Elves or Elf creatures that enter the battlefield under your control later in the turn won’t get the bonuses."
+          "text": "Only Elf creatures you control when the last ability resolves will get +3/+3 and gain trample until end of turn. Non-Elf creatures that become Elves or Elf creatures that enter the battlefield under your control later in the turn won't get the bonuses."
         }
       ],
       "subtypes": [
@@ -18633,7 +18645,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Fresh Meat counts all creatures you owned that went to the graveyard this turn, including creature tokens that entered the battlefield under your control and nontoken creatures you owned but didn’t control."
+          "text": "Fresh Meat counts all creatures you owned that went to the graveyard this turn, including creature tokens that entered the battlefield under your control and nontoken creatures you owned but didn't control."
         }
       ],
       "text": "Create a 3/3 green Beast creature token for each creature put into your graveyard from the battlefield this turn.",
@@ -18832,7 +18844,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can’t pay this cost more than once to get a multiple effect."
+          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can't pay this cost more than once to get a multiple effect."
         },
         {
           "date": "2004-10-04",
@@ -18840,7 +18852,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
@@ -19426,7 +19438,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Lys Alana Huntmaster’s ability will resolve before the Elf spell that caused it to trigger."
+          "text": "Lys Alana Huntmaster's ability will resolve before the Elf spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -19643,7 +19655,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -19824,11 +19836,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then resolve Praetor’s Counsel, you have no maximum hand size. However, if those events happened in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then resolve Praetor's Counsel, you have no maximum hand size. However, if those events happened in the opposite order, your maximum hand size would be two."
         },
         {
           "date": "2011-06-01",
-          "text": "Later effects that modify your maximum hand size, but don’t set it to a specific number, will have no effect."
+          "text": "Later effects that modify your maximum hand size, but don't set it to a specific number, will have no effect."
         }
       ],
       "text": "Return all cards from your graveyard to your hand. Exile Praetor's Counsel. You have no maximum hand size for the rest of the game.",
@@ -20110,7 +20122,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -20399,7 +20411,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "A creature card that enters the battlefield as a copy of a token creature is still a nontoken creature. You’ll be able to draw a card."
+          "text": "A creature card that enters the battlefield as a copy of a token creature is still a nontoken creature. You'll be able to draw a card."
         }
       ],
       "subtypes": [
@@ -20682,7 +20694,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If a targeted permanent has indestructible or regenerates, its controller won’t get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner’s graveyard, its controller won’t get an Elephant token for it."
+          "text": "If a targeted permanent has indestructible or regenerates, its controller won't get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner's graveyard, its controller won't get an Elephant token for it."
         }
       ],
       "subtypes": [
@@ -20872,7 +20884,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf’s ability resolves. If Timberwatch Elf is still on the battlefield, it’ll count itself."
+          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf's ability resolves. If Timberwatch Elf is still on the battlefield, it'll count itself."
         }
       ],
       "subtypes": [
@@ -21057,11 +21069,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -21069,7 +21081,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -21440,7 +21452,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -21538,11 +21550,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Wren’s Run Packmaster gives deathtouch to all Wolf permanents you control, not just the tokens it creates."
+          "text": "Wren's Run Packmaster gives deathtouch to all Wolf permanents you control, not just the tokens it creates."
         },
         {
           "date": "2009-10-01",
-          "text": "A Wolf’s deathtouch ability will apply if both Wren’s Run Packmaster and that Wolf are on the battlefield at the time the Wolf deals damage. The creature dealt damage by the Wolf will be destroyed the next time state-based actions are checked, even if the Wolf or Wren’s Run Packmaster leaves the battlefield."
+          "text": "A Wolf's deathtouch ability will apply if both Wren's Run Packmaster and that Wolf are on the battlefield at the time the Wolf deals damage. The creature dealt damage by the Wolf will be destroyed the next time state-based actions are checked, even if the Wolf or Wren's Run Packmaster leaves the battlefield."
         }
       ],
       "subtypes": [
@@ -21730,15 +21742,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If there are no creature cards in any graveyard when Bonehoard’s living weapon ability resolves, the Germ will be 0/0 and put into its owner’s graveyard."
+          "text": "If there are no creature cards in any graveyard when Bonehoard's living weapon ability resolves, the Germ will be 0/0 and put into its owner's graveyard."
         },
         {
           "date": "2011-06-01",
-          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won’t increase the bonus granted by Bonehoard, however briefly."
+          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won't increase the bonus granted by Bonehoard, however briefly."
         },
         {
           "date": "2011-06-01",
-          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won’t get an additional bonus from the other creature."
+          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won't get an additional bonus from the other creature."
         }
       ],
       "subtypes": [
@@ -22099,7 +22111,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Caged Sun’s triggered ability is a mana ability, which means the ability doesn’t use the stack and can’t be responded to."
+          "text": "Caged Sun's triggered ability is a mana ability, which means the ability doesn't use the stack and can't be responded to."
         }
       ],
       "text": "As Caged Sun enters the battlefield, choose a color.\nCreatures you control of the chosen color get +1/+1.\nWhenever a land's ability adds one or more mana of the chosen color to your mana pool, add one additional mana of that color to your mana pool.",
@@ -22195,7 +22207,7 @@
         },
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -22442,7 +22454,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -22462,7 +22474,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Green spells you cast cost {1} less to cast.",
@@ -22552,39 +22564,39 @@
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -22847,7 +22859,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The ability will trigger when Ichor Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn’t resolved yet."
+          "text": "The ability will trigger when Ichor Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn't resolved yet."
         }
       ],
       "text": "When Ichor Wellspring enters the battlefield or is put into a graveyard from the battlefield, draw a card.",
@@ -23003,7 +23015,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -23023,7 +23035,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Black spells you cast cost {1} less to cast.",
@@ -23277,7 +23289,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Becoming an artifact doesn’t change what color(s) a permanent is."
+          "text": "Becoming an artifact doesn't change what color(s) a permanent is."
         }
       ],
       "text": "{T}: Target permanent becomes an artifact in addition to its other types until end of turn.",
@@ -23862,7 +23874,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The ability will trigger when Mycosynth Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn’t resolved yet."
+          "text": "The ability will trigger when Mycosynth Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn't resolved yet."
         }
       ],
       "text": "When Mycosynth Wellspring enters the battlefield or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
@@ -23949,11 +23961,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You choose the value for X as the last ability resolves. You can’t choose a value for X that’s greater than the number of untapped Myr you control."
+          "text": "You choose the value for X as the last ability resolves. You can't choose a value for X that's greater than the number of untapped Myr you control."
         },
         {
           "date": "2011-01-01",
-          "text": "You can tap any untapped Myr you control as the last ability resolves, not just the Myr tokens you put onto the battlefield with the first ability. This includes Myr that haven’t been under your control since your most recent turn began."
+          "text": "You can tap any untapped Myr you control as the last ability resolves, not just the Myr tokens you put onto the battlefield with the first ability. This includes Myr that haven't been under your control since your most recent turn began."
         },
         {
           "date": "2011-01-01",
@@ -23961,7 +23973,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "As the last ability resolves, you can tap untapped Myr you control even if Myr Battlesphere is no longer on the battlefield by then. If that has happened, Myr Battlesphere won’t be able to get the +X/+0 bonus, but it will still deal X damage to the defending player."
+          "text": "As the last ability resolves, you can tap untapped Myr you control even if Myr Battlesphere is no longer on the battlefield by then. If that has happened, Myr Battlesphere won't be able to get the +X/+0 bonus, but it will still deal X damage to the defending player."
         }
       ],
       "subtypes": [
@@ -24229,7 +24241,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -24475,7 +24487,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -24495,7 +24507,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "White spells you cast cost {1} less to cast.",
@@ -24583,11 +24595,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus's other abilities."
         },
         {
           "date": "2011-09-22",
-          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus’s second activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus's second activated ability, not just ones created by Pentavus's other abilities."
         }
       ],
       "subtypes": [
@@ -24857,7 +24869,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Pristine Talisman has a mana ability. Its ability doesn’t use the stack and can’t be responded to."
+          "text": "Pristine Talisman has a mana ability. Its ability doesn't use the stack and can't be responded to."
         }
       ],
       "text": "{T}: Add {C} to your mana pool. You gain 1 life.",
@@ -24937,7 +24949,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -24957,7 +24969,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Red spells you cast cost {1} less to cast.",
@@ -25037,7 +25049,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -25057,7 +25069,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Blue spells you cast cost {1} less to cast.",
@@ -25146,7 +25158,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -25581,7 +25593,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Spine of Ish Sah’s last ability doesn’t allow you to sacrifice it. You must find another way to get Spine of Ish Sah into the graveyard."
+          "text": "Spine of Ish Sah's last ability doesn't allow you to sacrifice it. You must find another way to get Spine of Ish Sah into the graveyard."
         }
       ],
       "text": "When Spine of Ish Sah enters the battlefield, destroy target permanent.\nWhen Spine of Ish Sah is put into a graveyard from the battlefield, return Spine of Ish Sah to its owner's hand.",
@@ -25667,27 +25679,27 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Steel Hellkite’s last ability destroys only nonland permanents whose converted mana cost is exactly equal to X, and only those controlled by players who have been dealt combat damage by Steel Hellkite this turn."
+          "text": "Steel Hellkite's last ability destroys only nonland permanents whose converted mana cost is exactly equal to X, and only those controlled by players who have been dealt combat damage by Steel Hellkite this turn."
         },
         {
           "date": "2011-01-01",
-          "text": "It doesn’t matter who controlled those permanents at the time Steel Hellkite dealt combat damage, or if those permanents were even on the battlefield at that time."
+          "text": "It doesn't matter who controlled those permanents at the time Steel Hellkite dealt combat damage, or if those permanents were even on the battlefield at that time."
         },
         {
           "date": "2011-01-01",
-          "text": "You may activate the last ability even if Steel Hellkite hasn’t dealt combat damage to any players that turn. If you do, the ability won’t do anything."
+          "text": "You may activate the last ability even if Steel Hellkite hasn't dealt combat damage to any players that turn. If you do, the ability won't do anything."
         },
         {
           "date": "2011-01-01",
-          "text": "If Steel Hellkite’s third ability is activated with X equal to 0, it will destroy each nonland permanent with converted mana cost 0 the appropriate players control."
+          "text": "If Steel Hellkite's third ability is activated with X equal to 0, it will destroy each nonland permanent with converted mana cost 0 the appropriate players control."
         },
         {
           "date": "2011-01-01",
-          "text": "The converted mana cost of a permanent is determined solely by the mana symbols printed in its upper right corner, unless it’s copying something else (see below). The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {3}{U}{U} has converted mana cost 5."
+          "text": "The converted mana cost of a permanent is determined solely by the mana symbols printed in its upper right corner, unless it's copying something else (see below). The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {3}{U}{U} has converted mana cost 5."
         },
         {
           "date": "2011-01-01",
-          "text": "If a permanent is copying something else, its converted mana cost is the converted mana cost of whatever it’s copying."
+          "text": "If a permanent is copying something else, its converted mana cost is the converted mana cost of whatever it's copying."
         },
         {
           "date": "2011-01-01",
@@ -25699,7 +25711,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If a nonland permanent has no mana symbols in its upper right corner (because it’s a token that’s not copying of something else, for example), its converted mana cost is 0."
+          "text": "If a nonland permanent has no mana symbols in its upper right corner (because it's a token that's not copying of something else, for example), its converted mana cost is 0."
         }
       ],
       "subtypes": [
@@ -25876,7 +25888,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can’t be the target of spells and abilities you control."
+          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can't be the target of spells and abilities you control."
         }
       ],
       "subtypes": [
@@ -27100,7 +27112,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Although Darksteel Citadel is an artifact, it can’t be cast as a spell. Playing it follows the normal rules for playing a land."
+          "text": "Although Darksteel Citadel is an artifact, it can't be cast as a spell. Playing it follows the normal rules for playing a land."
         }
       ],
       "text": "Indestructible\n{T}: Add {C} to your mana pool.",
@@ -27352,7 +27364,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Emeria, the Sky Ruin’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control seven or more Plains as your upkeep starts, and (2) the ability will do nothing if you control fewer than seven Plains by the time it resolves."
+          "text": "Emeria, the Sky Ruin's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control seven or more Plains as your upkeep starts, and (2) the ability will do nothing if you control fewer than seven Plains by the time it resolves."
         }
       ],
       "text": "Emeria, the Sky Ruin enters the battlefield tapped.\nAt the beginning of your upkeep, if you control seven or more Plains, you may return target creature card from your graveyard to the battlefield.\n{T}: Add {W} to your mana pool.",
@@ -27481,6 +27493,10 @@
       "imageName": "evolving wilds",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Battle for Zendikar Block",
           "legality": "Legal"
@@ -27801,15 +27817,15 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won’t get to search for a land card."
+          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won't get to search for a land card."
         },
         {
           "date": "2011-09-22",
-          "text": "If the targeted land is an illegal target by the time Ghost Quarter’s ability resolves, it will be countered and none of its effects will happen. The land’s controller won’t get to search for a basic land card."
+          "text": "If the targeted land is an illegal target by the time Ghost Quarter's ability resolves, it will be countered and none of its effects will happen. The land's controller won't get to search for a basic land card."
         },
         {
           "date": "2013-07-01",
-          "text": "The target land’s controller gets to search for a basic land card even if that land wasn’t destroyed by Ghost Quarter’s ability. This may happen because the land has indestructible or because it was regenerated."
+          "text": "The target land's controller gets to search for a basic land card even if that land wasn't destroyed by Ghost Quarter's ability. This may happen because the land has indestructible or because it was regenerated."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it onto the battlefield, then shuffle his or her library.",
@@ -27975,11 +27991,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The creature card returned to your hand is chosen at random as the ability resolves. If any player responds to the ability, that player won’t yet know what card will be returned."
+          "text": "The creature card returned to your hand is chosen at random as the ability resolves. If any player responds to the ability, that player won't yet know what card will be returned."
         },
         {
           "date": "2011-01-22",
-          "text": "Because the ability doesn’t target any creature card, any creature card put into the graveyard in response to that ability may be returned to your hand."
+          "text": "Because the ability doesn't target any creature card, any creature card put into the graveyard in response to that ability may be returned to your hand."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{3}, {T}, Sacrifice Haunted Fengraf: Return a creature card at random from your graveyard to your hand.",
@@ -28390,11 +28406,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Oran-Rief’s third ability cares about permanents’ characteristics at the time the ability resolves, not their characteristics at the time they entered the battlefield. For example, if a blue creature enters the battlefield, then is turned green by a spell or ability, then Oran-Rief’s second ability resolves, you’ll put a +1/+1 counter on that creature."
+          "text": "Oran-Rief's third ability cares about permanents' characteristics at the time the ability resolves, not their characteristics at the time they entered the battlefield. For example, if a blue creature enters the battlefield, then is turned green by a spell or ability, then Oran-Rief's second ability resolves, you'll put a +1/+1 counter on that creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Oran-Rief’s second ability affects all permanents that are green creatures that entered the battlefield this turn, not just the ones you control."
+          "text": "Oran-Rief's second ability affects all permanents that are green creatures that entered the battlefield this turn, not just the ones you control."
         }
       ],
       "text": "Oran-Rief, the Vastwood enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{T}: Put a +1/+1 counter on each green creature that entered the battlefield this turn.",
@@ -28477,7 +28493,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Once you activate the ability and sacrifice an artifact, it’s too late for anyone to respond to try and prevent you from paying the cost."
+          "text": "Once you activate the ability and sacrifice an artifact, it's too late for anyone to respond to try and prevent you from paying the cost."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}, {T}, Sacrifice an artifact: You gain 1 life.",
@@ -28653,7 +28669,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you’ll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you'll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\n{T}: Add {C} to your mana pool.",
@@ -29085,11 +29101,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Tectonic Edge’s second ability checks how many lands an opponent controls only at the time you activate the ability."
+          "text": "Tectonic Edge's second ability checks how many lands an opponent controls only at the time you activate the ability."
         },
         {
           "date": "2010-03-01",
-          "text": "Assuming you can activate Tectonic Edge’s second ability, you can target any nonbasic land with it (not just one controlled by an opponent that controls four or more lands)."
+          "text": "Assuming you can activate Tectonic Edge's second ability, you can target any nonbasic land with it (not just one controlled by an opponent that controls four or more lands)."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}, {T}, Sacrifice Tectonic Edge: Destroy target nonbasic land. Activate this ability only if an opponent controls four or more lands.",

--- a/json/C15.json
+++ b/json/C15.json
@@ -90,15 +90,15 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "A “commander creature” is a permanent that’s both someone’s commander and a creature."
+          "text": "A \"commander creature\" is a permanent that's both someone's commander and a creature."
         },
         {
           "date": "2015-11-04",
-          "text": "Bastion Protector’s ability applies to any commander creature you control, whether you own it or not."
+          "text": "Bastion Protector's ability applies to any commander creature you control, whether you own it or not."
         },
         {
           "date": "2015-11-04",
-          "text": "Bastion Protector’s ability doesn’t apply to commanders that aren’t currently creatures."
+          "text": "Bastion Protector's ability doesn't apply to commanders that aren't currently creatures."
         }
       ],
       "subtypes": [
@@ -185,11 +185,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If any opponent has a creature card in his or her graveyard as Dawnbreak Reclaimer’s ability resolves, then you must choose one of those cards. You can’t choose a different opponent with no creature cards in his or her graveyard to avoid returning one of those cards."
+          "text": "If any opponent has a creature card in his or her graveyard as Dawnbreak Reclaimer's ability resolves, then you must choose one of those cards. You can't choose a different opponent with no creature cards in his or her graveyard to avoid returning one of those cards."
         },
         {
           "date": "2015-11-04",
-          "text": "If there are no creature cards in any opponent’s graveyard as Dawnbreak Reclaimer’s ability resolves, you’ll still have the option to return a creature card from your graveyard to the battlefield. You choose which opponent will choose a creature card in your graveyard."
+          "text": "If there are no creature cards in any opponent's graveyard as Dawnbreak Reclaimer's ability resolves, you'll still have the option to return a creature card from your graveyard to the battlefield. You choose which opponent will choose a creature card in your graveyard."
         }
       ],
       "subtypes": [
@@ -278,11 +278,11 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Auras attached to exiled nonland permanents will be put into their owners’ graveyards. Equipment attached to exiled creatures will become unattached and remain on the battlefield. Any counters on exiled nonland permanents will cease to exist."
+          "text": "Auras attached to exiled nonland permanents will be put into their owners' graveyards. Equipment attached to exiled creatures will become unattached and remain on the battlefield. Any counters on exiled nonland permanents will cease to exist."
         },
         {
           "date": "2015-11-04",
-          "text": "If a token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2015-11-04",
@@ -290,7 +290,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "In a multiplayer game, if Grasp of Fate’s owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Grasp of Fate's owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "When Grasp of Fate enters the battlefield, for each opponent, exile up to one target nonland permanent that player controls until Grasp of Fate leaves the battlefield. (Those permanents return under their owners' control.)",
@@ -372,11 +372,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The tokens created by the myriad ability enter the battlefield tapped even though they’ll have vigilance."
+          "text": "The tokens created by the myriad ability enter the battlefield tapped even though they'll have vigilance."
         },
         {
           "date": "2015-11-04",
-          "text": "The term “defending player” in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
+          "text": "The term \"defending player\" in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
         },
         {
           "date": "2015-11-04",
@@ -388,7 +388,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won’t trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won’t apply to the tokens."
+          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won't trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won't apply to the tokens."
         },
         {
           "date": "2015-11-04",
@@ -396,15 +396,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-11-04",
-          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it’s attacking the player or a planeswalker he or she controls."
+          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it's attacking the player or a planeswalker he or she controls."
         }
       ],
       "subtypes": [
@@ -490,15 +490,15 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If Kalemne’s Captain is already monstrous, the activated ability won’t do anything."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If Kalemne's Captain is already monstrous, the activated ability won't do anything."
         },
         {
           "date": "2015-11-04",
-          "text": "Monstrous isn’t an ability that the creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it continues to be monstrous."
+          "text": "Monstrous isn't an ability that the creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it continues to be monstrous."
         },
         {
           "date": "2015-11-04",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -585,11 +585,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The value of X is determined as Oreskos Explorer’s triggered ability resolves."
+          "text": "The value of X is determined as Oreskos Explorer's triggered ability resolves."
         },
         {
           "date": "2015-11-04",
-          "text": "If no player controls more lands than you do, you’ll still search and shuffle your library, although you can’t find any cards."
+          "text": "If no player controls more lands than you do, you'll still search and shuffle your library, although you can't find any cards."
         }
       ],
       "subtypes": [
@@ -675,15 +675,15 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If the third mode is chosen multiple times, each of those modes represents a separate life-gaining event. For example, if the third mode is chosen three times, and you control Karlov of the Ghost Council (a creature with the ability “Whenever you gain life, put two +1/+1 counters on Karlov of the Ghost Council.”), Karlov’s ability will trigger three times, for a total of six +1/+1 counters."
+          "text": "If the third mode is chosen multiple times, each of those modes represents a separate life-gaining event. For example, if the third mode is chosen three times, and you control Karlov of the Ghost Council (a creature with the ability \"Whenever you gain life, put two +1/+1 counters on Karlov of the Ghost Council.\"), Karlov's ability will trigger three times, for a total of six +1/+1 counters."
         },
         {
           "date": "2015-11-04",
-          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can’t be changed."
+          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-11-04",
-          "text": "If a mode requires a target, you can select that mode only if there’s a legal target available. Ignore the targeting requirements for modes you don’t choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
+          "text": "If a mode requires a target, you can select that mode only if there's a legal target available. Ignore the targeting requirements for modes you don't choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
         },
         {
           "date": "2015-11-04",
@@ -695,7 +695,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can’t choose new modes."
+          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can't choose new modes."
         },
         {
           "date": "2015-11-04",
@@ -862,11 +862,11 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If you gain control of an instant or sorcery spell, it will be put into its owner’s graveyard as it resolves."
+          "text": "If you gain control of an instant or sorcery spell, it will be put into its owner's graveyard as it resolves."
         },
         {
           "date": "2015-11-04",
-          "text": "You may change any or none of the spell’s targets. If you change a target, you must choose a legal target for the spell. If you can’t, you must leave the target unchanged (even if the current target is illegal). Notably, if you were originally chosen as a “target opponent” for a spell you gain control with Aethersnatch, you are now an illegal target as you aren’t your own opponent."
+          "text": "You may change any or none of the spell's targets. If you change a target, you must choose a legal target for the spell. If you can't, you must leave the target unchanged (even if the current target is illegal). Notably, if you were originally chosen as a \"target opponent\" for a spell you gain control with Aethersnatch, you are now an illegal target as you aren't your own opponent."
         },
         {
           "date": "2015-11-04",
@@ -874,7 +874,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If you gain control of a commander spell, the commander’s owner chooses whether to put it in the command zone if it later leaves the battlefield."
+          "text": "If you gain control of a commander spell, the commander's owner chooses whether to put it in the command zone if it later leaves the battlefield."
         }
       ],
       "text": "Gain control of target spell. You may choose new targets for it. (If that spell becomes a permanent, it enters the battlefield under your control.)",
@@ -956,7 +956,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The term “defending player” in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
+          "text": "The term \"defending player\" in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
         },
         {
           "date": "2015-11-04",
@@ -968,7 +968,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won’t trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won’t apply to the tokens."
+          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won't trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won't apply to the tokens."
         },
         {
           "date": "2015-11-04",
@@ -976,15 +976,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-11-04",
-          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it’s attacking the player or a planeswalker he or she controls."
+          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it's attacking the player or a planeswalker he or she controls."
         }
       ],
       "subtypes": [
@@ -1071,31 +1071,31 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The activated ability Gigantoplasm gives itself becomes part of its copiable values. Unless the ability is overwritten by another copy effect, a creature that’s a copy of Gigantoplasm will have that ability."
+          "text": "The activated ability Gigantoplasm gives itself becomes part of its copiable values. Unless the ability is overwritten by another copy effect, a creature that's a copy of Gigantoplasm will have that ability."
         },
         {
           "date": "2015-11-04",
-          "text": "However, the effect of that ability isn’t copiable. That is, if Gigantoplasm is a copy of a creature with base power and toughness 2/2 and you activate its ability making it a 4/4 creature, another creature that becomes a copy of Gigantoplasm will have base power and toughness 2/2."
+          "text": "However, the effect of that ability isn't copiable. That is, if Gigantoplasm is a copy of a creature with base power and toughness 2/2 and you activate its ability making it a 4/4 creature, another creature that becomes a copy of Gigantoplasm will have base power and toughness 2/2."
         },
         {
           "date": "2015-11-04",
-          "text": "Gigantoplasm copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, etc."
+          "text": "Gigantoplasm copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, etc."
         },
         {
           "date": "2015-11-04",
-          "text": "If Gigantoplasm isn’t a creature (perhaps because it copied a land that had temporarily become a creature), you can still activate the ability “{X}: This creature has base power and toughness X/X.” However, this ability won’t have any effect, and it won’t turn Gigantoplasm into a creature."
+          "text": "If Gigantoplasm isn't a creature (perhaps because it copied a land that had temporarily become a creature), you can still activate the ability \"{X}: This creature has base power and toughness X/X.\" However, this ability won't have any effect, and it won't turn Gigantoplasm into a creature."
         },
         {
           "date": "2015-11-04",
-          "text": "The activated ability overwrites all previous effects that set Gigantoplasm’s base power and/or toughness to specific values. Other effects that set its base power and/or toughness that start to apply after the ability resolves (including ones created by subsequent activations of the ability) will overwrite the effect of the ability."
+          "text": "The activated ability overwrites all previous effects that set Gigantoplasm's base power and/or toughness to specific values. Other effects that set its base power and/or toughness that start to apply after the ability resolves (including ones created by subsequent activations of the ability) will overwrite the effect of the ability."
         },
         {
           "date": "2015-11-04",
-          "text": "Effects that modify Gigantoplasm’s power and/or toughness, such as the effect of Giant Growth or Glorious Anthem, will apply to Gigantoplasm no matter when they started applying. The same is true for counters that affect its power and/or toughness and effects that switch its power and toughness."
+          "text": "Effects that modify Gigantoplasm's power and/or toughness, such as the effect of Giant Growth or Glorious Anthem, will apply to Gigantoplasm no matter when they started applying. The same is true for counters that affect its power and/or toughness and effects that switch its power and toughness."
         },
         {
           "date": "2015-11-04",
-          "text": "If the chosen creature has {X} in its mana cost, X is 0. The ability that Gigantoplasm gives itself doesn’t affect an {X} in its mana cost."
+          "text": "If the chosen creature has {X} in its mana cost, X is 0. The ability that Gigantoplasm gives itself doesn't affect an {X} in its mana cost."
         },
         {
           "date": "2015-11-04",
@@ -1103,15 +1103,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If the chosen creature is a token, Gigantoplasm copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Gigantoplasm isn’t a token, even if it’s copying one."
+          "text": "If the chosen creature is a token, Gigantoplasm copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Gigantoplasm isn't a token, even if it's copying one."
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Gigantoplasm enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Gigantoplasm enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2015-11-04",
-          "text": "If Gigantoplasm somehow enters the battlefield at the same time as another creature, it can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Gigantoplasm somehow enters the battlefield at the same time as another creature, it can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2015-11-04",
@@ -1202,11 +1202,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Creatures may be dealt damage greater than their toughness. For example, if a source deals 5 damage to Illusory Ambusher, you’ll draw five cards."
+          "text": "Creatures may be dealt damage greater than their toughness. For example, if a source deals 5 damage to Illusory Ambusher, you'll draw five cards."
         },
         {
           "date": "2015-11-04",
-          "text": "If Illusory Ambusher blocks a creature with trample, that creature’s controller can assign any amount of damage from 1 to that creature’s power to Illusory Ambusher. Excess damage doesn’t have to be assigned to the defending player."
+          "text": "If Illusory Ambusher blocks a creature with trample, that creature's controller can assign any amount of damage from 1 to that creature's power to Illusory Ambusher. Excess damage doesn't have to be assigned to the defending player."
         }
       ],
       "subtypes": [
@@ -1292,15 +1292,15 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "A token created by Mirror Match will be blocking the creature it’s copying even if that creature can’t be blocked or has an ability that would stop the token creature from blocking it (such as menace or protection). This is also true even if the token creature has an ability that would stop it from being declared as a blocker."
+          "text": "A token created by Mirror Match will be blocking the creature it's copying even if that creature can't be blocked or has an ability that would stop the token creature from blocking it (such as menace or protection). This is also true even if the token creature has an ability that would stop it from being declared as a blocker."
         },
         {
           "date": "2015-11-04",
-          "text": "Although the tokens enter the battlefield blocking, they were never declared as blockers. Abilities that trigger whenever a creature blocks won’t trigger. If there are any costs to have a creature block, those costs won’t apply to the tokens."
+          "text": "Although the tokens enter the battlefield blocking, they were never declared as blockers. Abilities that trigger whenever a creature blocks won't trigger. If there are any costs to have a creature block, those costs won't apply to the tokens."
         },
         {
           "date": "2015-11-04",
-          "text": "If the tokens aren’t creatures (perhaps because the attacking creature was an animated land), they’ll enter the battlefield but they won’t be blocking. Attacking creatures that weren’t otherwise blocked will remain unblocked."
+          "text": "If the tokens aren't creatures (perhaps because the attacking creature was an animated land), they'll enter the battlefield but they won't be blocking. Attacking creatures that weren't otherwise blocked will remain unblocked."
         },
         {
           "date": "2015-11-04",
@@ -1308,11 +1308,11 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If Mirror Match creates more than one token for any given attacking creature (due to an effect such as the one Doubling Season creates), each of those tokens will enter the battlefield blocking the creature it’s a copy of. All of those tokens will be exiled by the delayed triggered ability."
+          "text": "If Mirror Match creates more than one token for any given attacking creature (due to an effect such as the one Doubling Season creates), each of those tokens will enter the battlefield blocking the creature it's a copy of. All of those tokens will be exiled by the delayed triggered ability."
         },
         {
           "date": "2015-11-04",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-11-04",
@@ -1328,7 +1328,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         }
       ],
       "text": "Cast Mirror Match only during the declare blockers step.\nFor each creature attacking you or a planeswalker you control, create a token that's a copy of that creature and that's blocking that creature. Exile those tokens at end of combat.",
@@ -1409,11 +1409,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can’t be changed."
+          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-11-04",
-          "text": "If a mode requires a target, you can select that mode only if there’s a legal target available. Ignore the targeting requirements for modes you don’t choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
+          "text": "If a mode requires a target, you can select that mode only if there's a legal target available. Ignore the targeting requirements for modes you don't choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
         },
         {
           "date": "2015-11-04",
@@ -1425,7 +1425,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can’t choose new modes."
+          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can't choose new modes."
         },
         {
           "date": "2015-11-04",
@@ -1519,7 +1519,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "The cards you exile will stay in exile. They’re not part of the group you shuffle into your library."
+          "text": "The cards you exile will stay in exile. They're not part of the group you shuffle into your library."
         },
         {
           "date": "2015-11-04",
@@ -1527,11 +1527,11 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If the number of creatures you exile is greater than the number of creature cards remaining in your library, you’ll wind up revealing your entire library, putting all creature cards revealed that way onto the battlefield, then shuffling your library."
+          "text": "If the number of creatures you exile is greater than the number of creature cards remaining in your library, you'll wind up revealing your entire library, putting all creature cards revealed that way onto the battlefield, then shuffling your library."
         },
         {
           "date": "2015-11-04",
-          "text": "If you don’t reveal any noncreature cards this way (perhaps because all the creature cards you needed were on top of your library), you still shuffle your library."
+          "text": "If you don't reveal any noncreature cards this way (perhaps because all the creature cards you needed were on top of your library), you still shuffle your library."
         }
       ],
       "text": "Exile all creatures you control. At the beginning of the next end step, reveal cards from the top of your library until you reveal that many creature cards, put all creature cards revealed this way onto the battlefield, then shuffle the rest of the revealed cards into your library.",
@@ -1614,7 +1614,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The term “defending player” in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
+          "text": "The term \"defending player\" in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
         },
         {
           "date": "2015-11-04",
@@ -1626,7 +1626,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won’t trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won’t apply to the tokens."
+          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won't trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won't apply to the tokens."
         },
         {
           "date": "2015-11-04",
@@ -1634,15 +1634,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-11-04",
-          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it’s attacking the player or a planeswalker he or she controls."
+          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it's attacking the player or a planeswalker he or she controls."
         }
       ],
       "subtypes": [
@@ -1817,11 +1817,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Although Daxos’s Torment will become a creature after it enters the battlefield, it doesn’t enter as a creature. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "Although Daxos's Torment will become a creature after it enters the battlefield, it doesn't enter as a creature. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2015-11-04",
-          "text": "If the triggered ability resolves while Daxos’s Torment is already a creature, that ability will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
+          "text": "If the triggered ability resolves while Daxos's Torment is already a creature, that ability will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
         }
       ],
       "text": "Constellation — Whenever Daxos's Torment or another enchantment enters the battlefield under your control, Daxos's Torment becomes a 5/5 Demon creature with flying and haste in addition to its other types until end of turn.",
@@ -1903,7 +1903,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Creatures that aren’t destroyed this way (perhaps because they regenerated or have indestructible) don’t count toward the life lost."
+          "text": "Creatures that aren't destroyed this way (perhaps because they regenerated or have indestructible) don't count toward the life lost."
         }
       ],
       "text": "Destroy all creatures. Each player loses life equal to the number of creatures he or she controlled that were destroyed this way.",
@@ -1986,7 +1986,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If a creature card has an ability that replaces going to the graveyard with moving somewhere else “instead,” that card won’t count toward the number of Zombies you get. Conversely, creature cards with a triggered ability that removes them from the graveyard when they’re put there from anywhere (or your library) will count toward that number."
+          "text": "If a creature card has an ability that replaces going to the graveyard with moving somewhere else \"instead,\" that card won't count toward the number of Zombies you get. Conversely, creature cards with a triggered ability that removes them from the graveyard when they're put there from anywhere (or your library) will count toward that number."
         }
       ],
       "text": "Each player puts the top X cards of his or her library into his or her graveyard. For each creature card put into a graveyard this way, you create a tapped 2/2 black Zombie creature token.",
@@ -2070,7 +2070,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Casting Scourge of Nel Toth from your graveyard by paying the alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
+          "text": "Casting Scourge of Nel Toth from your graveyard by paying the alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
         },
         {
           "date": "2015-11-04",
@@ -2078,7 +2078,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "As soon as you start to cast Scourge of Nel Toth from your graveyard, it moves to the stack. At that point, it’s too late for an opponent to prevent you from casting it by removing it from your graveyard. It’s also too late for players to try to destroy the creatures you sacrifice to pay for the spell."
+          "text": "As soon as you start to cast Scourge of Nel Toth from your graveyard, it moves to the stack. At that point, it's too late for an opponent to prevent you from casting it by removing it from your graveyard. It's also too late for players to try to destroy the creatures you sacrifice to pay for the spell."
         }
       ],
       "subtypes": [
@@ -2167,7 +2167,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Experience counters aren’t removed from players this way, but loyalty counters are removed from planeswalkers."
+          "text": "Experience counters aren't removed from players this way, but loyalty counters are removed from planeswalkers."
         },
         {
           "date": "2015-11-04",
@@ -2257,11 +2257,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can’t be changed."
+          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-11-04",
-          "text": "If a mode requires a target, you can select that mode only if there’s a legal target available. Ignore the targeting requirements for modes you don’t choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
+          "text": "If a mode requires a target, you can select that mode only if there's a legal target available. Ignore the targeting requirements for modes you don't choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
         },
         {
           "date": "2015-11-04",
@@ -2273,7 +2273,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can’t choose new modes."
+          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can't choose new modes."
         },
         {
           "date": "2015-11-04",
@@ -2358,7 +2358,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If Awaken the Sky Tyrant isn’t on the battlefield as its ability resolves, you can’t sacrifice it. You won’t get the Dragon in that case."
+          "text": "If Awaken the Sky Tyrant isn't on the battlefield as its ability resolves, you can't sacrifice it. You won't get the Dragon in that case."
         },
         {
           "date": "2015-11-04",
@@ -2453,15 +2453,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If you cast an instant or sorcery card this way, it will go to your graveyard after it resolves or is countered. It won’t return to exile."
+          "text": "If you cast an instant or sorcery card this way, it will go to your graveyard after it resolves or is countered. It won't return to exile."
         },
         {
           "date": "2015-11-04",
-          "text": "Any cards you don’t cast will remain exiled."
+          "text": "Any cards you don't cast will remain exiled."
         },
         {
           "date": "2015-11-04",
-          "text": "Exiling all the cards from your library this way won’t cause you to lose the game. You’ll lose only if you attempt to draw a card from an empty library."
+          "text": "Exiling all the cards from your library this way won't cause you to lose the game. You'll lose only if you attempt to draw a card from an empty library."
         }
       ],
       "subtypes": [
@@ -2546,7 +2546,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If the first or second modes are chosen multiple times, each of those modes represents a separate damage-dealing event. For example, if your opponent casts Fiery Confluence choosing the second mode three times, and you control Guardian Seraph (a creature with the ability “If a source an opponent controls would deal damage to you, prevent 1 of that damage”), you’ll be dealt a total of 3 damage."
+          "text": "If the first or second modes are chosen multiple times, each of those modes represents a separate damage-dealing event. For example, if your opponent casts Fiery Confluence choosing the second mode three times, and you control Guardian Seraph (a creature with the ability \"If a source an opponent controls would deal damage to you, prevent 1 of that damage\"), you'll be dealt a total of 3 damage."
         },
         {
           "date": "2015-11-04",
@@ -2554,11 +2554,11 @@
         },
         {
           "date": "2015-11-04",
-          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can’t be changed."
+          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-11-04",
-          "text": "If a mode requires a target, you can select that mode only if there’s a legal target available. Ignore the targeting requirements for modes you don’t choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
+          "text": "If a mode requires a target, you can select that mode only if there's a legal target available. Ignore the targeting requirements for modes you don't choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
         },
         {
           "date": "2015-11-04",
@@ -2570,7 +2570,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can’t choose new modes."
+          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can't choose new modes."
         },
         {
           "date": "2015-11-04",
@@ -2738,15 +2738,15 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Meteor Blast can’t target the same creature or player more than once."
+          "text": "Meteor Blast can't target the same creature or player more than once."
         },
         {
           "date": "2015-11-04",
-          "text": "Meteor Blast can’t deal damage to both a player and a planeswalker he or she controls this way. Meteor Blast also can’t deal damage to more than one planeswalker controlled by the same player this way."
+          "text": "Meteor Blast can't deal damage to both a player and a planeswalker he or she controls this way. Meteor Blast also can't deal damage to more than one planeswalker controlled by the same player this way."
         },
         {
           "date": "2015-11-04",
-          "text": "If some but not all of Meteor Blast’s targets have become illegal by the time it tries to resolve, it will deal damage to the remaining legal targets. Illegal targets won’t be affected."
+          "text": "If some but not all of Meteor Blast's targets have become illegal by the time it tries to resolve, it will deal damage to the remaining legal targets. Illegal targets won't be affected."
         }
       ],
       "text": "Meteor Blast deals 4 damage to each of X target creatures and/or players.",
@@ -2827,23 +2827,23 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If Mizzix’s Mastery exiled multiple cards, you may cast the copies in any order. The last copy you cast will be the first one to resolve."
+          "text": "If Mizzix's Mastery exiled multiple cards, you may cast the copies in any order. The last copy you cast will be the first one to resolve."
         },
         {
           "date": "2015-11-04",
-          "text": "If you don’t cast one of the copies (perhaps because there are no legal targets available or you don’t want to), the copy will cease to exist."
+          "text": "If you don't cast one of the copies (perhaps because there are no legal targets available or you don't want to), the copy will cease to exist."
         },
         {
           "date": "2015-11-04",
-          "text": "Mizzix’s Mastery is still on the stack as it resolves. If you pay the overload cost, Mizzix’s Mastery won’t be exiled or copied."
+          "text": "Mizzix's Mastery is still on the stack as it resolves. If you pay the overload cost, Mizzix's Mastery won't be exiled or copied."
         },
         {
           "date": "2015-11-04",
-          "text": "The copies are created and cast during the resolution of Mizzix’s Mastery. You can’t wait to cast them later in the turn. Timing restrictions based on the copy’s type are ignored. Other restrictions (such as “Cast [this name] only during combat”) are not."
+          "text": "The copies are created and cast during the resolution of Mizzix's Mastery. You can't wait to cast them later in the turn. Timing restrictions based on the copy's type are ignored. Other restrictions (such as \"Cast [this name] only during combat\") are not."
         },
         {
           "date": "2015-11-04",
-          "text": "If you cast a spell “without paying its mana cost,” you can’t pay any alternative costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
+          "text": "If you cast a spell \"without paying its mana cost,\" you can't pay any alternative costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2015-11-04",
@@ -2936,7 +2936,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "The tokens aren’t named Elemental. They are named only Lightning Rager. The rule that says a token’s name is its creature types applies only if the tokens aren’t given a name by the effect that creates them."
+          "text": "The tokens aren't named Elemental. They are named only Lightning Rager. The rule that says a token's name is its creature types applies only if the tokens aren't given a name by the effect that creates them."
         }
       ],
       "text": "Creatures named Lightning Rager can't attack you or planeswalkers you control.\nAt the beginning of each player's upkeep, that player creates a 5/1 red Elemental creature token named Lightning Rager. It has trample, haste, and \"At the beginning of the end step, sacrifice this creature.\"",
@@ -3018,7 +3018,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The term “defending player” in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
+          "text": "The term \"defending player\" in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
         },
         {
           "date": "2015-11-04",
@@ -3030,7 +3030,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won’t trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won’t apply to the tokens."
+          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won't trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won't apply to the tokens."
         },
         {
           "date": "2015-11-04",
@@ -3038,15 +3038,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-11-04",
-          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it’s attacking the player or a planeswalker he or she controls."
+          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it's attacking the player or a planeswalker he or she controls."
         }
       ],
       "subtypes": [
@@ -3210,7 +3210,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If Bloodspore Thrinax enters the battlefield at the same time as other creatures you control, those creatures won’t get additional +1/+1 counters from Bloodspore Thrinax’s last ability. Those creatures also can’t be devoured by Bloodspore Thrinax."
+          "text": "If Bloodspore Thrinax enters the battlefield at the same time as other creatures you control, those creatures won't get additional +1/+1 counters from Bloodspore Thrinax's last ability. Those creatures also can't be devoured by Bloodspore Thrinax."
         }
       ],
       "subtypes": [
@@ -3297,7 +3297,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The term “defending player” in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
+          "text": "The term \"defending player\" in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
         },
         {
           "date": "2015-11-04",
@@ -3309,7 +3309,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won’t trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won’t apply to the tokens."
+          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won't trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won't apply to the tokens."
         },
         {
           "date": "2015-11-04",
@@ -3317,15 +3317,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-11-04",
-          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it’s attacking the player or a planeswalker he or she controls."
+          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it's attacking the player or a planeswalker he or she controls."
         }
       ],
       "subtypes": [
@@ -3412,7 +3412,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If Centaur Vinecrasher and a land card are put into your graveyard at the same time, Centaur Vinecrasher’s last ability will trigger. It doesn’t matter what zone Centaur Vinecrasher was previously in."
+          "text": "If Centaur Vinecrasher and a land card are put into your graveyard at the same time, Centaur Vinecrasher's last ability will trigger. It doesn't matter what zone Centaur Vinecrasher was previously in."
         }
       ],
       "subtypes": [
@@ -3499,7 +3499,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Players can’t cast spells or activate any abilities in between the Beasts entering the battlefield and fighting the other creatures. If the Beasts entering the battlefield cause any abilities to trigger, those abilities will be put onto the stack after Ezuri’s Predation is finished resolving."
+          "text": "Players can't cast spells or activate any abilities in between the Beasts entering the battlefield and fighting the other creatures. If the Beasts entering the battlefield cause any abilities to trigger, those abilities will be put onto the stack after Ezuri's Predation is finished resolving."
         },
         {
           "date": "2015-11-04",
@@ -3507,11 +3507,11 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each of the “fights” happens at the same time."
+          "text": "Each of the \"fights\" happens at the same time."
         },
         {
           "date": "2015-11-04",
-          "text": "If Ezuri’s Predation creates more than one token for any given creature (due to an effect such as the one Doubling Season creates), the extra tokens won’t fight any creature."
+          "text": "If Ezuri's Predation creates more than one token for any given creature (due to an effect such as the one Doubling Season creates), the extra tokens won't fight any creature."
         }
       ],
       "text": "For each creature your opponents control, create a 4/4 green Beast creature token. Each of those Beasts fights a different one of those creatures.",
@@ -3595,7 +3595,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Great Oak Guardian’s last ability targets only the player, not any creatures. Creatures with shroud that player controls will be affected, for example."
+          "text": "Great Oak Guardian's last ability targets only the player, not any creatures. Creatures with shroud that player controls will be affected, for example."
         },
         {
           "date": "2015-11-04",
@@ -3687,11 +3687,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The value of X is calculated as Pathbreaker Ibex’s ability resolves. Notably, if you attack with two Pathbreaker Ibex (and control no other creatures), the first ability to resolve will give those Ibex +3/+3. The second ability will then give them +6/+6."
+          "text": "The value of X is calculated as Pathbreaker Ibex's ability resolves. Notably, if you attack with two Pathbreaker Ibex (and control no other creatures), the first ability to resolve will give those Ibex +3/+3. The second ability will then give them +6/+6."
         },
         {
-          "date": "2015-11-04",
-          "text": "In some unusual cases, the greatest power among creatures you control may be negative. This is bad for you. For example, if the greatest power among creatures you control when the ability resolves is -2, creatures you control will get -2/-2 until end of turn."
+          "date": "2017-06-27",
+          "text": "If this creature's power is negative as its ability resolves, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -3778,7 +3778,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Skullwinder’s enters-the-battlefield ability targets only the card in your graveyard. If that card is an illegal target as the ability tries to resolve, the ability will be countered and none of its effects will happen. No cards will be returned to any player’s hand."
+          "text": "Skullwinder's enters-the-battlefield ability targets only the card in your graveyard. If that card is an illegal target as the ability tries to resolve, the ability will be countered and none of its effects will happen. No cards will be returned to any player's hand."
         },
         {
           "date": "2015-11-04",
@@ -3871,11 +3871,11 @@
         },
         {
           "date": "2015-11-04",
-          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can’t be changed."
+          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-11-04",
-          "text": "If a mode requires a target, you can select that mode only if there’s a legal target available. Ignore the targeting requirements for modes you don’t choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
+          "text": "If a mode requires a target, you can select that mode only if there's a legal target available. Ignore the targeting requirements for modes you don't choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
         },
         {
           "date": "2015-11-04",
@@ -3887,7 +3887,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can’t choose new modes."
+          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can't choose new modes."
         },
         {
           "date": "2015-11-04",
@@ -3975,7 +3975,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Damage dealt to Anya is tracked even if Anya has indestructible. For example, if Anya is dealt what would be lethal damage and Anya loses indestructible (perhaps because each opponent’s life total is too high), it will be destroyed the next time state-based actions are performed. However, the check for whether a creature dealt damage by a source with deathtouch is destroyed happens only the first time that state-based actions are performed after that damage-dealing event."
+          "text": "Damage dealt to Anya is tracked even if Anya has indestructible. For example, if Anya is dealt what would be lethal damage and Anya loses indestructible (perhaps because each opponent's life total is too high), it will be destroyed the next time state-based actions are performed. However, the check for whether a creature dealt damage by a source with deathtouch is destroyed happens only the first time that state-based actions are performed after that damage-dealing event."
         },
         {
           "date": "2015-11-04",
@@ -3983,7 +3983,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If a player’s starting life total is odd (Commander Vanguard? Sweet.), half that player’s life total will be a fraction, and that’s okay. For example, if an opponent’s starting life total is 41, half that number is 20 ½. If that player’s life total is 20 or less, Anya will have indestructible."
+          "text": "If a player's starting life total is odd (Commander Vanguard? Sweet.), half that player's life total will be a fraction, and that's okay. For example, if an opponent's starting life total is 41, half that number is 20 ½. If that player's life total is 20 or less, Anya will have indestructible."
         }
       ],
       "subtypes": [
@@ -4075,11 +4075,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Arjun’s triggered ability will resolve before the spell that caused it to trigger."
+          "text": "Arjun's triggered ability will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2015-11-04",
-          "text": "After Arjun’s ability triggers, players may cast instants and activate activated abilities. Each time, you cast an instant spell “in response, Arjun’s ability triggers again."
+          "text": "After Arjun's ability triggers, players may cast instants and activate activated abilities. Each time, you cast an instant spell \"in response, Arjun's ability triggers again."
         }
       ],
       "subtypes": [
@@ -4175,11 +4175,11 @@
         },
         {
           "date": "2015-11-04",
-          "text": "The ability that defines the token’s power and toughness is part of the token’s copiable values. Copies of the token will also have that ability."
+          "text": "The ability that defines the token's power and toughness is part of the token's copiable values. Copies of the token will also have that ability."
         },
         {
           "date": "2015-11-04",
-          "text": "Putting an enchantment creature token onto the battlefield won’t cause Daxos’s first ability to trigger. On the other hand, constellation abilities trigger whenever an enchantment enters the battlefield under your control, so those abilities will trigger."
+          "text": "Putting an enchantment creature token onto the battlefield won't cause Daxos's first ability to trigger. On the other hand, constellation abilities trigger whenever an enchantment enters the battlefield under your control, so those abilities will trigger."
         },
         {
           "date": "2015-11-04",
@@ -4191,7 +4191,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each game pack includes a card labeled “Experience” with the suggestion “Place your experience counters here.” This card isn’t required for play. It’s simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
+          "text": "Each game pack includes a card labeled \"Experience\" with the suggestion \"Place your experience counters here.\" This card isn't required for play. It's simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
         }
       ],
       "subtypes": [
@@ -4201,7 +4201,7 @@
       "supertypes": [
         "Legendary"
       ],
-      "text": "Whenever you cast an enchantment spell, you get an experience counter. \n{1}{W}{B}: Create a white and black Spirit enchantment creature token. It has \"This creature's power and toughness are each equal to the number of experience counters you have.\"",
+      "text": "Whenever you cast an enchantment spell, you get an experience counter.\n{1}{W}{B}: Create a white and black Spirit enchantment creature token. It has \"This creature's power and toughness are each equal to the number of experience counters you have.\"",
       "toughness": "2",
       "type": "Legendary Creature — Zombie Soldier",
       "types": [
@@ -4291,7 +4291,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each game pack includes a card labeled “Experience” with the suggestion “Place your experience counters here.” This card isn’t required for play. It’s simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
+          "text": "Each game pack includes a card labeled \"Experience\" with the suggestion \"Place your experience counters here.\" This card isn't required for play. It's simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
         }
       ],
       "subtypes": [
@@ -4391,7 +4391,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each game pack includes a card labeled “Experience” with the suggestion “Place your experience counters here.” This card isn’t required for play. It’s simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
+          "text": "Each game pack includes a card labeled \"Experience\" with the suggestion \"Place your experience counters here.\" This card isn't required for play. It's simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
         }
       ],
       "subtypes": [
@@ -4484,7 +4484,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from an attacking creature with lifelink or 4 life from Faith’s Fetters."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from an attacking creature with lifelink or 4 life from Faith's Fetters."
         },
         {
           "date": "2015-11-04",
@@ -4492,7 +4492,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -4585,7 +4585,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Once a creature has been legally blocked, activating Kaseto’s ability targeting that creature won’t cause it to become unblocked. It will give it +2/+2 if it’s a Snake, though."
+          "text": "Once a creature has been legally blocked, activating Kaseto's ability targeting that creature won't cause it to become unblocked. It will give it +2/+2 if it's a Snake, though."
         }
       ],
       "subtypes": [
@@ -4679,15 +4679,15 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If a permanent is sacrificed to pay a cost of a spell or ability, Mazirek’s ability will resolve before that spell or ability. Conversely, if a permanent is sacrificed during the resolution of a spell or ability, that spell or ability will finish resolving before Mazirek’s ability is put onto the stack."
+          "text": "If a permanent is sacrificed to pay a cost of a spell or ability, Mazirek's ability will resolve before that spell or ability. Conversely, if a permanent is sacrificed during the resolution of a spell or ability, that spell or ability will finish resolving before Mazirek's ability is put onto the stack."
         },
         {
           "date": "2015-11-04",
-          "text": "Mazirek itself doesn’t allow any player to sacrifice any permanents. Its ability triggers whenever a player sacrifices a permanent because some other spell, ability, or cost instructed the player to do so."
+          "text": "Mazirek itself doesn't allow any player to sacrifice any permanents. Its ability triggers whenever a player sacrifices a permanent because some other spell, ability, or cost instructed the player to do so."
         },
         {
           "date": "2015-11-04",
-          "text": "A legendary creature that dies because of the “legend rule” isn’t sacrificed. The same is true for a planeswalker that is affected by the “planeswalker uniqueness rule.”"
+          "text": "A legendary creature that dies because of the \"legend rule\" isn't sacrificed. The same is true for a planeswalker that is affected by the \"planeswalker uniqueness rule.\""
         }
       ],
       "subtypes": [
@@ -4784,7 +4784,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "You can’t choose to put the creature card into your hand if its converted mana cost is less than or equal to the number of experience counters you have as the ability resolves."
+          "text": "You can't choose to put the creature card into your hand if its converted mana cost is less than or equal to the number of experience counters you have as the ability resolves."
         },
         {
           "date": "2015-11-04",
@@ -4800,7 +4800,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each game pack includes a card labeled “Experience” with the suggestion “Place your experience counters here.” This card isn’t required for play. It’s simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
+          "text": "Each game pack includes a card labeled \"Experience\" with the suggestion \"Place your experience counters here.\" This card isn't required for play. It's simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
         }
       ],
       "subtypes": [
@@ -4892,19 +4892,19 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "You finish casting a spell, including paying its costs, before Mizzix’s first ability triggers. The ability that gives you the experience counter will resolve before the spell that caused it to trigger."
+          "text": "You finish casting a spell, including paying its costs, before Mizzix's first ability triggers. The ability that gives you the experience counter will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2015-11-04",
-          "text": "Mizzix’s last ability doesn’t change the mana cost or converted mana cost of any spell. It changes only the total cost you pay."
+          "text": "Mizzix's last ability doesn't change the mana cost or converted mana cost of any spell. It changes only the total cost you pay."
         },
         {
           "date": "2015-11-04",
-          "text": "Mizzix’s last ability can’t reduce the amount of colored mana you pay for a spell. It reduces only the generic component of that cost."
+          "text": "Mizzix's last ability can't reduce the amount of colored mana you pay for a spell. It reduces only the generic component of that cost."
         },
         {
           "date": "2015-11-04",
-          "text": "If there are additional costs to cast a spell, or if the cost to cast a spell is increased by an effect (such as the one created by Thalia, Guardian of Thraben’s ability), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, or if the cost to cast a spell is increased by an effect (such as the one created by Thalia, Guardian of Thraben's ability), apply those increases before applying cost reductions."
         },
         {
           "date": "2015-11-04",
@@ -4912,7 +4912,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If an instant or sorcery spell you cast has {X} in its mana cost, you choose the value of X before calculating the spell’s total cost. For example, if that spell’s mana cost is {X}{R} and you have one experience counter, you could choose 5 as the value of X and pay {4}{R} to cast the spell."
+          "text": "If an instant or sorcery spell you cast has {X} in its mana cost, you choose the value of X before calculating the spell's total cost. For example, if that spell's mana cost is {X}{R} and you have one experience counter, you could choose 5 as the value of X and pay {4}{R} to cast the spell."
         },
         {
           "date": "2015-11-04",
@@ -4924,7 +4924,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each game pack includes a card labeled “Experience” with the suggestion “Place your experience counters here.” This card isn’t required for play. It’s simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
+          "text": "Each game pack includes a card labeled \"Experience\" with the suggestion \"Place your experience counters here.\" This card isn't required for play. It's simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
         }
       ],
       "subtypes": [
@@ -5007,19 +5007,19 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If a creature has multiple instances of myriad, each triggers separately. You’ll get two tokens per opponent other than the defending player."
+          "text": "If a creature has multiple instances of myriad, each triggers separately. You'll get two tokens per opponent other than the defending player."
         },
         {
           "date": "2015-11-04",
-          "text": "If the tokens aren’t creatures (perhaps because the equipped creature was an animated land), they’ll enter the battlefield but they won’t be attacking. You’ll still exile those tokens at end of combat."
+          "text": "If the tokens aren't creatures (perhaps because the equipped creature was an animated land), they'll enter the battlefield but they won't be attacking. You'll still exile those tokens at end of combat."
         },
         {
           "date": "2015-11-04",
-          "text": "If the equipped creature is legendary, the tokens will all enter the battlefield. Then you’ll choose one of them to remain on the battlefield. The others will be put into your graveyard. Any enters-the-battlefield or dies triggers of the tokens will work."
+          "text": "If the equipped creature is legendary, the tokens will all enter the battlefield. Then you'll choose one of them to remain on the battlefield. The others will be put into your graveyard. Any enters-the-battlefield or dies triggers of the tokens will work."
         },
         {
           "date": "2015-11-04",
-          "text": "The term “defending player” in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
+          "text": "The term \"defending player\" in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
         },
         {
           "date": "2015-11-04",
@@ -5031,7 +5031,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won’t trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won’t apply to the tokens."
+          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won't trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won't apply to the tokens."
         },
         {
           "date": "2015-11-04",
@@ -5039,15 +5039,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-11-04",
-          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it’s attacking the player or a planeswalker he or she controls."
+          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it's attacking the player or a planeswalker he or she controls."
         }
       ],
       "subtypes": [
@@ -5200,7 +5200,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Scytheclaw’s triggered ability triggers and resolves after combat damage is dealt. For example, if the Germ token deals 1 combat damage to a player with 10 life, combat damage will reduce that player’s life total to 9. Then Scytheclaw’s ability will cause the player to lose 5 life, leaving the player at 4."
+          "text": "Scytheclaw's triggered ability triggers and resolves after combat damage is dealt. For example, if the Germ token deals 1 combat damage to a player with 10 life, combat damage will reduce that player's life total to 9. Then Scytheclaw's ability will cause the player to lose 5 life, leaving the player at 4."
         },
         {
           "date": "2015-11-04",
@@ -5287,15 +5287,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Seal of the Guildpact’s last ability doesn’t change the mana cost or converted mana cost of any spell. It changes only the total cost you pay."
+          "text": "Seal of the Guildpact's last ability doesn't change the mana cost or converted mana cost of any spell. It changes only the total cost you pay."
         },
         {
           "date": "2015-11-04",
-          "text": "Seal of the Guildpact’s last ability can’t reduce the amount of colored mana you pay for a spell. It reduces only the generic component of that cost."
+          "text": "Seal of the Guildpact's last ability can't reduce the amount of colored mana you pay for a spell. It reduces only the generic component of that cost."
         },
         {
           "date": "2015-11-04",
-          "text": "If there are additional costs to cast a spell, or if the cost to cast a spell is increased by an effect (such as the one created by Thalia, Guardian of Thraben’s ability), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, or if the cost to cast a spell is increased by an effect (such as the one created by Thalia, Guardian of Thraben's ability), apply those increases before applying cost reductions."
         },
         {
           "date": "2015-11-04",
@@ -5303,7 +5303,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If a spell you cast has {X} in its mana cost, you choose the value of X before calculating the spell’s total cost. For example, if that spell’s mana cost is {X}{R}{G} and you’ve chosen red and green, you could choose 5 as the value of X and pay {3}{R}{G} to cast the spell."
+          "text": "If a spell you cast has {X} in its mana cost, you choose the value of X before calculating the spell's total cost. For example, if that spell's mana cost is {X}{R}{G} and you've chosen red and green, you could choose 5 as the value of X and pay {3}{R}{G} to cast the spell."
         }
       ],
       "text": "As Seal of the Guildpact enters the battlefield, choose two colors.\nEach spell you cast costs {1} less to cast for each of the chosen colors it is.",
@@ -5449,15 +5449,15 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If you cast a commander from your hand, the additional cost based on the number of times you’ve cast it from your command zone (sometimes referred to as the “commander tax”) doesn’t apply. Additionally, that casting won’t add to the tax if you later cast the commander from the command zone."
+          "text": "If you cast a commander from your hand, the additional cost based on the number of times you've cast it from your command zone (sometimes referred to as the \"commander tax\") doesn't apply. Additionally, that casting won't add to the tax if you later cast the commander from the command zone."
         },
         {
           "date": "2015-11-04",
-          "text": "If your commander isn’t in the command zone (or you’re not playing Commander) as the last ability resolves, nothing happens."
+          "text": "If your commander isn't in the command zone (or you're not playing Commander) as the last ability resolves, nothing happens."
         },
         {
           "date": "2016-11-08",
-          "text": "If you have two commanders with the partner ability in the command zone, Command Beacon’s effect puts one of your choice into your hand, not both."
+          "text": "If you have two commanders with the partner ability in the command zone, Command Beacon's effect puts one of your choice into your hand, not both."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Command Beacon: Put your commander into your hand from the command zone.",
@@ -5542,6 +5542,24 @@
         "C15"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-07-01",
+          "text": "The ability doesn't trigger until the enchantment enters the battlefield. This means that, for example, you can't cast an Aura with enchant creature if there are no legal targets available, hoping to enchant the Cat token. Ajani's Chosen itself, however, may be a legal target for the Aura."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If you cast an Aura targeting an opponent or a permanent controlled by an opponent, you control that Aura when it enters the battlefield. The ability of Ajani's Chosen will trigger."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "You may attach the Aura to the token only if it can legally enchant that token. For example, if the enchantment that entered the battlefield is an Aura with \"enchant land,\" it won't move."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "You may attach the Aura to the Cat token only if the Aura and the token are both on the battlefield when the triggered ability resolves. If the Aura leaves the battlefield before the ability resolves, it won't become attached to the token. If the token leaves the battlefield before the ability resolves, the Aura won't move."
+        }
+      ],
       "subtypes": [
         "Cat",
         "Soldier"
@@ -5643,11 +5661,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "You choose the targets as part of putting the enters-the-battlefield trigger on the stack. Because that ability includes “you may,” you choose whether to exile the targets when the ability resolves."
+          "text": "You choose the targets as part of putting the enters-the-battlefield trigger on the stack. Because that ability includes \"you may,\" you choose whether to exile the targets when the ability resolves."
         },
         {
           "date": "2013-01-24",
-          "text": "If a creature targeted by the enters-the-battlefield ability dies before that ability resolves, it will become an illegal target even though it may be a creature card in a graveyard when the ability resolves. It won’t be exiled."
+          "text": "If a creature targeted by the enters-the-battlefield ability dies before that ability resolves, it will become an illegal target even though it may be a creature card in a graveyard when the ability resolves. It won't be exiled."
         }
       ],
       "subtypes": [
@@ -5748,7 +5766,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "In other multiplayer formats, each player’s life total is set to the highest life total within his or her range of influence. These changes happen at the same time. For example, if each player has a range of influence of one, and the players in the game are Alice (4 life), Barry (8 life), Carrie (11 life), and Doug (7 life), in that order, then Alice’s life total will become 8 and Barry and Doug’s life totals will each become 11."
+          "text": "In other multiplayer formats, each player's life total is set to the highest life total within his or her range of influence. These changes happen at the same time. For example, if each player has a range of influence of one, and the players in the game are Alice (4 life), Barry (8 life), Carrie (11 life), and Doug (7 life), in that order, then Alice's life total will become 8 and Barry and Doug's life totals will each become 11."
         },
         {
           "date": "2010-06-15",
@@ -5941,27 +5959,27 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Banishing Light’s ability causes a zone change with a duration, a new style of ability that’s somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Banishing Light have a single ability that creates two one-shot effects: one that exiles the permanent when the ability resolves, and another that returns the exiled card to the battlefield immediately after Banishing Light leaves the battlefield."
+          "text": "Banishing Light's ability causes a zone change with a duration, a new style of ability that's somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Banishing Light have a single ability that creates two one-shot effects: one that exiles the permanent when the ability resolves, and another that returns the exiled card to the battlefield immediately after Banishing Light leaves the battlefield."
         },
         {
           "date": "2014-04-26",
-          "text": "If Banishing Light leaves the battlefield before its enters-the-battlefield ability resolves, the target nonland permanent won’t be exiled."
+          "text": "If Banishing Light leaves the battlefield before its enters-the-battlefield ability resolves, the target nonland permanent won't be exiled."
         },
         {
           "date": "2014-04-26",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         },
         {
           "date": "2014-04-26",
-          "text": "If a token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2014-04-26",
-          "text": "The exiled card returns to the battlefield immediately after Banishing Light leaves the battlefield. Nothing happens between the two events, including state-based actions. Banishing Light and the returned card aren’t on the battlefield at the same time."
+          "text": "The exiled card returns to the battlefield immediately after Banishing Light leaves the battlefield. Nothing happens between the two events, including state-based actions. Banishing Light and the returned card aren't on the battlefield at the same time."
         },
         {
           "date": "2014-04-26",
-          "text": "In a multiplayer game, if Banishing Light’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Banishing Light's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "When Banishing Light enters the battlefield, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield. (That permanent returns under its owner's control.)",
@@ -6234,31 +6252,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -6442,11 +6460,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You choose which mode you’re using—or that you’re using both modes—as you’re casting the spell. Once this choice is made, it can’t be changed later while the spell is on the stack."
+          "text": "You choose which mode you're using—or that you're using both modes—as you're casting the spell. Once this choice is made, it can't be changed later while the spell is on the stack."
         },
         {
           "date": "2014-02-01",
-          "text": "Dawn to Dusk won’t affect any target that is illegal when it tries to resolve. If you chose to use both modes and both targets are illegal at that time, Dawn to Dusk will be countered."
+          "text": "Dawn to Dusk won't affect any target that is illegal when it tries to resolve. If you chose to use both modes and both targets are illegal at that time, Dawn to Dusk will be countered."
         }
       ],
       "text": "Choose one or both —\n• Return target enchantment card from your graveyard to your hand.\n• Destroy target enchantment.",
@@ -6716,11 +6734,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Faith’s Fetters doesn’t stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
+          "text": "Faith's Fetters doesn't stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -6814,31 +6832,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -7033,7 +7051,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Karmic Justice will not trigger if an opponent’s spell or ability causes your permanent to be destroyed indirectly. For example, if the spell caused an ability you control to trigger, and thereby destroy your permanent."
+          "text": "Karmic Justice will not trigger if an opponent's spell or ability causes your permanent to be destroyed indirectly. For example, if the spell caused an ability you control to trigger, and thereby destroy your permanent."
         }
       ],
       "text": "Whenever a spell or ability an opponent controls destroys a noncreature permanent you control, you may destroy target permanent that opponent controls.",
@@ -7306,15 +7324,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Mesa Enchantress’s last ability will resolve before the spell that caused it to trigger."
+          "text": "Mesa Enchantress's last ability will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "If the enchantment spell is countered, Mesa Enchantress’s last ability still resolves and causes you to draw a card."
+          "text": "If the enchantment spell is countered, Mesa Enchantress's last ability still resolves and causes you to draw a card."
         },
         {
           "date": "2016-06-08",
-          "text": "Enchantments put onto the battlefield without being cast won’t cause Mesa Enchantress’s last ability to trigger."
+          "text": "Enchantments put onto the battlefield without being cast won't cause Mesa Enchantress's last ability to trigger."
         }
       ],
       "subtypes": [
@@ -7500,11 +7518,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "An Aura put onto the battlefield this way can’t enchant an artifact or enchantment that’s also being put onto the battlefield with Open the Vaults."
+          "text": "An Aura put onto the battlefield this way can't enchant an artifact or enchantment that's also being put onto the battlefield with Open the Vaults."
         },
         {
           "date": "2009-10-01",
-          "text": "If an Aura can be returned to the battlefield with Open the Vaults, it must be, even if its owner doesn’t like what it would enchant."
+          "text": "If an Aura can be returned to the battlefield with Open the Vaults, it must be, even if its owner doesn't like what it would enchant."
         },
         {
           "date": "2009-10-01",
@@ -7780,11 +7798,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can’t play an Aura spell intending to enchant the Angel that will be created as a result."
+          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can't play an Aura spell intending to enchant the Angel that will be created as a result."
         },
         {
           "date": "2009-02-01",
-          "text": "Casting Sigil of the Empty Throne won’t trigger its own ability. It has to be on the battlefield for its ability to work."
+          "text": "Casting Sigil of the Empty Throne won't trigger its own ability. It has to be on the battlefield for its ability to work."
         }
       ],
       "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
@@ -7877,11 +7895,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "If you return an enchantment creature card with bestow to the battlefield, you can’t pay its bestow cost. It won’t be an Aura and can’t be attached to a creature."
+          "text": "If you return an enchantment creature card with bestow to the battlefield, you can't pay its bestow cost. It won't be an Aura and can't be attached to a creature."
         },
         {
           "date": "2014-02-01",
-          "text": "If the enchantment card is an Aura, you choose a legal player or object for that Aura to enchant as it enters the battlefield. This doesn’t target the player or object, so it’s possible to enchant an opposing creature with hexproof this way, for example. If there’s no player or object the Aura can legally enchant, it stays in the graveyard."
+          "text": "If the enchantment card is an Aura, you choose a legal player or object for that Aura to enchant as it enters the battlefield. This doesn't target the player or object, so it's possible to enchant an opposing creature with hexproof this way, for example. If there's no player or object the Aura can legally enchant, it stays in the graveyard."
         }
       ],
       "subtypes": [
@@ -7990,7 +8008,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         }
       ],
       "subtypes": [
@@ -8091,7 +8109,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Victory’s Herald also gains flying (which will likely be redundant) and lifelink if it’s still attacking when the ability resolves."
+          "text": "Victory's Herald also gains flying (which will likely be redundant) and lifelink if it's still attacking when the ability resolves."
         }
       ],
       "subtypes": [
@@ -8268,7 +8286,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat. There’s no such thing as an attacking creature outside of the combat phase."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat. There's no such thing as an attacking creature outside of the combat phase."
         }
       ],
       "text": "Return all attacking creatures to their owner's hand.",
@@ -8364,7 +8382,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "supertypes": [
@@ -8455,7 +8473,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a permanent changes controller after being targeted but before this spell resolves, you won’t gain control of that permanent."
+          "text": "If a permanent changes controller after being targeted but before this spell resolves, you won't gain control of that permanent."
         },
         {
           "date": "2004-10-04",
@@ -8552,11 +8570,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         },
         {
           "date": "2011-06-01",
-          "text": "You follow the instructions in order. You won’t be able to draw the same Blue Sun’s Zenith that you cast."
+          "text": "You follow the instructions in order. You won't be able to draw the same Blue Sun's Zenith that you cast."
         }
       ],
       "text": "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.",
@@ -8647,23 +8665,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -8671,7 +8689,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Tap target creature you don't control.\nOverload {3}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -9130,7 +9148,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Each pile may contain from zero to five cards; they don’t have to be split “evenly.”"
+          "text": "Each pile may contain from zero to five cards; they don't have to be split \"evenly.\""
         }
       ],
       "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
@@ -9315,19 +9333,19 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You must put one of the cards into your hand, even if you’d rather put all four on the bottom of your library."
+          "text": "You must put one of the cards into your hand, even if you'd rather put all four on the bottom of your library."
         },
         {
           "date": "2012-05-01",
-          "text": "If you control Lone Revenant and any other creature (including another Lone Revenant), its ability won’t trigger."
+          "text": "If you control Lone Revenant and any other creature (including another Lone Revenant), its ability won't trigger."
         },
         {
           "date": "2012-05-01",
-          "text": "Check whether Lone Revenant’s ability triggers after combat damage is dealt but before any creatures that are destroyed due to combat damage leave the battlefield. For example, if you control Lone Revenant and another creature, and that other creature takes lethal damage in the same combat damage step that Lone Revenant deals damage to a player, Lone Revenant’s ability won’t trigger."
+          "text": "Check whether Lone Revenant's ability triggers after combat damage is dealt but before any creatures that are destroyed due to combat damage leave the battlefield. For example, if you control Lone Revenant and another creature, and that other creature takes lethal damage in the same combat damage step that Lone Revenant deals damage to a player, Lone Revenant's ability won't trigger."
         },
         {
           "date": "2012-05-01",
-          "text": "If you control no creatures when Lone Revenant’s ability resolves, you’ll still look at the top four cards and put one into your hand."
+          "text": "If you control no creatures when Lone Revenant's ability resolves, you'll still look at the top four cards and put one into your hand."
         }
       ],
       "subtypes": [
@@ -9518,7 +9536,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Mystic Retrieval can’t target itself. It’s on the stack when you choose its target."
+          "text": "Mystic Retrieval can't target itself. It's on the stack when you choose its target."
         }
       ],
       "text": "Return target instant or sorcery card from your graveyard to your hand.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -9702,7 +9720,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -9882,7 +9900,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Rapid Hybridization resolves and the creature isn’t destroyed (perhaps because it has indestructible), its controller will still get the Frog Lizard token."
+          "text": "If Rapid Hybridization resolves and the creature isn't destroyed (perhaps because it has indestructible), its controller will still get the Frog Lizard token."
         }
       ],
       "text": "Destroy target creature. It can't be regenerated. That creature's controller creates a 3/3 green Frog Lizard creature token.",
@@ -10152,15 +10170,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Rite of Replication resolves, the entire spell is countered. You won’t get any tokens."
+          "text": "If the targeted creature is an illegal target by the time Rite of Replication resolves, the entire spell is countered. You won't get any tokens."
         },
         {
           "date": "2009-10-01",
-          "text": "As the token or tokens are created, they check the printed values of the creature they’re copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "As the token or tokens are created, they check the printed values of the creature they're copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, or so on."
         },
         {
           "date": "2009-10-01",
-          "text": "The tokens see each other enter the battlefield. If they have a triggered ability that triggers when a creature enters the battlefield, they’ll all trigger for one another."
+          "text": "The tokens see each other enter the battlefield. If they have a triggered ability that triggers when a creature enters the battlefield, they'll all trigger for one another."
         }
       ],
       "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nCreate a token that's a copy of target creature. If Rite of Replication was kicked, create five of those tokens instead.",
@@ -10249,11 +10267,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The second part of Sleep’s effect affects all creatures the targeted player controls as Sleep resolves, not just the ones that Sleep actually caused to become tapped."
+          "text": "The second part of Sleep's effect affects all creatures the targeted player controls as Sleep resolves, not just the ones that Sleep actually caused to become tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Sleep tracks both the player and the creatures. If one of the creatures controlled by the targeted player as Sleep resolves changes controllers, the creature will untap as normal during its new controller’s next untap step."
+          "text": "Sleep tracks both the player and the creatures. If one of the creatures controlled by the targeted player as Sleep resolves changes controllers, the creature will untap as normal during its new controller's next untap step."
         }
       ],
       "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
@@ -10347,7 +10365,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If you can’t cast the nonland card (perhaps because there are no legal targets available) or if you choose not to cast it, it will remain exiled."
+          "text": "If you can't cast the nonland card (perhaps because there are no legal targets available) or if you choose not to cast it, it will remain exiled."
         },
         {
           "date": "2012-05-01",
@@ -10355,7 +10373,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs, such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs, such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-05-01",
@@ -10536,7 +10554,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You’ll put the Drake token onto the battlefield before the spell that caused the ability to trigger resolves. However, that Drake token isn’t on the battlefield when you choose targets for that spell."
+          "text": "You'll put the Drake token onto the battlefield before the spell that caused the ability to trigger resolves. However, that Drake token isn't on the battlefield when you choose targets for that spell."
         },
         {
           "date": "2012-07-01",
@@ -10639,19 +10657,19 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Thought Reflection doesn’t cause you to draw cards. Rather, it causes card-drawing effects to have you draw more cards. It also causes the draw action during your draw step to have you draw two cards."
+          "text": "Thought Reflection doesn't cause you to draw cards. Rather, it causes card-drawing effects to have you draw more cards. It also causes the draw action during your draw step to have you draw two cards."
         },
         {
           "date": "2008-05-01",
-          "text": "If a spell or ability causes you to draw multiple cards, Thought Reflection’s effect doubles the total number you would draw. For example, if you cast Concentrate (“Draw three cards”), you’ll draw six cards."
+          "text": "If a spell or ability causes you to draw multiple cards, Thought Reflection's effect doubles the total number you would draw. For example, if you cast Concentrate (\"Draw three cards\"), you'll draw six cards."
         },
         {
           "date": "2008-05-01",
-          "text": "The effects of multiple Thought Reflections are cumulative. For example, if you have three Thought Reflections on the battlefield, you’ll draw eight times the original number of cards."
+          "text": "The effects of multiple Thought Reflections are cumulative. For example, if you have three Thought Reflections on the battlefield, you'll draw eight times the original number of cards."
         },
         {
           "date": "2008-05-01",
-          "text": "If two or more replacement effects would apply to a card-drawing event, the player who’s drawing the card chooses what order to apply them."
+          "text": "If two or more replacement effects would apply to a card-drawing event, the player who's drawing the card chooses what order to apply them."
         }
       ],
       "text": "If you would draw a card, draw two cards instead.",
@@ -11115,7 +11133,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Barter in Blood doesn’t target any creatures and may be cast even if a player controls fewer than two creatures."
+          "text": "Barter in Blood doesn't target any creatures and may be cast even if a player controls fewer than two creatures."
         }
       ],
       "text": "Each player sacrifices two creatures.",
@@ -11389,15 +11407,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners’ graveyards at the same time, Butcher of Malakir’s triggered ability will trigger that many times."
+          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners' graveyards at the same time, Butcher of Malakir's triggered ability will trigger that many times."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers’ abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
+          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers' abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player’s Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player’s Butcher to trigger, and so on."
+          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player's Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player's Butcher to trigger, and so on."
         }
       ],
       "subtypes": [
@@ -11494,7 +11512,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You choose the targets of the first ability as you activate that ability, before you pay any costs. You can’t target any of the creatures you sacrifice."
+          "text": "You choose the targets of the first ability as you activate that ability, before you pay any costs. You can't target any of the creatures you sacrifice."
         },
         {
           "date": "2014-02-01",
@@ -11591,7 +11609,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the creature is on the battlefield and is returned to its owner’s hand or is exiled, this card loses track of the creature and has no further effects in the future."
+          "text": "If the creature is on the battlefield and is returned to its owner's hand or is exiled, this card loses track of the creature and has no further effects in the future."
         }
       ],
       "text": "When Diabolic Servitude enters the battlefield, return target creature card from your graveyard to the battlefield.\nWhen the creature put onto the battlefield with Diabolic Servitude dies, exile it and return Diabolic Servitude to its owner's hand.\nWhen Diabolic Servitude leaves the battlefield, exile the creature put onto the battlefield with Diabolic Servitude.",
@@ -11688,7 +11706,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -11792,7 +11810,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -11988,11 +12006,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon’s triggered ability will trigger."
+          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon's triggered ability will trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "You can target any player with Extractor Demon’s triggered ability. The target doesn’t have to be the controller of the creature that left the battlefield."
+          "text": "You can target any player with Extractor Demon's triggered ability. The target doesn't have to be the controller of the creature that left the battlefield."
         }
       ],
       "subtypes": [
@@ -12086,7 +12104,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The creature’s controller (not Fallen Ideal’s controller) can activate the “sacrifice a creature” ability."
+          "text": "The creature's controller (not Fallen Ideal's controller) can activate the \"sacrifice a creature\" ability."
         }
       ],
       "subtypes": [
@@ -12275,7 +12293,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If the creature isn’t a legal target as Gild tries to resolve, the spell will be countered and none of its effects will happen. No token will be created."
+          "text": "If the creature isn't a legal target as Gild tries to resolve, the spell will be countered and none of its effects will happen. No token will be created."
         }
       ],
       "text": "Exile target creature. Create a colorless artifact token named Gold. It has \"Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
@@ -12370,7 +12388,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If multiple nonblack creatures enter the battlefield at the same time, Grave Peril will destroy only one of them. Grave Peril’s ability will trigger multiple times, but only the first one to resolve will do anything."
+          "text": "If multiple nonblack creatures enter the battlefield at the same time, Grave Peril will destroy only one of them. Grave Peril's ability will trigger multiple times, but only the first one to resolve will do anything."
         },
         {
           "date": "2007-05-01",
@@ -12466,35 +12484,35 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Nighthowler’s last ability functions only from the battlefield. In other zones, Nighthowler is a 0/0 enchantment creature."
+          "text": "Nighthowler's last ability functions only from the battlefield. In other zones, Nighthowler is a 0/0 enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -12871,7 +12889,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "{1}{B}, Pay 2 life: Return target creature card from your graveyard to your hand.",
@@ -12974,19 +12992,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
+          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -13170,7 +13188,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Only creatures on the battlefield will be exiled. In other zones, they’re “creature cards,” not “creatures.”"
+          "text": "Only creatures on the battlefield will be exiled. In other zones, they're \"creature cards,\" not \"creatures.\""
         },
         {
           "date": "2017-03-14",
@@ -13178,11 +13196,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named “Beast.”"
+          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named \"Beast.\""
         },
         {
           "date": "2017-03-14",
-          "text": "A double-faced creature only has the name of the face that’s up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn’t be exiled."
+          "text": "A double-faced creature only has the name of the face that's up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn't be exiled."
         }
       ],
       "text": "Exile target creature and all other creatures with the same name as that creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -13463,19 +13481,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You must choose two targets. You can’t cast Victimize targeting only one creature card."
+          "text": "You must choose two targets. You can't cast Victimize targeting only one creature card."
         },
         {
           "date": "2016-06-08",
-          "text": "The creature you sacrifice isn’t chosen until Victimize resolves. You can’t return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
+          "text": "The creature you sacrifice isn't chosen until Victimize resolves. You can't return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
         },
         {
           "date": "2016-06-08",
-          "text": "As Victimize resolves, you must sacrifice a creature if able. You can’t change your mind and choose not to sacrifice anything."
+          "text": "As Victimize resolves, you must sacrifice a creature if able. You can't change your mind and choose not to sacrifice anything."
         },
         {
           "date": "2016-06-08",
-          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you’ll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won’t sacrifice a creature."
+          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you'll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won't sacrifice a creature."
         },
         {
           "date": "2016-06-08",
@@ -13661,19 +13679,19 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "Act of Aggression can target any creature an opponent controls, even one that’s untapped."
+          "text": "Act of Aggression can target any creature an opponent controls, even one that's untapped."
         },
         {
           "date": "2011-06-01",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "text": "({R/P} can be paid with either {R} or 2 life.)\nGain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn.",
@@ -14032,11 +14050,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The instant or sorcery card returned to your hand is chosen at random as the triggered ability resolves. If any player responds to the ability, that player won’t yet know what card will be returned."
+          "text": "The instant or sorcery card returned to your hand is chosen at random as the triggered ability resolves. If any player responds to the ability, that player won't yet know what card will be returned."
         },
         {
           "date": "2011-09-22",
-          "text": "Because the first ability doesn’t target the instant or sorcery card, any instants or sorceries put into your graveyard in response to that ability may be returned to your hand."
+          "text": "Because the first ability doesn't target the instant or sorcery card, any instants or sorceries put into your graveyard in response to that ability may be returned to your hand."
         }
       ],
       "subtypes": [
@@ -14134,7 +14152,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The number of targets you choose for Comet Storm is one more than the number of times it’s kicked. First you declare how many times you’re going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you’ll kick the spell and the time you choose the targets."
+          "text": "The number of targets you choose for Comet Storm is one more than the number of times it's kicked. First you declare how many times you're going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you'll kick the spell and the time you choose the targets."
         },
         {
           "date": "2010-03-01",
@@ -14142,7 +14160,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you’re kicking the spell twice. You’ll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
+          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you're kicking the spell twice. You'll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
         },
         {
           "date": "2010-03-01",
@@ -14241,11 +14259,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If there are multiple combat phases in a turn, each creature must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, each creature must attack only in the first one in which it's able to."
         },
         {
           "date": "2011-09-22",
-          "text": "If, during the enchanted player’s declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having the creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during the enchanted player's declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having the creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -14903,11 +14921,11 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "As Fall of the Hammer tries to resolve, if only one of the targets is legal, Fall of the Hammer will still resolve but will have no effect: If the first target creature is illegal, it can’t deal damage to anything. If the second target creature is illegal, it can’t be dealt damage."
+          "text": "As Fall of the Hammer tries to resolve, if only one of the targets is legal, Fall of the Hammer will still resolve but will have no effect: If the first target creature is illegal, it can't deal damage to anything. If the second target creature is illegal, it can't be dealt damage."
         },
         {
           "date": "2014-02-01",
-          "text": "The amount of damage dealt is based on the first target creature’s power as Fall of the Hammer resolves."
+          "text": "The amount of damage dealt is based on the first target creature's power as Fall of the Hammer resolves."
         }
       ],
       "text": "Target creature you control deals damage equal to its power to another target creature.",
@@ -14998,15 +15016,15 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "X is variable. The bushido bonus is calculated each time Fumiko’s bushido trigger resolves, based on the number of attackers at that time."
+          "text": "X is variable. The bushido bonus is calculated each time Fumiko's bushido trigger resolves, based on the number of attackers at that time."
         },
         {
           "date": "2005-02-01",
-          "text": "Fumiko’s ability doesn’t force an opponent to pay for effects in order to be able to attack with his or her creatures (such as Ghostly Prison, for example)."
+          "text": "Fumiko's ability doesn't force an opponent to pay for effects in order to be able to attack with his or her creatures (such as Ghostly Prison, for example)."
         },
         {
           "date": "2005-02-01",
-          "text": "Fumiko’s ability doesn’t force tapped creatures or creatures with summoning sickness to attack."
+          "text": "Fumiko's ability doesn't force tapped creatures or creatures with summoning sickness to attack."
         }
       ],
       "subtypes": [
@@ -15298,23 +15316,23 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If a spell you control would deal damage to an opponent and that opponent controls a planeswalker, that opponent chooses which of your effects to apply first. — If that player chooses to apply Hostility’s effect first, the damage is prevented, you put some tokens onto the battlefield, and the planeswalker redirection effect is moot because there’s no damage to redirect. — If that player chooses to apply the planeswalker redirection effect first, you have a choice. You can redirect the damage to the planeswalker (in which case Hostility’s prevention effect is moot because nothing’s dealing damage to the player anymore) or you can have your spell continue to deal damage to the opponent. If you choose the latter, Hostility’s effect then applies, the damage is prevented, and you get the tokens."
+          "text": "If a spell you control would deal damage to an opponent and that opponent controls a planeswalker, that opponent chooses which of your effects to apply first. — If that player chooses to apply Hostility's effect first, the damage is prevented, you put some tokens onto the battlefield, and the planeswalker redirection effect is moot because there's no damage to redirect. — If that player chooses to apply the planeswalker redirection effect first, you have a choice. You can redirect the damage to the planeswalker (in which case Hostility's prevention effect is moot because nothing's dealing damage to the player anymore) or you can have your spell continue to deal damage to the opponent. If you choose the latter, Hostility's effect then applies, the damage is prevented, and you get the tokens."
         },
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -15506,7 +15524,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You divide the damage as you put Inferno Titan’s triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
+          "text": "You divide the damage as you put Inferno Titan's triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
         }
       ],
       "subtypes": [
@@ -15690,7 +15708,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Magmaquake doesn’t target any creature or planeswalker. For example, it will deal damage to a creature without flying that has hexproof."
+          "text": "Magmaquake doesn't target any creature or planeswalker. For example, it will deal damage to a creature without flying that has hexproof."
         }
       ],
       "text": "Magmaquake deals X damage to each creature without flying and each planeswalker.",
@@ -15781,23 +15799,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -15805,7 +15823,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -15989,23 +16007,23 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If blockers have already been declared when Stoneshock Giant’s last ability resolves, those blocks won’t change or become undone."
+          "text": "If blockers have already been declared when Stoneshock Giant's last ability resolves, those blocks won't change or become undone."
         },
         {
           "date": "2013-09-15",
-          "text": "Your opponents can’t assign any creature without flying to block that turn, even if that creature had flying or wasn’t on the battlefield under one of your opponent’s control when Stoneshock Giant’s ability resolved."
+          "text": "Your opponents can't assign any creature without flying to block that turn, even if that creature had flying or wasn't on the battlefield under one of your opponent's control when Stoneshock Giant's ability resolved."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -16372,11 +16390,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This spell has a self-replacement in it . This means that if Urza’s Rage is kicked, the 3 damage is replaced with 10 unpreventable damage before any other replacements can be applied. For example, you can’t use Healing Salve to prevent the 3 damage before it gets changed."
+          "text": "This spell has a self-replacement in it . This means that if Urza's Rage is kicked, the 3 damage is replaced with 10 unpreventable damage before any other replacements can be applied. For example, you can't use Healing Salve to prevent the 3 damage before it gets changed."
         },
         {
           "date": "2004-10-04",
-          "text": "You can target this spell with spells and abilities, so you can change its target. Those spells and abilities just can’t counter it."
+          "text": "You can target this spell with spells and abilities, so you can change its target. Those spells and abilities just can't counter it."
         },
         {
           "date": "2004-10-04",
@@ -16388,7 +16406,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Counterspells can be cast that target it, but when they resolve they simply don’t counter it since it can’t be countered."
+          "text": "Counterspells can be cast that target it, but when they resolve they simply don't counter it since it can't be countered."
         }
       ],
       "text": "Kicker {8}{R} (You may pay an additional {8}{R} as you cast this spell.)\nUrza's Rage can't be countered by spells or abilities.\nUrza's Rage deals 3 damage to target creature or player. If Urza's Rage was kicked, instead it deals 10 damage to that creature or player and the damage can't be prevented.",
@@ -16479,23 +16497,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -16503,7 +16521,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -16593,11 +16611,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it’s no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
+          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it's no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2011-09-22",
-          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn’t target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
+          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn't target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to target creature or player.",
@@ -16693,23 +16711,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntap target permanent and gain control of it until end of turn. It gains haste until end of turn.",
@@ -16893,15 +16911,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -16990,11 +17008,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Bane of Progress’s ability destroys all artifacts and enchantments, including those you control."
+          "text": "Bane of Progress's ability destroys all artifacts and enchantments, including those you control."
         },
         {
           "date": "2013-10-17",
-          "text": "If an artifact or enchantment isn’t destroyed (perhaps because it has indestructible or it regenerated), it won’t count toward the number of +1/+1 counters put on Bane of Progress. However, if an artifact or enchantment is destroyed but doesn’t go to its owner’s graveyard due to a replacement effect (like the one Rest in Peace creates), it will count."
+          "text": "If an artifact or enchantment isn't destroyed (perhaps because it has indestructible or it regenerated), it won't count toward the number of +1/+1 counters put on Bane of Progress. However, if an artifact or enchantment is destroyed but doesn't go to its owner's graveyard due to a replacement effect (like the one Rest in Peace creates), it will count."
         }
       ],
       "subtypes": [
@@ -17091,7 +17109,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you attack with multiple creatures, Beastmaster Ascension’s first ability triggers multiple times."
+          "text": "If you attack with multiple creatures, Beastmaster Ascension's first ability triggers multiple times."
         }
       ],
       "text": "Whenever a creature you control attacks, you may put a quest counter on Beastmaster Ascension.\nAs long as Beastmaster Ascension has seven or more quest counters on it, creatures you control get +5/+5.",
@@ -17455,11 +17473,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -17467,7 +17485,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A spell or ability destroys a permanent only if that spell or ability specifically contains the word “destroy” in its text. If a spell or ability an opponent controls exiles a noncreature permanent you control, causes you to sacrifice a noncreature permanent, removes all loyalty counters from a planeswalker you control, or causes an ability you control to trigger (and then that ability destroys a permanent you control), Cobra Trap’s alternative cost condition hasn’t been met."
+          "text": "A spell or ability destroys a permanent only if that spell or ability specifically contains the word \"destroy\" in its text. If a spell or ability an opponent controls exiles a noncreature permanent you control, causes you to sacrifice a noncreature permanent, removes all loyalty counters from a planeswalker you control, or causes an ability you control to trigger (and then that ability destroys a permanent you control), Cobra Trap's alternative cost condition hasn't been met."
         }
       ],
       "subtypes": [
@@ -17846,7 +17864,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If removing two +1/+1 counters from Experiment One causes the amount of damage already marked on Experiment One to be equal to or greater than its toughness, it will be put into its owner’s graveyard as a state-based action before the regeneration shield is created."
+          "text": "If removing two +1/+1 counters from Experiment One causes the amount of damage already marked on Experiment One to be equal to or greater than its toughness, it will be put into its owner's graveyard as a state-based action before the regeneration shield is created."
         },
         {
           "date": "2013-04-15",
@@ -17854,7 +17872,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -17870,7 +17888,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -18174,7 +18192,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "You declare which player or planeswalker each token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Kessig Cagebreakers is attacking."
+          "text": "You declare which player or planeswalker each token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Kessig Cagebreakers is attacking."
         },
         {
           "date": "2011-09-22",
@@ -18379,23 +18397,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
@@ -18487,7 +18505,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "Loaming Shaman’s controller chooses all the targets when the ability is put on the stack."
+          "text": "Loaming Shaman's controller chooses all the targets when the ability is put on the stack."
         }
       ],
       "subtypes": [
@@ -18683,19 +18701,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         },
         {
           "date": "2008-10-01",
-          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn’t matter where the +1/+1 counters came from."
+          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn't matter where the +1/+1 counters came from."
         }
       ],
       "subtypes": [
@@ -18790,31 +18808,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -19022,7 +19040,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -19203,7 +19221,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -19298,7 +19316,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Kicker—Sacrifice a creature. (You may sacrifice a creature in addition to any other costs as you cast this spell.)\nSearch your library for a basic land card, put that card onto the battlefield, then shuffle your library. If Primal Growth was kicked, instead search your library for up to two basic land cards, put them onto the battlefield, then shuffle your library.",
@@ -19413,7 +19431,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -19890,7 +19908,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If a targeted permanent has indestructible or regenerates, its controller won’t get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner’s graveyard, its controller won’t get an Elephant token for it."
+          "text": "If a targeted permanent has indestructible or regenerates, its controller won't get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner's graveyard, its controller won't get an Elephant token for it."
         }
       ],
       "subtypes": [
@@ -20164,7 +20182,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Verdant Force’s controller gets the tokens. That is the controller at the beginning of upkeep."
+          "text": "Verdant Force's controller gets the tokens. That is the controller at the beginning of upkeep."
         },
         {
           "date": "2005-08-01",
@@ -20651,7 +20669,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -20847,23 +20865,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -20871,7 +20889,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Counterflux can't be countered by spells or abilities.\nCounter target spell you don't control.\nOverload {1}{U}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -21053,15 +21071,15 @@
         },
         {
           "date": "2012-10-01",
-          "text": "When casting an instant or sorcery card this way, ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "When casting an instant or sorcery card this way, ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2012-10-01",
-          "text": "If you can’t cast an instant or sorcery card, perhaps because there are no legal targets available, or if you choose not to cast one, it will be put into your graveyard."
+          "text": "If you can't cast an instant or sorcery card, perhaps because there are no legal targets available, or if you choose not to cast one, it will be put into your graveyard."
         },
         {
           "date": "2012-10-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-10-01",
@@ -21152,7 +21170,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Etherium-Horn Sorcerer’s first ability can only be activated when it is on the battlefield. If Etherium-Horn Sorcerer isn’t on the battlefield when the ability resolves, the ability won’t do anything."
+          "text": "Etherium-Horn Sorcerer's first ability can only be activated when it is on the battlefield. If Etherium-Horn Sorcerer isn't on the battlefield when the ability resolves, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -21251,7 +21269,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You don’t have to find any instant cards in your library, even if they are there."
+          "text": "You don't have to find any instant cards in your library, even if they are there."
         },
         {
           "date": "2012-10-01",
@@ -21356,7 +21374,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "If damage dealt by a source you control is being divided among multiple permanents an opponent controls or among an opponent and one or more permanents he or she controls simultaneously, divide the original amount and double the results. For example, if you attack with a 5/5 creature with trample and your opponent blocks with a 2/2 creature, you can assign 2 damage to the blocker and 3 damage to the defending player. These amounts are then doubled to 4 and 6 damage, respectively. You can’t double the damage to 10 first and then assign 2 to the creature and 8 to the player."
+          "text": "If damage dealt by a source you control is being divided among multiple permanents an opponent controls or among an opponent and one or more permanents he or she controls simultaneously, divide the original amount and double the results. For example, if you attack with a 5/5 creature with trample and your opponent blocks with a 2/2 creature, you can assign 2 damage to the blocker and 3 damage to the defending player. These amounts are then doubled to 4 and 6 damage, respectively. You can't double the damage to 10 first and then assign 2 to the creature and 8 to the player."
         }
       ],
       "subtypes": [
@@ -21464,11 +21482,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Goblin Electromancer can’t reduce colored mana costs or {C} in the cost of instant or sorcery spells."
+          "text": "Goblin Electromancer can't reduce colored mana costs or {C} in the cost of instant or sorcery spells."
         },
         {
           "date": "2017-03-14",
-          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben’s ability), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben's ability), apply those increases before applying cost reductions."
         },
         {
           "date": "2017-03-14",
@@ -21749,7 +21767,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Jarad’s first ability applies only when Jarad is on the battlefield."
+          "text": "Jarad's first ability applies only when Jarad is on the battlefield."
         },
         {
           "date": "2012-10-01",
@@ -21757,7 +21775,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "To activate Jarad’s last ability, you must sacrifice two lands. It doesn’t matter what other land types the two lands have, as long as one is a Swamp and one is a Forest. Even if one of the lands you sacrifice is both a Swamp and a Forest, you have to sacrifice another land that is a Swamp or a Forest."
+          "text": "To activate Jarad's last ability, you must sacrifice two lands. It doesn't matter what other land types the two lands have, as long as one is a Swamp and one is a Forest. Even if one of the lands you sacrifice is both a Swamp and a Forest, you have to sacrifice another land that is a Swamp or a Forest."
         },
         {
           "date": "2012-10-01",
@@ -21865,7 +21883,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Use the sacrificed creature’s toughness when it was last on the battlefield to determine the value of X."
+          "text": "Use the sacrificed creature's toughness when it was last on the battlefield to determine the value of X."
         }
       ],
       "subtypes": [
@@ -21966,11 +21984,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "If a spell or ability causes you to draw multiple cards, Lorescale Coatl’s ability triggers that many times."
+          "text": "If a spell or ability causes you to draw multiple cards, Lorescale Coatl's ability triggers that many times."
         },
         {
           "date": "2009-05-01",
-          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word “draw,” Lorescale Coatl’s ability won’t trigger."
+          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word \"draw,\" Lorescale Coatl's ability won't trigger."
         }
       ],
       "subtypes": [
@@ -22162,27 +22180,27 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Melek doesn’t affect the timing rules associated with when you can cast the card. If it’s a sorcery card, you can cast it only during your main phase when the stack is empty."
+          "text": "Melek doesn't affect the timing rules associated with when you can cast the card. If it's a sorcery card, you can cast it only during your main phase when the stack is empty."
         },
         {
           "date": "2013-04-15",
-          "text": "You still pay all costs for that spell, including additional costs. You may also pay alternative costs, such as overload costs. Although you can’t pay additional costs for the copy that’s created, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
+          "text": "You still pay all costs for that spell, including additional costs. You may also pay alternative costs, such as overload costs. Although you can't pay additional costs for the copy that's created, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2013-04-15",
-          "text": "Melek’s last ability will copy any instant or sorcery spell you cast from your library, not just one with targets."
+          "text": "Melek's last ability will copy any instant or sorcery spell you cast from your library, not just one with targets."
         },
         {
           "date": "2013-04-15",
-          "text": "When the last ability resolves, it creates a copy of the spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When the last ability resolves, it creates a copy of the spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell being copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell being copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2013-04-15",
@@ -22190,15 +22208,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Instant and sorcery cards with miracle allow a player to cast a card immediately upon drawing it. If you cast a spell this way, you’re casting it from your hand, not your library. Melek’s ability won’t trigger."
+          "text": "Instant and sorcery cards with miracle allow a player to cast a card immediately upon drawing it. If you cast a spell this way, you're casting it from your hand, not your library. Melek's ability won't trigger."
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -22404,7 +22422,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Necromancer’s Covenant grants lifelink to all Zombies you control, not just the tokens put onto the battlefield with its first ability."
+          "text": "Necromancer's Covenant grants lifelink to all Zombies you control, not just the tokens put onto the battlefield with its first ability."
         }
       ],
       "text": "When Necromancer's Covenant enters the battlefield, exile all creature cards from target player's graveyard, then create a 2/2 black Zombie creature token for each card exiled this way.\nZombies you control have lifelink.",
@@ -22501,11 +22519,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The number of cards you draw equals Prime Speaker Zegana’s power when the last ability resolves."
+          "text": "The number of cards you draw equals Prime Speaker Zegana's power when the last ability resolves."
         },
         {
           "date": "2013-01-24",
-          "text": "If Prime Speaker Zegana enters the battlefield at the same time as another creature you control, you won’t consider that creature when determining the greatest power among creatures you control."
+          "text": "If Prime Speaker Zegana enters the battlefield at the same time as another creature you control, you won't consider that creature when determining the greatest power among creatures you control."
         }
       ],
       "subtypes": [
@@ -22701,7 +22719,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an artifact, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an artifact, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target artifact or creature. It can't be regenerated.",
@@ -22795,7 +22813,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Steam Augury doesn’t target any opponent. In a multiplayer game, you choose the opponent as the spell resolves."
+          "text": "Steam Augury doesn't target any opponent. In a multiplayer game, you choose the opponent as the spell resolves."
         },
         {
           "date": "2013-09-15",
@@ -22892,19 +22910,19 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Protection from creatures means that Teysa, Envoy of Ghosts can’t be the target of abilities of creatures or abilities of creature cards in other zones, such as bloodrush abilities. Teysa also can’t be blocked by creatures, and all damage that would be dealt to Teysa by creatures is prevented."
+          "text": "Protection from creatures means that Teysa, Envoy of Ghosts can't be the target of abilities of creatures or abilities of creature cards in other zones, such as bloodrush abilities. Teysa also can't be blocked by creatures, and all damage that would be dealt to Teysa by creatures is prevented."
         },
         {
           "date": "2013-04-15",
-          "text": "Teysa’s last ability doesn’t target the creature. It will destroy a creature with hexproof or protection from white, for example."
+          "text": "Teysa's last ability doesn't target the creature. It will destroy a creature with hexproof or protection from white, for example."
         },
         {
           "date": "2013-04-15",
-          "text": "Teysa’s controller gets the Spirit creature token, not the controller of the creature that dealt combat damage."
+          "text": "Teysa's controller gets the Spirit creature token, not the controller of the creature that dealt combat damage."
         },
         {
           "date": "2013-07-01",
-          "text": "You get a Spirit creature token even if Teysa’s triggered ability doesn’t destroy the creature (perhaps because it regenerated or has indestructible)."
+          "text": "You get a Spirit creature token even if Teysa's triggered ability doesn't destroy the creature (perhaps because it regenerated or has indestructible)."
         }
       ],
       "subtypes": [
@@ -23010,11 +23028,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -23210,7 +23228,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -23317,11 +23335,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The ability doesn’t care why a card goes to your opponent’s graveyard — only that it does. The ability triggers when a card is put into your opponent’s graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player’s hand (a card is discarded), from the player’s library (from a Millstone-like effect), or from any other zone."
+          "text": "The ability doesn't care why a card goes to your opponent's graveyard — only that it does. The ability triggers when a card is put into your opponent's graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player's hand (a card is discarded), from the player's library (from a Millstone-like effect), or from any other zone."
         },
         {
           "date": "2005-10-01",
-          "text": "This ability triggers only on cards, so it won’t trigger when a token is put into your opponent’s graveyard."
+          "text": "This ability triggers only on cards, so it won't trigger when a token is put into your opponent's graveyard."
         }
       ],
       "subtypes": [
@@ -23514,7 +23532,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -23522,11 +23540,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Create a 5/5 blue and red Elemental creature token with flying.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -23713,7 +23731,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Snakeform doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering."
+          "text": "Snakeform doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering."
         },
         {
           "date": "2008-08-01",
@@ -23725,7 +23743,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The power/toughness-setting effect overwrites other effects that set power and toughness only if those effects existed before this spell resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after this spell resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The power/toughness-setting effect overwrites other effects that set power and toughness only if those effects existed before this spell resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after this spell resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "text": "Until end of turn, target creature loses all abilities and becomes a green Snake with base power and toughness 1/1.\nDraw a card.",
@@ -23993,15 +24011,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If there are no creature cards in any graveyard when Bonehoard’s living weapon ability resolves, the Germ will be 0/0 and put into its owner’s graveyard."
+          "text": "If there are no creature cards in any graveyard when Bonehoard's living weapon ability resolves, the Germ will be 0/0 and put into its owner's graveyard."
         },
         {
           "date": "2011-06-01",
-          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won’t increase the bonus granted by Bonehoard, however briefly."
+          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won't increase the bonus granted by Bonehoard, however briefly."
         },
         {
           "date": "2011-06-01",
-          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won’t get an additional bonus from the other creature."
+          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won't get an additional bonus from the other creature."
         }
       ],
       "subtypes": [
@@ -24670,11 +24688,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you control any creatures as the triggered ability resolves, you must sacrifice one. You can’t choose to sacrifice Eldrazi Monument instead. You sacrifice the Monument only if you had no creatures to sacrifice."
+          "text": "If you control any creatures as the triggered ability resolves, you must sacrifice one. You can't choose to sacrifice Eldrazi Monument instead. You sacrifice the Monument only if you had no creatures to sacrifice."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "text": "Creatures you control get +1/+1 and have flying and indestructible.\nAt the beginning of your upkeep, sacrifice a creature. If you can't, sacrifice Eldrazi Monument.",
@@ -24765,7 +24783,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This works even if the opponent’s lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
+          "text": "This works even if the opponent's lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
         },
         {
           "date": "2004-10-04",
@@ -24773,19 +24791,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, take into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, take into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Fellwar Stone doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -25051,7 +25069,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You are not allowed to “unequip” equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won’t be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
+          "text": "You are not allowed to \"unequip\" equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won't be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
         }
       ],
       "subtypes": [
@@ -25658,7 +25676,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -25758,7 +25776,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {G} or {U} to your mana pool.\n{G}{U}: Simic Keyrune becomes a 2/3 green and blue Crab artifact creature with hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
@@ -26270,7 +26288,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can’t be the target of spells and abilities you control."
+          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can't be the target of spells and abilities you control."
         }
       ],
       "subtypes": [
@@ -27117,15 +27135,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander's color."
         },
         {
           "date": "2011-09-22",
-          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower’s ability produces no mana."
+          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower's ability produces no mana."
         },
         {
           "date": "2011-09-22",
-          "text": "In formats other than Commander, Command Tower’s ability produces no mana."
+          "text": "In formats other than Commander, Command Tower's ability produces no mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color in your commander's color identity.",
@@ -27258,6 +27276,10 @@
       "imageName": "evolving wilds",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Battle for Zendikar Block",
           "legality": "Legal"
@@ -27504,15 +27526,15 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won’t get to search for a land card."
+          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won't get to search for a land card."
         },
         {
           "date": "2011-09-22",
-          "text": "If the targeted land is an illegal target by the time Ghost Quarter’s ability resolves, it will be countered and none of its effects will happen. The land’s controller won’t get to search for a basic land card."
+          "text": "If the targeted land is an illegal target by the time Ghost Quarter's ability resolves, it will be countered and none of its effects will happen. The land's controller won't get to search for a basic land card."
         },
         {
           "date": "2013-07-01",
-          "text": "The target land’s controller gets to search for a basic land card even if that land wasn’t destroyed by Ghost Quarter’s ability. This may happen because the land has indestructible or because it was regenerated."
+          "text": "The target land's controller gets to search for a basic land card even if that land wasn't destroyed by Ghost Quarter's ability. This may happen because the land has indestructible or because it was regenerated."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it onto the battlefield, then shuffle his or her library.",
@@ -28221,7 +28243,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The +1/+1 counter won’t affect Llanowar Reborn in any way unless another effect turns it into a creature."
+          "text": "The +1/+1 counter won't affect Llanowar Reborn in any way unless another effect turns it into a creature."
         }
       ],
       "text": "Llanowar Reborn enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nGraft 1 (This land enters the battlefield with a +1/+1 counter on it. Whenever a creature enters the battlefield, you may move a +1/+1 counter from this land onto it.)",
@@ -28560,11 +28582,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Oran-Rief’s third ability cares about permanents’ characteristics at the time the ability resolves, not their characteristics at the time they entered the battlefield. For example, if a blue creature enters the battlefield, then is turned green by a spell or ability, then Oran-Rief’s second ability resolves, you’ll put a +1/+1 counter on that creature."
+          "text": "Oran-Rief's third ability cares about permanents' characteristics at the time the ability resolves, not their characteristics at the time they entered the battlefield. For example, if a blue creature enters the battlefield, then is turned green by a spell or ability, then Oran-Rief's second ability resolves, you'll put a +1/+1 counter on that creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Oran-Rief’s second ability affects all permanents that are green creatures that entered the battlefield this turn, not just the ones you control."
+          "text": "Oran-Rief's second ability affects all permanents that are green creatures that entered the battlefield this turn, not just the ones you control."
         }
       ],
       "text": "Oran-Rief, the Vastwood enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{T}: Put a +1/+1 counter on each green creature that entered the battlefield this turn.",
@@ -28928,7 +28950,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you’ll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you'll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\n{T}: Add {C} to your mana pool.",
@@ -29014,7 +29036,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Activating the second ability of Rogue’s Passage after a creature has become blocked won’t cause it to become unblocked."
+          "text": "Activating the second ability of Rogue's Passage after a creature has become blocked won't cause it to become unblocked."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}, {T}: Target creature can't be blocked this turn.",
@@ -29633,15 +29655,15 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "At the time the last ability resolves, you’ll get to play the card if a player who is currently your opponent, or a player who was your opponent at the time he or she left the game, has been dealt 7 damage over the course of the turn."
+          "text": "At the time the last ability resolves, you'll get to play the card if a player who is currently your opponent, or a player who was your opponent at the time he or she left the game, has been dealt 7 damage over the course of the turn."
         },
         {
           "date": "2007-10-01",
-          "text": "It doesn’t matter how the opponent was dealt damage or by whom, as long as the total damage is 7 or more. You don’t specify an opponent when you activate the ability."
+          "text": "It doesn't matter how the opponent was dealt damage or by whom, as long as the total damage is 7 or more. You don't specify an opponent when you activate the ability."
         },
         {
           "date": "2007-10-01",
-          "text": "You’ll get to play the card even if Spinerock Knoll wasn’t on the battlefield at the time some or all of the 7 damage was dealt."
+          "text": "You'll get to play the card even if Spinerock Knoll wasn't on the battlefield at the time some or all of the 7 damage was dealt."
         }
       ],
       "text": "Hideaway (This land enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\n{T}: Add {R} to your mana pool.\n{R}, {T}: You may play the exiled card without paying its mana cost if an opponent was dealt 7 or more damage this turn.",

--- a/json/C16.json
+++ b/json/C16.json
@@ -90,7 +90,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "The ability of Duelist’s Heritage triggers whenever any player attacks with one or more creatures, not just when you do. You know which players and planeswalkers the creatures are attacking before you choose the target creature."
+          "text": "The ability of Duelist's Heritage triggers whenever any player attacks with one or more creatures, not just when you do. You know which players and planeswalkers the creatures are attacking before you choose the target creature."
         }
       ],
       "text": "Whenever one or more creatures attack, you may have target attacking creature gain double strike until end of turn.",
@@ -176,7 +176,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "An “attacking creature” is one that has been declared as an attacker or put onto the battlefield attacking during this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker or put onto the battlefield attacking during this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2016-11-08",
@@ -184,7 +184,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Entrapment Maneuver doesn’t target the creature to be sacrificed. The target player chooses one as it resolves. No player may take any other actions between the target player choosing the creature and you creating Soldier tokens."
+          "text": "Entrapment Maneuver doesn't target the creature to be sacrificed. The target player chooses one as it resolves. No player may take any other actions between the target player choosing the creature and you creating Soldier tokens."
         },
         {
           "date": "2016-11-08",
@@ -275,19 +275,19 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "While resolving Orzhov Advokist’s ability, you choose a creature you control or choose not to put any counters on a creature, then each other player in turn order does the same. Each player will know the choices made by players who chose before them. Then simultaneously each player who chose a creature puts two +1/+1 counters on the creature he or she chose."
+          "text": "While resolving Orzhov Advokist's ability, you choose a creature you control or choose not to put any counters on a creature, then each other player in turn order does the same. Each player will know the choices made by players who chose before them. Then simultaneously each player who chose a creature puts two +1/+1 counters on the creature he or she chose."
         },
         {
           "date": "2016-11-08",
-          "text": "Orzhov Advokist’s ability doesn’t target the creatures that receive +1/+1 counters. Their controllers choose them as the ability resolves. Players can’t take actions between making their choices and the +1/+1 counters being placed."
+          "text": "Orzhov Advokist's ability doesn't target the creatures that receive +1/+1 counters. Their controllers choose them as the ability resolves. Players can't take actions between making their choices and the +1/+1 counters being placed."
         },
         {
           "date": "2016-11-08",
-          "text": "If a player chooses to accept Orzhov Advokist’s gift, that player can’t attack you or a planeswalker you control with any creatures during his or her next turn, even creatures that weren’t on the battlefield as Orzhov Advokist’s ability resolved."
+          "text": "If a player chooses to accept Orzhov Advokist's gift, that player can't attack you or a planeswalker you control with any creatures during his or her next turn, even creatures that weren't on the battlefield as Orzhov Advokist's ability resolved."
         },
         {
           "date": "2016-11-08",
-          "text": "Orzhov Advokist’s effect keeps creatures from attacking you even if Orzhov Advokist leaves the battlefield, if the creature that received counters is no longer on the battlefield, or if an effect has moved those counters off of the creature that received them and put them onto another creature."
+          "text": "Orzhov Advokist's effect keeps creatures from attacking you even if Orzhov Advokist leaves the battlefield, if the creature that received counters is no longer on the battlefield, or if an effect has moved those counters off of the creature that received them and put them onto another creature."
         }
       ],
       "subtypes": [
@@ -378,15 +378,15 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Selfless Squire’s first triggered ability prevents all damage that would be dealt to you this turn after the triggered ability resolves, even if Selfless Squire leaves the battlefield."
+          "text": "Selfless Squire's first triggered ability prevents all damage that would be dealt to you this turn after the triggered ability resolves, even if Selfless Squire leaves the battlefield."
         },
         {
           "date": "2016-11-08",
-          "text": "Selfless Squire’s second triggered ability doesn’t trigger only when damage is prevented by its first triggered ability’s effect. Any effect that uses the word “prevent” will cause it to trigger."
+          "text": "Selfless Squire's second triggered ability doesn't trigger only when damage is prevented by its first triggered ability's effect. Any effect that uses the word \"prevent\" will cause it to trigger."
         },
         {
           "date": "2016-11-08",
-          "text": "If a prevention effect applies to damage that would be dealt to you while you control a planeswalker, you choose whether to apply that prevention effect before or after the planeswalker redirection effect. If you apply the prevention effect first, the planeswalker redirection effect no longer applies. If you apply the planeswalker redirection effect and your opponent chooses to have the damage dealt to a planeswalker you control, that damage isn’t prevented."
+          "text": "If a prevention effect applies to damage that would be dealt to you while you control a planeswalker, you choose whether to apply that prevention effect before or after the planeswalker redirection effect. If you apply the prevention effect first, the planeswalker redirection effect no longer applies. If you apply the planeswalker redirection effect and your opponent chooses to have the damage dealt to a planeswalker you control, that damage isn't prevented."
         }
       ],
       "subtypes": [
@@ -477,11 +477,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Causing an opponent to lose the game after you’ve announced that you’re casting a spell with undaunted and determined its total cost won’t cause you to have to pay more mana."
+          "text": "Causing an opponent to lose the game after you've announced that you're casting a spell with undaunted and determined its total cost won't cause you to have to pay more mana."
         },
         {
           "date": "2016-11-08",
-          "text": "Effects that reduce what you pay to cast a spell don’t affect its converted mana cost. Sublime Exhalation’s converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
+          "text": "Effects that reduce what you pay to cast a spell don't affect its converted mana cost. Sublime Exhalation's converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
         }
       ],
       "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy all creatures.",
@@ -567,11 +567,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Causing an opponent to lose the game after you’ve announced that you’re casting a spell with undaunted and determined its total cost won’t cause you to have to pay more mana."
+          "text": "Causing an opponent to lose the game after you've announced that you're casting a spell with undaunted and determined its total cost won't cause you to have to pay more mana."
         },
         {
           "date": "2016-11-08",
-          "text": "Effects that reduce what you pay to cast a spell don’t affect its converted mana cost. Sublime Exhalation’s converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
+          "text": "Effects that reduce what you pay to cast a spell don't affect its converted mana cost. Sublime Exhalation's converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
         }
       ],
       "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nReturn all nonland permanents to their owners' hands.",
@@ -658,15 +658,15 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "You can choose no targets if you don’t want to double the counters on any permanents."
+          "text": "You can choose no targets if you don't want to double the counters on any permanents."
         },
         {
           "date": "2016-11-08",
-          "text": "To double the number of each kind of counter on a permanent, put another counter on it for each counter it already has. Effects that interact with counters being put onto permanents (such as that of Corpsejack Menace or Fathom Mage) apply if appropriate. For example, if Corpsejack Menace has two +1/+1 counters and a divinity counter on it, Deepglow Skate’s ability gives Corpsejack Menace four more +1/+1 counters and one more divinity counter."
+          "text": "To double the number of each kind of counter on a permanent, put another counter on it for each counter it already has. Effects that interact with counters being put onto permanents (such as that of Corpsejack Menace or Fathom Mage) apply if appropriate. For example, if Corpsejack Menace has two +1/+1 counters and a divinity counter on it, Deepglow Skate's ability gives Corpsejack Menace four more +1/+1 counters and one more divinity counter."
         },
         {
           "date": "2016-11-08",
-          "text": "As Deepglow Skate’s ability resolves, you must double each kind of counter on the permanents it targets."
+          "text": "As Deepglow Skate's ability resolves, you must double each kind of counter on the permanents it targets."
         }
       ],
       "subtypes": [
@@ -756,11 +756,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "If you control multiple Faerie Artisans, each one’s ability only exiles tokens created with the ability of that specific Faerie Artisans."
+          "text": "If you control multiple Faerie Artisans, each one's ability only exiles tokens created with the ability of that specific Faerie Artisans."
         },
         {
           "date": "2016-11-08",
-          "text": "The token copies exactly what was printed on the original permanent and nothing else (unless that permanent is copying something else; see below). It doesn’t copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "The token copies exactly what was printed on the original permanent and nothing else (unless that permanent is copying something else; see below). It doesn't copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2016-11-08",
@@ -776,11 +776,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "If the permanent copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the permanent copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         },
         {
           "date": "2016-11-08",
-          "text": "A token creature that’s a copy of a player’s commander isn’t a commander."
+          "text": "A token creature that's a copy of a player's commander isn't a commander."
         }
       ],
       "subtypes": [
@@ -875,7 +875,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "If the Equipment doesn’t provide a toughness boost, your Germ token will have 0 toughness and die. You’ll still control the Equipment."
+          "text": "If the Equipment doesn't provide a toughness boost, your Germ token will have 0 toughness and die. You'll still control the Equipment."
         }
       ],
       "text": "Gain control of target Equipment, then create a 0/0 black Germ creature token and attach that Equipment to it.",
@@ -960,7 +960,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "If there aren’t enough nonland cards for each opponent to choose one, all of the nonland cards are put into your hand."
+          "text": "If there aren't enough nonland cards for each opponent to choose one, all of the nonland cards are put into your hand."
         },
         {
           "date": "2016-11-08",
@@ -968,7 +968,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "After Manifold Insights resolves, if it’s your turn, you may play one of the cards if it’s legal to do so before any other player can take any action."
+          "text": "After Manifold Insights resolves, if it's your turn, you may play one of the cards if it's legal to do so before any other player can take any action."
         }
       ],
       "text": "Reveal the top ten cards of your library. Starting with the next opponent in turn order, each opponent chooses a different nonland card from among them. Put the chosen cards into your hand and the rest on the bottom of your library in a random order.",
@@ -1053,7 +1053,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Cruel Entertainment’s controller may be one of its targets, even if it’s less entertaining this way."
+          "text": "Cruel Entertainment's controller may be one of its targets, even if it's less entertaining this way."
         },
         {
           "date": "2016-11-08",
@@ -1061,7 +1061,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "The controlling player can’t make the player being controlled concede. A player may choose to concede at any time, even while under another player’s control."
+          "text": "The controlling player can't make the player being controlled concede. A player may choose to concede at any time, even while under another player's control."
         },
         {
           "date": "2016-11-08",
@@ -1073,7 +1073,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "While controlling another player, the controlling player can see all cards in the game that the player being controlled can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library that he or she may look at."
+          "text": "While controlling another player, the controlling player can see all cards in the game that the player being controlled can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library that he or she may look at."
         },
         {
           "date": "2016-11-08",
@@ -1081,19 +1081,19 @@
         },
         {
           "date": "2016-11-08",
-          "text": "The controlling player can’t make any illegal decisions or illegal choices—that player can’t do anything that the player being controlled couldn’t do. The controlling player can’t make choices or decisions for that player that aren’t called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the player being controlled would normally make (as Master Warcraft does), that effect takes precedence. In other words, if the player being controlled wouldn’t make a decision, the controlling player can’t make that decision on his or her behalf."
+          "text": "The controlling player can't make any illegal decisions or illegal choices—that player can't do anything that the player being controlled couldn't do. The controlling player can't make choices or decisions for that player that aren't called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the player being controlled would normally make (as Master Warcraft does), that effect takes precedence. In other words, if the player being controlled wouldn't make a decision, the controlling player can't make that decision on his or her behalf."
         },
         {
           "date": "2016-11-08",
-          "text": "The controlling player also can’t make any choices or decisions for the player being controlled that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
+          "text": "The controlling player also can't make any choices or decisions for the player being controlled that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
         },
         {
           "date": "2016-11-08",
-          "text": "The controlling player only controls the player. The controlling player doesn’t control any of that player’s permanents, spells, or abilities."
+          "text": "The controlling player only controls the player. The controlling player doesn't control any of that player's permanents, spells, or abilities."
         },
         {
           "date": "2016-11-08",
-          "text": "The controlling player can use only the resources of the player being controlled (cards, mana, and so on) to pay costs for that player; the controlling player can’t use his or her own resources to pay costs for the player being controlled. Similarly, the controlling player can’t spend the resources of the player being controlled on any of the controlling player’s own costs."
+          "text": "The controlling player can use only the resources of the player being controlled (cards, mana, and so on) to pay costs for that player; the controlling player can't use his or her own resources to pay costs for the player being controlled. Similarly, the controlling player can't spend the resources of the player being controlled on any of the controlling player's own costs."
         },
         {
           "date": "2016-11-08",
@@ -1105,7 +1105,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Controlling a player doesn’t allow the controlling player to look at the controlled player’s sideboard. If an effect instructs that player to choose a card from outside the game, the controlling player can’t have that player choose a card."
+          "text": "Controlling a player doesn't allow the controlling player to look at the controlled player's sideboard. If an effect instructs that player to choose a card from outside the game, the controlling player can't have that player choose a card."
         }
       ],
       "text": "Choose target player and another target player. The first player controls the second player during the second player's next turn, and the second player controls the first player during the first player's next turn.",
@@ -1190,11 +1190,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Curse of Vengeance’s first triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Curse of Vengeance's first triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         },
         {
           "date": "2016-11-08",
-          "text": "If you and the enchanted player both reach 0 or less life at the same time, you’ll lose the game before Curse of Vengeance’s second triggered ability gives you more life."
+          "text": "If you and the enchanted player both reach 0 or less life at the same time, you'll lose the game before Curse of Vengeance's second triggered ability gives you more life."
         }
       ],
       "subtypes": [
@@ -1284,15 +1284,15 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "You can’t cast Curtains’ Call without two creatures to target. If one becomes an illegal target after you’ve cast Curtains’ Call, the other will still be destroyed."
+          "text": "You can't cast Curtains' Call without two creatures to target. If one becomes an illegal target after you've cast Curtains' Call, the other will still be destroyed."
         },
         {
           "date": "2016-11-08",
-          "text": "Causing an opponent to lose the game after you’ve announced that you’re casting a spell with undaunted and determined its total cost won’t cause you to have to pay more mana."
+          "text": "Causing an opponent to lose the game after you've announced that you're casting a spell with undaunted and determined its total cost won't cause you to have to pay more mana."
         },
         {
           "date": "2016-11-08",
-          "text": "Effects that reduce what you pay to cast a spell don’t affect its converted mana cost. Sublime Exhalation’s converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
+          "text": "Effects that reduce what you pay to cast a spell don't affect its converted mana cost. Sublime Exhalation's converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
         }
       ],
       "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy two target creatures.",
@@ -1379,15 +1379,15 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Cards that would be put into your graveyard are exiled even if you didn’t play them this turn, such as a nontoken creature that would die."
+          "text": "Cards that would be put into your graveyard are exiled even if you didn't play them this turn, such as a nontoken creature that would die."
         },
         {
           "date": "2016-11-08",
-          "text": "Creature tokens are put into your graveyard as normal (and cease to exist soon after). Abilities that trigger when a creature dies can trigger on token creatures being put into your graveyard but won’t trigger on nontoken creatures being exiled instead of being put into your graveyard."
+          "text": "Creature tokens are put into your graveyard as normal (and cease to exist soon after). Abilities that trigger when a creature dies can trigger on token creatures being put into your graveyard but won't trigger on nontoken creatures being exiled instead of being put into your graveyard."
         },
         {
           "date": "2016-11-08",
-          "text": "You pay the costs for a card in your graveyard if you cast it. You may pay alternative costs such as emerge rather than the card’s mana cost."
+          "text": "You pay the costs for a card in your graveyard if you cast it. You may pay alternative costs such as emerge rather than the card's mana cost."
         },
         {
           "date": "2016-11-08",
@@ -1395,11 +1395,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Magus of the Will doesn’t change when you can play the cards in your graveyard. For example, if you have a creature card without flash in your graveyard, you can cast it only during your main phase while the stack is empty."
+          "text": "Magus of the Will doesn't change when you can play the cards in your graveyard. For example, if you have a creature card without flash in your graveyard, you can cast it only during your main phase while the stack is empty."
         },
         {
           "date": "2016-11-08",
-          "text": "If another effect tries to change where a spell is put as it resolves, such as that of a rebound or buyback ability, you may choose whether to exile the card to Magus of the Will’s effect or to apply the other effect."
+          "text": "If another effect tries to change where a spell is put as it resolves, such as that of a rebound or buyback ability, you may choose whether to exile the card to Magus of the Will's effect or to apply the other effect."
         }
       ],
       "subtypes": [
@@ -1490,15 +1490,15 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Parting Thoughts can target a creature without any counters on it. You’ll lose no life and draw no cards."
+          "text": "Parting Thoughts can target a creature without any counters on it. You'll lose no life and draw no cards."
         },
         {
           "date": "2016-11-08",
-          "text": "Parting Thoughts counts every kind of counter on that creature. Effects such as that of Giant Growth, Auras, and Equipment aren’t counters."
+          "text": "Parting Thoughts counts every kind of counter on that creature. Effects such as that of Giant Growth, Auras, and Equipment aren't counters."
         },
         {
           "date": "2016-11-08",
-          "text": "If a creature has +1/+1 counters and -1/-1 counters on it, state-based actions remove the same number of each so that it has only one of those kinds of counters on it. There won’t be any counters of the other kind for Parting Thoughts to count."
+          "text": "If a creature has +1/+1 counters and -1/-1 counters on it, state-based actions remove the same number of each so that it has only one of those kinds of counters on it. There won't be any counters of the other kind for Parting Thoughts to count."
         }
       ],
       "text": "Destroy target creature. You draw X cards and you lose X life, where X is the number of counters on that creature.",
@@ -1584,19 +1584,19 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Charging Cinderhorn’s triggered ability doesn’t trigger at all if a creature attacked this turn. It won’t get a fury counter or deal damage."
+          "text": "Charging Cinderhorn's triggered ability doesn't trigger at all if a creature attacked this turn. It won't get a fury counter or deal damage."
         },
         {
           "date": "2016-11-08",
-          "text": "Charging Cinderhorn’s triggered ability triggers at the beginning of each player’s end step if no creatures attacked, including yours, and even if it wasn’t on the battlefield during combat."
+          "text": "Charging Cinderhorn's triggered ability triggers at the beginning of each player's end step if no creatures attacked, including yours, and even if it wasn't on the battlefield during combat."
         },
         {
           "date": "2016-11-08",
-          "text": "If Charging Cinderhorn leaves the battlefield in response to its triggered ability, it won’t get a new fury counter, but it will deal damage equal to the number of fury counters it had before leaving the battlefield."
+          "text": "If Charging Cinderhorn leaves the battlefield in response to its triggered ability, it won't get a new fury counter, but it will deal damage equal to the number of fury counters it had before leaving the battlefield."
         },
         {
           "date": "2016-11-08",
-          "text": "If a player loses the game during that player’s own turn, the turn continues to completion. If no creatures attacked, Charging Cinderhorn will get a fury counter even though it won’t deal damage to any player."
+          "text": "If a player loses the game during that player's own turn, the turn continues to completion. If no creatures attacked, Charging Cinderhorn will get a fury counter even though it won't deal damage to any player."
         }
       ],
       "subtypes": [
@@ -1686,19 +1686,19 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "You can’t cast Divergent Transformations without two target creatures. If a targeted creature becomes an illegal target for Divergent Transformations after it’s been cast, its controller won’t exile or replace that creature, but the other creature is still affected."
+          "text": "You can't cast Divergent Transformations without two target creatures. If a targeted creature becomes an illegal target for Divergent Transformations after it's been cast, its controller won't exile or replace that creature, but the other creature is still affected."
         },
         {
           "date": "2016-11-08",
-          "text": "If two players’ creatures are exiled this way, start with the player whose turn it is. If that player controlled a creature exiled this way, that player follows the process on Divergent Transformations to replace it. If not, proceed to the next player in turn order. Repeat until the players who controlled the exiled creatures have each replaced those creatures."
+          "text": "If two players' creatures are exiled this way, start with the player whose turn it is. If that player controlled a creature exiled this way, that player follows the process on Divergent Transformations to replace it. If not, proceed to the next player in turn order. Repeat until the players who controlled the exiled creatures have each replaced those creatures."
         },
         {
           "date": "2016-11-08",
-          "text": "If one player’s creatures are exiled this way, that player repeats this process twice."
+          "text": "If one player's creatures are exiled this way, that player repeats this process twice."
         },
         {
           "date": "2016-11-08",
-          "text": "The two creatures that are put onto the battlefield are put onto the battlefield sequentially. Triggered abilities of the second won’t see the first enter the battlefield."
+          "text": "The two creatures that are put onto the battlefield are put onto the battlefield sequentially. Triggered abilities of the second won't see the first enter the battlefield."
         },
         {
           "date": "2016-11-08",
@@ -1710,11 +1710,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Causing an opponent to lose the game after you’ve announced that you’re casting a spell with undaunted and determined its total cost won’t cause you to have to pay more mana."
+          "text": "Causing an opponent to lose the game after you've announced that you're casting a spell with undaunted and determined its total cost won't cause you to have to pay more mana."
         },
         {
           "date": "2016-11-08",
-          "text": "Effects that reduce what you pay to cast a spell don’t affect its converted mana cost. Sublime Exhalation’s converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
+          "text": "Effects that reduce what you pay to cast a spell don't affect its converted mana cost. Sublime Exhalation's converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
         }
       ],
       "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nExile two target creatures. For each of those creatures, its controller reveals cards from the top of his or her library until he or she reveals a creature card, puts that card onto the battlefield, then shuffles the rest into his or her library.",
@@ -1800,11 +1800,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "The triggered ability triggers both when Frenzied Fugue enters the battlefield and at the beginning of your upkeep. You don’t have to choose only one."
+          "text": "The triggered ability triggers both when Frenzied Fugue enters the battlefield and at the beginning of your upkeep. You don't have to choose only one."
         },
         {
           "date": "2016-11-08",
-          "text": "You won’t control the enchanted permanent as your upkeep begins. Any “at the beginning of your upkeep” abilities it has won’t trigger during your upkeep (unless you already controlled the permanent). Similarly, if you have an “at the beginning of your upkeep” ability that targets a permanent you control, that ability can’t target it."
+          "text": "You won't control the enchanted permanent as your upkeep begins. Any \"at the beginning of your upkeep\" abilities it has won't trigger during your upkeep (unless you already controlled the permanent). Similarly, if you have an \"at the beginning of your upkeep\" ability that targets a permanent you control, that ability can't target it."
         }
       ],
       "subtypes": [
@@ -1894,7 +1894,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "If, during your declare attackers step, a creature you control is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack, even if you control one of Goblin Spymaster’s tokens. If there’s a cost associated with having a creature attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, a creature you control is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack, even if you control one of Goblin Spymaster's tokens. If there's a cost associated with having a creature attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -1986,7 +1986,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Exiling Runehorn Hellkite from your graveyard is part of the cost of its activated ability. An opponent can’t remove Runehorn Hellkite from your graveyard in response to you activating the ability."
+          "text": "Exiling Runehorn Hellkite from your graveyard is part of the cost of its activated ability. An opponent can't remove Runehorn Hellkite from your graveyard in response to you activating the ability."
         },
         {
           "date": "2016-11-08",
@@ -2079,15 +2079,15 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "You must cast Benefactor’s Draught before blockers are declared in order to draw any cards from its delayed triggered ability."
+          "text": "You must cast Benefactor's Draught before blockers are declared in order to draw any cards from its delayed triggered ability."
         },
         {
           "date": "2016-11-08",
-          "text": "Each player will have a chance to cast instants and activate abilities after Benefactor’s Draught’s delayed triggered abilities have resolved, before combat damage is dealt."
+          "text": "Each player will have a chance to cast instants and activate abilities after Benefactor's Draught's delayed triggered abilities have resolved, before combat damage is dealt."
         },
         {
           "date": "2016-11-08",
-          "text": "If multiple copies of Benefactor’s Draught resolve in one turn, each creates a delayed triggered ability and each will trigger when its condition is met."
+          "text": "If multiple copies of Benefactor's Draught resolve in one turn, each creates a delayed triggered ability and each will trigger when its condition is met."
         }
       ],
       "text": "Untap all creatures. Until end of turn, whenever a creature an opponent controls blocks, draw a card.\nDraw a card.",
@@ -2173,15 +2173,15 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "You choose two targets for Evolutionary Escalation’s ability as it’s put onto the stack. No player may cast spells or activate abilities during your turn before this happens."
+          "text": "You choose two targets for Evolutionary Escalation's ability as it's put onto the stack. No player may cast spells or activate abilities during your turn before this happens."
         },
         {
           "date": "2016-11-08",
-          "text": "If there aren’t two legal targets for Evolutionary Escalation’s ability as it’s put onto the stack, it’s taken off the stack and no creature gets +1/+1 counters."
+          "text": "If there aren't two legal targets for Evolutionary Escalation's ability as it's put onto the stack, it's taken off the stack and no creature gets +1/+1 counters."
         },
         {
           "date": "2016-11-08",
-          "text": "If one target becomes illegal before Evolutionary Escalation’s ability resolves, you’ll put three +1/+1 counters on the target that’s still legal."
+          "text": "If one target becomes illegal before Evolutionary Escalation's ability resolves, you'll put three +1/+1 counters on the target that's still legal."
         }
       ],
       "text": "At the beginning of your upkeep, put three +1/+1 counters on target creature you control and three +1/+1 counters on target creature an opponent controls.",
@@ -2272,7 +2272,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Primeval Protector’s ability can’t reduce its cost below {G}."
+          "text": "Primeval Protector's ability can't reduce its cost below {G}."
         }
       ],
       "subtypes": [
@@ -2361,19 +2361,19 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "If one target becomes illegal before Seeds of Renewal resolves, you’ll still return the legal target from your graveyard to your hand."
+          "text": "If one target becomes illegal before Seeds of Renewal resolves, you'll still return the legal target from your graveyard to your hand."
         },
         {
           "date": "2016-11-08",
-          "text": "If each target is illegal as Seeds of Renewal resolves, Seeds of Renewal is countered and put into its owner’s graveyard. It’s not exiled."
+          "text": "If each target is illegal as Seeds of Renewal resolves, Seeds of Renewal is countered and put into its owner's graveyard. It's not exiled."
         },
         {
           "date": "2016-11-08",
-          "text": "Causing an opponent to lose the game after you’ve announced that you’re casting a spell with undaunted and determined its total cost won’t cause you to have to pay more mana."
+          "text": "Causing an opponent to lose the game after you've announced that you're casting a spell with undaunted and determined its total cost won't cause you to have to pay more mana."
         },
         {
           "date": "2016-11-08",
-          "text": "Effects that reduce what you pay to cast a spell don’t affect its converted mana cost. Sublime Exhalation’s converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
+          "text": "Effects that reduce what you pay to cast a spell don't affect its converted mana cost. Sublime Exhalation's converted mana cost is 7, regardless of how many opponents you have or how much mana you spent to cast it."
         }
       ],
       "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nReturn up to two target cards from your graveyard to your hand. Exile Seeds of Renewal.",
@@ -2548,7 +2548,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -2556,11 +2556,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -2660,11 +2660,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "The number of cards in your hand is counted only as Ancient Excavation resolves. Ancient Excavation is on the stack at this time, so it’s not counted."
+          "text": "The number of cards in your hand is counted only as Ancient Excavation resolves. Ancient Excavation is on the stack at this time, so it's not counted."
         },
         {
           "date": "2016-11-08",
-          "text": "The number of cards drawn this way might not be equal to the number of cards in your hand (for example, if you apply Necroplasm’s dredge ability instead of drawing one of those cards). The number of cards that you actually drew is what determines how many cards you discard."
+          "text": "The number of cards drawn this way might not be equal to the number of cards in your hand (for example, if you apply Necroplasm's dredge ability instead of drawing one of those cards). The number of cards that you actually drew is what determines how many cards you discard."
         }
       ],
       "text": "Draw cards equal to the number of cards in your hand, then discard a card for each card drawn this way.\nBasic landcycling {2} ({2}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
@@ -2760,11 +2760,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2016-11-08",
-          "text": "You don’t have to choose every permanent or player that has a counter; you choose only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter; you choose only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2016-11-08",
@@ -2772,11 +2772,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         },
         {
           "date": "2016-11-08",
-          "text": "If a creature has +1/+1 counters and -1/-1 counters on it, state-based actions remove the same number of each so that it has only one of those kinds of counters on it. There won’t be any counters of the other kind to put onto it as you proliferate."
+          "text": "If a creature has +1/+1 counters and -1/-1 counters on it, state-based actions remove the same number of each so that it has only one of those kinds of counters on it. There won't be any counters of the other kind to put onto it as you proliferate."
         }
       ],
       "subtypes": [
@@ -2876,11 +2876,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "You choose which mode you’re using as you activate the ability."
+          "text": "You choose which mode you're using as you activate the ability."
         },
         {
           "date": "2016-11-08",
-          "text": "You can sacrifice any two artifacts you control to pay the cost of Breya’s ability, including Breya itself."
+          "text": "You can sacrifice any two artifacts you control to pay the cost of Breya's ability, including Breya itself."
         }
       ],
       "subtypes": [
@@ -2976,11 +2976,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "The triggered ability triggers both when Bruse Tarl enters the battlefield and whenever it attacks. You don’t have to choose only one."
+          "text": "The triggered ability triggers both when Bruse Tarl enters the battlefield and whenever it attacks. You don't have to choose only one."
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -2988,11 +2988,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -3174,11 +3174,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "The amount of life you gain is determined as Ikra Shidiqi’s triggered ability resolves. If that creature is no longer on the battlefield, use its toughness as it last existed on the battlefield to determine how much life to gain."
+          "text": "The amount of life you gain is determined as Ikra Shidiqi's triggered ability resolves. If that creature is no longer on the battlefield, use its toughness as it last existed on the battlefield to determine how much life to gain."
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -3186,11 +3186,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -3291,11 +3291,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Ishai’s triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Ishai's triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -3303,11 +3303,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -3408,23 +3408,23 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "One player must cast two spells for Kraum’s triggered ability to trigger. Two spells from different opponents won’t trigger it."
+          "text": "One player must cast two spells for Kraum's triggered ability to trigger. Two spells from different opponents won't trigger it."
         },
         {
           "date": "2016-11-08",
-          "text": "Kraum’s triggered ability can trigger only once each turn for each opponent."
+          "text": "Kraum's triggered ability can trigger only once each turn for each opponent."
         },
         {
           "date": "2016-11-08",
-          "text": "Kraum’s triggered ability will resolve regardless of whether the first or second spell that a given opponent cast that turn has resolved, was countered, or is still on the stack. Notably, the ability will always resolve before the second spell resolves."
+          "text": "Kraum's triggered ability will resolve regardless of whether the first or second spell that a given opponent cast that turn has resolved, was countered, or is still on the stack. Notably, the ability will always resolve before the second spell resolves."
         },
         {
           "date": "2016-11-08",
-          "text": "Kraum’s ability looks at the entire turn to determine which spell is a player’s second spell. It doesn’t matter whether Kraum was on the battlefield when the first spell was cast."
+          "text": "Kraum's ability looks at the entire turn to determine which spell is a player's second spell. It doesn't matter whether Kraum was on the battlefield when the first spell was cast."
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -3432,11 +3432,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -3537,19 +3537,19 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Kydele’s ability counts each card you’ve drawn this turn, whether or not they’re still in your hand and whether or not Kydele was on the battlefield or under your control at the time they were drawn."
+          "text": "Kydele's ability counts each card you've drawn this turn, whether or not they're still in your hand and whether or not Kydele was on the battlefield or under your control at the time they were drawn."
         },
         {
           "date": "2016-11-08",
-          "text": "Cards put into your hand without an instruction to “draw” them, such as those found with a basic landcycling ability, weren’t drawn."
+          "text": "Cards put into your hand without an instruction to \"draw\" them, such as those found with a basic landcycling ability, weren't drawn."
         },
         {
           "date": "2016-11-08",
-          "text": "If you haven’t drawn any cards this turn, you can activate Kydele’s mana ability, but it won’t produce any mana."
+          "text": "If you haven't drawn any cards this turn, you can activate Kydele's mana ability, but it won't produce any mana."
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -3557,11 +3557,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -3666,7 +3666,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Starting with you and proceeding in turn order, each player chooses a land card from his or her hand or chooses not to choose one, but doesn’t reveal any chosen lands yet. Once all players have made this choice, all chosen lands are revealed and enter the battlefield simultaneously."
+          "text": "Starting with you and proceeding in turn order, each player chooses a land card from his or her hand or chooses not to choose one, but doesn't reveal any chosen lands yet. Once all players have made this choice, all chosen lands are revealed and enter the battlefield simultaneously."
         },
         {
           "date": "2016-11-08",
@@ -3779,23 +3779,23 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Ludevic’s triggered ability triggers at the beginning of each player’s end step, including yours, even if no player has lost life that turn. Whether or not a player has lost life is checked only as the triggered ability resolves."
+          "text": "Ludevic's triggered ability triggers at the beginning of each player's end step, including yours, even if no player has lost life that turn. Whether or not a player has lost life is checked only as the triggered ability resolves."
         },
         {
           "date": "2016-11-08",
-          "text": "Ludevic’s triggered ability will allow the player to draw a card if any player other than Ludevic’s controller, including the player whose turn it is, lost life this turn."
+          "text": "Ludevic's triggered ability will allow the player to draw a card if any player other than Ludevic's controller, including the player whose turn it is, lost life this turn."
         },
         {
           "date": "2016-11-08",
-          "text": "Ludevic’s ability looks at the entire turn to determine whether the player may draw a card or not. It doesn’t matter whether Ludevic was on the battlefield when the opponent lost life."
+          "text": "Ludevic's ability looks at the entire turn to determine whether the player may draw a card or not. It doesn't matter whether Ludevic was on the battlefield when the opponent lost life."
         },
         {
           "date": "2016-11-08",
-          "text": "Ludevic’s ability checks only if another player lost life during the turn, not whether that player’s life total decreased over the course of the turn. For example, if a player other than Ludevic’s controller lost 2 life and then gained 8 life this turn, the player whose turn it is may draw a card."
+          "text": "Ludevic's ability checks only if another player lost life during the turn, not whether that player's life total decreased over the course of the turn. For example, if a player other than Ludevic's controller lost 2 life and then gained 8 life this turn, the player whose turn it is may draw a card."
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -3803,11 +3803,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -3988,7 +3988,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -3996,11 +3996,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -4104,7 +4104,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -4112,11 +4112,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -4224,15 +4224,15 @@
         },
         {
           "date": "2016-11-08",
-          "text": "The damage that Saskia’s ability causes a creature to deal isn’t combat damage."
+          "text": "The damage that Saskia's ability causes a creature to deal isn't combat damage."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the chosen player has left the game, Saskia’s triggered ability will have no effect."
+          "text": "Once the chosen player has left the game, Saskia's triggered ability will have no effect."
         },
         {
           "date": "2016-11-08",
-          "text": "If Saskia leaves the battlefield and returns, you choose a player again. It doesn’t remember the previously chosen player."
+          "text": "If Saskia leaves the battlefield and returns, you choose a player again. It doesn't remember the previously chosen player."
         }
       ],
       "subtypes": [
@@ -4328,11 +4328,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Sidar Kondo’s blocking restriction applies to creatures your opponents control even when an opponent is attacking a player other than you."
+          "text": "Sidar Kondo's blocking restriction applies to creatures your opponents control even when an opponent is attacking a player other than you."
         },
         {
           "date": "2016-11-08",
-          "text": "Once an attacking creature has been blocked by a creature without flying or reach, reducing its power to 2 or less won’t change or undo that block."
+          "text": "Once an attacking creature has been blocked by a creature without flying or reach, reducing its power to 2 or less won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -4428,7 +4428,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "You pay the costs for the target artifact card if you cast it. You may pay alternative costs rather than the card’s mana cost."
+          "text": "You pay the costs for the target artifact card if you cast it. You may pay alternative costs rather than the card's mana cost."
         },
         {
           "date": "2016-11-08",
@@ -4436,23 +4436,23 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Silas Renn doesn’t change when you can cast the target artifact card. For example, if you target an artifact card without flash, you can cast it only during your main phase when the stack is empty."
+          "text": "Silas Renn doesn't change when you can cast the target artifact card. For example, if you target an artifact card without flash, you can cast it only during your main phase when the stack is empty."
         },
         {
           "date": "2016-11-08",
-          "text": "An effect that instructs you to “cast” a card doesn’t allow you to play lands."
+          "text": "An effect that instructs you to \"cast\" a card doesn't allow you to play lands."
         },
         {
           "date": "2016-11-08",
-          "text": "Casting the card causes it to leave your graveyard and become a new object. You can’t cast it multiple times."
+          "text": "Casting the card causes it to leave your graveyard and become a new object. You can't cast it multiple times."
         },
         {
           "date": "2016-11-08",
-          "text": "If you don’t cast the card, it remains in your graveyard."
+          "text": "If you don't cast the card, it remains in your graveyard."
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -4460,11 +4460,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -4645,7 +4645,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -4653,11 +4653,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -4758,11 +4758,11 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "No player may take another action while you’re resolving the activated ability."
+          "text": "No player may take another action while you're resolving the activated ability."
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -4770,11 +4770,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -4955,19 +4955,19 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "You must pay exactly X life or none. You can’t pay less life to draw fewer cards."
+          "text": "You must pay exactly X life or none. You can't pay less life to draw fewer cards."
         },
         {
           "date": "2016-11-08",
-          "text": "If a player was dealt combat damage and subsequently lost the game, Tymna’s triggered ability counts that player to determine the value of X."
+          "text": "If a player was dealt combat damage and subsequently lost the game, Tymna's triggered ability counts that player to determine the value of X."
         },
         {
           "date": "2016-11-08",
-          "text": "If an effect creates an additional combat phase in a turn, it may also create an additional main phase after that combat phase. Tymna’s ability triggers at the beginning of each of these postcombat main phases."
+          "text": "If an effect creates an additional combat phase in a turn, it may also create an additional main phase after that combat phase. Tymna's ability triggers at the beginning of each of these postcombat main phases."
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -4975,11 +4975,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -5079,19 +5079,19 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "Vial Smasher’s triggered ability triggers when you cast your first spell each turn, regardless of whose turn it is."
+          "text": "Vial Smasher's triggered ability triggers when you cast your first spell each turn, regardless of whose turn it is."
         },
         {
           "date": "2016-11-08",
-          "text": "Vial Smasher has to be on the battlefield at the moment you cast your first spell. If that spell causes Vial Smasher to leave the battlefield as an additional cost to cast it, Vial Smasher’s ability can’t trigger. If that spell is Vial Smasher itself, Vial Smasher’s ability can’t trigger."
+          "text": "Vial Smasher has to be on the battlefield at the moment you cast your first spell. If that spell causes Vial Smasher to leave the battlefield as an additional cost to cast it, Vial Smasher's ability can't trigger. If that spell is Vial Smasher itself, Vial Smasher's ability can't trigger."
         },
         {
           "date": "2016-11-08",
-          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine the spell’s converted mana cost."
+          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine the spell's converted mana cost."
         },
         {
           "date": "2016-11-08",
-          "text": "Vial Smasher’s triggered ability resolves before the spell that caused it to trigger. If Vial Smasher’s ability resolves and the spell that caused it to trigger has been countered, use that spell’s converted mana cost as it last existed on the stack to determine how much damage is dealt."
+          "text": "Vial Smasher's triggered ability resolves before the spell that caused it to trigger. If Vial Smasher's ability resolves and the spell that caused it to trigger has been countered, use that spell's converted mana cost as it last existed on the stack to determine how much damage is dealt."
         },
         {
           "date": "2016-11-08",
@@ -5099,7 +5099,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders’ combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
+          "text": "If your Commander deck has two commanders, you can only include cards whose own color identities are also found in your commanders' combined color identities. If Akiri and Silas Renn are your commanders, your deck may contain cards with white, blue, black, and red in their color identity, but not green."
         },
         {
           "date": "2016-11-08",
@@ -5107,11 +5107,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn’t cause either to cease to be your commander."
+          "text": "To have two commanders, both must have the partner ability as the game begins. Losing the ability during the game doesn't cause either to cease to be your commander."
         },
         {
           "date": "2016-11-08",
-          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won’t have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon’s effect puts one into your hand from the command zone, not both."
+          "text": "Once the game begins, your two commanders are tracked separately. If you cast one, you won't have to pay an additional {2} the first time you cast the other. A player loses the game after having been dealt 21 damage from one of them, not from both of them combined. Command Beacon's effect puts one into your hand from the command zone, not both."
         },
         {
           "date": "2016-11-08",
@@ -5219,7 +5219,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "If Yidris’s triggered ability resolves more than once in one turn, spells you cast from your hand will gain cascade that many times. Each instance of cascade triggers separately; resolve one cascade trigger and the spell you cast from it before resolving the next cascade trigger."
+          "text": "If Yidris's triggered ability resolves more than once in one turn, spells you cast from your hand will gain cascade that many times. Each instance of cascade triggers separately; resolve one cascade trigger and the spell you cast from it before resolving the next cascade trigger."
         },
         {
           "date": "2016-11-08",
@@ -5239,7 +5239,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "You don’t have to cast the last card exiled by a cascade ability. If you choose to do so, you’re casting it as a spell. It can be countered. Since it’s cast from exile, Ydris’s ability won’t give the new spell cascade."
+          "text": "You don't have to cast the last card exiled by a cascade ability. If you choose to do so, you're casting it as a spell. It can be countered. Since it's cast from exile, Ydris's ability won't give the new spell cascade."
         }
       ],
       "subtypes": [
@@ -5328,19 +5328,19 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "The triggered ability triggers both when Armory Automaton enters the battlefield and whenever it attacks. You don’t have to choose only one."
+          "text": "The triggered ability triggers both when Armory Automaton enters the battlefield and whenever it attacks. You don't have to choose only one."
         },
         {
           "date": "2016-11-08",
-          "text": "You can choose to target no Equipment if you don’t want to attach any to Armory Automaton. Because the ability is optional, you also don’t have to attach the Equipment it targets as you resolve the ability. However, you must either attach all of the target Equipment or attach none of them."
+          "text": "You can choose to target no Equipment if you don't want to attach any to Armory Automaton. Because the ability is optional, you also don't have to attach the Equipment it targets as you resolve the ability. However, you must either attach all of the target Equipment or attach none of them."
         },
         {
           "date": "2016-11-08",
-          "text": "Armory Automaton’s ability can cause an Equipment one player controls to become attached to a creature another player controls. The controller of the Equipment can pay the equip cost to move that Equipment to a creature he or she controls, but only any time that player could cast a sorcery. The controller of Armory Automaton can’t pay the equip cost to move Equipment he or she doesn’t control."
+          "text": "Armory Automaton's ability can cause an Equipment one player controls to become attached to a creature another player controls. The controller of the Equipment can pay the equip cost to move that Equipment to a creature he or she controls, but only any time that player could cast a sorcery. The controller of Armory Automaton can't pay the equip cost to move Equipment he or she doesn't control."
         },
         {
           "date": "2016-11-08",
-          "text": "If an Equipment an opponent controls is attached to a creature you control, any ability of that Equipment that says “you” refers to that opponent. However, if the Equipment says that the equipped creature has an ability, the word “you” in that ability refers to you, the controller of the creature."
+          "text": "If an Equipment an opponent controls is attached to a creature you control, any ability of that Equipment that says \"you\" refers to that opponent. However, if the Equipment says that the equipped creature has an ability, the word \"you\" in that ability refers to you, the controller of the creature."
         },
         {
           "date": "2016-11-08",
@@ -5348,7 +5348,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "An ability of an Equipment that triggers “whenever equipped creature attacks” triggers only if the Equipment was attached to a creature at the moment that creature was declared as an attacker, and any references to “that creature” in the effect refer to the creature the Equipment was attached to when the ability triggered."
+          "text": "An ability of an Equipment that triggers \"whenever equipped creature attacks\" triggers only if the Equipment was attached to a creature at the moment that creature was declared as an attacker, and any references to \"that creature\" in the effect refer to the creature the Equipment was attached to when the ability triggered."
         }
       ],
       "subtypes": [
@@ -5433,7 +5433,7 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "You flip a coin as Boompile’s ability resolves. No player may take actions between seeing the result of the flip and all nonland permanents being destroyed."
+          "text": "You flip a coin as Boompile's ability resolves. No player may take actions between seeing the result of the flip and all nonland permanents being destroyed."
         },
         {
           "date": "2016-11-08",
@@ -5516,15 +5516,15 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "The first ability of Conqueror’s Flail constantly updates as the number of colors among permanents you control changes. If the number of colors decreases and the damage that was marked on the equipped creature earlier in the turn is now lethal damage, that creature is destroyed. Similarly, if its toughness becomes 0, that creature is put into its owner’s graveyard."
+          "text": "The first ability of Conqueror's Flail constantly updates as the number of colors among permanents you control changes. If the number of colors decreases and the damage that was marked on the equipped creature earlier in the turn is now lethal damage, that creature is destroyed. Similarly, if its toughness becomes 0, that creature is put into its owner's graveyard."
         },
         {
           "date": "2016-11-08",
-          "text": "The five colors are white, blue, black, red, and green. Conqueror’s Flail can’t give a creature more than +5/+5. (Gold, artifact, and colorless aren’t colors.)"
+          "text": "The five colors are white, blue, black, red, and green. Conqueror's Flail can't give a creature more than +5/+5. (Gold, artifact, and colorless aren't colors.)"
         },
         {
           "date": "2016-11-08",
-          "text": "If you move Conqueror’s Flail from one creature to another, there’s no time in between that it’s not attached to a creature. Assuming it’s your turn, your opponents won’t be able to cast spells."
+          "text": "If you move Conqueror's Flail from one creature to another, there's no time in between that it's not attached to a creature. Assuming it's your turn, your opponents won't be able to cast spells."
         }
       ],
       "subtypes": [
@@ -5611,7 +5611,7 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Unless a spell or ability allows you to, you can’t choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can’t ignore that cost reduction in order to spend more colors of mana."
+          "text": "Unless a spell or ability allows you to, you can't choose to pay more mana for a spell with a converge ability just to spend more colors of mana. Likewise, if a spell or ability reduces the amount of mana it costs you to cast a spell with converge, you can't ignore that cost reduction in order to spend more colors of mana."
         },
         {
           "date": "2016-11-08",
@@ -5703,19 +5703,19 @@
       "rulings": [
         {
           "date": "2016-11-08",
-          "text": "The colors of mana that Prismatic Geoscope can produce aren’t related to the specific basic land types among lands you control. For example, if you control a Plains and an Island, you can activate Prismatic Geoscope’s ability to add {R}{G} to your mana pool."
+          "text": "The colors of mana that Prismatic Geoscope can produce aren't related to the specific basic land types among lands you control. For example, if you control a Plains and an Island, you can activate Prismatic Geoscope's ability to add {R}{G} to your mana pool."
         },
         {
           "date": "2016-11-08",
-          "text": "You can activate Prismatic Geoscope’s mana ability if you have no basic land types among lands you control, but it won’t produce any mana."
+          "text": "You can activate Prismatic Geoscope's mana ability if you have no basic land types among lands you control, but it won't produce any mana."
         },
         {
           "date": "2016-11-08",
-          "text": "Prismatic Geoscope can’t produce colorless mana."
+          "text": "Prismatic Geoscope can't produce colorless mana."
         },
         {
           "date": "2016-11-08",
-          "text": "To determine the number of basic land types among lands you control, look for the Plains, Island, Swamp, Mountain, and Forest subtypes among the lands you control. Count each subtype that appears one or more times toward the number of basic land types among lands you control. This number can’t exceed five."
+          "text": "To determine the number of basic land types among lands you control, look for the Plains, Island, Swamp, Mountain, and Forest subtypes among the lands you control. Count each subtype that appears one or more times toward the number of basic land types among lands you control. This number can't exceed five."
         },
         {
           "date": "2016-11-08",
@@ -5723,11 +5723,11 @@
         },
         {
           "date": "2016-11-08",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp."
         },
         {
           "date": "2016-11-08",
-          "text": "Some nonbasic lands do have basic land types. Domain abilities don’t count the number of lands you control—they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, a Blood Crypt, and a Forest, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "Some nonbasic lands do have basic land types. Domain abilities don't count the number of lands you control—they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, a Blood Crypt, and a Forest, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Prismatic Geoscope enters the battlefield tapped.\nDomain — {T}: Add X mana in any combination of colors to your mana pool, where X is the number of basic land types among lands you control.",
@@ -5894,7 +5894,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -6000,7 +6000,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -6103,11 +6103,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "text": "Extort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\nArtifacts and creatures your opponents control enter the battlefield tapped.",
@@ -6298,7 +6298,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The creature that entered the battlefield and caused the ability to trigger will also get a +1/+1 counter, provided it’s still on the battlefield when the ability resolves."
+          "text": "The creature that entered the battlefield and caused the ability to trigger will also get a +1/+1 counter, provided it's still on the battlefield when the ability resolves."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
@@ -6396,11 +6396,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The words “Khans” and “Dragons” are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. “[Anchor word] — [Ability]” means “As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].” Notably, the anchor word “Dragons” has no connection to the creature type Dragon."
+          "text": "The words \"Khans\" and \"Dragons\" are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. \"[Anchor word] — [Ability]\" means \"As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].\" Notably, the anchor word \"Dragons\" has no connection to the creature type Dragon."
         },
         {
           "date": "2014-11-24",
-          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won’t depend on the choice made for the original permanent."
+          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won't depend on the choice made for the original permanent."
         }
       ],
       "text": "As Citadel Siege enters the battlefield, choose Khans or Dragons.\n• Khans — At the beginning of combat on your turn, put two +1/+1 counters on target creature you control.\n• Dragons — At the beginning of combat on each opponent's turn, tap target creature that player controls.",
@@ -6677,7 +6677,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -6790,7 +6790,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -6884,7 +6884,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If a spell or ability has you draw multiple cards, Hoofprints of the Stag’s ability triggers that many times."
+          "text": "If a spell or ability has you draw multiple cards, Hoofprints of the Stag's ability triggers that many times."
         }
       ],
       "subtypes": [
@@ -6980,7 +6980,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Triggered abilities use the word “when,” “whenever,” or “at.” They’re often written as “[Trigger condition], [effect].”"
+          "text": "Triggered abilities use the word \"when,\" \"whenever,\" or \"at.\" They're often written as \"[Trigger condition], [effect].\""
         },
         {
           "date": "2014-07-18",
@@ -6988,19 +6988,19 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Abilities that apply “as [this creature] enters the battlefield,” such as choosing a creature to copy with Mercurial Pretender, are also unaffected."
+          "text": "Abilities that apply \"as [this creature] enters the battlefield,\" such as choosing a creature to copy with Mercurial Pretender, are also unaffected."
         },
         {
           "date": "2014-07-18",
-          "text": "Hushwing Gryff’s ability stops a creature’s own enters-the-battlefield triggered abilities as well as other triggered abilities that would trigger when a creature enters the battlefield."
+          "text": "Hushwing Gryff's ability stops a creature's own enters-the-battlefield triggered abilities as well as other triggered abilities that would trigger when a creature enters the battlefield."
         },
         {
           "date": "2014-07-18",
-          "text": "The trigger event doesn’t have to specify “creatures” entering the battlefield. For example, Amulet of Vigor says “Whenever a permanent enters the battlefield tapped and under your control, untap it.” If a creature enters the battlefield tapped and under your control, Amulet of Vigor’s ability would not trigger. If a land (that isn’t also a creature) enters the battlefield tapped and under your control, Amulet of Vigor’s ability would trigger."
+          "text": "The trigger event doesn't have to specify \"creatures\" entering the battlefield. For example, Amulet of Vigor says \"Whenever a permanent enters the battlefield tapped and under your control, untap it.\" If a creature enters the battlefield tapped and under your control, Amulet of Vigor's ability would not trigger. If a land (that isn't also a creature) enters the battlefield tapped and under your control, Amulet of Vigor's ability would trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "Look at the permanent as it exists on the battlefield, taking into account continuous effects, to determine whether any triggered abilities will trigger. For example, if you control March of the Machines, which says, in part, “Each noncreature artifact is an artifact creature,” each artifact will be a creature at the time it enters the battlefield and will not cause triggered abilities to trigger."
+          "text": "Look at the permanent as it exists on the battlefield, taking into account continuous effects, to determine whether any triggered abilities will trigger. For example, if you control March of the Machines, which says, in part, \"Each noncreature artifact is an artifact creature,\" each artifact will be a creature at the time it enters the battlefield and will not cause triggered abilities to trigger."
         },
         {
           "date": "2014-07-18",
@@ -7110,7 +7110,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Apply power bonuses from counters the creature enters the battlefield with and continuous effects like Mayor of Avabruck’s when checking to see if Mentor of the Meek’s ability will trigger."
+          "text": "Apply power bonuses from counters the creature enters the battlefield with and continuous effects like Mayor of Avabruck's when checking to see if Mentor of the Meek's ability will trigger."
         },
         {
           "date": "2011-09-22",
@@ -7226,7 +7226,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         },
         {
           "date": "2013-07-01",
@@ -7417,11 +7417,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "An Aura put onto the battlefield this way can’t enchant an artifact or enchantment that’s also being put onto the battlefield with Open the Vaults."
+          "text": "An Aura put onto the battlefield this way can't enchant an artifact or enchantment that's also being put onto the battlefield with Open the Vaults."
         },
         {
           "date": "2009-10-01",
-          "text": "If an Aura can be returned to the battlefield with Open the Vaults, it must be, even if its owner doesn’t like what it would enchant."
+          "text": "If an Aura can be returned to the battlefield with Open the Vaults, it must be, even if its owner doesn't like what it would enchant."
         },
         {
           "date": "2009-10-01",
@@ -7520,11 +7520,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Any triggered abilities that trigger because a creature was destroyed won’t be put onto the stack until after Phyrexian Rebirth finishes resolving. This means the Horror creature token can be targeted by those abilities, if applicable."
+          "text": "Any triggered abilities that trigger because a creature was destroyed won't be put onto the stack until after Phyrexian Rebirth finishes resolving. This means the Horror creature token can be targeted by those abilities, if applicable."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature regenerates or has indestructible, it won’t be counted when determining the value of X."
+          "text": "If a creature regenerates or has indestructible, it won't be counted when determining the value of X."
         }
       ],
       "text": "Destroy all creatures, then create an X/X colorless Horror artifact creature token, where X is the number of creatures destroyed this way.",
@@ -7620,7 +7620,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -7628,23 +7628,23 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         },
         {
           "date": "2008-04-01",
-          "text": "Reveillark’s ability may target zero, one, or two creature cards in your graveyard. Each target must have power 2 or less."
+          "text": "Reveillark's ability may target zero, one, or two creature cards in your graveyard. Each target must have power 2 or less."
         }
       ],
       "subtypes": [
@@ -7747,7 +7747,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t split up a life total when you redistribute it. For example, suppose that in a two-player game your life total is 5 and your opponent’s life total is 15 when Reverse the Sands starts to resolve. You can choose to (a) leave the life totals as they are or (b) make your life total 15 and your opponent’s 5. You can’t choose to make your life total 20 and your opponent’s 0."
+          "text": "You can't split up a life total when you redistribute it. For example, suppose that in a two-player game your life total is 5 and your opponent's life total is 15 when Reverse the Sands starts to resolve. You can choose to (a) leave the life totals as they are or (b) make your life total 15 and your opponent's 5. You can't choose to make your life total 20 and your opponent's 0."
         }
       ],
       "text": "Redistribute any number of players' life totals. (Each of those players gets one life total back.)",
@@ -7949,7 +7949,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "In a Two-Headed Giant game, if one player controls Sphere of Safety, creatures can’t attack that player’s team or a planeswalker that player controls unless their controller pays {X} for each of those creatures he or she controls. Creatures can attack planeswalkers controlled by that player’s teammate without having to pay this cost."
+          "text": "In a Two-Headed Giant game, if one player controls Sphere of Safety, creatures can't attack that player's team or a planeswalker that player controls unless their controller pays {X} for each of those creatures he or she controls. Creatures can attack planeswalkers controlled by that player's teammate without having to pay this cost."
         }
       ],
       "text": "Creatures can't attack you or a planeswalker you control unless their controller pays {X} for each of those creatures, where X is the number of enchantments you control.",
@@ -8063,7 +8063,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -8254,7 +8254,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -8445,43 +8445,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -8582,7 +8582,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "The controller of the countered spell doesn’t choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
+          "text": "The controller of the countered spell doesn't choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
         }
       ],
       "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
@@ -8761,7 +8761,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If enough -1/-1 counters are put on Chasm Skulker at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got any -1/-1 counters will be used to determine how many Squid tokens you get. For example, if there are two +1/+1 counters on Chasm Skulker and it gets three -1/-1 counters, you’ll get two Squid tokens."
+          "text": "If enough -1/-1 counters are put on Chasm Skulker at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got any -1/-1 counters will be used to determine how many Squid tokens you get. For example, if there are two +1/+1 counters on Chasm Skulker and it gets three -1/-1 counters, you'll get two Squid tokens."
         }
       ],
       "subtypes": [
@@ -8863,31 +8863,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -9077,7 +9077,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "A face-down spell has converted mana cost 0 and can’t be targeted by Disdainful Stroke."
+          "text": "A face-down spell has converted mana cost 0 and can't be targeted by Disdainful Stroke."
         }
       ],
       "text": "Counter target spell with converted mana cost 4 or greater.",
@@ -9178,11 +9178,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This effect doesn’t change the mana cost or converted mana cost of an artifact spell. Rather, it reduces the total cost of the spell, which is the amount you actually pay while casting it. The total cost takes into account additional or alternative costs."
+          "text": "This effect doesn't change the mana cost or converted mana cost of an artifact spell. Rather, it reduces the total cost of the spell, which is the amount you actually pay while casting it. The total cost takes into account additional or alternative costs."
         },
         {
           "date": "2008-10-01",
-          "text": "This effect can reduce only the generic portion of the artifact spell’s total cost."
+          "text": "This effect can reduce only the generic portion of the artifact spell's total cost."
         }
       ],
       "subtypes": [
@@ -9486,7 +9486,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Since Master of Etherium is an artifact itself, while it’s on the battlefield you will usually control at least one artifact."
+          "text": "Since Master of Etherium is an artifact itself, while it's on the battlefield you will usually control at least one artifact."
         }
       ],
       "subtypes": [
@@ -9578,7 +9578,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The card-drawing part of the effect is not optional. A player can’t choose to draw fewer than X cards."
+          "text": "The card-drawing part of the effect is not optional. A player can't choose to draw fewer than X cards."
         }
       ],
       "text": "Join forces — Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.",
@@ -9691,7 +9691,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -9973,11 +9973,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Spelltwine has two targets: the instant or sorcery card in your graveyard and the one in an opponent’s graveyard. You can’t cast Spelltwine unless you can choose both legal targets."
+          "text": "Spelltwine has two targets: the instant or sorcery card in your graveyard and the one in an opponent's graveyard. You can't cast Spelltwine unless you can choose both legal targets."
         },
         {
           "date": "2012-07-01",
-          "text": "If one of Spelltwine’s targets is illegal when Spelltwine tries to resolve, you’ll still exile and copy the remaining legal target."
+          "text": "If one of Spelltwine's targets is illegal when Spelltwine tries to resolve, you'll still exile and copy the remaining legal target."
         },
         {
           "date": "2012-07-01",
@@ -9993,7 +9993,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-07-01",
@@ -10092,7 +10092,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Swan Song can target a spell that can’t be countered. That spell won’t be countered when Swan Song resolves, but its controller will get a Bird token."
+          "text": "Swan Song can target a spell that can't be countered. That spell won't be countered when Swan Song resolves, but its controller will get a Bird token."
         }
       ],
       "text": "Counter target enchantment, instant, or sorcery spell. Its controller creates a 2/2 blue Bird creature token with flying.",
@@ -10199,11 +10199,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({U/P} can be paid with either {U} or 2 life.)\nDraw two cards, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -10303,11 +10303,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -10315,7 +10315,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -10415,23 +10415,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDraw three cards.",
@@ -11007,7 +11007,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Put target artifact or creature card from a graveyard onto the battlefield under your control. Shuffle Beacon of Unrest into its owner's library.",
@@ -11109,19 +11109,19 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If there’s a cost associated with having a creature block and you choose for that creature to block, its controller can choose to pay that cost or not. If that player decides to not pay that cost, you must propose a new set of blocking creatures."
+          "text": "If there's a cost associated with having a creature block and you choose for that creature to block, its controller can choose to pay that cost or not. If that player decides to not pay that cost, you must propose a new set of blocking creatures."
         },
         {
           "date": "2014-11-24",
-          "text": "You’ll choose how each creature controlled by an opponent blocks, even if that creature wasn’t on the battlefield or wasn’t controlled by an opponent as the activated ability resolved."
+          "text": "You'll choose how each creature controlled by an opponent blocks, even if that creature wasn't on the battlefield or wasn't controlled by an opponent as the activated ability resolved."
         },
         {
           "date": "2014-11-24",
-          "text": "In a multiplayer game, if more than one player activates Brutal Hordechief’s activated ability on the same turn, the controller of the last ability to resolve will choose how any creatures controlled by players who didn’t resolve this ability will block."
+          "text": "In a multiplayer game, if more than one player activates Brutal Hordechief's activated ability on the same turn, the controller of the last ability to resolve will choose how any creatures controlled by players who didn't resolve this ability will block."
         },
         {
           "date": "2014-11-24",
-          "text": "The defending player affected by Brutal Hordechief’s triggered ability is determined relative to the creature that attacked. For example, if Brutal Hordechief attacked one opponent and two other creatures you control attacked another opponent, the first opponent would lose 1 life and the second opponent would lose 2 life. You’d gain a total of 3 life."
+          "text": "The defending player affected by Brutal Hordechief's triggered ability is determined relative to the creature that attacked. For example, if Brutal Hordechief attacked one opponent and two other creatures you control attacked another opponent, the first opponent would lose 1 life and the second opponent would lose 2 life. You'd gain a total of 3 life."
         }
       ],
       "subtypes": [
@@ -11418,11 +11418,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -11430,27 +11430,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -11458,15 +11458,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Exile all creature cards from target player's graveyard in a face-down pile, shuffle that pile, then manifest those cards. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -11557,7 +11557,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -11833,11 +11833,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -11937,7 +11937,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If one or more creatures an opponent controls are put into the graveyard at the same time as Sangromancer, Sangromancer’s first ability will trigger that many times."
+          "text": "If one or more creatures an opponent controls are put into the graveyard at the same time as Sangromancer, Sangromancer's first ability will trigger that many times."
         }
       ],
       "subtypes": [
@@ -12124,7 +12124,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Wight of Precinct Six’s ability applies only if Wight of Precinct Six is on the battlefield."
+          "text": "Wight of Precinct Six's ability applies only if Wight of Precinct Six is on the battlefield."
         }
       ],
       "subtypes": [
@@ -12227,7 +12227,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose which opponent or opposing planeswalker the creature is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Alesha is attacking."
+          "text": "You choose which opponent or opposing planeswalker the creature is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Alesha is attacking."
         },
         {
           "date": "2014-11-24",
@@ -12339,11 +12339,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Blasphemous Act’s ability can’t reduce the total cost to cast the spell below {R}."
+          "text": "Blasphemous Act's ability can't reduce the total cost to cast the spell below {R}."
         },
         {
           "date": "2011-09-22",
-          "text": "Although players may respond to Blasphemous Act once it’s been cast, once it’s announced, they can’t respond before the cost is calculated and paid."
+          "text": "Although players may respond to Blasphemous Act once it's been cast, once it's announced, they can't respond before the cost is calculated and paid."
         }
       ],
       "text": "Blasphemous Act costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
@@ -12437,7 +12437,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If there isn’t a legal creature to attach Breath of Fury to after the enchanted creature is sacrificed, you don’t untap your creatures or get an additional combat phase, and Breath of Fury is put into its owner’s graveyard as a state-based action."
+          "text": "If there isn't a legal creature to attach Breath of Fury to after the enchanted creature is sacrificed, you don't untap your creatures or get an additional combat phase, and Breath of Fury is put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -12529,7 +12529,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player’s library this way, that player shuffles before revealing the top card of that library."
+          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player's library this way, that player shuffles before revealing the top card of that library."
         },
         {
           "date": "2011-09-22",
@@ -12541,7 +12541,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the revealed card is a permanent card but can’t enter the battlefield (perhaps because it’s an Aura with nothing to enchant), it remains on top of that library."
+          "text": "If the revealed card is a permanent card but can't enter the battlefield (perhaps because it's an Aura with nothing to enchant), it remains on top of that library."
         },
         {
           "date": "2011-09-22",
@@ -12632,7 +12632,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "You may choose to discard zero cards as the first ability resolves. In that case, you won’t draw any cards."
+          "text": "You may choose to discard zero cards as the first ability resolves. In that case, you won't draw any cards."
         },
         {
           "date": "2014-11-07",
@@ -12640,7 +12640,7 @@
         },
         {
           "date": "2014-11-07",
-          "text": "The ability of Daretti’s emblem will return the artifact card only if it’s still in your graveyard when the delayed triggered ability resolves at the beginning of the next end step. If the artifact card left your graveyard before that point (even if it was put back into your graveyard), the ability won’t return it to the battlefield."
+          "text": "The ability of Daretti's emblem will return the artifact card only if it's still in your graveyard when the delayed triggered ability resolves at the beginning of the next end step. If the artifact card left your graveyard before that point (even if it was put back into your graveyard), the ability won't return it to the battlefield."
         }
       ],
       "subtypes": [
@@ -12836,7 +12836,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Unlike other effects that grant additional combat phases, you don’t get an additional main phase with Godo, Bandit Warlord. The additional combat phase happens immediately after the first combat phase."
+          "text": "Unlike other effects that grant additional combat phases, you don't get an additional main phase with Godo, Bandit Warlord. The additional combat phase happens immediately after the first combat phase."
         }
       ],
       "subtypes": [
@@ -12942,11 +12942,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If you choose the “sacrifice a creature” mode, you choose the target of the damage on announcement, but don’t choose what to sacrifice until resolution. You must sacrifice a creature when Grab the Reins resolves, even if you don’t want to. If you don’t control any creatures at that time, Grab the Reins deals no damage."
+          "text": "If you choose the \"sacrifice a creature\" mode, you choose the target of the damage on announcement, but don't choose what to sacrifice until resolution. You must sacrifice a creature when Grab the Reins resolves, even if you don't want to. If you don't control any creatures at that time, Grab the Reins deals no damage."
         },
         {
           "date": "2004-12-01",
-          "text": "If you cast this with Entwine, you don’t get priority in the middle of resolution. You can’t steal something, do anything (like attack with it), and then sacrifice it."
+          "text": "If you cast this with Entwine, you don't get priority in the middle of resolution. You can't steal something, do anything (like attack with it), and then sacrifice it."
         }
       ],
       "text": "Choose one —\n• Until end of turn, you gain control of target creature and it gains haste.\n• Sacrifice a creature. Grab the Reins deals damage equal to that creature's power to target creature or player.\nEntwine {2}{R} (Choose both if you pay the entwine cost.)",
@@ -13141,7 +13141,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If you don’t control twenty or more artifacts at the beginning of your upkeep, Hellkite Tyrant’s last ability won’t trigger. If it does trigger, it will check again when it tries to resolve. If you don’t control twenty or more artifacts at that time, the ability will do nothing."
+          "text": "If you don't control twenty or more artifacts at the beginning of your upkeep, Hellkite Tyrant's last ability won't trigger. If it does trigger, it will check again when it tries to resolve. If you don't control twenty or more artifacts at that time, the ability will do nothing."
         }
       ],
       "subtypes": [
@@ -13241,11 +13241,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Humble Defector’s ability can be activated any time during your turn, including in response to a spell or ability."
+          "text": "Humble Defector's ability can be activated any time during your turn, including in response to a spell or ability."
         },
         {
           "date": "2014-11-24",
-          "text": "If Humble Defector isn’t on the battlefield as its ability resolves, but the target player is still a legal target, the ability will resolve. You’ll draw two cards, even though the player won’t gain control of Humble Defector."
+          "text": "If Humble Defector isn't on the battlefield as its ability resolves, but the target player is still a legal target, the ability will resolve. You'll draw two cards, even though the player won't gain control of Humble Defector."
         },
         {
           "date": "2014-11-24",
@@ -13350,15 +13350,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "You’re the defending player if a creature is attacking you or a planeswalker you control."
+          "text": "You're the defending player if a creature is attacking you or a planeswalker you control."
         },
         {
           "date": "2010-03-01",
-          "text": "If you’re the defending player, Kazuul’s ability triggers once for each creature that attacks, not just once per combat. The attacking player chooses whether to pay {3} or let you have an Ogre token each time one of those abilities resolves."
+          "text": "If you're the defending player, Kazuul's ability triggers once for each creature that attacks, not just once per combat. The attacking player chooses whether to pay {3} or let you have an Ogre token each time one of those abilities resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "As the ability resolves, you can’t put the Ogre token onto the battlefield without explicitly giving the attacking player the option to pay {3}, even if the attacking player has forgotten about this ability."
+          "text": "As the ability resolves, you can't put the Ogre token onto the battlefield without explicitly giving the attacking player the option to pay {3}, even if the attacking player has forgotten about this ability."
         },
         {
           "date": "2010-03-01",
@@ -13366,11 +13366,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If an attacking creature has a “Whenever this creature attacks” ability, that ability is put on the stack first, then Kazuul’s ability is put on the stack. Although Kazuul’s ability will resolve first, and potentially create an Ogre token, any target of the other ability will already have been chosen at this point, and thus could not have been the new Ogre token."
+          "text": "If an attacking creature has a \"Whenever this creature attacks\" ability, that ability is put on the stack first, then Kazuul's ability is put on the stack. Although Kazuul's ability will resolve first, and potentially create an Ogre token, any target of the other ability will already have been chosen at this point, and thus could not have been the new Ogre token."
         },
         {
           "date": "2010-03-01",
-          "text": "In a multiplayer game, the ability checks whether you’re the defending player for each individual attacking creature. For example, if one creature attacks you and two creatures attack another player, Kazuul’s ability triggers just once."
+          "text": "In a multiplayer game, the ability checks whether you're the defending player for each individual attacking creature. For example, if one creature attacks you and two creatures attack another player, Kazuul's ability triggers just once."
         }
       ],
       "subtypes": [
@@ -13472,12 +13472,8 @@
       "rarity": "Mythic Rare",
       "rulings": [
         {
-          "date": "2013-07-01",
-          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
-        },
-        {
           "date": "2017-03-14",
-          "text": "Only instant and sorcery cards in your graveyard when Past in Flames resolves will gain flashback. Instant and sorcery cards that are put into your graveyard later in the turn, including the resolving Past in Flames, won’t gain flashback."
+          "text": "Only instant and sorcery cards in your graveyard when Past in Flames resolves will gain flashback. Instant and sorcery cards that are put into your graveyard later in the turn, including the resolving Past in Flames, won't gain flashback."
         },
         {
           "date": "2017-03-14",
@@ -13490,6 +13486,10 @@
         {
           "date": "2017-03-14",
           "text": "You may pay any optional additional costs the spell has, such as conspire costs. You must pay any mandatory additional costs the spell has, such as that of Bone Splinters."
+        },
+        {
+          "date": "2017-04-18",
+          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
         }
       ],
       "text": "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -14059,7 +14059,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If the target instant or sorcery card becomes an illegal target before Volcanic Vision resolves, the spell will be countered and none of its effects will happen. No damage will be dealt and Volcanic Vision won’t be exiled."
+          "text": "If the target instant or sorcery card becomes an illegal target before Volcanic Vision resolves, the spell will be countered and none of its effects will happen. No damage will be dealt and Volcanic Vision won't be exiled."
         },
         {
           "date": "2015-02-25",
@@ -14154,44 +14154,40 @@
       "rarity": "Rare",
       "rulings": [
         {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "date": "2013-06-07",
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
-        },
-        {
-          "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -14199,11 +14195,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 4—{1}{R} (Rather than cast this card from your hand, pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nEach player discards his or her hand, then draws seven cards.",
@@ -14305,7 +14301,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If you put all permanents you control into one pile, you’ll have a two-thirds chance of not having to sacrifice any permanents, but a one-third chance of having to sacrifice all of them."
+          "text": "If you put all permanents you control into one pile, you'll have a two-thirds chance of not having to sacrifice any permanents, but a one-third chance of having to sacrifice all of them."
         }
       ],
       "text": "Starting with you, each player separates all permanents he or she controls into three piles. Then each player chooses one of his or her piles at random and sacrifices those permanents. (Piles can be empty.)",
@@ -14494,7 +14490,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent’s controller won’t get a Beast token."
+          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent's controller won't get a Beast token."
         },
         {
           "date": "2013-07-01",
@@ -14595,7 +14591,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you attack with multiple creatures, Beastmaster Ascension’s first ability triggers multiple times."
+          "text": "If you attack with multiple creatures, Beastmaster Ascension's first ability triggers multiple times."
         }
       ],
       "text": "Whenever a creature you control attacks, you may put a quest counter on Beastmaster Ascension.\nAs long as Beastmaster Ascension has seven or more quest counters on it, creatures you control get +5/+5.",
@@ -14782,15 +14778,15 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Creatures with power less than Champion of Lambholt can’t block any creature you control, not just Champion of Lambholt."
+          "text": "Creatures with power less than Champion of Lambholt can't block any creature you control, not just Champion of Lambholt."
         },
         {
           "date": "2012-05-01",
-          "text": "Champion of Lambholt’s ability works even if it isn’t attacking."
+          "text": "Champion of Lambholt's ability works even if it isn't attacking."
         },
         {
           "date": "2012-05-01",
-          "text": "The comparison of power is only done when blockers are declared. Increasing the power of a blocking creature (or decreasing the power of Champion of Lambholt) after this point won’t cause any creature to stop blocking or become unblocked."
+          "text": "The comparison of power is only done when blockers are declared. Increasing the power of a blocking creature (or decreasing the power of Champion of Lambholt) after this point won't cause any creature to stop blocking or become unblocked."
         }
       ],
       "subtypes": [
@@ -15074,15 +15070,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You compare Den Protector’s power to the power of any creature trying to block it only as blockers are assigned. Once Den Protector has been legally blocked by a creature, changing the power of either creature won’t change or undo the block."
+          "text": "You compare Den Protector's power to the power of any creature trying to block it only as blockers are assigned. Once Den Protector has been legally blocked by a creature, changing the power of either creature won't change or undo the block."
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -15581,7 +15577,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "“Placed on a creature you control” includes that creature entering the battlefield with +1/+1 counters on it. If a creature would enter the battlefield with a number of +1/+1 counters on it while you control Hardened Scales, it enters with that many counters plus one."
+          "text": "\"Placed on a creature you control\" includes that creature entering the battlefield with +1/+1 counters on it. If a creature would enter the battlefield with a number of +1/+1 counters on it while you control Hardened Scales, it enters with that many counters plus one."
         },
         {
           "date": "2014-09-20",
@@ -15683,7 +15679,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Creatures you control that have +1/+1 counters put on them after Inspiring Call resolves won’t gain indestructible."
+          "text": "Creatures you control that have +1/+1 counters put on them after Inspiring Call resolves won't gain indestructible."
         }
       ],
       "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn.",
@@ -15775,7 +15771,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "To double the number of +1/+1 counters on a creature, determine how many +1/+1 counters are on the creature and put that many more on it. Effects that interact with counters (such as the one created by Corpsejack Menace’s ability) may change the number of counters ultimately put on the creature."
+          "text": "To double the number of +1/+1 counters on a creature, determine how many +1/+1 counters are on the creature and put that many more on it. Effects that interact with counters (such as the one created by Corpsejack Menace's ability) may change the number of counters ultimately put on the creature."
         }
       ],
       "subtypes": [
@@ -15975,11 +15971,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You must put the revealed card onto the battlefield if it’s a creature card. If it’s not a creature card and you don’t put it on the bottom of your library, it stops being revealed and simply remains on top of your library."
+          "text": "You must put the revealed card onto the battlefield if it's a creature card. If it's not a creature card and you don't put it on the bottom of your library, it stops being revealed and simply remains on top of your library."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Whenever an opponent casts a spell, reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, you may put that card on the bottom of your library.",
@@ -16071,7 +16067,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Managorger Hydra’s last ability will resolve before the spell that caused it to trigger."
+          "text": "Managorger Hydra's last ability will resolve before the spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -16178,19 +16174,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         },
         {
           "date": "2008-10-01",
-          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn’t matter where the +1/+1 counters came from."
+          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn't matter where the +1/+1 counters came from."
         }
       ],
       "subtypes": [
@@ -16291,7 +16287,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can’t be targeted by this ability unless it’s true, and the ability will be countered on resolution if it’s no longer true at that time."
+          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can't be targeted by this ability unless it's true, and the ability will be countered on resolution if it's no longer true at that time."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player chooses target player who controls more creatures than he or she does and is his or her opponent. The first player may reveal cards from the top of his or her library until he or she reveals a creature card. If he or she does, that player puts that card onto the battlefield and all other cards revealed this way into his or her graveyard.",
@@ -16383,7 +16379,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the opponent only has lands that produce colorless or no mana, this card’s ability can still be activated; it just won’t produce any mana."
+          "text": "If the opponent only has lands that produce colorless or no mana, this card's ability can still be activated; it just won't produce any mana."
         }
       ],
       "subtypes": [
@@ -16508,7 +16504,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -16596,7 +16592,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "If Realm Seekers enters the battlefield directly from a player’s hand without being cast, it counts itself when determining the value of X."
+          "text": "If Realm Seekers enters the battlefield directly from a player's hand without being cast, it counts itself when determining the value of X."
         },
         {
           "date": "2014-05-29",
@@ -16996,7 +16992,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. No +1/+1 counter will be put on Scavenging Ooze and you won’t gain life. Notably, this means that if you activate Scavenging Ooze’s ability multiple times targeting the same creature card, only the first instance of the ability to resolve will have any effect."
+          "text": "If the target card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. No +1/+1 counter will be put on Scavenging Ooze and you won't gain life. Notably, this means that if you activate Scavenging Ooze's ability multiple times targeting the same creature card, only the first instance of the ability to resolve will have any effect."
         }
       ],
       "subtypes": [
@@ -17097,7 +17093,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Draw a card for each creature you control.\nFerocious — You gain 4 life for each creature you control with power 4 or greater.",
@@ -17195,19 +17191,19 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -17585,15 +17581,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player’s commander."
+          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player's commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won’t check whether its owner controls his or her commander."
+          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won't check whether its owner controls his or her commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature’s toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
+          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature's toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
         },
         {
           "date": "2014-11-07",
@@ -17697,7 +17693,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -17998,7 +17994,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "The value of X is determined when the triggered ability resolves. If Wild Beastmaster is no longer on the battlefield at that time, use its last known power to determine the value of X. This could be bad for you if Wild Beastmaster’s power was negative. For example, if Wild Beastmaster’s power is -4, each other creature you control will get -4/-4 until end of turn."
+          "text": "The value of X is determined when the triggered ability resolves. If Wild Beastmaster is no longer on the battlefield at that time, use its last known power to determine the value of X."
+        },
+        {
+          "date": "2017-06-27",
+          "text": "If this creature's power is negative as its ability resolves, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -18101,7 +18101,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If you choose the third mode, you choose how the counters will be distributed as you cast the spell. Notably, if you choose to put one +1/+1 counter on each of two target creatures, and one of those creatures becomes an illegal target in response, the +1/+1 counter that would have been put on that creature is lost. It can’t be put on the remaining legal target."
+          "text": "If you choose the third mode, you choose how the counters will be distributed as you cast the spell. Notably, if you choose to put one +1/+1 counter on each of two target creatures, and one of those creatures becomes an illegal target in response, the +1/+1 counter that would have been put on that creature is lost. It can't be put on the remaining legal target."
         }
       ],
       "text": "Choose one —\n• Exile target creature with power 3 or greater.\n• You draw two cards and you lose 2 life.\n• Distribute two +1/+1 counters among one or two target creatures.",
@@ -18598,11 +18598,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -18706,15 +18706,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Blood Tyrant’s second ability causes each player to lose 1 life, including you. Blood Tyrant will count each player’s life loss, including yours, when determining how many +1/+1 counters it gets."
+          "text": "Blood Tyrant's second ability causes each player to lose 1 life, including you. Blood Tyrant will count each player's life loss, including yours, when determining how many +1/+1 counters it gets."
         },
         {
           "date": "2009-02-01",
-          "text": "Blood Tyrant’s third ability will trigger no matter how a player loses the game: due to a state-based action (as a result of having a life total of 0 or less, trying to draw a card from an empty library, or having ten poison counters), a spell or ability that says that player loses the game, a concession, or a game loss awarded by a judge."
+          "text": "Blood Tyrant's third ability will trigger no matter how a player loses the game: due to a state-based action (as a result of having a life total of 0 or less, trying to draw a card from an empty library, or having ten poison counters), a spell or ability that says that player loses the game, a concession, or a game loss awarded by a judge."
         },
         {
           "date": "2009-02-01",
-          "text": "In a multiplayer game using the limited range of influence option (such as a Grand Melee game), if a spell or ability says that you win the game, it instead causes all of your opponents within your range of influence to lose the game. This is another way by which Blood Tyrant’s third ability can trigger."
+          "text": "In a multiplayer game using the limited range of influence option (such as a Grand Melee game), if a spell or ability says that you win the game, it instead causes all of your opponents within your range of influence to lose the game. This is another way by which Blood Tyrant's third ability can trigger."
         }
       ],
       "subtypes": [
@@ -18835,11 +18835,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -18949,7 +18949,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Planeswalkers with indestructible will still have loyalty counters removed from them as they are dealt damage. If planeswalker with indestructible has no loyalty counters, it will still be put into its owner’s graveyard, as the rule that does this doesn’t destroy the planeswalker."
+          "text": "Planeswalkers with indestructible will still have loyalty counters removed from them as they are dealt damage. If planeswalker with indestructible has no loyalty counters, it will still be put into its owner's graveyard, as the rule that does this doesn't destroy the planeswalker."
         }
       ],
       "text": "Choose one —\n• Boros Charm deals 4 damage to target player.\n• Permanents you control gain indestructible until end of turn.\n• Target creature gains double strike until end of turn.",
@@ -19046,7 +19046,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "A creature that deals combat damage to a player must have a +1/+1 counter on it at the time damage is dealt in order for Bred for the Hunt’s ability to trigger."
+          "text": "A creature that deals combat damage to a player must have a +1/+1 counter on it at the time damage is dealt in order for Bred for the Hunt's ability to trigger."
         }
       ],
       "text": "Whenever a creature you control with a +1/+1 counter on it deals combat damage to a player, you may draw a card.",
@@ -19351,7 +19351,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The cards will be put into graveyards before the spell you cast to cause the ability to trigger resolves. However, none of those cards will be in a graveyard as you cast that spell, so they can’t be chosen as a target of that spell."
+          "text": "The cards will be put into graveyards before the spell you cast to cause the ability to trigger resolves. However, none of those cards will be in a graveyard as you cast that spell, so they can't be chosen as a target of that spell."
         }
       ],
       "subtypes": [
@@ -19566,11 +19566,11 @@
         },
         {
           "date": "2014-09-20",
-          "text": "The sacrifice is not dependent on the damage being dealt. It doesn’t matter if that damage is prevented or redirected."
+          "text": "The sacrifice is not dependent on the damage being dealt. It doesn't matter if that damage is prevented or redirected."
         },
         {
           "date": "2014-09-20",
-          "text": "Crackling Doom doesn’t target any player or creature. For example, a creature with protection from black could be sacrificed."
+          "text": "Crackling Doom doesn't target any player or creature. For example, a creature with protection from black could be sacrificed."
         },
         {
           "date": "2014-09-20",
@@ -19672,7 +19672,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Once Dauntless Escort’s ability resolves, the set of creatures it affects is locked in. It won’t affect creatures that enter the battlefield after the ability has finished resolving."
+          "text": "Once Dauntless Escort's ability resolves, the set of creatures it affects is locked in. It won't affect creatures that enter the battlefield after the ability has finished resolving."
         },
         {
           "date": "2013-07-01",
@@ -19680,7 +19680,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -19779,7 +19779,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You no longer need four distinct targets for Decimate. If the spell or ability uses the word target in multiple places, the same object or player can be chosen once for each instance of the word “target.” For example, you could choose Tree of Tales for both the artifact and the land. You still need a legal target enchantment and creature as well."
+          "text": "You no longer need four distinct targets for Decimate. If the spell or ability uses the word target in multiple places, the same object or player can be chosen once for each instance of the word \"target.\" For example, you could choose Tree of Tales for both the artifact and the land. You still need a legal target enchantment and creature as well."
         }
       ],
       "text": "Destroy target artifact, target creature, target enchantment, and target land.",
@@ -19879,7 +19879,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You decide which creature to spare as Duneblast resolves. This choice doesn’t target the creature. If you don’t choose a creature, then all creatures will be destroyed."
+          "text": "You decide which creature to spare as Duneblast resolves. This choice doesn't target the creature. If you don't choose a creature, then all creatures will be destroyed."
         }
       ],
       "text": "Choose up to one creature. Destroy the rest.",
@@ -19972,7 +19972,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric’s ability to trigger. The creature’s controller chooses whether to draw a card."
+          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric's ability to trigger. The creature's controller chooses whether to draw a card."
         },
         {
           "date": "2011-09-22",
@@ -20082,15 +20082,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature entering the battlefield with one or more +1/+1 counters on it will cause Enduring Scalelord’s ability to trigger."
+          "text": "A creature entering the battlefield with one or more +1/+1 counters on it will cause Enduring Scalelord's ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If +1/+1 counters are put on multiple creatures you control (other than Enduring Scalelord) at the same time, Enduring Scalelord’s ability will trigger once for each of those creatures."
+          "text": "If +1/+1 counters are put on multiple creatures you control (other than Enduring Scalelord) at the same time, Enduring Scalelord's ability will trigger once for each of those creatures."
         },
         {
           "date": "2015-02-25",
-          "text": "If you control two Enduring Scalelords, putting a +1/+1 counter on one of them will cause the ability of the other one to trigger. When this ability resolves, you’ll put a +1/+1 counter on the other Scalelord. This will cause the ability of the first one to trigger. This loop will repeat until you choose not to put a +1/+1 counter on one of the Enduring Scalelords."
+          "text": "If you control two Enduring Scalelords, putting a +1/+1 counter on one of them will cause the ability of the other one to trigger. When this ability resolves, you'll put a +1/+1 counter on the other Scalelord. This will cause the ability of the first one to trigger. This loop will repeat until you choose not to put a +1/+1 counter on one of the Enduring Scalelords."
         }
       ],
       "subtypes": [
@@ -20185,7 +20185,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Etherium-Horn Sorcerer’s first ability can only be activated when it is on the battlefield. If Etherium-Horn Sorcerer isn’t on the battlefield when the ability resolves, the ability won’t do anything."
+          "text": "Etherium-Horn Sorcerer's first ability can only be activated when it is on the battlefield. If Etherium-Horn Sorcerer isn't on the battlefield when the ability resolves, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -20289,7 +20289,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Fathom Mage’s last ability will trigger whenever any +1/+1 counter is placed on it, not just ones due to the evolve ability."
+          "text": "Fathom Mage's last ability will trigger whenever any +1/+1 counter is placed on it, not just ones due to the evolve ability."
         },
         {
           "date": "2013-01-24",
@@ -20305,7 +20305,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -20321,7 +20321,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -20425,7 +20425,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Filigree Angel’s enters-the-battlefield ability counts Filigree Angel itself, assuming that it’s still on the battlefield and still an artifact by the time the ability resolves."
+          "text": "Filigree Angel's enters-the-battlefield ability counts Filigree Angel itself, assuming that it's still on the battlefield and still an artifact by the time the ability resolves."
         }
       ],
       "subtypes": [
@@ -20725,7 +20725,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "Creatures with bribery counters on them can’t be declared as attackers or blockers. However, if a bribery counter is put on a creature that’s already been declared as an attacker or blocker, that creature will continue to attack or block that combat."
+          "text": "Creatures with bribery counters on them can't be declared as attackers or blockers. However, if a bribery counter is put on a creature that's already been declared as an attacker or blocker, that creature will continue to attack or block that combat."
         }
       ],
       "subtypes": [
@@ -20928,7 +20928,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If you draw multiple cards, Horizon Chimera’s ability will trigger that many times. Each of these abilities will cause a separate life-gaining event."
+          "text": "If you draw multiple cards, Horizon Chimera's ability will trigger that many times. Each of these abilities will cause a separate life-gaining event."
         }
       ],
       "subtypes": [
@@ -21029,11 +21029,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Iroas’s last ability prevents all damage dealt to attacking creatures you control, not just combat damage."
+          "text": "Iroas's last ability prevents all damage dealt to attacking creatures you control, not just combat damage."
         },
         {
           "date": "2014-04-26",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2014-04-26",
@@ -21045,7 +21045,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2014-04-26",
@@ -21053,7 +21053,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-04-26",
@@ -21061,11 +21061,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
@@ -21277,7 +21277,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "The creature doesn’t enter the battlefield with a +1/+1 counter on it. It enters the battlefield, then the ability triggers. If either that creature or Juniper Order Ranger leaves the battlefield before the ability resolves, the remaining creature will still get a +1/+1 counter."
+          "text": "The creature doesn't enter the battlefield with a +1/+1 counter on it. It enters the battlefield, then the ability triggers. If either that creature or Juniper Order Ranger leaves the battlefield before the ability resolves, the remaining creature will still get a +1/+1 counter."
         }
       ],
       "subtypes": [
@@ -21382,7 +21382,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Use the sacrificed creature’s toughness when it was last on the battlefield to determine the value of X."
+          "text": "Use the sacrificed creature's toughness when it was last on the battlefield to determine the value of X."
         }
       ],
       "subtypes": [
@@ -21490,7 +21490,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Because Lavalanche doesn’t target any creatures, it will deal damage to creatures with shroud. Any damage it would deal to creatures with appropriate protection abilities will still be prevented, however."
+          "text": "Because Lavalanche doesn't target any creatures, it will deal damage to creatures with shroud. Any damage it would deal to creatures with appropriate protection abilities will still be prevented, however."
         }
       ],
       "text": "Lavalanche deals X damage to target player and each creature he or she controls.",
@@ -21588,7 +21588,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "To determine how many additional +1/+1 counters a creature enters the battlefield with, use Master Biomancer’s power as that creature is entering the battlefield."
+          "text": "To determine how many additional +1/+1 counters a creature enters the battlefield with, use Master Biomancer's power as that creature is entering the battlefield."
         }
       ],
       "subtypes": [
@@ -21791,7 +21791,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target creature or enchantment.",
@@ -21991,11 +21991,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -22098,7 +22098,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the targeted card is removed from the graveyard before the ability resolves, the ability is countered. You won’t get a Saproling token."
+          "text": "If the targeted card is removed from the graveyard before the ability resolves, the ability is countered. You won't get a Saproling token."
         }
       ],
       "text": "{2}: Exile target creature card from a graveyard. Create a 1/1 green Saproling creature token.",
@@ -22195,7 +22195,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Progenitor Mimic copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Progenitor Mimic copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2013-04-15",
@@ -22203,15 +22203,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to have Progenitor Mimic enter the battlefield as a copy of a creature, the triggered ability it gains will become part of its copiable values. For example, suppose Progenitor Mimic enters the battlefield as a copy of Runeclaw Bear, a 2/2 green Bear creature with mana cost {1}{G}. The resulting object is a 2/2 green Bear creature named Runeclaw Bear with mana cost {1}{G} and with “At the beginning of your upkeep, if this creature isn’t a token, put a token onto the battlefield that’s a copy of this creature.” If another Progenitor Mimic enters the battlefield as a copy of that creature, it will be a Runeclaw Bear with two instances of the triggered ability."
+          "text": "If you choose to have Progenitor Mimic enter the battlefield as a copy of a creature, the triggered ability it gains will become part of its copiable values. For example, suppose Progenitor Mimic enters the battlefield as a copy of Runeclaw Bear, a 2/2 green Bear creature with mana cost {1}{G}. The resulting object is a 2/2 green Bear creature named Runeclaw Bear with mana cost {1}{G} and with \"At the beginning of your upkeep, if this creature isn't a token, put a token onto the battlefield that's a copy of this creature.\" If another Progenitor Mimic enters the battlefield as a copy of that creature, it will be a Runeclaw Bear with two instances of the triggered ability."
         },
         {
           "date": "2013-04-15",
-          "text": "If the chosen creature is a token, Progenitor Mimic copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Copying a token doesn’t make Progenitor Mimic become a token."
+          "text": "If the chosen creature is a token, Progenitor Mimic copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Copying a token doesn't make Progenitor Mimic become a token."
         },
         {
           "date": "2013-04-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Progenitor Mimic enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Progenitor Mimic enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2013-04-15",
@@ -22219,7 +22219,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If Progenitor Mimic somehow enters the battlefield at the same time as another creature, it can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Progenitor Mimic somehow enters the battlefield at the same time as another creature, it can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2013-04-15",
@@ -22334,7 +22334,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an artifact, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an artifact, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target artifact or creature. It can't be regenerated.",
@@ -22430,7 +22430,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Damage dealt by creatures because of the third mode can’t be redirected to a planeswalker."
+          "text": "Damage dealt by creatures because of the third mode can't be redirected to a planeswalker."
         }
       ],
       "text": "Choose one —\n• Exile all cards from target player's graveyard.\n• Destroy target artifact.\n• Each creature deals 1 damage to its controller.",
@@ -22528,11 +22528,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The ability that defines Rubblehulk’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Rubblehulk's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2013-01-24",
-          "text": "If you activate Rubblehulk’s bloodrush ability, the value of X is the number of lands you control when that ability resolves."
+          "text": "If you activate Rubblehulk's bloodrush ability, the value of X is the number of lands you control when that ability resolves."
         }
       ],
       "subtypes": [
@@ -22627,11 +22627,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Selvala’s parley ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Selvala's parley ability is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-05-29",
-          "text": "If you activate Selvala’s ability while casting a spell, and you discover you can’t produce enough mana to pay that spell’s costs, the spell is reversed. The spell returns to whatever zone you were casting it from. You may reverse other mana abilities you activated while casting the spell, but Selvala’s ability can’t be reversed. Whatever mana that ability produced will be in your mana pool and each player will have drawn a card."
+          "text": "If you activate Selvala's ability while casting a spell, and you discover you can't produce enough mana to pay that spell's costs, the spell is reversed. The spell returns to whatever zone you were casting it from. You may reverse other mana abilities you activated while casting the spell, but Selvala's ability can't be reversed. Whatever mana that ability produced will be in your mana pool and each player will have drawn a card."
         },
         {
           "date": "2014-05-29",
@@ -22846,7 +22846,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The ability that defines Spellheart Chimera’s power functions in all zones, not just the battlefield."
+          "text": "The ability that defines Spellheart Chimera's power functions in all zones, not just the battlefield."
         }
       ],
       "subtypes": [
@@ -23043,15 +23043,15 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-10-17",
-          "text": "If the noncreature artifact had any other supertypes, types, or subtypes, it will keep those. In most cases, the artifact creature won’t have any creature types."
+          "text": "If the noncreature artifact had any other supertypes, types, or subtypes, it will keep those. In most cases, the artifact creature won't have any creature types."
         },
         {
           "date": "2013-10-17",
-          "text": "If an Equipment attached to a creature becomes a creature, it becomes unattached. An Equipment that is also a creature can’t equip another creature."
+          "text": "If an Equipment attached to a creature becomes a creature, it becomes unattached. An Equipment that is also a creature can't equip another creature."
         },
         {
           "date": "2013-10-17",
@@ -23357,7 +23357,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The effect of Vorel’s ability will essentially double the counters on the target artifact, creature, or land. For example, if a creature has three +1/+1 counters and a divinity counter on it before the ability resolves, it will have six +1/+1 counters and two divinity counters on it after the ability resolves."
+          "text": "The effect of Vorel's ability will essentially double the counters on the target artifact, creature, or land. For example, if a creature has three +1/+1 counters and a divinity counter on it before the ability resolves, it will have six +1/+1 counters and two divinity counters on it after the ability resolves."
         }
       ],
       "subtypes": [
@@ -23466,11 +23466,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The ability doesn’t care why a card goes to your opponent’s graveyard — only that it does. The ability triggers when a card is put into your opponent’s graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player’s hand (a card is discarded), from the player’s library (from a Millstone-like effect), or from any other zone."
+          "text": "The ability doesn't care why a card goes to your opponent's graveyard — only that it does. The ability triggers when a card is put into your opponent's graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player's hand (a card is discarded), from the player's library (from a Millstone-like effect), or from any other zone."
         },
         {
           "date": "2005-10-01",
-          "text": "This ability triggers only on cards, so it won’t trigger when a token is put into your opponent’s graveyard."
+          "text": "This ability triggers only on cards, so it won't trigger when a token is put into your opponent's graveyard."
         }
       ],
       "subtypes": [
@@ -23575,19 +23575,19 @@
         },
         {
           "date": "2013-01-24",
-          "text": "You’ll draw cards before deciding which creature (if any) Whispering Madness will be encoded on."
+          "text": "You'll draw cards before deciding which creature (if any) Whispering Madness will be encoded on."
         },
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -23603,15 +23603,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -23814,7 +23814,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If either the opponent or the permanent you control becomes an illegal target by the time Zedruu’s last ability tries to resolve, the ability does nothing."
+          "text": "If either the opponent or the permanent you control becomes an illegal target by the time Zedruu's last ability tries to resolve, the ability does nothing."
         }
       ],
       "subtypes": [
@@ -23921,7 +23921,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Zhur-Taa Druid’s last ability doesn’t trigger if it becomes tapped for any other reason. However, if Zhur-Taa Druid gains another mana ability that requires you tap it, its ability will trigger."
+          "text": "Zhur-Taa Druid's last ability doesn't trigger if it becomes tapped for any other reason. However, if Zhur-Taa Druid gains another mana ability that requires you tap it, its ability will trigger."
         },
         {
           "date": "2013-04-15",
@@ -23929,7 +23929,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Zhur-Taa Druid’s last ability isn’t a mana ability. It uses the stack and can be responded to."
+          "text": "Zhur-Taa Druid's last ability isn't a mana ability. It uses the stack and can be responded to."
         }
       ],
       "subtypes": [
@@ -24035,31 +24035,31 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If a cost includes life gain (like Invigorate’s alternative cost does), that cost can’t be paid."
+          "text": "If a cost includes life gain (like Invigorate's alternative cost does), that cost can't be paid."
         },
         {
           "date": "2008-05-01",
-          "text": "Effects that would replace gaining life with some other effect won’t be able to do anything because it’s impossible for players to gain life."
+          "text": "Effects that would replace gaining life with some other effect won't be able to do anything because it's impossible for players to gain life."
         },
         {
           "date": "2008-05-01",
-          "text": "Effects that replace an event with gaining life (like Words of Worship’s effect does) will end up replacing the event with nothing."
+          "text": "Effects that replace an event with gaining life (like Words of Worship's effect does) will end up replacing the event with nothing."
         },
         {
           "date": "2008-05-01",
-          "text": "If an effect says to set your life total to a certain number, and that number is higher than your current life total, that effect will normally cause you to gain life equal to the difference. With Everlasting Torment on the battlefield, that part of the effect won’t do anything. (If the number is lower than your current life total, the effect will work as normal.)"
+          "text": "If an effect says to set your life total to a certain number, and that number is higher than your current life total, that effect will normally cause you to gain life equal to the difference. With Everlasting Torment on the battlefield, that part of the effect won't do anything. (If the number is lower than your current life total, the effect will work as normal.)"
         },
         {
           "date": "2008-05-01",
-          "text": "The “damage can’t be prevented” statement overrides all forms of preventing damage, including protection abilities. Damage prevention spells and abilities can still be cast and played; they just don’t do anything."
+          "text": "The \"damage can't be prevented\" statement overrides all forms of preventing damage, including protection abilities. Damage prevention spells and abilities can still be cast and played; they just don't do anything."
         },
         {
           "date": "2008-05-01",
-          "text": "Spells and abilities that replace or redirect damage aren’t affected by Everlasting Torment’s second ability. They’ll work as normal."
+          "text": "Spells and abilities that replace or redirect damage aren't affected by Everlasting Torment's second ability. They'll work as normal."
         },
         {
           "date": "2008-05-01",
-          "text": "The last ability affects all damage, whether it’s dealt by creatures, other permanents, spells, or cards that aren’t on the battlefield. Wither works everywhere."
+          "text": "The last ability affects all damage, whether it's dealt by creatures, other permanents, spells, or cards that aren't on the battlefield. Wither works everywhere."
         }
       ],
       "text": "Players can't gain life.\nDamage can't be prevented.\nAll damage is dealt as though its source had wither. (A source with wither deals damage to creatures in the form of -1/-1 counters.)",
@@ -24156,15 +24156,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Each other creature copies the printed values of the targeted creature, plus any copy effects that have been applied to that creature. They won’t copy other effects that have changed the targeted creature’s power, toughness, types, color, or so on. They also won’t copy counters on the targeted creature (they’ll each just retain the counters they already have)."
+          "text": "Each other creature copies the printed values of the targeted creature, plus any copy effects that have been applied to that creature. They won't copy other effects that have changed the targeted creature's power, toughness, types, color, or so on. They also won't copy counters on the targeted creature (they'll each just retain the counters they already have)."
         },
         {
           "date": "2008-05-01",
-          "text": "If the targeted creature is itself copying a creature, each other creature will become whatever it’s copying, as modified by that copy effect. For example, if you target a Cemetery Puca that’s copying a Grizzly Bears (a 2/2 creature with no abilities), each other creature will become a Grizzly Bears with the Cemetery Puca ability."
+          "text": "If the targeted creature is itself copying a creature, each other creature will become whatever it's copying, as modified by that copy effect. For example, if you target a Cemetery Puca that's copying a Grizzly Bears (a 2/2 creature with no abilities), each other creature will become a Grizzly Bears with the Cemetery Puca ability."
         },
         {
           "date": "2008-05-01",
-          "text": "This effect can cause each other creature to stop being a creature. For example, if you target an animated Mutavault (a land with an activated ability that turns it into a creature), only the printed wording will be copied — the “becomes a creature” effect won’t. Each other creature will become an unanimated Mutavault."
+          "text": "This effect can cause each other creature to stop being a creature. For example, if you target an animated Mutavault (a land with an activated ability that turns it into a creature), only the printed wording will be copied — the \"becomes a creature\" effect won't. Each other creature will become an unanimated Mutavault."
         },
         {
           "date": "2008-05-01",
@@ -24172,11 +24172,11 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If the targeted creature is a token, each other creature copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Those creatures don’t become tokens."
+          "text": "If the targeted creature is a token, each other creature copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Those creatures don't become tokens."
         },
         {
           "date": "2008-05-01",
-          "text": "As the turn ends, the other creatures revert to what they were before. If two Mirrorweaves are cast on the same turn, they’ll both wear off at the same time."
+          "text": "As the turn ends, the other creatures revert to what they were before. If two Mirrorweaves are cast on the same turn, they'll both wear off at the same time."
         }
       ],
       "text": "Each other creature becomes a copy of target nonlegendary creature until end of turn.",
@@ -24374,7 +24374,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -24382,15 +24382,15 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         },
         {
           "date": "2008-08-01",
-          "text": "As the token is created, it checks the printed values of the creature it’s copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "As the token is created, it checks the printed values of the creature it's copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, or so on."
         }
       ],
       "text": "Create a token that's a copy of target creature.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -24587,7 +24587,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -24595,11 +24595,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         },
         {
           "date": "2008-08-01",
@@ -25058,11 +25058,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Akroan Horse’s enters-the-battlefield ability doesn’t target any opponent. In a multiplayer game, you choose the opponent as the ability resolves."
+          "text": "Akroan Horse's enters-the-battlefield ability doesn't target any opponent. In a multiplayer game, you choose the opponent as the ability resolves."
         },
         {
           "date": "2013-09-15",
-          "text": "In the last ability, “each opponent” refers to opponents of Akroan Horse’s controller. In most situations in two-player games, your opponent will control Akroan Horse and you’ll put Soldier tokens onto the battlefield."
+          "text": "In the last ability, \"each opponent\" refers to opponents of Akroan Horse's controller. In most situations in two-player games, your opponent will control Akroan Horse and you'll put Soldier tokens onto the battlefield."
         }
       ],
       "subtypes": [
@@ -25148,11 +25148,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The equipped creature can’t be sacrificed for any reason. If an effect instructs you to sacrifice it, you can’t and it remains on the battlefield. You also can’t sacrifice it to pay a cost that requires you to sacrifice a creature."
+          "text": "The equipped creature can't be sacrificed for any reason. If an effect instructs you to sacrifice it, you can't and it remains on the battlefield. You also can't sacrifice it to pay a cost that requires you to sacrifice a creature."
         },
         {
           "date": "2014-11-07",
-          "text": "If an effect instructs you to sacrifice a creature, and you control any creatures other than the creature equipped with Assault Suit, you must sacrifice one of them. You can’t try to sacrifice the equipped creature, fail, and therefore ignore the effect."
+          "text": "If an effect instructs you to sacrifice a creature, and you control any creatures other than the creature equipped with Assault Suit, you must sacrifice one of them. You can't try to sacrifice the equipped creature, fail, and therefore ignore the effect."
         }
       ],
       "subtypes": [
@@ -25247,7 +25247,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "The last ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The last ability is a mana ability. It doesn't use the stack and can't be responded to."
         }
       ],
       "text": "Astral Cornucopia enters the battlefield with X charge counters on it.\n{T}: Choose a color. Add one mana of that color to your mana pool for each charge counter on Astral Cornucopia.",
@@ -25340,7 +25340,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The “precombat main phase” is the first main phase of the turn. All other main phases are “postcombat main phases.”"
+          "text": "The \"precombat main phase\" is the first main phase of the turn. All other main phases are \"postcombat main phases.\""
         }
       ],
       "text": "At the beginning of each player's precombat main phase, if Blinkmoth Urn is untapped, that player adds {C} to his or her mana pool for each artifact he or she controls.",
@@ -25435,15 +25435,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If there are no creature cards in any graveyard when Bonehoard’s living weapon ability resolves, the Germ will be 0/0 and put into its owner’s graveyard."
+          "text": "If there are no creature cards in any graveyard when Bonehoard's living weapon ability resolves, the Germ will be 0/0 and put into its owner's graveyard."
         },
         {
           "date": "2011-06-01",
-          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won’t increase the bonus granted by Bonehoard, however briefly."
+          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won't increase the bonus granted by Bonehoard, however briefly."
         },
         {
           "date": "2011-06-01",
-          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won’t get an additional bonus from the other creature."
+          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won't get an additional bonus from the other creature."
         }
       ],
       "subtypes": [
@@ -25534,7 +25534,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If a nontoken creature that gains persist this way is put into a graveyard, that card will be returned to the battlefield with a -1/-1 counter on it. However, because it’s a new object with no relation to its previous existence, the returned creature will not have persist."
+          "text": "If a nontoken creature that gains persist this way is put into a graveyard, that card will be returned to the battlefield with a -1/-1 counter on it. However, because it's a new object with no relation to its previous existence, the returned creature will not have persist."
         },
         {
           "date": "2013-06-07",
@@ -25546,23 +25546,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "text": "{T}: Choose any number of target creatures. Each of those creatures gains persist until end of turn. (When it dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
@@ -25652,7 +25652,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Lands you control won’t lose any other abilities they had. They also won’t gain or lose any land types."
+          "text": "Lands you control won't lose any other abilities they had. They also won't gain or lose any land types."
         }
       ],
       "text": "Lands you control have \"{T}: Add one mana of any color to your mana pool.\"\n{T}: Add one mana of any color to your mana pool.",
@@ -25734,15 +25734,15 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even if your commander is in a hidden zone (such as your hand or your library) or if an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even if your commander is in a hidden zone (such as your hand or your library) or if an effect changes your commander's color."
         },
         {
           "date": "2014-11-07",
-          "text": "If your commander has no colors in its color identity, Commander’s Sphere produces no mana."
+          "text": "If your commander has no colors in its color identity, Commander's Sphere produces no mana."
         },
         {
           "date": "2014-11-07",
-          "text": "In formats other than Commander, Commander’s Sphere produces no mana."
+          "text": "In formats other than Commander, Commander's Sphere produces no mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
@@ -26286,7 +26286,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This works even if the opponent’s lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
+          "text": "This works even if the opponent's lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
         },
         {
           "date": "2004-10-04",
@@ -26294,19 +26294,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, take into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, take into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Fellwar Stone doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -26689,7 +26689,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The ability will trigger when Ichor Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn’t resolved yet."
+          "text": "The ability will trigger when Ichor Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn't resolved yet."
         }
       ],
       "text": "When Ichor Wellspring enters the battlefield or is put into a graveyard from the battlefield, draw a card.",
@@ -26778,7 +26778,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The value of X is determined as the ability starts to resolve. If the targeted player has five cards in his or her graveyard at that time, for example, this ability will put five more cards into that graveyard from the top of that player’s library."
+          "text": "The value of X is determined as the ability starts to resolve. If the targeted player has five cards in his or her graveyard at that time, for example, this ability will put five more cards into that graveyard from the top of that player's library."
         }
       ],
       "text": "{5}, {T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of cards in that player's graveyard.",
@@ -26874,7 +26874,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You are not allowed to “unequip” equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won’t be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
+          "text": "You are not allowed to \"unequip\" equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won't be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
         }
       ],
       "subtypes": [
@@ -27060,7 +27060,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The ability will trigger when Mycosynth Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn’t resolved yet."
+          "text": "The ability will trigger when Mycosynth Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn't resolved yet."
         }
       ],
       "text": "When Mycosynth Wellspring enters the battlefield or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
@@ -27151,11 +27151,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You choose the value for X as the last ability resolves. You can’t choose a value for X that’s greater than the number of untapped Myr you control."
+          "text": "You choose the value for X as the last ability resolves. You can't choose a value for X that's greater than the number of untapped Myr you control."
         },
         {
           "date": "2011-01-01",
-          "text": "You can tap any untapped Myr you control as the last ability resolves, not just the Myr tokens you put onto the battlefield with the first ability. This includes Myr that haven’t been under your control since your most recent turn began."
+          "text": "You can tap any untapped Myr you control as the last ability resolves, not just the Myr tokens you put onto the battlefield with the first ability. This includes Myr that haven't been under your control since your most recent turn began."
         },
         {
           "date": "2011-01-01",
@@ -27163,7 +27163,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "As the last ability resolves, you can tap untapped Myr you control even if Myr Battlesphere is no longer on the battlefield by then. If that has happened, Myr Battlesphere won’t be able to get the +X/+0 bonus, but it will still deal X damage to the defending player."
+          "text": "As the last ability resolves, you can tap untapped Myr you control even if Myr Battlesphere is no longer on the battlefield by then. If that has happened, Myr Battlesphere won't be able to get the +X/+0 bonus, but it will still deal X damage to the defending player."
         }
       ],
       "subtypes": [
@@ -27354,7 +27354,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -27723,7 +27723,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Because the artifact lands of the original _Mirrodin_(R) block aren’t cast, Shimmer Myr’s ability doesn’t affect them."
+          "text": "Because the artifact lands of the original _Mirrodin_(R) block aren't cast, Shimmer Myr's ability doesn't affect them."
         }
       ],
       "subtypes": [
@@ -28184,7 +28184,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Exiling the Soul from your graveyard is part of the last ability’s activation cost. A player can’t remove the Soul in response to prevent you from activating the ability."
+          "text": "Exiling the Soul from your graveyard is part of the last ability's activation cost. A player can't remove the Soul in response to prevent you from activating the ability."
         }
       ],
       "subtypes": [
@@ -28282,15 +28282,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You can’t pay the cost of the second ability unless Sunforger is attached to a creature."
+          "text": "You can't pay the cost of the second ability unless Sunforger is attached to a creature."
         },
         {
           "date": "2005-10-01",
-          "text": "Any card you find must be legally castable (for example, you have to be able to choose a legal target for it). If you can’t find a castable card (or choose not to), nothing happens and you shuffle your library."
+          "text": "Any card you find must be legally castable (for example, you have to be able to choose a legal target for it). If you can't find a castable card (or choose not to), nothing happens and you shuffle your library."
         },
         {
           "date": "2005-10-01",
-          "text": "The card is cast from your library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can’t be paid."
+          "text": "The card is cast from your library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can't be paid."
         }
       ],
       "subtypes": [
@@ -28382,7 +28382,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can’t be the target of spells and abilities you control."
+          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can't be the target of spells and abilities you control."
         }
       ],
       "subtypes": [
@@ -28634,7 +28634,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Venser’s Journal onto the battlefield, you’ll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Venser's Journal onto the battlefield, you'll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\nAt the beginning of your upkeep, you gain 1 life for each card in your hand.",
@@ -29178,7 +29178,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -29266,15 +29266,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander's color."
         },
         {
           "date": "2011-09-22",
-          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower’s ability produces no mana."
+          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower's ability produces no mana."
         },
         {
           "date": "2011-09-22",
-          "text": "In formats other than Commander, Command Tower’s ability produces no mana."
+          "text": "In formats other than Commander, Command Tower's ability produces no mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color in your commander's color identity.",
@@ -29455,7 +29455,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Although Darksteel Citadel is an artifact, it can’t be cast as a spell. Playing it follows the normal rules for playing a land."
+          "text": "Although Darksteel Citadel is an artifact, it can't be cast as a spell. Playing it follows the normal rules for playing a land."
         }
       ],
       "text": "Indestructible\n{T}: Add {C} to your mana pool.",
@@ -29808,11 +29808,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don’t have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don't have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
@@ -29950,6 +29950,10 @@
       "imageName": "evolving wilds",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Battle for Zendikar Block",
           "legality": "Legal"
@@ -30105,23 +30109,23 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-02-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there are more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there are more than one, consider them in any possible order."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Exotic Orchard doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Lands that produce mana based only on what other lands “could produce” won’t help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent’s Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent’s Reflecting Pool can each produce {G} because your opponent’s Exotic Orchard can produce {G}."
+          "text": "Lands that produce mana based only on what other lands \"could produce\" won't help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent's Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent's Reflecting Pool can each produce {G} because your opponent's Exotic Orchard can produce {G}."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -31261,7 +31265,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Murmuring Bosk is a Forest, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do. For example, you can’t find Murmuring Bosk with Fertilid’s ability (“searches his or her library for a basic land card”), but you can find Murmuring Bosk with Everbark Shaman’s ability (“search your library for two Forest cards”)."
+          "text": "Murmuring Bosk is a Forest, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do. For example, you can't find Murmuring Bosk with Fertilid's ability (\"searches his or her library for a basic land card\"), but you can find Murmuring Bosk with Everbark Shaman's ability (\"search your library for two Forest cards\")."
         }
       ],
       "subtypes": [
@@ -31596,19 +31600,19 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "The “number of times it’s been cast from the command zone” includes the most recent time. For example, the first time you cast your commander from the command zone in a game, if you spent mana from Opal Palace’s last ability to do so, it will enter the battlefield with a +1/+1 counter."
+          "text": "The \"number of times it's been cast from the command zone\" includes the most recent time. For example, the first time you cast your commander from the command zone in a game, if you spent mana from Opal Palace's last ability to do so, it will enter the battlefield with a +1/+1 counter."
         },
         {
           "date": "2013-10-17",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even if your commander is in a hidden zone (like the hand or library) or an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even if your commander is in a hidden zone (like the hand or library) or an effect changes your commander's color."
         },
         {
           "date": "2013-10-17",
-          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Opal Palace’s last ability produces no mana."
+          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Opal Palace's last ability produces no mana."
         },
         {
           "date": "2013-10-17",
-          "text": "In formats other than Commander, Opal Palace’s last ability produces no mana."
+          "text": "In formats other than Commander, Opal Palace's last ability produces no mana."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add to your mana pool one mana of any color in your commander's color identity. If you spend this mana to cast your commander, it enters the battlefield with a number of additional +1/+1 counters on it equal to the number of times it's been cast from the command zone this game.",
@@ -31976,7 +31980,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you’ll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you'll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\n{T}: Add {C} to your mana pool.",
@@ -32066,11 +32070,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don’t have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don't have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
@@ -32957,15 +32961,15 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "At the time the last ability resolves, you’ll get to play the card if a player who is currently your opponent, or a player who was your opponent at the time he or she left the game, has been dealt 7 damage over the course of the turn."
+          "text": "At the time the last ability resolves, you'll get to play the card if a player who is currently your opponent, or a player who was your opponent at the time he or she left the game, has been dealt 7 damage over the course of the turn."
         },
         {
           "date": "2007-10-01",
-          "text": "It doesn’t matter how the opponent was dealt damage or by whom, as long as the total damage is 7 or more. You don’t specify an opponent when you activate the ability."
+          "text": "It doesn't matter how the opponent was dealt damage or by whom, as long as the total damage is 7 or more. You don't specify an opponent when you activate the ability."
         },
         {
           "date": "2007-10-01",
-          "text": "You’ll get to play the card even if Spinerock Knoll wasn’t on the battlefield at the time some or all of the 7 damage was dealt."
+          "text": "You'll get to play the card even if Spinerock Knoll wasn't on the battlefield at the time some or all of the 7 damage was dealt."
         }
       ],
       "text": "Hideaway (This land enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\n{T}: Add {R} to your mana pool.\n{R}, {T}: You may play the exiled card without paying its mana cost if an opponent was dealt 7 or more damage this turn.",
@@ -33135,11 +33139,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don’t have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don't have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
@@ -33758,7 +33762,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "At the time the ability resolves, you’ll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered the battlefield attacking (such as a token created by Militia’s Pride) doesn’t count because you never attacked with it."
+          "text": "At the time the ability resolves, you'll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered the battlefield attacking (such as a token created by Militia's Pride) doesn't count because you never attacked with it."
         }
       ],
       "text": "Hideaway (This land enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\n{T}: Add {W} to your mana pool.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",

--- a/json/CED.json
+++ b/json/CED.json
@@ -582,7 +582,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "source": "SQUARE EDGES AND GOLD-BORDERED BACKSIDE, NOT TOURNAMENT LEGAL",
@@ -9166,6 +9167,10 @@
       "imageName": "giant spider",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -26200,6 +26205,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"

--- a/json/CEI.json
+++ b/json/CEI.json
@@ -582,7 +582,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "source": "SQUARE EDGES AND GOLD-BORDERED BACKSIDE, NOT TOURNAMENT LEGAL",
@@ -9167,6 +9168,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -15944,6 +15949,7 @@
         "BTD",
         "INV",
         "7ED",
+        "ODY",
         "DKM",
         "ONS",
         "8ED",
@@ -16235,6 +16241,7 @@
         "BTD",
         "INV",
         "7ED",
+        "ODY",
         "DKM",
         "ONS",
         "8ED",
@@ -16526,6 +16533,7 @@
         "BTD",
         "INV",
         "7ED",
+        "ODY",
         "DKM",
         "ONS",
         "8ED",
@@ -26197,6 +26205,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"

--- a/json/CHK.json
+++ b/json/CHK.json
@@ -124,15 +124,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -156,37 +156,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Bushi Tenderfoot",
+          "name": "无情的谦造",
           "multiverseid": 85200
         },
         {
           "language": "French",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo l'impitoyable",
           "multiverseid": 85507
         },
         {
           "language": "German",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo der Hartherzige",
           "multiverseid": 85814
         },
         {
           "language": "Italian",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo Cuoreduro",
           "multiverseid": 86121
         },
         {
           "language": "Japanese",
-          "name": "Bushi Tenderfoot",
+          "name": "冷酷なる者、謙造",
           "multiverseid": 86428
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo o Impiedoso",
           "multiverseid": 86735
         },
         {
           "language": "Spanish",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo el de corazón duro",
           "multiverseid": 87042
         }
       ],
@@ -254,37 +254,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Bushi Tenderfoot",
+          "name": "无情的谦造",
           "multiverseid": 85200
         },
         {
           "language": "French",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo l'impitoyable",
           "multiverseid": 85507
         },
         {
           "language": "German",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo der Hartherzige",
           "multiverseid": 85814
         },
         {
           "language": "Italian",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo Cuoreduro",
           "multiverseid": 86121
         },
         {
           "language": "Japanese",
-          "name": "Bushi Tenderfoot",
+          "name": "冷酷なる者、謙造",
           "multiverseid": 86428
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo o Impiedoso",
           "multiverseid": 86735
         },
         {
           "language": "Spanish",
-          "name": "Bushi Tenderfoot",
+          "name": "Kenzo el de corazón duro",
           "multiverseid": 87042
         }
       ],
@@ -447,7 +447,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"General Takeno glared at us as if we were the enemy. ‘The day is not over yet,' he shouted, ‘and unless you have a nezumi's heart, you will stand and fight'\"\n—Battle of Akagi River: A Survivor's Tale",
+      "flavor": "\"General Takeno glared at us as if we were the enemy. 'The day is not over yet,' he shouted, 'and unless you have a nezumi's heart, you will stand and fight'\"\n—Battle of Akagi River: A Survivor's Tale",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -616,15 +616,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -1116,7 +1116,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -3398,7 +3398,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Masako allows tapped creatures to block only if they could otherwise block. It doesn’t allow creatures that “can’t block” to block, nonflying creatures to block fliers, etc."
+          "text": "Masako allows tapped creatures to block only if they could otherwise block. It doesn't allow creatures that \"can't block\" to block, nonflying creatures to block fliers, etc."
         }
       ],
       "subtypes": [
@@ -3803,11 +3803,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Any Aura attached to the creature is put into its owner’s graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
+          "text": "Any Aura attached to the creature is put into its owner's graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
         },
         {
           "date": "2005-08-01",
-          "text": "If Otherworldly Journey is cast during an end step, the creature won’t return until the beginning of the next end step."
+          "text": "If Otherworldly Journey is cast during an end step, the creature won't return until the beginning of the next end step."
         }
       ],
       "subtypes": [
@@ -4187,7 +4187,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t split up a life total when you redistribute it. For example, suppose that in a two-player game your life total is 5 and your opponent’s life total is 15 when Reverse the Sands starts to resolve. You can choose to (a) leave the life totals as they are or (b) make your life total 15 and your opponent’s 5. You can’t choose to make your life total 20 and your opponent’s 0."
+          "text": "You can't split up a life total when you redistribute it. For example, suppose that in a two-player game your life total is 5 and your opponent's life total is 15 when Reverse the Sands starts to resolve. You can choose to (a) leave the life totals as they are or (b) make your life total 15 and your opponent's 5. You can't choose to make your life total 20 and your opponent's 0."
         }
       ],
       "text": "Redistribute any number of players' life totals. (Each of those players gets one life total back.)",
@@ -4471,7 +4471,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The training counter just marks which creatures have been changed; an effect that removes the counter doesn’t change the creature’s types or abilities."
+          "text": "The training counter just marks which creatures have been changed; an effect that removes the counter doesn't change the creature's types or abilities."
         },
         {
           "date": "2004-12-01",
@@ -5435,15 +5435,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -5725,15 +5725,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -6204,7 +6204,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You can choose to find fewer than four cards if you want. If you find one or two cards, your opponent must choose for them to be put into your graveyard, even if he or she doesn’t want to."
+          "text": "You can choose to find fewer than four cards if you want. If you find one or two cards, your opponent must choose for them to be put into your graveyard, even if he or she doesn't want to."
         }
       ],
       "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
@@ -6300,7 +6300,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Graceful Adept onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Graceful Adept onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "subtypes": [
@@ -6887,37 +6887,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Jushi Apprentice",
+          "name": "示现师智也",
           "multiverseid": 85296
         },
         {
           "language": "French",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya le divulgateur",
           "multiverseid": 85603
         },
         {
           "language": "German",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya der Enthüller",
           "multiverseid": 85910
         },
         {
           "language": "Italian",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya il Rivelatore",
           "multiverseid": 86217
         },
         {
           "language": "Japanese",
-          "name": "Jushi Apprentice",
+          "name": "暴く者、智也",
           "multiverseid": 86524
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya, o Revelador",
           "multiverseid": 86831
         },
         {
           "language": "Spanish",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya el revelador",
           "multiverseid": 87138
         }
       ],
@@ -6985,37 +6985,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Jushi Apprentice",
+          "name": "示现师智也",
           "multiverseid": 85296
         },
         {
           "language": "French",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya le divulgateur",
           "multiverseid": 85603
         },
         {
           "language": "German",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya der Enthüller",
           "multiverseid": 85910
         },
         {
           "language": "Italian",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya il Rivelatore",
           "multiverseid": 86217
         },
         {
           "language": "Japanese",
-          "name": "Jushi Apprentice",
+          "name": "暴く者、智也",
           "multiverseid": 86524
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya, o Revelador",
           "multiverseid": 86831
         },
         {
           "language": "Spanish",
-          "name": "Jushi Apprentice",
+          "name": "Tomoya el revelador",
           "multiverseid": 87138
         }
       ],
@@ -7355,15 +7355,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -7846,7 +7846,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If you don’t reveal an instant or sorcery card, put all the revealed cards on the bottom of your library in any order."
+          "text": "If you don't reveal an instant or sorcery card, put all the revealed cards on the bottom of your library in any order."
         }
       ],
       "subtypes": [
@@ -8045,15 +8045,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -8252,7 +8252,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "With the introduction of the Tribal type it became possible for an instant or sorcery card to share a type with the sacrificed permanent (ie, a Tribal instant card shares a type with a Tribal Enchantment card). Reweave has received errata so that the effect looks for a *permanent* card that shares a type with the sacrificed permanent. A permanent card is a card that could be put onto the battlefield, which is any card that isn’t an instant or sorcery."
+          "text": "With the introduction of the Tribal type it became possible for an instant or sorcery card to share a type with the sacrificed permanent (ie, a Tribal instant card shares a type with a Tribal Enchantment card). Reweave has received errata so that the effect looks for a *permanent* card that shares a type with the sacrificed permanent. A permanent card is a card that could be put onto the battlefield, which is any card that isn't an instant or sorcery."
         },
         {
           "date": "2013-06-07",
@@ -8260,15 +8260,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -9212,11 +9212,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Squelch can’t target a mana ability because mana abilities don’t use the stack."
+          "text": "Squelch can't target a mana ability because mana abilities don't use the stack."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Counter target activated ability. (Mana abilities can't be targeted.)\nDraw a card.",
@@ -9513,7 +9513,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Swirl the Mists’ ability also affects spells that are cast and permanents that enter the battlefield after Swirl the Mists enters the battlefield."
+          "text": "Swirl the Mists' ability also affects spells that are cast and permanents that enter the battlefield after Swirl the Mists enters the battlefield."
         }
       ],
       "text": "As Swirl the Mists enters the battlefield, choose a color word.\nAll instances of color words in the text of spells and permanents are changed to the chosen color word.",
@@ -9797,19 +9797,19 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Exiling a spell or ability prevents that spell or ability from resolving, but it doesn’t technically “counter” anything. This means that Time Stop can exile spells and abilities that “can’t be countered.”"
+          "text": "Exiling a spell or ability prevents that spell or ability from resolving, but it doesn't technically \"counter\" anything. This means that Time Stop can exile spells and abilities that \"can't be countered.\""
         },
         {
           "date": "2004-12-01",
-          "text": "Unless Time Stop is cast during the Ending phase, any “at the beginning of the end step”-triggered abilities don’t get the chance to trigger on the turn Time Stop is cast. These abilities will trigger at the beginning of the next end step."
+          "text": "Unless Time Stop is cast during the Ending phase, any \"at the beginning of the end step\"-triggered abilities don't get the chance to trigger on the turn Time Stop is cast. These abilities will trigger at the beginning of the next end step."
         },
         {
           "date": "2007-07-15",
-          "text": "Ending the turn this way means the following things happen in order: 1) All spells and abilities on the stack are exiled. This includes Time Stop, though it will continue to resolve. It also includes spells and abilities that can’t be countered. 2) All attacking and blocking creatures are removed from combat. 3) State-based actions are checked. No player gets priority, and no triggered abilities are put onto the stack. 4) The current phase and/or step ends. The game skips straight to the cleanup step. The cleanup step happens in its entirety."
+          "text": "Ending the turn this way means the following things happen in order: 1) All spells and abilities on the stack are exiled. This includes Time Stop, though it will continue to resolve. It also includes spells and abilities that can't be countered. 2) All attacking and blocking creatures are removed from combat. 3) State-based actions are checked. No player gets priority, and no triggered abilities are put onto the stack. 4) The current phase and/or step ends. The game skips straight to the cleanup step. The cleanup step happens in its entirety."
         },
         {
           "date": "2007-07-15",
-          "text": "If any triggered abilities do trigger during this process, they’re put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn finally ends."
+          "text": "If any triggered abilities do trigger during this process, they're put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn finally ends."
         }
       ],
       "text": "End the turn. (Exile all spells and abilities on the stack, including this card. The player whose turn it is discards down to his or her maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
@@ -10003,7 +10003,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If you copy an Arcane spell that has cards spliced onto it, you’ll copy the spliced text as well as the original spell text."
+          "text": "If you copy an Arcane spell that has cards spliced onto it, you'll copy the spliced text as well as the original spell text."
         }
       ],
       "subtypes": [
@@ -11432,7 +11432,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -11537,15 +11537,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -12417,7 +12417,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Marrow-Gnawer’s ability counts the number of Rats on the battlefield when it resolves, so you don’t count the sacrificed Rat."
+          "text": "Marrow-Gnawer's ability counts the number of Rats on the battlefield when it resolves, so you don't count the sacrificed Rat."
         }
       ],
       "subtypes": [
@@ -12715,7 +12715,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -12836,37 +12836,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Nezumi Graverobber",
+          "name": "亵渎者夜目",
           "multiverseid": 85360
         },
         {
           "language": "French",
-          "name": "Nezumi Graverobber",
+          "name": "Noctœil le profanateur",
           "multiverseid": 85667
         },
         {
           "language": "German",
-          "name": "Nezumi Graverobber",
+          "name": "Nachtauge der Schänder",
           "multiverseid": 85974
         },
         {
           "language": "Italian",
-          "name": "Nezumi Graverobber",
+          "name": "Occhi-della-Notte il Profanatore",
           "multiverseid": 86281
         },
         {
           "language": "Japanese",
-          "name": "Nezumi Graverobber",
+          "name": "冒涜する者、夜目",
           "multiverseid": 86588
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Nezumi Graverobber",
+          "name": "Olhos-Noturnos, o Profanador",
           "multiverseid": 86895
         },
         {
           "language": "Spanish",
-          "name": "Nezumi Graverobber",
+          "name": "Ojos nocturnos el profanador",
           "multiverseid": 87202
         }
       ],
@@ -12935,37 +12935,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Nezumi Graverobber",
+          "name": "亵渎者夜目",
           "multiverseid": 85360
         },
         {
           "language": "French",
-          "name": "Nezumi Graverobber",
+          "name": "Noctœil le profanateur",
           "multiverseid": 85667
         },
         {
           "language": "German",
-          "name": "Nezumi Graverobber",
+          "name": "Nachtauge der Schänder",
           "multiverseid": 85974
         },
         {
           "language": "Italian",
-          "name": "Nezumi Graverobber",
+          "name": "Occhi-della-Notte il Profanatore",
           "multiverseid": 86281
         },
         {
           "language": "Japanese",
-          "name": "Nezumi Graverobber",
+          "name": "冒涜する者、夜目",
           "multiverseid": 86588
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Nezumi Graverobber",
+          "name": "Olhos-Noturnos, o Profanador",
           "multiverseid": 86895
         },
         {
           "language": "Spanish",
-          "name": "Nezumi Graverobber",
+          "name": "Ojos nocturnos el profanador",
           "multiverseid": 87202
         }
       ],
@@ -13132,37 +13132,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Nezumi Shortfang",
+          "name": "可憎的刺须",
           "multiverseid": 85362
         },
         {
           "language": "French",
-          "name": "Nezumi Shortfang",
+          "name": "Perce-moustaches l'odieux",
           "multiverseid": 85669
         },
         {
           "language": "German",
-          "name": "Nezumi Shortfang",
+          "name": "Dolchbart der Widerliche",
           "multiverseid": 85976
         },
         {
           "language": "Italian",
-          "name": "Nezumi Shortfang",
+          "name": "Pungibaffo il Detestabile",
           "multiverseid": 86283
         },
         {
           "language": "Japanese",
-          "name": "Nezumi Shortfang",
+          "name": "憎まれ者の傷弄り",
           "multiverseid": 86590
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Nezumi Shortfang",
+          "name": "Estimista, o Detestável",
           "multiverseid": 86897
         },
         {
           "language": "Spanish",
-          "name": "Nezumi Shortfang",
+          "name": "Cortabigotes el odioso",
           "multiverseid": 87204
         }
       ],
@@ -13230,37 +13230,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Nezumi Shortfang",
+          "name": "可憎的刺须",
           "multiverseid": 85362
         },
         {
           "language": "French",
-          "name": "Nezumi Shortfang",
+          "name": "Perce-moustaches l'odieux",
           "multiverseid": 85669
         },
         {
           "language": "German",
-          "name": "Nezumi Shortfang",
+          "name": "Dolchbart der Widerliche",
           "multiverseid": 85976
         },
         {
           "language": "Italian",
-          "name": "Nezumi Shortfang",
+          "name": "Pungibaffo il Detestabile",
           "multiverseid": 86283
         },
         {
           "language": "Japanese",
-          "name": "Nezumi Shortfang",
+          "name": "憎まれ者の傷弄り",
           "multiverseid": 86590
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Nezumi Shortfang",
+          "name": "Estimista, o Detestável",
           "multiverseid": 86897
         },
         {
           "language": "Spanish",
-          "name": "Nezumi Shortfang",
+          "name": "Cortabigotes el odioso",
           "multiverseid": 87204
         }
       ],
@@ -14522,15 +14522,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -15185,7 +15185,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The “activate this ability only once each turn” restriction applies even if the creature changes controllers."
+          "text": "The \"activate this ability only once each turn\" restriction applies even if the creature changes controllers."
         }
       ],
       "subtypes": [
@@ -15308,37 +15308,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Akki Lavarunner",
+          "name": "火山鬼托托",
           "multiverseid": 85179
         },
         {
           "language": "French",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok, né du volcan",
           "multiverseid": 85486
         },
         {
           "language": "German",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok der Vulkangeborene",
           "multiverseid": 85793
         },
         {
           "language": "Italian",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok, Figlio del Vulcano",
           "multiverseid": 86100
         },
         {
           "language": "Japanese",
-          "name": "Akki Lavarunner",
+          "name": "溶岩生まれのトクトク",
           "multiverseid": 86407
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok, Filho do Vulcão",
           "multiverseid": 86714
         },
         {
           "language": "Spanish",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok, nacido del volcán",
           "multiverseid": 87021
         }
       ],
@@ -15406,37 +15406,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Akki Lavarunner",
+          "name": "火山鬼托托",
           "multiverseid": 85179
         },
         {
           "language": "French",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok, né du volcan",
           "multiverseid": 85486
         },
         {
           "language": "German",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok der Vulkangeborene",
           "multiverseid": 85793
         },
         {
           "language": "Italian",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok, Figlio del Vulcano",
           "multiverseid": 86100
         },
         {
           "language": "Japanese",
-          "name": "Akki Lavarunner",
+          "name": "溶岩生まれのトクトク",
           "multiverseid": 86407
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok, Filho do Vulcão",
           "multiverseid": 86714
         },
         {
           "language": "Spanish",
-          "name": "Akki Lavarunner",
+          "name": "Tok-Tok, nacido del volcán",
           "multiverseid": 87021
         }
       ],
@@ -15582,7 +15582,7 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -15605,7 +15605,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Deep inside the Sokenzan Mountains, a band of akki discovered a cache of ancient items of power. Their ensuing spree of destruction became known as ‘The Three Days of Fun.'\"\n—Observations of the Kami War",
+      "flavor": "\"Deep inside the Sokenzan Mountains, a band of akki discovered a cache of ancient items of power. Their ensuing spree of destruction became known as 'The Three Days of Fun.'\"\n—Observations of the Kami War",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -16639,19 +16639,19 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         },
         {
           "date": "2013-06-07",
-          "text": "Desperate Ritual isn’t a mana ability. When cast, it (or the spell it’s spliced onto) goes on the stack like any spell and can be responded to."
+          "text": "Desperate Ritual isn't a mana ability. When cast, it (or the spell it's spliced onto) goes on the stack like any spell and can be responded to."
         }
       ],
       "subtypes": [
@@ -17134,15 +17134,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -17241,7 +17241,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Unlike other effects that grant additional combat phases, you don’t get an additional main phase with Godo, Bandit Warlord. The additional combat phase happens immediately after the first combat phase."
+          "text": "Unlike other effects that grant additional combat phases, you don't get an additional main phase with Godo, Bandit Warlord. The additional combat phase happens immediately after the first combat phase."
         }
       ],
       "subtypes": [
@@ -17555,37 +17555,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Initiate of Blood",
+          "name": "邪道刚火",
           "multiverseid": 85283
         },
         {
           "language": "French",
-          "name": "Initiate of Blood",
+          "name": "Goka l'injuste",
           "multiverseid": 85590
         },
         {
           "language": "German",
-          "name": "Initiate of Blood",
+          "name": "Goka der Ungerechte",
           "multiverseid": 85897
         },
         {
           "language": "Italian",
-          "name": "Initiate of Blood",
+          "name": "Goka l'Iniquo",
           "multiverseid": 86204
         },
         {
           "language": "Japanese",
-          "name": "Initiate of Blood",
+          "name": "無法者の剛火",
           "multiverseid": 86511
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Initiate of Blood",
+          "name": "Goka, o Injusto",
           "multiverseid": 86818
         },
         {
           "language": "Spanish",
-          "name": "Initiate of Blood",
+          "name": "Goka el injusto",
           "multiverseid": 87125
         }
       ],
@@ -17653,37 +17653,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Initiate of Blood",
+          "name": "邪道刚火",
           "multiverseid": 85283
         },
         {
           "language": "French",
-          "name": "Initiate of Blood",
+          "name": "Goka l'injuste",
           "multiverseid": 85590
         },
         {
           "language": "German",
-          "name": "Initiate of Blood",
+          "name": "Goka der Ungerechte",
           "multiverseid": 85897
         },
         {
           "language": "Italian",
-          "name": "Initiate of Blood",
+          "name": "Goka l'Iniquo",
           "multiverseid": 86204
         },
         {
           "language": "Japanese",
-          "name": "Initiate of Blood",
+          "name": "無法者の剛火",
           "multiverseid": 86511
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Initiate of Blood",
+          "name": "Goka, o Injusto",
           "multiverseid": 86818
         },
         {
           "language": "Spanish",
-          "name": "Initiate of Blood",
+          "name": "Goka el injusto",
           "multiverseid": 87125
         }
       ],
@@ -17925,11 +17925,11 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "As the token is created, it checks the printed values of the creature it’s copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "As the token is created, it checks the printed values of the creature it's copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, or so on."
         },
         {
           "date": "2013-06-07",
-          "text": "Haste is part of the token’s copiable values. Copies of that token will also have haste."
+          "text": "Haste is part of the token's copiable values. Copies of that token will also have haste."
         }
       ],
       "subtypes": [
@@ -18036,7 +18036,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If a creature dealt damage by Kumano this turn would be put into a graveyard, exile it, even if it’s going to the graveyard at the same time as Kumano."
+          "text": "If a creature dealt damage by Kumano this turn would be put into a graveyard, exile it, even if it's going to the graveyard at the same time as Kumano."
         }
       ],
       "subtypes": [
@@ -18140,11 +18140,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If a creature dealt damage by Kumano’s Pupils this turn would be put into a graveyard, exile it instead, even if it’s going to the graveyard at the same time as Kumano’s Pupils."
+          "text": "If a creature dealt damage by Kumano's Pupils this turn would be put into a graveyard, exile it instead, even if it's going to the graveyard at the same time as Kumano's Pupils."
         },
         {
           "date": "2004-12-01",
-          "text": "Kumano’s Pupils must be on the battlefield when the creature would be put into a graveyard in order to exile it."
+          "text": "Kumano's Pupils must be on the battlefield when the creature would be put into a graveyard in order to exile it."
         }
       ],
       "subtypes": [
@@ -19000,7 +19000,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You sacrifice the permanents before Shimatsu enters the battlefield, so you can’t sacrifice any creatures that enter the battlefield at the same time it does."
+          "text": "You sacrifice the permanents before Shimatsu enters the battlefield, so you can't sacrifice any creatures that enter the battlefield at the same time it does."
         }
       ],
       "subtypes": [
@@ -19600,7 +19600,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         },
         {
           "date": "2013-06-07",
@@ -19608,15 +19608,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -19707,7 +19707,8 @@
       "originalText": "Put a creature card from your hand into play. That creature has haste. Sacrifice that creature at end of turn.\nSplice onto Arcane {2}{R}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
       "originalType": "Instant — Arcane",
       "printings": [
-        "CHK"
+        "CHK",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -19721,15 +19722,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -19826,11 +19827,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Tide of War’s ability triggers only once each combat and only if at least one blocker is declared. The effect does nothing to unblocked attacking creatures."
+          "text": "Tide of War's ability triggers only once each combat and only if at least one blocker is declared. The effect does nothing to unblocked attacking creatures."
         },
         {
           "date": "2004-12-01",
-          "text": "Tide of War’s controller always flips the coin. This means that you want to win the flip when you’re attacking but lose the flip when you’re defending."
+          "text": "Tide of War's controller always flips the coin. This means that you want to win the flip when you're attacking but lose the flip when you're defending."
         },
         {
           "date": "2004-12-01",
@@ -20584,11 +20585,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Budoka Gardener flips if you control ten or more lands when its ability resolves, even if you don’t use its ability to put a land onto the battlefield."
+          "text": "Budoka Gardener flips if you control ten or more lands when its ability resolves, even if you don't use its ability to put a land onto the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Budoka Gardener flips even if you put a second copy of a legendary land onto the battlefield. You’ll have ten lands on the battlefield while the ability is resolving, so the Gardener flips. Then you will choose one of the legendary lands to keep and put the other into its owner’s graveyard as a state-based action."
+          "text": "Budoka Gardener flips even if you put a second copy of a legendary land onto the battlefield. You'll have ten lands on the battlefield while the ability is resolving, so the Gardener flips. Then you will choose one of the legendary lands to keep and put the other into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -20883,7 +20884,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If you don’t reveal a creature card, put all the revealed cards on the bottom of your library in any order."
+          "text": "If you don't reveal a creature card, put all the revealed cards on the bottom of your library in any order."
         }
       ],
       "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
@@ -20979,7 +20980,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Dosan’s ability only stops players from casting spells. It doesn’t stop activated or triggered abilities."
+          "text": "Dosan's ability only stops players from casting spells. It doesn't stop activated or triggered abilities."
         }
       ],
       "subtypes": [
@@ -21916,11 +21917,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The targets of Iname, Life Aspect’s ability are chosen when the ability is put onto the stack, but you don’t choose whether to exile Iname, Life Aspect until the ability resolves."
+          "text": "The targets of Iname, Life Aspect's ability are chosen when the ability is put onto the stack, but you don't choose whether to exile Iname, Life Aspect until the ability resolves."
         },
         {
           "date": "2004-12-01",
-          "text": "You may target Iname, Life Aspect. However, this doesn’t do anything since the card will no longer be in your graveyard when the creature cards are returned to your hand."
+          "text": "You may target Iname, Life Aspect. However, this doesn't do anything since the card will no longer be in your graveyard when the creature cards are returned to your hand."
         },
         {
           "date": "2004-12-01",
@@ -21928,7 +21929,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "In a Commander game, you may send Iname to the Command Zone instead of exiling it during the resolution of its ability. If you do, its ability still works. Iname’s ability only requires that you attempted to exile it, not that it actually gets to the exile zone. This is similar to how destroying a creature (with, for example, Rest in Peace) doesn’t necessarily ensure that creature will end up in the graveyard; it just so happens that the action of exiling something and the exile zone both use the same word: “exile”."
+          "text": "In a Commander game, you may send Iname to the Command Zone instead of exiling it during the resolution of its ability. If you do, its ability still works. Iname's ability only requires that you attempted to exile it, not that it actually gets to the exile zone. This is similar to how destroying a creature (with, for example, Rest in Peace) doesn't necessarily ensure that creature will end up in the graveyard; it just so happens that the action of exiling something and the exile zone both use the same word: \"exile\"."
         }
       ],
       "subtypes": [
@@ -22123,7 +22124,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You announce the target creatures and how you’re distributing the +1/+1 counters as you put the triggered ability on the stack. If one of the target creatures becomes illegal, you can’t change how the counters will be distributed."
+          "text": "You announce the target creatures and how you're distributing the +1/+1 counters as you put the triggered ability on the stack. If one of the target creatures becomes illegal, you can't change how the counters will be distributed."
         }
       ],
       "subtypes": [
@@ -22801,15 +22802,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -23832,7 +23833,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"Only orochi hatched from eggs ‘touched by the kami' may become shamans. These days, there are fewer and fewer new shamans being born.\"",
+      "flavor": "\"Only orochi hatched from eggs 'touched by the kami' may become shamans. These days, there are fewer and fewer new shamans being born.\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -24776,7 +24777,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -25435,15 +25436,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -25954,7 +25955,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Whenever you cast a Spirit or Arcane spell, Jade Idol becomes a 4/4 Spirit artifact creature until end of turn.",
@@ -26208,7 +26209,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "A creature can’t get more than +2/+2 from Konda’s Banner. Sharing more than one color or more than one creature type with the equipped creature does nothing."
+          "text": "A creature can't get more than +2/+2 from Konda's Banner. Sharing more than one color or more than one creature type with the equipped creature does nothing."
         },
         {
           "date": "2004-12-01",
@@ -26216,7 +26217,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The equipped creature shares a creature type with itself, as long as it has one or more creature types. “Artifact” is not a creature type."
+          "text": "The equipped creature shares a creature type with itself, as long as it has one or more creature types. \"Artifact\" is not a creature type."
         }
       ],
       "subtypes": [
@@ -26485,11 +26486,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Note that Moonring Mirror’s first ability is not a replacement effect."
+          "text": "Note that Moonring Mirror's first ability is not a replacement effect."
         },
         {
           "date": "2004-12-01",
-          "text": "If you choose to use Moonring Mirror’s second ability, you return all the cards you own exiled by both of its abilities, but not any of the cards you just exiled from your hand."
+          "text": "If you choose to use Moonring Mirror's second ability, you return all the cards you own exiled by both of its abilities, but not any of the cards you just exiled from your hand."
         }
       ],
       "text": "Whenever you draw a card, exile the top card of your library face down.\nAt the beginning of your upkeep, you may exile all cards from your hand face down. If you do, put all other cards you own exiled with Moonring Mirror into your hand.",
@@ -26578,7 +26579,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The damaged creature will be exiled even if Nine-Ringed Bo isn’t on the battlefield when that creature would be put into a graveyard."
+          "text": "The damaged creature will be exiled even if Nine-Ringed Bo isn't on the battlefield when that creature would be put into a graveyard."
         }
       ],
       "text": "{T}: Nine-Ringed Bo deals 1 damage to target Spirit creature. If that creature would die this turn, exile it instead.",
@@ -26752,7 +26753,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Oathkeeper’s second ability checks whether the card’s creature type is Samurai, not whether the creature was a Samurai when it left the battlefield."
+          "text": "Oathkeeper's second ability checks whether the card's creature type is Samurai, not whether the creature was a Samurai when it left the battlefield."
         }
       ],
       "subtypes": [
@@ -26988,7 +26989,7 @@
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
+          "legality": "Banned"
         },
         {
           "format": "Modern",
@@ -27015,11 +27016,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sensei’s Divining Top’s second ability may be activated in response to its first ability. If so, you’ll draw a card, put Sensei’s Divining Top on top of your library, and then look at the top three cards and rearrange them."
+          "text": "Sensei's Divining Top's second ability may be activated in response to its first ability. If so, you'll draw a card, put Sensei's Divining Top on top of your library, and then look at the top three cards and rearrange them."
         },
         {
           "date": "2016-06-08",
-          "text": "If Sensei’s Divining Top leaves the battlefield while its second ability is on the stack, you’ll draw a card and leave Sensei’s Divining Top in the zone it’s moved to."
+          "text": "If Sensei's Divining Top leaves the battlefield while its second ability is on the stack, you'll draw a card and leave Sensei's Divining Top in the zone it's moved to."
         }
       ],
       "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
@@ -27107,11 +27108,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Shell of the Last Kappa’s first ability can only target a spell that targets you."
+          "text": "Shell of the Last Kappa's first ability can only target a spell that targets you."
         },
         {
           "date": "2004-12-01",
-          "text": "Exiling a spell prevents that spell from resolving, but it doesn’t technically “counter” anything. This means that Shell of the Last Kappa can exile spells which “can’t be countered.”"
+          "text": "Exiling a spell prevents that spell from resolving, but it doesn't technically \"counter\" anything. This means that Shell of the Last Kappa can exile spells which \"can't be countered.\""
         }
       ],
       "supertypes": [
@@ -27378,11 +27379,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You can’t play cards you exiled with Uba Mask on previous turns."
+          "text": "You can't play cards you exiled with Uba Mask on previous turns."
         },
         {
           "date": "2004-12-01",
-          "text": "Any cards you don’t play just remain exiled when the turn ends."
+          "text": "Any cards you don't play just remain exiled when the turn ends."
         }
       ],
       "text": "If a player would draw a card, that player exiles that card face up instead.\nEach player may play cards he or she exiled with Uba Mask this turn.",
@@ -27469,11 +27470,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The spell can’t be countered if the mana produced by Boseiju is spent to cover any cost of the spell, even an additional cost such as a splice cost. This is true even if you pay an additional cost while casting a spell “without paying its mana cost.”"
+          "text": "The spell can't be countered if the mana produced by Boseiju is spent to cover any cost of the spell, even an additional cost such as a splice cost. This is true even if you pay an additional cost while casting a spell \"without paying its mana cost.\""
         },
         {
           "date": "2004-12-01",
-          "text": "Suppose mana produced by Boseiju is spent on a spell and an effect creates a copy of that spell. The copy can be countered, even though the original can’t."
+          "text": "Suppose mana produced by Boseiju is spent on a spell and an effect creates a copy of that spell. The copy can be countered, even though the original can't."
         }
       ],
       "supertypes": [
@@ -27820,7 +27821,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The effect that grants haste doesn’t wear off at end of turn."
+          "text": "The effect that grants haste doesn't wear off at end of turn."
         }
       ],
       "supertypes": [

--- a/json/CHR.json
+++ b/json/CHR.json
@@ -214,7 +214,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Aladdin’s ability can take control of more than one artifact, although only one each time the ability is used."
+          "text": "Aladdin's ability can take control of more than one artifact, although only one each time the ability is used."
         },
         {
           "date": "2008-08-01",
@@ -328,7 +328,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As long as Arcades Sabboth is untapped and isn’t attacking, it’ll get +0/+2 from its own third ability."
+          "text": "As long as Arcades Sabboth is untapped and isn't attacking, it'll get +0/+2 from its own third ability."
         }
       ],
       "subtypes": [
@@ -511,7 +511,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "It’s the ability, not the counter that makes the creature an artifact. The creature remains an artifact even if the +1/+1 counter is removed."
+          "text": "It's the ability, not the counter that makes the creature an artifact. The creature remains an artifact even if the +1/+1 counter is removed."
         }
       ],
       "text": "{T}, Sacrifice Ashnod's Transmogrant: Put a +1/+1 counter on target nonartifact creature. That creature becomes an artifact in addition to its other types.",
@@ -564,15 +564,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Each time a creature is put into a graveyard from play, check whether Axelrod Gunnarson had dealt any damage to it at any time during that turn. (This includes combat damage.) If so, Axelrod Gunnarson’s second ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from play, check whether Axelrod Gunnarson had dealt any damage to it at any time during that turn. (This includes combat damage.) If so, Axelrod Gunnarson's second ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2009-10-01",
-          "text": "If Axelrod Gunnarson and a creature it dealt damage to are both put into a graveyard at the same time, Axelrod Gunnarson’s second ability will trigger."
+          "text": "If Axelrod Gunnarson and a creature it dealt damage to are both put into a graveyard at the same time, Axelrod Gunnarson's second ability will trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "The player you target with Axelrod Gunnarson’s ability doesn’t have to be the player that controlled the creature that was put into a graveyard."
+          "text": "The player you target with Axelrod Gunnarson's ability doesn't have to be the player that controlled the creature that was put into a graveyard."
         }
       ],
       "subtypes": [
@@ -631,7 +631,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -647,7 +647,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -764,7 +764,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Banshee’s ability resolves, the ability is countered. You won’t be dealt damage."
+          "text": "If the targeted creature or player is an illegal target by the time Banshee's ability resolves, the ability is countered. You won't be dealt damage."
         }
       ],
       "subtypes": [
@@ -814,19 +814,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Does not prevent a creature from untapping at other times. It just stops the “normal” untap during the untap step."
+          "text": "Does not prevent a creature from untapping at other times. It just stops the \"normal\" untap during the untap step."
         },
         {
           "date": "2009-10-01",
-          "text": "You may target any creature with this ability. It doesn’t have to be tapped."
+          "text": "You may target any creature with this ability. It doesn't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when the targeted creature is tapped."
+          "text": "If the targeted creature is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when the targeted creature is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Barl’s Cage doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Barl's Cage doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "text": "{3}: Target creature doesn't untap during its controller's next untap step.",
@@ -927,25 +927,26 @@
         "8ED",
         "9ED",
         "MMA",
-        "MM3"
+        "MM3",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability “{T}: Add {R} to your mana pool.”"
+          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability \"{T}: Add {R} to your mana pool.\""
         },
         {
           "date": "2017-03-14",
-          "text": "Blood Moon’s effect doesn’t affect names or supertypes. It won’t turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won’t be named “Mountain.”"
+          "text": "Blood Moon's effect doesn't affect names or supertypes. It won't turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won't be named \"Mountain.\""
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply “as” a land enters the battlefield, such as the first ability of Cavern of Souls."
+          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply \"as\" a land enters the battlefield, such as the first ability of Cavern of Souls."
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that triggers “when” it enters the battlefield, it will lose that ability before it triggers."
+          "text": "If a nonbasic land has an ability that triggers \"when\" it enters the battlefield, it will lose that ability before it triggers."
         }
       ],
       "text": "Nonbasic lands are Mountains.",
@@ -1084,7 +1085,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t spend yourself to below zero life. You can’t spend life you don’t have."
+          "text": "You can't spend yourself to below zero life. You can't spend life you don't have."
         }
       ],
       "text": "{2}, Pay 2 life: Draw a card.",
@@ -1356,7 +1357,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass’s triggered ability is put on the stack on top of it. City of Brass’s ability will resolve first."
+          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass's triggered ability is put on the stack on top of it. City of Brass's ability will resolve first."
         },
         {
           "date": "2004-10-04",
@@ -1470,7 +1471,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
@@ -1588,7 +1589,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different opposing player each time it is used. You also don’t have to choose the same player that you targeted with the effect (or whose creature you targeted)."
+          "text": "In multiplayer games you can choose a different opposing player each time it is used. You also don't have to choose the same player that you targeted with the effect (or whose creature you targeted)."
         },
         {
           "date": "2004-10-04",
@@ -1831,7 +1832,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Dance of Many leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and put a token onto the battlefield. That token won’t have any connection to a Dance of Many permanent, so it won’t be exiled when a Dance of Many leaves the battlefield."
+          "text": "If Dance of Many leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and put a token onto the battlefield. That token won't have any connection to a Dance of Many permanent, so it won't be exiled when a Dance of Many leaves the battlefield."
         }
       ],
       "text": "When Dance of Many enters the battlefield, create a token that's a copy of target nontoken creature.\nWhen Dance of Many leaves the battlefield, exile the token.\nWhen the token leaves the battlefield, sacrifice Dance of Many.\nAt the beginning of your upkeep, sacrifice Dance of Many unless you pay {U}{U}.",
@@ -1959,7 +1960,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you’ll still gain the life."
+          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you'll still gain the life."
         }
       ],
       "text": "Destroy target artifact. You gain life equal to its converted mana cost.",
@@ -2062,7 +2063,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "If you change this card’s target, you can change which Aura is targeted, but you can’t choose where that Aura will be moved."
+          "text": "If you change this card's target, you can change which Aura is targeted, but you can't choose where that Aura will be moved."
         },
         {
           "date": "2005-08-01",
@@ -2124,7 +2125,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different player’s creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
+          "text": "In multiplayer games you can choose a different player's creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
         },
         {
           "date": "2004-10-04",
@@ -2548,11 +2549,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As you activate the ability, the targets you choose must be two artifacts, two creatures, or two lands. As the ability resolves, both targets will be legal only if they are two artifacts, two creatures, or two lands at that time as well, though they may be a different type than they were at the time the ability was activated. For example, if the targets were a creature and an artifact creature when the ability was activated, but the first target became a noncreature artifact by the time the ability resolves, both targets will still be legal (since they’re both artifacts)."
+          "text": "As you activate the ability, the targets you choose must be two artifacts, two creatures, or two lands. As the ability resolves, both targets will be legal only if they are two artifacts, two creatures, or two lands at that time as well, though they may be a different type than they were at the time the ability was activated. For example, if the targets were a creature and an artifact creature when the ability was activated, but the first target became a noncreature artifact by the time the ability resolves, both targets will still be legal (since they're both artifacts)."
         },
         {
           "date": "2009-10-01",
-          "text": "If one of the targets is illegal by the time the ability resolves (because the wrong player controls it, or it’s the wrong card type, or for any other reason), the exchange doesn’t happen. The target that’s still legal will remain under its controller’s control. Since the exchange doesn’t happen, no Auras are destroyed. (If both targets are illegal, the ability is countered.)"
+          "text": "If one of the targets is illegal by the time the ability resolves (because the wrong player controls it, or it's the wrong card type, or for any other reason), the exchange doesn't happen. The target that's still legal will remain under its controller's control. Since the exchange doesn't happen, no Auras are destroyed. (If both targets are illegal, the ability is countered.)"
         }
       ],
       "text": "{5}, Sacrifice Gauntlets of Chaos: Exchange control of target artifact, creature, or land you control and target permanent an opponent controls that shares one of those types with it. If those permanents are exchanged this way, destroy all Auras attached to them.",
@@ -2652,7 +2653,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the Slug changes controllers after the mana is spent, the player who activates this ability selects a landwalk during their next upkeep even if they don’t control it at the time."
+          "text": "If the Slug changes controllers after the mana is spent, the player who activates this ability selects a landwalk during their next upkeep even if they don't control it at the time."
         },
         {
           "date": "2004-10-04",
@@ -2813,7 +2814,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Works even if placed on one of your opponent’s Mountains."
+          "text": "Works even if placed on one of your opponent's Mountains."
         }
       ],
       "subtypes": [
@@ -2989,7 +2990,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -3082,7 +3083,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Despite the name, this card only prevents damage and not destroy effects. It’s also not an Aura."
+          "text": "Despite the name, this card only prevents damage and not destroy effects. It's also not an Aura."
         }
       ],
       "text": "Prevent all damage that would be dealt to target creature this turn.",
@@ -3342,7 +3343,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "First creatures are exchanged, then artifacts are exchanged. It’s possible that the same artifact creature may be involved in both exchanges."
+          "text": "First creatures are exchanged, then artifacts are exchanged. It's possible that the same artifact creature may be involved in both exchanges."
         },
         {
           "date": "2007-09-16",
@@ -3350,7 +3351,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If one of the players doesn’t control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn’t control an artifact at the time the exchange would be made, that part of the effect does nothing."
+          "text": "If one of the players doesn't control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn't control an artifact at the time the exchange would be made, that part of the effect does nothing."
         }
       ],
       "text": "You and target player exchange control of the creature you each control with the highest converted mana cost. Then exchange control of artifacts the same way. If two or more permanents a player controls are tied for highest cost, their controller chooses one of them.",
@@ -3502,11 +3503,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The damage done when you discard a land only applies to lands which are discarded by choice using the Land’s Edge ability. It does not work on forced discards of any type."
+          "text": "The damage done when you discard a land only applies to lands which are discarded by choice using the Land's Edge ability. It does not work on forced discards of any type."
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -3763,11 +3764,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t name a card until the ability resolves. Once you name a card, it’s too late for the targeted opponent to respond."
+          "text": "You don't name a card until the ability resolves. Once you name a card, it's too late for the targeted opponent to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "You may activate the ability only during your turn, but you may do so any time you have priority. (In other words, it’s not restricted to only the times you could cast a sorcery.)"
+          "text": "You may activate the ability only during your turn, but you may do so any time you have priority. (In other words, it's not restricted to only the times you could cast a sorcery.)"
         }
       ],
       "subtypes": [
@@ -3840,7 +3841,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Nicol Bolas’s third ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Nicol Bolas's third ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -3996,7 +3997,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the targeted player’s library is empty, that player still names a card, but nothing further happens. That player will not lose the game."
+          "text": "If the targeted player's library is empty, that player still names a card, but nothing further happens. That player will not lose the game."
         }
       ],
       "subtypes": [
@@ -4104,7 +4105,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You only get the opportunity to pay {U}{U}{U} (and thus to return Puppet Master to its owner’s hand) if the creature card actually gets returned to its owner’s hand. If it isn’t (for instance, if it was removed from the graveyard prior to this ability resolving), you don’t get the option to pay."
+          "text": "You only get the opportunity to pay {U}{U}{U} (and thus to return Puppet Master to its owner's hand) if the creature card actually gets returned to its owner's hand. If it isn't (for instance, if it was removed from the graveyard prior to this ability resolving), you don't get the option to pay."
         }
       ],
       "subtypes": [
@@ -4268,11 +4269,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t discard cards until Recall resolves. If you don’t have X cards in your hand at that time, you discard all the cards in your hand."
+          "text": "You don't discard cards until Recall resolves. If you don't have X cards in your hand at that time, you discard all the cards in your hand."
         },
         {
           "date": "2009-10-01",
-          "text": "You don’t choose which cards in your graveyard you’ll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
+          "text": "You don't choose which cards in your graveyard you'll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
         }
       ],
       "text": "Discard X cards, then return a card from your graveyard to your hand for each card discarded this way. Exile Recall.",
@@ -4335,7 +4336,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -4435,7 +4436,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -4499,11 +4500,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won’t gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
+          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won't gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the targeted permanent remains a legal target for the ability, only that it’s on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
+          "text": "Once the ability resolves, it doesn't care whether the targeted permanent remains a legal target for the ability, only that it's on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
         }
       ],
       "subtypes": [
@@ -4605,11 +4606,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If changed to another land type, the creature cards are not lost but can’t be released until the land reverts to normal."
+          "text": "If changed to another land type, the creature cards are not lost but can't be released until the land reverts to normal."
         },
         {
           "date": "2004-10-04",
-          "text": "When the creature leaves the battlefield any damage or “will be destroyed at some future time” effects are removed from the creature."
+          "text": "When the creature leaves the battlefield any damage or \"will be destroyed at some future time\" effects are removed from the creature."
         },
         {
           "date": "2004-10-04",
@@ -4722,7 +4723,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -4862,7 +4863,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can redirect damage from combat and from abilities, but the creature must be attacking before you can use this card’s ability."
+          "text": "Can redirect damage from combat and from abilities, but the creature must be attacking before you can use this card's ability."
         }
       ],
       "subtypes": [
@@ -5042,11 +5043,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Stangg’s delayed triggered abilities track only the token created by that particular Stangg."
+          "text": "Stangg's delayed triggered abilities track only the token created by that particular Stangg."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stangg leaves the battlefield before its ability has resolved, that ability will still create a Stangg Twin token, but its delayed triggered abilities will never have a chance to trigger. That token will remain on the battlefield indefinitely (until it’s dealt lethal damage, or anything else causes it to leave the battlefield)."
+          "text": "If Stangg leaves the battlefield before its ability has resolved, that ability will still create a Stangg Twin token, but its delayed triggered abilities will never have a chance to trigger. That token will remain on the battlefield indefinitely (until it's dealt lethal damage, or anything else causes it to leave the battlefield)."
         }
       ],
       "subtypes": [
@@ -5148,19 +5149,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the creature leaves the battlefield without going to the graveyard, Takklemaggot is simply put into its owner’s graveyard."
+          "text": "If the creature leaves the battlefield without going to the graveyard, Takklemaggot is simply put into its owner's graveyard."
         },
         {
           "date": "2008-05-01",
-          "text": "Takklemaggot’s controller no longer changes as it returns to the battlefield. The player who controlled it when it left the battlefield is the same player that controls it when it returns to the battlefield, even though a different player may be choosing what it will be attached to after returning onto the battlefield."
+          "text": "Takklemaggot's controller no longer changes as it returns to the battlefield. The player who controlled it when it left the battlefield is the same player that controls it when it returns to the battlefield, even though a different player may be choosing what it will be attached to after returning onto the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "When the enchanted creature is put into a graveyard, Takklemaggot’s second ability triggers, then Takklemaggot is put into its owner’s graveyard as a state-based action. When the ability resolves, if Takklemaggot is still in that graveyard, it’s returned to the battlefield."
+          "text": "When the enchanted creature is put into a graveyard, Takklemaggot's second ability triggers, then Takklemaggot is put into its owner's graveyard as a state-based action. When the ability resolves, if Takklemaggot is still in that graveyard, it's returned to the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "The player who controlled the creature that went to the graveyard (and caused Takklemaggot’s second ability to trigger) chooses what creature Takklemaggot will return to the battlefield attached to. The creature isn’t chosen until the ability resolves, so no player can respond between the time the creature is chosen and the time Takklemaggot returns to the battlefield attached to it. The ability doesn’t target a creature, so a creature with shroud, for example, can be chosen. However, only a creature that can be legally enchanted by Takklemaggot can be chosen, so a creature with protection from black, for example, can’t be chosen. If the player can choose a creature, he or she must do so, no matter who controls it. If the player can’t choose a creature, Takklemaggot returns to the battlefield as a non-Aura enchantment, and that player is the player that Takklemaggot will deal damage to."
+          "text": "The player who controlled the creature that went to the graveyard (and caused Takklemaggot's second ability to trigger) chooses what creature Takklemaggot will return to the battlefield attached to. The creature isn't chosen until the ability resolves, so no player can respond between the time the creature is chosen and the time Takklemaggot returns to the battlefield attached to it. The ability doesn't target a creature, so a creature with shroud, for example, can be chosen. However, only a creature that can be legally enchanted by Takklemaggot can be chosen, so a creature with protection from black, for example, can't be chosen. If the player can choose a creature, he or she must do so, no matter who controls it. If the player can't choose a creature, Takklemaggot returns to the battlefield as a non-Aura enchantment, and that player is the player that Takklemaggot will deal damage to."
         }
       ],
       "subtypes": [
@@ -5266,11 +5267,11 @@
         },
         {
           "date": "2007-09-16",
-          "text": "The Fallen’s ability causes it to deal damage only to opponents of its current controller. If The Fallen has dealt damage to you, and then you gain control of it, you won’t be damaged during your upkeep."
+          "text": "The Fallen's ability causes it to deal damage only to opponents of its current controller. If The Fallen has dealt damage to you, and then you gain control of it, you won't be damaged during your upkeep."
         },
         {
           "date": "2007-09-16",
-          "text": "The effect isn’t cumulative. When it resolves, The Fallen deals 1 damage to each opponent previously dealt damage by it, regardless of how many times The Fallen dealt damage to that opponent before."
+          "text": "The effect isn't cumulative. When it resolves, The Fallen deals 1 damage to each opponent previously dealt damage by it, regardless of how many times The Fallen dealt damage to that opponent before."
         }
       ],
       "subtypes": [
@@ -5330,15 +5331,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Any blocking creatures that regenerated during combat will have been removed from combat. Since such creatures are no longer in combat, they cannot be blocking The Wretched, which means you won’t be able to gain control of them."
+          "text": "Any blocking creatures that regenerated during combat will have been removed from combat. Since such creatures are no longer in combat, they cannot be blocking The Wretched, which means you won't be able to gain control of them."
         },
         {
           "date": "2009-05-01",
-          "text": "If The Wretched itself regenerated during combat, then it will have been removed from combat. Since it is no longer in combat, there cannot be any creatures blocking it, which means you won’t be able to gain control of any creatures."
+          "text": "If The Wretched itself regenerated during combat, then it will have been removed from combat. Since it is no longer in combat, there cannot be any creatures blocking it, which means you won't be able to gain control of any creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "The Wretched’s ability triggers only if it’s still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it’s blocked by a 7/7 creature and is destroyed, its ability won’t trigger at all."
+          "text": "The Wretched's ability triggers only if it's still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it's blocked by a 7/7 creature and is destroyed, its ability won't trigger at all."
         },
         {
           "date": "2009-10-01",
@@ -5346,11 +5347,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you lose control of The Wretched before its ability resolves, you won’t gain control of the creatures blocking it at all."
+          "text": "If you lose control of The Wretched before its ability resolves, you won't gain control of the creatures blocking it at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the permanents you gained control of remain creatures, only that they remain on the battlefield."
+          "text": "Once the ability resolves, it doesn't care whether the permanents you gained control of remain creatures, only that they remain on the battlefield."
         }
       ],
       "subtypes": [
@@ -5564,7 +5565,7 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Note that the wording “Effects that alter the creature’s power alter its toughness instead, and vice versa, this turn” has been removed."
+          "text": "Note that the wording \"Effects that alter the creature's power alter its toughness instead, and vice versa, this turn\" has been removed."
         },
         {
           "date": "2013-04-15",
@@ -5572,7 +5573,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "text": "Switch target creature's power and toughness until end of turn.",
@@ -5620,7 +5621,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "{3}, {T}: Put a hatchling counter on Triassic Egg.\nSacrifice Triassic Egg: Choose one —\n• You may put a creature card from your hand onto the battlefield. Activate this ability only if two or more hatchling counters are on Triassic Egg.\n• Return target creature card from your graveyard to the battlefield. Activate this ability only if two or more hatchling counters are on Triassic Egg.",
@@ -5669,7 +5670,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -5727,7 +5728,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -5785,7 +5786,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -5843,7 +5844,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -5901,7 +5902,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -5959,7 +5960,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -6017,7 +6018,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -6075,7 +6076,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -6393,15 +6394,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Voodoo Doll’s second ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless Voodoo Doll is untapped, and (2) the ability will do nothing if Voodoo Doll is tapped by the time it resolves. If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see if it was tapped or untapped."
+          "text": "Voodoo Doll's second ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless Voodoo Doll is untapped, and (2) the ability will do nothing if Voodoo Doll is tapped by the time it resolves. If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see if it was tapped or untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Each X in the cost of Voodoo Doll’s third ability is the number of pin counters on Voodoo Doll at the time you activate the ability. The X in the ability’s effect is the number of pin counters on Voodoo Doll at the time it resolves, which may not be the same number (if a spell or ability put counters on it or removed counters from it in the meantime). If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see how many pin counters were on it."
+          "text": "Each X in the cost of Voodoo Doll's third ability is the number of pin counters on Voodoo Doll at the time you activate the ability. The X in the ability's effect is the number of pin counters on Voodoo Doll at the time it resolves, which may not be the same number (if a spell or ability put counters on it or removed counters from it in the meantime). If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see how many pin counters were on it."
         },
         {
           "date": "2011-01-01",
-          "text": "Voodoo Doll’s second ability causes it to be destroyed regardless of whether it actually deals damage to you or not. Voodoo Doll is destroyed even if all the damage is prevented or redirected."
+          "text": "Voodoo Doll's second ability causes it to be destroyed regardless of whether it actually deals damage to you or not. Voodoo Doll is destroyed even if all the damage is prevented or redirected."
         }
       ],
       "text": "At the beginning of your upkeep, put a pin counter on Voodoo Doll.\nAt the beginning of your end step, if Voodoo Doll is untapped, destroy Voodoo Doll and it deals damage to you equal to the number of pin counters on it.\n{X}{X}, {T}: Voodoo Doll deals damage equal to the number of pin counters on it to target creature or player. X is the number of pin counters on Voodoo Doll.",
@@ -6549,7 +6550,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can be targeted by a modal spell that can target a non-Wall in one of its modes, even if it has a mode that targets only Walls. That spell can, in theory, target a non-Wall, so it is not a “spell that can target only Walls”."
+          "text": "Can be targeted by a modal spell that can target a non-Wall in one of its modes, even if it has a mode that targets only Walls. That spell can, in theory, target a non-Wall, so it is not a \"spell that can target only Walls\"."
         }
       ],
       "subtypes": [
@@ -6709,7 +6710,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",

--- a/json/CM1.json
+++ b/json/CM1.json
@@ -36,7 +36,6 @@
         }
       ],
       "manaCost": "{2}{R}",
-      "mciNumber": "1",
       "multiverseid": 338441,
       "name": "Chaos Warp",
       "number": "1",
@@ -53,7 +52,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player’s library this way, that player shuffles before revealing the top card of that library."
+          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player's library this way, that player shuffles before revealing the top card of that library."
         },
         {
           "date": "2011-09-22",
@@ -65,7 +64,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the revealed card is a permanent card but can’t enter the battlefield (perhaps because it’s an Aura with nothing to enchant), it remains on top of that library."
+          "text": "If the revealed card is a permanent card but can't enter the battlefield (perhaps because it's an Aura with nothing to enchant), it remains on top of that library."
         },
         {
           "date": "2011-09-22",
@@ -98,7 +97,7 @@
           "legality": "Legal"
         }
       ],
-      "mciNumber": "2",
+      "mciNumber": "245",
       "multiverseid": 338442,
       "name": "Command Tower",
       "number": "2",
@@ -117,15 +116,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander's color."
         },
         {
           "date": "2011-09-22",
-          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower’s ability produces no mana."
+          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower's ability produces no mana."
         },
         {
           "date": "2011-09-22",
-          "text": "In formats other than Commander, Command Tower’s ability produces no mana."
+          "text": "In formats other than Commander, Command Tower's ability produces no mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color in your commander's color identity.",
@@ -165,7 +164,6 @@
         }
       ],
       "manaCost": "{6}{B}{B}",
-      "mciNumber": "3",
       "multiverseid": 338453,
       "name": "Decree of Pain",
       "number": "3",
@@ -188,7 +186,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way.\nCycling {3}{B}{B} ({3}{B}{B}, Discard this card: Draw a card.)\nWhen you cycle Decree of Pain, all creatures get -2/-2 until end of turn.",
@@ -229,7 +227,6 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
-      "mciNumber": "4",
       "multiverseid": 338454,
       "name": "Desertion",
       "number": "4",
@@ -245,7 +242,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The card is put onto the battlefield, but any effects that check if the original card was “cast from your hand” will not trigger or otherwise consider the card to have been cast from your hand. The card was put onto the battlefield by the effect of Desertion instead."
+          "text": "The card is put onto the battlefield, but any effects that check if the original card was \"cast from your hand\" will not trigger or otherwise consider the card to have been cast from your hand. The card was put onto the battlefield by the effect of Desertion instead."
         },
         {
           "date": "2004-10-04",
@@ -253,7 +250,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then this card’s ability does not put the card onto the battlefield. The spell continues to resolve as normal."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then this card's ability does not put the card onto the battlefield. The spell continues to resolve as normal."
         }
       ],
       "text": "Counter target spell. If an artifact or creature spell is countered this way, put that card onto the battlefield under your control instead of into its owner's graveyard.",
@@ -289,7 +286,6 @@
         }
       ],
       "manaCost": "{3}{R}",
-      "mciNumber": "5",
       "multiverseid": 338449,
       "name": "Diaochan, Artful Beauty",
       "number": "5",
@@ -351,7 +347,6 @@
         }
       ],
       "manaCost": "{2}{R}{R}{G}{G}",
-      "mciNumber": "6",
       "multiverseid": 338446,
       "name": "Dragonlair Spider",
       "number": "6",
@@ -372,7 +367,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "The triggered ability won’t be affected if the spell that caused it to trigger is countered."
+          "text": "The triggered ability won't be affected if the spell that caused it to trigger is countered."
         }
       ],
       "subtypes": [
@@ -414,7 +409,6 @@
         }
       ],
       "manaCost": "{6}",
-      "mciNumber": "7",
       "multiverseid": 338451,
       "name": "Duplicant",
       "number": "7",
@@ -436,11 +430,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Duplicant’s base power and toughness change to the imprinted card’s power and toughness. Counters and other effects that modify Duplicant’s power and toughness still apply."
+          "text": "Duplicant's base power and toughness change to the imprinted card's power and toughness. Counters and other effects that modify Duplicant's power and toughness still apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Abilities that define a creature’s power and toughness apply while that card is in exile, but abilities that add or subtract from it don’t. For example, the ability of Battle Squadron applies to determine Duplicant’s power and toughness, but the ability of Werebear doesn’t. Duplicant’s power and toughness are constantly updated if the exiled card’s power and/or toughness change."
+          "text": "Abilities that define a creature's power and toughness apply while that card is in exile, but abilities that add or subtract from it don't. For example, the ability of Battle Squadron applies to determine Duplicant's power and toughness, but the ability of Werebear doesn't. Duplicant's power and toughness are constantly updated if the exiled card's power and/or toughness change."
         },
         {
           "date": "2016-06-08",
@@ -448,7 +442,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If a melded permanent is exiled by Duplicant’s triggered ability, that ability’s controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
+          "text": "If a melded permanent is exiled by Duplicant's triggered ability, that ability's controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
         }
       ],
       "subtypes": [
@@ -492,7 +486,6 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
-      "mciNumber": "8",
       "multiverseid": 338443,
       "name": "Edric, Spymaster of Trest",
       "number": "8",
@@ -510,7 +503,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric’s ability to trigger. The creature’s controller chooses whether to draw a card."
+          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric's ability to trigger. The creature's controller chooses whether to draw a card."
         },
         {
           "date": "2011-09-22",
@@ -563,7 +556,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}{R}",
-      "mciNumber": "9",
+      "mciNumber": "180",
       "multiverseid": 338444,
       "name": "Kaalia of the Vast",
       "number": "9",
@@ -579,15 +572,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Kaalia’s ability doesn’t trigger if it attacks a planeswalker."
+          "text": "Kaalia's ability doesn't trigger if it attacks a planeswalker."
         },
         {
           "date": "2011-09-22",
-          "text": "The creature card is already tapped and attacking as it’s put onto the battlefield. Any abilities that trigger when a creature becomes tapped or when a creature attacks won’t trigger for that card."
+          "text": "The creature card is already tapped and attacking as it's put onto the battlefield. Any abilities that trigger when a creature becomes tapped or when a creature attacks won't trigger for that card."
         },
         {
           "date": "2011-09-22",
-          "text": "If the opponent Kaalia attacked is no longer in the game when its ability resolves, you may put an Angel, Demon, or Dragon creature card onto the battlefield tapped, but it won’t be attacking anyone and it won’t be an attacking creature."
+          "text": "If the opponent Kaalia attacked is no longer in the game when its ability resolves, you may put an Angel, Demon, or Dragon creature card onto the battlefield tapped, but it won't be attacking anyone and it won't be an attacking creature."
         }
       ],
       "subtypes": [
@@ -631,7 +624,6 @@
         }
       ],
       "manaCost": "{2}{W}",
-      "mciNumber": "10",
       "multiverseid": 338450,
       "name": "Loyal Retainers",
       "number": "10",
@@ -693,7 +685,6 @@
         }
       ],
       "manaCost": "{5}{U}{R}{G}",
-      "mciNumber": "11",
       "multiverseid": 338447,
       "name": "Maelstrom Wanderer",
       "number": "11",
@@ -718,7 +709,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "No matter what spell you cast with the first cascade trigger (or with any cascade triggers that result from casting that spell), the second cascade trigger will look for a spell with converted mana cost less than Maelstrom Wanderer’s converted mana cost of 8."
+          "text": "No matter what spell you cast with the first cascade trigger (or with any cascade triggers that result from casting that spell), the second cascade trigger will look for a spell with converted mana cost less than Maelstrom Wanderer's converted mana cost of 8."
         }
       ],
       "subtypes": [
@@ -765,7 +756,6 @@
         }
       ],
       "manaCost": "{2}{G}{U}{B}",
-      "mciNumber": "12",
       "multiverseid": 338445,
       "name": "The Mimeoplasm",
       "number": "12",
@@ -780,7 +770,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can’t choose to exile just one creature card."
+          "text": "You can't choose to exile just one creature card."
         },
         {
           "date": "2011-09-22",
@@ -792,7 +782,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Treat The Mimeoplasm as though it were the creature card it’s copying entering the battlefield. Any “As [this card] enters the battlefield,” “[This card] enters the battlefield with,” and “When [this card] enters the battlefield” abilities of that creature card will work."
+          "text": "Treat The Mimeoplasm as though it were the creature card it's copying entering the battlefield. Any \"As [this card] enters the battlefield,\" \"[This card] enters the battlefield with,\" and \"When [this card] enters the battlefield\" abilities of that creature card will work."
         },
         {
           "date": "2011-09-22",
@@ -842,7 +832,6 @@
         }
       ],
       "manaCost": "{5}",
-      "mciNumber": "13",
       "multiverseid": 338452,
       "name": "Mind's Eye",
       "number": "13",
@@ -894,7 +883,6 @@
         }
       ],
       "manaCost": "{3}{G}{W}",
-      "mciNumber": "14",
       "multiverseid": 338455,
       "name": "Mirari's Wake",
       "number": "14",
@@ -945,7 +933,6 @@
         }
       ],
       "manaCost": "{2}{U}",
-      "mciNumber": "15",
       "multiverseid": 338457,
       "name": "Rhystic Study",
       "number": "15",
@@ -963,7 +950,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t have to decide whether or not you are drawing until after the player decides whether or not to pay."
+          "text": "You don't have to decide whether or not you are drawing until after the player decides whether or not to pay."
         }
       ],
       "text": "Whenever an opponent casts a spell, you may draw a card unless that player pays {1}.",
@@ -997,7 +984,6 @@
         }
       ],
       "manaCost": "{2}",
-      "mciNumber": "16",
       "multiverseid": 338458,
       "name": "Scroll Rack",
       "number": "16",
@@ -1048,7 +1034,6 @@
         }
       ],
       "manaCost": "{1}{G}",
-      "mciNumber": "17",
       "multiverseid": 338456,
       "name": "Sylvan Library",
       "number": "17",
@@ -1067,19 +1052,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player’s draw step."
+          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player's draw step."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library’s ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
+          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library's ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
         },
         {
           "date": "2016-06-08",
-          "text": "Any cards drawn prior to Sylvan Library’s ability resolving, including in your upkeep or in response to Sylvan Library’s triggered ability, can be chosen to be put back using this effect. Sylvan Library’s controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
+          "text": "Any cards drawn prior to Sylvan Library's ability resolving, including in your upkeep or in response to Sylvan Library's triggered ability, can be chosen to be put back using this effect. Sylvan Library's controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don’t get to draw all the cards at once and then put them all back at once."
+          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don't get to draw all the cards at once and then put them all back at once."
         },
         {
           "date": "2016-06-08",
@@ -1087,11 +1072,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library’s ability still happens. If you’ve actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven’t actually drawn any cards that turn, the rest of the ability has no effect."
+          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library's ability still happens. If you've actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven't actually drawn any cards that turn, the rest of the ability has no effect."
         },
         {
           "date": "2016-06-08",
-          "text": "It’s not possible to take any actions between drawing the cards and choosing two cards. You can’t cast the cards you drew to avoid having two cards to choose."
+          "text": "It's not possible to take any actions between drawing the cards and choosing two cards. You can't cast the cards you drew to avoid having two cards to choose."
         }
       ],
       "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
@@ -1130,7 +1115,6 @@
         }
       ],
       "manaCost": "{4}{U}{B}",
-      "mciNumber": "18",
       "multiverseid": 338448,
       "name": "Vela the Night-Clad",
       "number": "18",

--- a/json/CMA.json
+++ b/json/CMA.json
@@ -223,23 +223,23 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "During your turn, Angelic Arbiter’s abilities have no effect on the game."
+          "text": "During your turn, Angelic Arbiter's abilities have no effect on the game."
         },
         {
           "date": "2010-08-15",
-          "text": "During an opponent’s turn, that opponent may either cast spells or attack with creatures, but not both (assuming that Angelic Arbiter is on the battlefield for the entirety of that turn). The player may perform other actions, such as activating abilities and playing lands."
+          "text": "During an opponent's turn, that opponent may either cast spells or attack with creatures, but not both (assuming that Angelic Arbiter is on the battlefield for the entirety of that turn). The player may perform other actions, such as activating abilities and playing lands."
         },
         {
           "date": "2010-08-15",
-          "text": "If Angelic Arbiter leaves the battlefield during an opponent’s turn, its abilities cease to affect the game. For example, if an opponent casts Doom Blade to destroy Angelic Arbiter, that player may then attack with creatures."
+          "text": "If Angelic Arbiter leaves the battlefield during an opponent's turn, its abilities cease to affect the game. For example, if an opponent casts Doom Blade to destroy Angelic Arbiter, that player may then attack with creatures."
         },
         {
           "date": "2010-08-15",
-          "text": "If Angelic Arbiter enters the battlefield during an opponent’s turn, its abilities take actions that player performed earlier in the turn into account, even though it wasn’t on the battlefield at the time. For example, if an opponent casts a spell, then you use Leyline of Anticipation’s ability to cast Angelic Arbiter as though it had flash, that player won’t be able to attack with creatures that turn."
+          "text": "If Angelic Arbiter enters the battlefield during an opponent's turn, its abilities take actions that player performed earlier in the turn into account, even though it wasn't on the battlefield at the time. For example, if an opponent casts a spell, then you use Leyline of Anticipation's ability to cast Angelic Arbiter as though it had flash, that player won't be able to attack with creatures that turn."
         },
         {
           "date": "2010-08-15",
-          "text": "Angelic Arbiter’s last ability applies if an opponent attacked with at least one creature during the current turn."
+          "text": "Angelic Arbiter's last ability applies if an opponent attacked with at least one creature during the current turn."
         }
       ],
       "subtypes": [
@@ -295,7 +295,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Archangel of Strife’s second and third abilities are linked. Similarly, its second and fourth abilities are linked. The bonus a player’s creatures get depends only on the choice that player made when Archangel of Strife entered the battlefield."
+          "text": "Archangel of Strife's second and third abilities are linked. Similarly, its second and fourth abilities are linked. The bonus a player's creatures get depends only on the choice that player made when Archangel of Strife entered the battlefield."
         },
         {
           "date": "2011-09-22",
@@ -303,7 +303,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Archangel of Strife’s bonuses apply immediately. Depending on your choice, Archangel of Strife will enter the battlefield as either a 9/6 or 6/9 creature."
+          "text": "Archangel of Strife's bonuses apply immediately. Depending on your choice, Archangel of Strife will enter the battlefield as either a 9/6 or 6/9 creature."
         },
         {
           "date": "2011-09-22",
@@ -383,11 +383,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
+          "text": "A creature \"shares a color\" with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
         },
         {
           "date": "2005-10-01",
-          "text": "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+          "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
         },
         {
           "date": "2005-10-01",
@@ -509,7 +509,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse’s color (or any other characteristic the Curse has), the Curse will be put into its owner’s graveyard."
+          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse's color (or any other characteristic the Curse has), the Curse will be put into its owner's graveyard."
         },
         {
           "date": "2013-10-17",
@@ -521,7 +521,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "The ability won’t trigger when a creature attacks a planeswalker controlled by the enchanted player."
+          "text": "The ability won't trigger when a creature attacks a planeswalker controlled by the enchanted player."
         },
         {
           "date": "2013-10-17",
@@ -588,11 +588,11 @@
         },
         {
           "date": "2013-10-17",
-          "text": "Darksteel Mutation overwrites any previous effects that set the enchanted creature’s power or toughness to a specific value. Any such effects that start to apply after Darksteel Mutation entered the battlefield will work normally."
+          "text": "Darksteel Mutation overwrites any previous effects that set the enchanted creature's power or toughness to a specific value. Any such effects that start to apply after Darksteel Mutation entered the battlefield will work normally."
         },
         {
           "date": "2013-10-17",
-          "text": "However, Darksteel Mutation does not overwrite effects that change the enchanted creature’s power or toughness without setting it to a specific value (such as the ones created by Giant Growth or Glorious Anthem). It also won’t overwrite the effect of counters."
+          "text": "However, Darksteel Mutation does not overwrite effects that change the enchanted creature's power or toughness without setting it to a specific value (such as the ones created by Giant Growth or Glorious Anthem). It also won't overwrite the effect of counters."
         },
         {
           "date": "2013-10-17",
@@ -600,15 +600,15 @@
         },
         {
           "date": "2013-10-17",
-          "text": "In some rare cases, the creature may have subtypes other than creature types before becoming enchanted with Darksteel Mutation. If it had any other artifact subtypes (such as Equipment), it will retain those. If it had any subtypes other than artifact types and creature types (such as Shrine), it won’t retain those."
+          "text": "In some rare cases, the creature may have subtypes other than creature types before becoming enchanted with Darksteel Mutation. If it had any other artifact subtypes (such as Equipment), it will retain those. If it had any subtypes other than artifact types and creature types (such as Shrine), it won't retain those."
         },
         {
           "date": "2013-10-17",
-          "text": "The creature will keep any supertypes it previously had. Notably, if Darksteel Mutation is enchanting a legendary creature, that creature will continue to be legendary. Also, if it’s enchanting a commander, that creature will continue to be a commander."
+          "text": "The creature will keep any supertypes it previously had. Notably, if Darksteel Mutation is enchanting a legendary creature, that creature will continue to be legendary. Also, if it's enchanting a commander, that creature will continue to be a commander."
         },
         {
           "date": "2013-10-17",
-          "text": "Darksteel Mutation doesn’t affect the enchanted creature’s colors, if any. It will continue to be whatever color or colors it was before Darksteel Mutation entered the battlefield."
+          "text": "Darksteel Mutation doesn't affect the enchanted creature's colors, if any. It will continue to be whatever color or colors it was before Darksteel Mutation entered the battlefield."
         },
         {
           "date": "2013-10-17",
@@ -741,7 +741,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The card that was enchanted comes back onto the battlefield first, regardless of whether it’s still a creature. Then any Auras exiled that can legally enchant that card come back. Any Auras that can’t enchant that permanent remain exiled."
+          "text": "The card that was enchanted comes back onto the battlefield first, regardless of whether it's still a creature. Then any Auras exiled that can legally enchant that card come back. Any Auras that can't enchant that permanent remain exiled."
         },
         {
           "date": "2005-10-01",
@@ -749,7 +749,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the enchanted creature was also enchanted by Copy Enchantment, Copy Enchantment will return to the battlefield attached to that permanent. As Copy Enchantment returns to the battlefield, its controller may choose any enchantment on the battlefield for it to copy. It can’t copy Flickerform or any other Aura returning to the battlefield at the same time. If it copies a non-Aura enchantment, it returns to the battlefield unattached instead."
+          "text": "If the enchanted creature was also enchanted by Copy Enchantment, Copy Enchantment will return to the battlefield attached to that permanent. As Copy Enchantment returns to the battlefield, its controller may choose any enchantment on the battlefield for it to copy. It can't copy Flickerform or any other Aura returning to the battlefield at the same time. If it copies a non-Aura enchantment, it returns to the battlefield unattached instead."
         },
         {
           "date": "2014-02-01",
@@ -825,7 +825,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won’t trigger that turn."
+          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won't trigger that turn."
         }
       ],
       "subtypes": [
@@ -1065,7 +1065,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         },
         {
           "date": "2013-07-01",
@@ -1250,11 +1250,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature’s controller won’t search for a basic land card."
+          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature's controller won't search for a basic land card."
         },
         {
           "date": "2017-03-14",
-          "text": "The controller of the exiled creature isn’t required to search his or her library for a basic land. If that player doesn’t, the player won’t shuffle his or her library."
+          "text": "The controller of the exiled creature isn't required to search his or her library for a basic land. If that player doesn't, the player won't shuffle his or her library."
         }
       ],
       "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
@@ -1315,7 +1315,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there’s only one legal target. If it’s cast at a time other than its controller’s main phase and a second target is chosen, nothing will happen to that target."
+          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there's only one legal target. If it's cast at a time other than its controller's main phase and a second target is chosen, nothing will happen to that target."
         }
       ],
       "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
@@ -1621,11 +1621,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -1735,11 +1735,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are fewer than X cards in that player’s library, put that permanent on the bottom of that library."
+          "text": "If there are fewer than X cards in that player's library, put that permanent on the bottom of that library."
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose 0 as the value for X, put that permanent on top of its owner’s library."
+          "text": "If you choose 0 as the value for X, put that permanent on top of its owner's library."
         }
       ],
       "text": "Put target nonland permanent into its owner's library just beneath the top X cards of that library.",
@@ -1905,7 +1905,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "The controller of the countered spell doesn’t choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
+          "text": "The controller of the countered spell doesn't choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
         }
       ],
       "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
@@ -2029,11 +2029,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         },
         {
           "date": "2011-06-01",
-          "text": "You follow the instructions in order. You won’t be able to draw the same Blue Sun’s Zenith that you cast."
+          "text": "You follow the instructions in order. You won't be able to draw the same Blue Sun's Zenith that you cast."
         }
       ],
       "text": "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.",
@@ -2143,7 +2143,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -2197,7 +2197,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse’s color (or any other characteristic the Curse has), the Curse will be put into its owner’s graveyard."
+          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse's color (or any other characteristic the Curse has), the Curse will be put into its owner's graveyard."
         },
         {
           "date": "2013-10-17",
@@ -2209,7 +2209,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "The ability won’t trigger when a creature attacks a planeswalker controlled by the enchanted player."
+          "text": "The ability won't trigger when a creature attacks a planeswalker controlled by the enchanted player."
         },
         {
           "date": "2013-10-17",
@@ -2217,7 +2217,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "Curse of Inertia’s ability will trigger only once per attacking player per combat phase, no matter how many creatures that player attacks with."
+          "text": "Curse of Inertia's ability will trigger only once per attacking player per combat phase, no matter how many creatures that player attacks with."
         },
         {
           "date": "2013-10-17",
@@ -2392,7 +2392,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "You don’t have to control either target."
+          "text": "You don't have to control either target."
         },
         {
           "date": "2013-10-17",
@@ -2400,7 +2400,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "If one of the creatures is an illegal target when the ability resolves, the exchange won’t happen. If both creatures are illegal targets, the ability will be countered."
+          "text": "If one of the creatures is an illegal target when the ability resolves, the exchange won't happen. If both creatures are illegal targets, the ability will be countered."
         }
       ],
       "subtypes": [
@@ -2468,11 +2468,11 @@
         },
         {
           "date": "2011-01-22",
-          "text": "If you gain control of the creature that’s being prevented from untapping, that creature won’t untap during your untap step for as long as you control Dungeon Geists."
+          "text": "If you gain control of the creature that's being prevented from untapping, that creature won't untap during your untap step for as long as you control Dungeon Geists."
         },
         {
           "date": "2013-04-15",
-          "text": "The ability can target a tapped creature. If the targeted creature is already tapped when it resolves, that creature just remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "The ability can target a tapped creature. If the targeted creature is already tapped when it resolves, that creature just remains tapped and doesn't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -2536,23 +2536,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -2610,11 +2610,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "Lu Xun’s second ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Lu Xun's second ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -2966,7 +2966,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The term “defending player” in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
+          "text": "The term \"defending player\" in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
         },
         {
           "date": "2015-11-04",
@@ -2978,7 +2978,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won’t trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won’t apply to the tokens."
+          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won't trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won't apply to the tokens."
         },
         {
           "date": "2015-11-04",
@@ -2986,15 +2986,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-11-04",
-          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it’s attacking the player or a planeswalker he or she controls."
+          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it's attacking the player or a planeswalker he or she controls."
         }
       ],
       "subtypes": [
@@ -3074,7 +3074,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Barter in Blood doesn’t target any creatures and may be cast even if a player controls fewer than two creatures."
+          "text": "Barter in Blood doesn't target any creatures and may be cast even if a player controls fewer than two creatures."
         }
       ],
       "text": "Each player sacrifices two creatures.",
@@ -3198,15 +3198,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners’ graveyards at the same time, Butcher of Malakir’s triggered ability will trigger that many times."
+          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners' graveyards at the same time, Butcher of Malakir's triggered ability will trigger that many times."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers’ abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
+          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers' abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player’s Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player’s Butcher to trigger, and so on."
+          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player's Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player's Butcher to trigger, and so on."
         }
       ],
       "subtypes": [
@@ -3271,7 +3271,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You choose the targets of the first ability as you activate that ability, before you pay any costs. You can’t target any of the creatures you sacrifice."
+          "text": "You choose the targets of the first ability as you activate that ability, before you pay any costs. You can't target any of the creatures you sacrifice."
         },
         {
           "date": "2014-02-01",
@@ -3393,7 +3393,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the creature is on the battlefield and is returned to its owner’s hand or is exiled, this card loses track of the creature and has no further effects in the future."
+          "text": "If the creature is on the battlefield and is returned to its owner's hand or is exiled, this card loses track of the creature and has no further effects in the future."
         }
       ],
       "text": "When Diabolic Servitude enters the battlefield, return target creature card from your graveyard to the battlefield.\nWhen the creature put onto the battlefield with Diabolic Servitude dies, exile it and return Diabolic Servitude to its owner's hand.\nWhen Diabolic Servitude leaves the battlefield, exile the creature put onto the battlefield with Diabolic Servitude.",
@@ -3516,11 +3516,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you put Dread Cacodemon directly onto the battlefield from your hand, perhaps because of Kaalia of the Vast’s ability, its ability won’t trigger."
+          "text": "If you put Dread Cacodemon directly onto the battlefield from your hand, perhaps because of Kaalia of the Vast's ability, its ability won't trigger."
         },
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -3575,7 +3575,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If a creature card has an ability that replaces going to the graveyard with moving somewhere else “instead,” that card won’t count toward the number of Zombies you get. Conversely, creature cards with a triggered ability that removes them from the graveyard when they’re put there from anywhere (or your library) will count toward that number."
+          "text": "If a creature card has an ability that replaces going to the graveyard with moving somewhere else \"instead,\" that card won't count toward the number of Zombies you get. Conversely, creature cards with a triggered ability that removes them from the graveyard when they're put there from anywhere (or your library) will count toward that number."
         }
       ],
       "text": "Each player puts the top X cards of his or her library into his or her graveyard. For each creature card put into a graveyard this way, you create a tapped 2/2 black Zombie creature token.",
@@ -3748,11 +3748,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon’s triggered ability will trigger."
+          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon's triggered ability will trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "You can target any player with Extractor Demon’s triggered ability. The target doesn’t have to be the controller of the creature that left the battlefield."
+          "text": "You can target any player with Extractor Demon's triggered ability. The target doesn't have to be the controller of the creature that left the battlefield."
         }
       ],
       "subtypes": [
@@ -4077,7 +4077,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -4152,19 +4152,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
+          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -4216,7 +4216,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Casting Scourge of Nel Toth from your graveyard by paying the alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
+          "text": "Casting Scourge of Nel Toth from your graveyard by paying the alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
         },
         {
           "date": "2015-11-04",
@@ -4224,7 +4224,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "As soon as you start to cast Scourge of Nel Toth from your graveyard, it moves to the stack. At that point, it’s too late for an opponent to prevent you from casting it by removing it from your graveyard. It’s also too late for players to try to destroy the creatures you sacrifice to pay for the spell."
+          "text": "As soon as you start to cast Scourge of Nel Toth from your graveyard, it moves to the stack. At that point, it's too late for an opponent to prevent you from casting it by removing it from your graveyard. It's also too late for players to try to destroy the creatures you sacrifice to pay for the spell."
         }
       ],
       "subtypes": [
@@ -4290,7 +4290,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Only creatures on the battlefield will be exiled. In other zones, they’re “creature cards,” not “creatures.”"
+          "text": "Only creatures on the battlefield will be exiled. In other zones, they're \"creature cards,\" not \"creatures.\""
         },
         {
           "date": "2017-03-14",
@@ -4298,11 +4298,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named “Beast.”"
+          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named \"Beast.\""
         },
         {
           "date": "2017-03-14",
-          "text": "A double-faced creature only has the name of the face that’s up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn’t be exiled."
+          "text": "A double-faced creature only has the name of the face that's up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn't be exiled."
         }
       ],
       "text": "Exile target creature and all other creatures with the same name as that creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -4521,7 +4521,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Experience counters aren’t removed from players this way, but loyalty counters are removed from planeswalkers."
+          "text": "Experience counters aren't removed from players this way, but loyalty counters are removed from planeswalkers."
         },
         {
           "date": "2015-11-04",
@@ -4588,19 +4588,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You must choose two targets. You can’t cast Victimize targeting only one creature card."
+          "text": "You must choose two targets. You can't cast Victimize targeting only one creature card."
         },
         {
           "date": "2016-06-08",
-          "text": "The creature you sacrifice isn’t chosen until Victimize resolves. You can’t return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
+          "text": "The creature you sacrifice isn't chosen until Victimize resolves. You can't return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
         },
         {
           "date": "2016-06-08",
-          "text": "As Victimize resolves, you must sacrifice a creature if able. You can’t change your mind and choose not to sacrifice anything."
+          "text": "As Victimize resolves, you must sacrifice a creature if able. You can't change your mind and choose not to sacrifice anything."
         },
         {
           "date": "2016-06-08",
-          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you’ll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won’t sacrifice a creature."
+          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you'll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won't sacrifice a creature."
         },
         {
           "date": "2016-06-08",
@@ -4702,11 +4702,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can’t be changed."
+          "text": "You choose the modes as you cast the spell. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-11-04",
-          "text": "If a mode requires a target, you can select that mode only if there’s a legal target available. Ignore the targeting requirements for modes you don’t choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
+          "text": "If a mode requires a target, you can select that mode only if there's a legal target available. Ignore the targeting requirements for modes you don't choose. Each time you select that mode, you can choose a different target, or you can choose the same target."
         },
         {
           "date": "2015-11-04",
@@ -4718,7 +4718,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can’t choose new modes."
+          "text": "If a Confluence is copied, the effect that creates the copy will usually allow you to choose new targets, but you can't choose new modes."
         },
         {
           "date": "2015-11-04",
@@ -4856,7 +4856,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The timestamp for the “in your graveyard” ability is set at the time that this card goes to your graveyard, regardless of whether you control a Mountain at that time."
+          "text": "The timestamp for the \"in your graveyard\" ability is set at the time that this card goes to your graveyard, regardless of whether you control a Mountain at that time."
         }
       ],
       "subtypes": [
@@ -4912,11 +4912,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2011-09-22",
-          "text": "If there are multiple combat phases in a turn, creatures must attack only in the first one in which they’re able to."
+          "text": "If there are multiple combat phases in a turn, creatures must attack only in the first one in which they're able to."
         }
       ],
       "subtypes": [
@@ -4984,11 +4984,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
+          "text": "A creature \"shares a color\" with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
         },
         {
           "date": "2005-10-01",
-          "text": "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+          "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
         },
         {
           "date": "2005-10-01",
@@ -5058,7 +5058,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The number of targets you choose for Comet Storm is one more than the number of times it’s kicked. First you declare how many times you’re going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you’ll kick the spell and the time you choose the targets."
+          "text": "The number of targets you choose for Comet Storm is one more than the number of times it's kicked. First you declare how many times you're going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you'll kick the spell and the time you choose the targets."
         },
         {
           "date": "2010-03-01",
@@ -5066,7 +5066,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you’re kicking the spell twice. You’ll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
+          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you're kicking the spell twice. You'll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
         },
         {
           "date": "2010-03-01",
@@ -5125,7 +5125,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If Death by Dragons resolves, the player who’s targeted is the only one who won’t put a Dragon token onto the battlefield."
+          "text": "If Death by Dragons resolves, the player who's targeted is the only one who won't put a Dragon token onto the battlefield."
         }
       ],
       "text": "Each player other than target player creates a 5/5 red Dragon creature token with flying.",
@@ -5196,11 +5196,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -5515,7 +5515,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -5570,27 +5570,27 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If your opponent controls a Stranglehold and an effect says “You may search your library . . . If you do, shuffle your library,” you can’t choose to search, so you won’t shuffle."
+          "text": "If your opponent controls a Stranglehold and an effect says \"You may search your library . . . If you do, shuffle your library,\" you can't choose to search, so you won't shuffle."
         },
         {
           "date": "2011-09-22",
-          "text": "If your opponent controls a Stranglehold and an effect says “Search your library . . . Then shuffle your library,” the search effect fails, but you will still have to shuffle."
+          "text": "If your opponent controls a Stranglehold and an effect says \"Search your library . . . Then shuffle your library,\" the search effect fails, but you will still have to shuffle."
         },
         {
           "date": "2011-09-22",
-          "text": "Since opponents can’t search libraries, they won’t be able to find any cards in a library. The effect applies to all opponents and all libraries, including your library. If a spell or ability’s effect has other parts that don’t depend on searching for or finding cards, they will still work normally."
+          "text": "Since opponents can't search libraries, they won't be able to find any cards in a library. The effect applies to all opponents and all libraries, including your library. If a spell or ability's effect has other parts that don't depend on searching for or finding cards, they will still work normally."
         },
         {
           "date": "2011-09-22",
-          "text": "Effects that tell an opponent to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word “search” will fail."
+          "text": "Effects that tell an opponent to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word \"search\" will fail."
         },
         {
           "date": "2011-09-22",
-          "text": "An “extra turn” means a turn created by a spell or ability. It doesn’t refer to a turn taken in a sanctioned tournament after the time limit for the round has expired."
+          "text": "An \"extra turn\" means a turn created by a spell or ability. It doesn't refer to a turn taken in a sanctioned tournament after the time limit for the round has expired."
         },
         {
           "date": "2011-09-22",
-          "text": "If an opponent’s extra turn is created while Stranglehold is on the battlefield, but Stranglehold leaves the battlefield before that turn would begin, that opponent takes the extra turn as normal."
+          "text": "If an opponent's extra turn is created while Stranglehold is on the battlefield, but Stranglehold leaves the battlefield before that turn would begin, that opponent takes the extra turn as normal."
         }
       ],
       "text": "Your opponents can't search libraries.\nIf an opponent would begin an extra turn, that player skips that turn instead.",
@@ -5807,11 +5807,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "Bane of Progress’s ability destroys all artifacts and enchantments, including those you control."
+          "text": "Bane of Progress's ability destroys all artifacts and enchantments, including those you control."
         },
         {
           "date": "2013-10-17",
-          "text": "If an artifact or enchantment isn’t destroyed (perhaps because it has indestructible or it regenerated), it won’t count toward the number of +1/+1 counters put on Bane of Progress. However, if an artifact or enchantment is destroyed but doesn’t go to its owner’s graveyard due to a replacement effect (like the one Rest in Peace creates), it will count."
+          "text": "If an artifact or enchantment isn't destroyed (perhaps because it has indestructible or it regenerated), it won't count toward the number of +1/+1 counters put on Bane of Progress. However, if an artifact or enchantment is destroyed but doesn't go to its owner's graveyard due to a replacement effect (like the one Rest in Peace creates), it will count."
         }
       ],
       "subtypes": [
@@ -5876,7 +5876,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you attack with multiple creatures, Beastmaster Ascension’s first ability triggers multiple times."
+          "text": "If you attack with multiple creatures, Beastmaster Ascension's first ability triggers multiple times."
         }
       ],
       "text": "Whenever a creature you control attacks, you may put a quest counter on Beastmaster Ascension.\nAs long as Beastmaster Ascension has seven or more quest counters on it, creatures you control get +5/+5.",
@@ -5927,7 +5927,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If Bloodspore Thrinax enters the battlefield at the same time as other creatures you control, those creatures won’t get additional +1/+1 counters from Bloodspore Thrinax’s last ability. Those creatures also can’t be devoured by Bloodspore Thrinax."
+          "text": "If Bloodspore Thrinax enters the battlefield at the same time as other creatures you control, those creatures won't get additional +1/+1 counters from Bloodspore Thrinax's last ability. Those creatures also can't be devoured by Bloodspore Thrinax."
         }
       ],
       "subtypes": [
@@ -5982,7 +5982,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The term “defending player” in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
+          "text": "The term \"defending player\" in the myriad rules (or any other ability of an attacking creature) refers to the player the creature with myriad was attacking at the time it became an attacking creature this combat, or the controller of the planeswalker the creature was attacking at the time it became an attacking creature this combat."
         },
         {
           "date": "2015-11-04",
@@ -5994,7 +5994,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won’t trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won’t apply to the tokens."
+          "text": "Although the tokens enter the battlefield attacking, they were never declared as attackers. Abilities that trigger whenever a creature attacks won't trigger, including the myriad ability of the tokens. If there any costs to have a creature attack, those costs won't apply to the tokens."
         },
         {
           "date": "2015-11-04",
@@ -6002,15 +6002,15 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-11-04",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-11-04",
-          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it’s attacking the player or a planeswalker he or she controls."
+          "text": "If myriad creates more than one token for any given player (due to an effect such as the one Doubling Season creates), you may choose separately for each token whether it's attacking the player or a planeswalker he or she controls."
         }
       ],
       "subtypes": [
@@ -6065,7 +6065,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If Centaur Vinecrasher and a land card are put into your graveyard at the same time, Centaur Vinecrasher’s last ability will trigger. It doesn’t matter what zone Centaur Vinecrasher was previously in."
+          "text": "If Centaur Vinecrasher and a land card are put into your graveyard at the same time, Centaur Vinecrasher's last ability will trigger. It doesn't matter what zone Centaur Vinecrasher was previously in."
         }
       ],
       "subtypes": [
@@ -6242,11 +6242,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The activated ability overwrites all previous effects that set the target creature’s base power and/or toughness to specific values. Other effects that set its base power and/or toughness that start to apply after Creeperhulk’s ability resolves will overwrite Creeperhulk’s effect."
+          "text": "The activated ability overwrites all previous effects that set the target creature's base power and/or toughness to specific values. Other effects that set its base power and/or toughness that start to apply after Creeperhulk's ability resolves will overwrite Creeperhulk's effect."
         },
         {
           "date": "2014-11-07",
-          "text": "Effects that modify the target creature’s power and/or toughness, such as the effect of Giant Growth or Glorious Anthem, will apply to the creature no matter when they started applying. The same is true for counters that affect the target creature’s power and toughness and effects that switch its power and toughness."
+          "text": "Effects that modify the target creature's power and/or toughness, such as the effect of Giant Growth or Glorious Anthem, will apply to the creature no matter when they started applying. The same is true for counters that affect the target creature's power and toughness and effects that switch its power and toughness."
         }
       ],
       "subtypes": [
@@ -6302,7 +6302,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse’s color (or any other characteristic the Curse has), the Curse will be put into its owner’s graveyard."
+          "text": "A Curse spell targets the player it will enchant like any other Aura spell, and a Curse stays on the battlefield like any other Aura. If the enchanted player gains protection from the Curse's color (or any other characteristic the Curse has), the Curse will be put into its owner's graveyard."
         },
         {
           "date": "2013-10-17",
@@ -6314,7 +6314,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "The ability won’t trigger when a creature attacks a planeswalker controlled by the enchanted player."
+          "text": "The ability won't trigger when a creature attacks a planeswalker controlled by the enchanted player."
         },
         {
           "date": "2013-10-17",
@@ -6499,11 +6499,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Elvish Archdruid’s first ability affects only other Elves you control. However, Elvish Archdruid’s second ability counts all Elves you control — including itself."
+          "text": "Elvish Archdruid's first ability affects only other Elves you control. However, Elvish Archdruid's second ability counts all Elves you control — including itself."
         },
         {
           "date": "2011-09-22",
-          "text": "Elvish Archdruid’s activated ability is a mana ability. It doesn’t use the stack and players can’t respond to it."
+          "text": "Elvish Archdruid's activated ability is a mana ability. It doesn't use the stack and players can't respond to it."
         }
       ],
       "subtypes": [
@@ -6894,11 +6894,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Ezuri’s first ability can’t affect itself, but its second ability does."
+          "text": "Ezuri's first ability can't affect itself, but its second ability does."
         },
         {
           "date": "2011-01-01",
-          "text": "Only Elf creatures you control when the last ability resolves will get +3/+3 and gain trample until end of turn. Non-Elf creatures that become Elves or Elf creatures that enter the battlefield under your control later in the turn won’t get the bonuses."
+          "text": "Only Elf creatures you control when the last ability resolves will get +3/+3 and gain trample until end of turn. Non-Elf creatures that become Elves or Elf creatures that enter the battlefield under your control later in the turn won't get the bonuses."
         }
       ],
       "subtypes": [
@@ -7027,7 +7027,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Fresh Meat counts all creatures you owned that went to the graveyard this turn, including creature tokens that entered the battlefield under your control and nontoken creatures you owned but didn’t control."
+          "text": "Fresh Meat counts all creatures you owned that went to the graveyard this turn, including creature tokens that entered the battlefield under your control and nontoken creatures you owned but didn't control."
         }
       ],
       "text": "Create a 3/3 green Beast creature token for each creature put into your graveyard from the battlefield this turn.",
@@ -7127,7 +7127,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The creature type each player chooses applies only to that player. For example, if another player chose Elf, you wouldn’t return Elf cards to your hand unless you also chose Elf (or if an Elf card in your graveyard also had the creature type you chose)."
+          "text": "The creature type each player chooses applies only to that player. For example, if another player chose Elf, you wouldn't return Elf cards to your hand unless you also chose Elf (or if an Elf card in your graveyard also had the creature type you chose)."
         }
       ],
       "subtypes": [
@@ -7184,7 +7184,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Great Oak Guardian’s last ability targets only the player, not any creatures. Creatures with shroud that player controls will be affected, for example."
+          "text": "Great Oak Guardian's last ability targets only the player, not any creatures. Creatures with shroud that player controls will be affected, for example."
         },
         {
           "date": "2015-11-04",
@@ -7327,7 +7327,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can’t pay this cost more than once to get a multiple effect."
+          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can't pay this cost more than once to get a multiple effect."
         },
         {
           "date": "2004-10-04",
@@ -7335,7 +7335,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
@@ -7706,23 +7706,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -7792,7 +7792,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "You declare which player or planeswalker each token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Kessig Cagebreakers is attacking."
+          "text": "You declare which player or planeswalker each token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Kessig Cagebreakers is attacking."
         },
         {
           "date": "2011-09-22",
@@ -7868,23 +7868,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
@@ -7936,7 +7936,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "Use Lifeblood Hydra’s power when it died (including any +1/+1 counters it had) to determine how much life to gain and how many cards to draw."
+          "text": "Use Lifeblood Hydra's power when it died (including any +1/+1 counters it had) to determine how much life to gain and how many cards to draw."
         }
       ],
       "subtypes": [
@@ -8084,7 +8084,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Lys Alana Huntmaster’s ability will resolve before the Elf spell that caused it to trigger."
+          "text": "Lys Alana Huntmaster's ability will resolve before the Elf spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -8287,19 +8287,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         },
         {
           "date": "2008-10-01",
-          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn’t matter where the +1/+1 counters came from."
+          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn't matter where the +1/+1 counters came from."
         }
       ],
       "subtypes": [
@@ -8380,7 +8380,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -8489,11 +8489,11 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "The value of X is calculated as Pathbreaker Ibex’s ability resolves. Notably, if you attack with two Pathbreaker Ibex (and control no other creatures), the first ability to resolve will give those Ibex +3/+3. The second ability will then give them +6/+6."
+          "text": "The value of X is calculated as Pathbreaker Ibex's ability resolves. Notably, if you attack with two Pathbreaker Ibex (and control no other creatures), the first ability to resolve will give those Ibex +3/+3. The second ability will then give them +6/+6."
         },
         {
-          "date": "2015-11-04",
-          "text": "In some unusual cases, the greatest power among creatures you control may be negative. This is bad for you. For example, if the greatest power among creatures you control when the ability resolves is -2, creatures you control will get -2/-2 until end of turn."
+          "date": "2017-06-27",
+          "text": "If this creature's power is negative as its ability resolves, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -8630,11 +8630,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then resolve Praetor’s Counsel, you have no maximum hand size. However, if those events happened in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then resolve Praetor's Counsel, you have no maximum hand size. However, if those events happened in the opposite order, your maximum hand size would be two."
         },
         {
           "date": "2011-06-01",
-          "text": "Later effects that modify your maximum hand size, but don’t set it to a specific number, will have no effect."
+          "text": "Later effects that modify your maximum hand size, but don't set it to a specific number, will have no effect."
         }
       ],
       "text": "Return all cards from your graveyard to your hand. Exile Praetor's Counsel. You have no maximum hand size for the rest of the game.",
@@ -8694,7 +8694,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The creature’s controller, not Presence of Gond’s controller, is the one who can activate the ability, so that’s the player who will get the token."
+          "text": "The creature's controller, not Presence of Gond's controller, is the one who can activate the ability, so that's the player who will get the token."
         }
       ],
       "subtypes": [
@@ -8819,7 +8819,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Kicker—Sacrifice a creature. (You may sacrifice a creature in addition to any other costs as you cast this spell.)\nSearch your library for a basic land card, put that card onto the battlefield, then shuffle your library. If Primal Growth was kicked, instead search your library for up to two basic land cards, put them onto the battlefield, then shuffle your library.",
@@ -8942,7 +8942,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -9232,7 +9232,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "You decide whether to assign a creature’s combat damage as though it weren’t blocked just before it assigns that damage. You may make a different choice for each creature you control—that is, you may have none, some, or all of those creatures assign combat damage as though they weren’t blocked."
+          "text": "You decide whether to assign a creature's combat damage as though it weren't blocked just before it assigns that damage. You may make a different choice for each creature you control—that is, you may have none, some, or all of those creatures assign combat damage as though they weren't blocked."
         }
       ],
       "subtypes": [
@@ -9349,7 +9349,7 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "Skullwinder’s enters-the-battlefield ability targets only the card in your graveyard. If that card is an illegal target as the ability tries to resolve, the ability will be countered and none of its effects will happen. No cards will be returned to any player’s hand."
+          "text": "Skullwinder's enters-the-battlefield ability targets only the card in your graveyard. If that card is an illegal target as the ability tries to resolve, the ability will be countered and none of its effects will happen. No cards will be returned to any player's hand."
         },
         {
           "date": "2015-11-04",
@@ -9408,7 +9408,7 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The enchanted permanent loses any card types, subtypes, and colors it previously had. It keeps any supertypes it had and its name remains unchanged. It gains “{T}: Add {G} to your mana pool” and loses all other abilities from its rules text. It will still have any abilities it gained from other effects."
+          "text": "The enchanted permanent loses any card types, subtypes, and colors it previously had. It keeps any supertypes it had and its name remains unchanged. It gains \"{T}: Add {G} to your mana pool\" and loses all other abilities from its rules text. It will still have any abilities it gained from other effects."
         },
         {
           "date": "2014-11-07",
@@ -9481,7 +9481,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "A creature card that enters the battlefield as a copy of a token creature is still a nontoken creature. You’ll be able to draw a card."
+          "text": "A creature card that enters the battlefield as a copy of a token creature is still a nontoken creature. You'll be able to draw a card."
         }
       ],
       "subtypes": [
@@ -9782,7 +9782,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If a targeted permanent has indestructible or regenerates, its controller won’t get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner’s graveyard, its controller won’t get an Elephant token for it."
+          "text": "If a targeted permanent has indestructible or regenerates, its controller won't get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner's graveyard, its controller won't get an Elephant token for it."
         }
       ],
       "subtypes": [
@@ -9905,15 +9905,15 @@
         },
         {
           "date": "2014-11-07",
-          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player’s commander."
+          "text": "Lieutenant abilities refer only to whether you control your commander, not any other player's commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won’t check whether its owner controls his or her commander."
+          "text": "If you gain control of a creature with a lieutenant ability owned by another player, that ability will check to see if you control your commander and will apply if you do. It won't check whether its owner controls his or her commander."
         },
         {
           "date": "2014-11-07",
-          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature’s toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
+          "text": "If you lose control of your commander, lieutenant abilities of creatures you control will immediately stop applying. If this causes a creature's toughness to become less than or equal to the amount of damage marked on it, the creature will be destroyed."
         },
         {
           "date": "2014-11-07",
@@ -9981,7 +9981,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf’s ability resolves. If Timberwatch Elf is still on the battlefield, it’ll count itself."
+          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf's ability resolves. If Timberwatch Elf is still on the battlefield, it'll count itself."
         }
       ],
       "subtypes": [
@@ -10154,11 +10154,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -10166,7 +10166,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -10284,7 +10284,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Verdant Force’s controller gets the tokens. That is the controller at the beginning of upkeep."
+          "text": "Verdant Force's controller gets the tokens. That is the controller at the beginning of upkeep."
         },
         {
           "date": "2005-08-01",
@@ -10739,6 +10739,12 @@
         "CMA"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2014-11-07",
+          "text": "Use the number of opponents who have four or more cards in hand as the ability resolves to determine the value of X."
+        }
+      ],
       "text": "At the beginning of your upkeep, create X 2/2 green Wolf creature tokens, where X is the number of your opponents with four or more cards in hand.",
       "type": "Enchantment",
       "types": [
@@ -10807,7 +10813,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -10873,11 +10879,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Wren’s Run Packmaster gives deathtouch to all Wolf permanents you control, not just the tokens it creates."
+          "text": "Wren's Run Packmaster gives deathtouch to all Wolf permanents you control, not just the tokens it creates."
         },
         {
           "date": "2009-10-01",
-          "text": "A Wolf’s deathtouch ability will apply if both Wren’s Run Packmaster and that Wolf are on the battlefield at the time the Wolf deals damage. The creature dealt damage by the Wolf will be destroyed the next time state-based actions are checked, even if the Wolf or Wren’s Run Packmaster leaves the battlefield."
+          "text": "A Wolf's deathtouch ability will apply if both Wren's Run Packmaster and that Wolf are on the battlefield at the time the Wolf deals damage. The creature dealt damage by the Wolf will be destroyed the next time state-based actions are checked, even if the Wolf or Wren's Run Packmaster leaves the battlefield."
         }
       ],
       "subtypes": [
@@ -10943,19 +10949,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If you don’t reveal any creature cards, or if you choose not to put a revealed creature card onto the battlefield, all the revealed cards go on the bottom of your library."
+          "text": "If you don't reveal any creature cards, or if you choose not to put a revealed creature card onto the battlefield, all the revealed cards go on the bottom of your library."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature that you put onto the battlefield leaves the battlefield before your next end step, it won’t be returned to your hand at the beginning of your next end step."
+          "text": "If the creature that you put onto the battlefield leaves the battlefield before your next end step, it won't be returned to your hand at the beginning of your next end step."
         },
         {
           "date": "2017-03-14",
-          "text": "If you put a creature onto the battlefield this way during your end step, it won’t be returned to your hand until your next end step."
+          "text": "If you put a creature onto the battlefield this way during your end step, it won't be returned to your hand until your next end step."
         },
         {
           "date": "2017-03-14",
-          "text": "The triggered ability that the creature gains won’t be copied if an effect creates a token that’s a copy of that creature or causes another object to become a copy of that creature."
+          "text": "The triggered ability that the creature gains won't be copied if an effect creates a token that's a copy of that creature or causes another object to become a copy of that creature."
         }
       ],
       "text": "Reveal the top four cards of your library. You may put a creature card from among them onto the battlefield. It gains \"At the beginning of your end step, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
@@ -11072,7 +11078,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "While Basandra, Battle Seraph is on the battlefield, players can’t cast any spells during the combat phase, including permanent spells with flash."
+          "text": "While Basandra, Battle Seraph is on the battlefield, players can't cast any spells during the combat phase, including permanent spells with flash."
         },
         {
           "date": "2011-09-22",
@@ -11080,7 +11086,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -11203,11 +11209,11 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "You can activate Derevi’s last ability only when it is in the command zone."
+          "text": "You can activate Derevi's last ability only when it is in the command zone."
         },
         {
           "date": "2013-10-17",
-          "text": "When you activate Derevi’s last ability, you’re not casting Derevi as a spell. The ability can’t be countered by something that counters only spells. The ability isn’t subject to the additional cost of casting commanders from the command zone."
+          "text": "When you activate Derevi's last ability, you're not casting Derevi as a spell. The ability can't be countered by something that counters only spells. The ability isn't subject to the additional cost of casting commanders from the command zone."
         }
       ],
       "subtypes": [
@@ -11391,7 +11397,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Jarad’s first ability applies only when Jarad is on the battlefield."
+          "text": "Jarad's first ability applies only when Jarad is on the battlefield."
         },
         {
           "date": "2012-10-01",
@@ -11399,7 +11405,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "To activate Jarad’s last ability, you must sacrifice two lands. It doesn’t matter what other land types the two lands have, as long as one is a Swamp and one is a Forest. Even if one of the lands you sacrifice is both a Swamp and a Forest, you have to sacrifice another land that is a Swamp or a Forest."
+          "text": "To activate Jarad's last ability, you must sacrifice two lands. It doesn't matter what other land types the two lands have, as long as one is a Swamp and one is a Forest. Even if one of the lands you sacrifice is both a Swamp and a Forest, you have to sacrifice another land that is a Swamp or a Forest."
         },
         {
           "date": "2012-10-01",
@@ -11468,15 +11474,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Kaalia’s ability doesn’t trigger if it attacks a planeswalker."
+          "text": "Kaalia's ability doesn't trigger if it attacks a planeswalker."
         },
         {
           "date": "2011-09-22",
-          "text": "The creature card is already tapped and attacking as it’s put onto the battlefield. Any abilities that trigger when a creature becomes tapped or when a creature attacks won’t trigger for that card."
+          "text": "The creature card is already tapped and attacking as it's put onto the battlefield. Any abilities that trigger when a creature becomes tapped or when a creature attacks won't trigger for that card."
         },
         {
           "date": "2011-09-22",
-          "text": "If the opponent Kaalia attacked is no longer in the game when its ability resolves, you may put an Angel, Demon, or Dragon creature card onto the battlefield tapped, but it won’t be attacking anyone and it won’t be an attacking creature."
+          "text": "If the opponent Kaalia attacked is no longer in the game when its ability resolves, you may put an Angel, Demon, or Dragon creature card onto the battlefield tapped, but it won't be attacking anyone and it won't be an attacking creature."
         }
       ],
       "subtypes": [
@@ -11548,7 +11554,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Use the sacrificed creature’s toughness when it was last on the battlefield to determine the value of X."
+          "text": "Use the sacrificed creature's toughness when it was last on the battlefield to determine the value of X."
         }
       ],
       "subtypes": [
@@ -11804,15 +11810,15 @@
       "rulings": [
         {
           "date": "2015-11-04",
-          "text": "If a permanent is sacrificed to pay a cost of a spell or ability, Mazirek’s ability will resolve before that spell or ability. Conversely, if a permanent is sacrificed during the resolution of a spell or ability, that spell or ability will finish resolving before Mazirek’s ability is put onto the stack."
+          "text": "If a permanent is sacrificed to pay a cost of a spell or ability, Mazirek's ability will resolve before that spell or ability. Conversely, if a permanent is sacrificed during the resolution of a spell or ability, that spell or ability will finish resolving before Mazirek's ability is put onto the stack."
         },
         {
           "date": "2015-11-04",
-          "text": "Mazirek itself doesn’t allow any player to sacrifice any permanents. Its ability triggers whenever a player sacrifices a permanent because some other spell, ability, or cost instructed the player to do so."
+          "text": "Mazirek itself doesn't allow any player to sacrifice any permanents. Its ability triggers whenever a player sacrifices a permanent because some other spell, ability, or cost instructed the player to do so."
         },
         {
           "date": "2015-11-04",
-          "text": "A legendary creature that dies because of the “legend rule” isn’t sacrificed. The same is true for a planeswalker that is affected by the “planeswalker uniqueness rule.”"
+          "text": "A legendary creature that dies because of the \"legend rule\" isn't sacrificed. The same is true for a planeswalker that is affected by the \"planeswalker uniqueness rule.\""
         }
       ],
       "subtypes": [
@@ -11877,7 +11883,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "You can’t choose to put the creature card into your hand if its converted mana cost is less than or equal to the number of experience counters you have as the ability resolves."
+          "text": "You can't choose to put the creature card into your hand if its converted mana cost is less than or equal to the number of experience counters you have as the ability resolves."
         },
         {
           "date": "2015-11-04",
@@ -11893,7 +11899,7 @@
         },
         {
           "date": "2015-11-04",
-          "text": "Each game pack includes a card labeled “Experience” with the suggestion “Place your experience counters here.” This card isn’t required for play. It’s simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
+          "text": "Each game pack includes a card labeled \"Experience\" with the suggestion \"Place your experience counters here.\" This card isn't required for play. It's simply a convenient spot to put your experience counters, which can be represented with dice, glass beads, or other small items."
         }
       ],
       "subtypes": [
@@ -11967,7 +11973,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target creature or enchantment.",
@@ -12104,7 +12110,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an artifact, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an artifact, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target artifact or creature. It can't be regenerated.",
@@ -12160,7 +12166,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "If Roon of the Hidden Realm’s ability targets a commander, that card’s owner may choose to have it go to the command zone rather than being exiled. The delayed triggered ability will return it to the battlefield no matter which of the two zones it went to, as long as it’s still in that zone when that triggered ability resolves."
+          "text": "If Roon of the Hidden Realm's ability targets a commander, that card's owner may choose to have it go to the command zone rather than being exiled. The delayed triggered ability will return it to the battlefield no matter which of the two zones it went to, as long as it's still in that zone when that triggered ability resolves."
         }
       ],
       "subtypes": [
@@ -12231,11 +12237,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won’t gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
+          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won't gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the targeted permanent remains a legal target for the ability, only that it’s on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
+          "text": "Once the ability resolves, it doesn't care whether the targeted permanent remains a legal target for the ability, only that it's on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
         }
       ],
       "subtypes": [
@@ -12422,7 +12428,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The creature card is chosen at random from among creature cards in the target opponent’s graveyard as the ability resolves. Players can respond to the ability knowing the targeted player, but they won’t know which creature card is about to enter the battlefield."
+          "text": "The creature card is chosen at random from among creature cards in the target opponent's graveyard as the ability resolves. Players can respond to the ability knowing the targeted player, but they won't know which creature card is about to enter the battlefield."
         }
       ],
       "subtypes": [
@@ -12561,11 +12567,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The ability doesn’t care why a card goes to your opponent’s graveyard — only that it does. The ability triggers when a card is put into your opponent’s graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player’s hand (a card is discarded), from the player’s library (from a Millstone-like effect), or from any other zone."
+          "text": "The ability doesn't care why a card goes to your opponent's graveyard — only that it does. The ability triggers when a card is put into your opponent's graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player's hand (a card is discarded), from the player's library (from a Millstone-like effect), or from any other zone."
         },
         {
           "date": "2005-10-01",
-          "text": "This ability triggers only on cards, so it won’t trigger when a token is put into your opponent’s graveyard."
+          "text": "This ability triggers only on cards, so it won't trigger when a token is put into your opponent's graveyard."
         }
       ],
       "subtypes": [
@@ -12814,7 +12820,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -12826,7 +12832,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -12893,7 +12899,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -12905,7 +12911,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -12971,15 +12977,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You choose attackers and make blocking assignments regardless of whether it’s your turn and regardless of whether the creatures are attacking you. Your choices must be legal within the normal rules for attacking and blocking."
+          "text": "You choose attackers and make blocking assignments regardless of whether it's your turn and regardless of whether the creatures are attacking you. Your choices must be legal within the normal rules for attacking and blocking."
         },
         {
           "date": "2006-01-01",
-          "text": "You can decide that a creature won’t block."
+          "text": "You can decide that a creature won't block."
         },
         {
           "date": "2008-04-01",
-          "text": "If the defending player controls a planeswalker, the person who cast Master Warcraft first chooses the complete group of creatures that are going to attack. Then, for each of those creatures, the active player chooses who or what it’s going to attack."
+          "text": "If the defending player controls a planeswalker, the person who cast Master Warcraft first chooses the complete group of creatures that are going to attack. Then, for each of those creatures, the active player chooses who or what it's going to attack."
         },
         {
           "date": "2013-09-20",
@@ -13113,15 +13119,15 @@
         },
         {
           "date": "2008-08-01",
-          "text": "All your green and/or blue creatures untap during each other player’s untap step. You have no choice about what untaps. Those creatures untap at the same time as the active player’s permanents."
+          "text": "All your green and/or blue creatures untap during each other player's untap step. You have no choice about what untaps. Those creatures untap at the same time as the active player's permanents."
         },
         {
           "date": "2008-08-01",
-          "text": "During each other player’s untap step, effects that would otherwise cause your green and/or blue creatures to stay tapped don’t apply because they only apply during *your* untap step. For example, if you control Nettle Sentinel (a green creature that says “Nettle Sentinel doesn’t untap during your untap step”), you untap it during each other player’s untap step."
+          "text": "During each other player's untap step, effects that would otherwise cause your green and/or blue creatures to stay tapped don't apply because they only apply during *your* untap step. For example, if you control Nettle Sentinel (a green creature that says \"Nettle Sentinel doesn't untap during your untap step\"), you untap it during each other player's untap step."
         },
         {
           "date": "2008-08-01",
-          "text": "Multiple Murkfiend Lieges are redundant when it comes to the untap effect. You can’t untap your permanents more than once in a single untap step."
+          "text": "Multiple Murkfiend Lieges are redundant when it comes to the untap effect. You can't untap your permanents more than once in a single untap step."
         }
       ],
       "subtypes": [
@@ -13349,11 +13355,11 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The equipped creature can’t be sacrificed for any reason. If an effect instructs you to sacrifice it, you can’t and it remains on the battlefield. You also can’t sacrifice it to pay a cost that requires you to sacrifice a creature."
+          "text": "The equipped creature can't be sacrificed for any reason. If an effect instructs you to sacrifice it, you can't and it remains on the battlefield. You also can't sacrifice it to pay a cost that requires you to sacrifice a creature."
         },
         {
           "date": "2014-11-07",
-          "text": "If an effect instructs you to sacrifice a creature, and you control any creatures other than the creature equipped with Assault Suit, you must sacrifice one of them. You can’t try to sacrifice the equipped creature, fail, and therefore ignore the effect."
+          "text": "If an effect instructs you to sacrifice a creature, and you control any creatures other than the creature equipped with Assault Suit, you must sacrifice one of them. You can't try to sacrifice the equipped creature, fail, and therefore ignore the effect."
         }
       ],
       "subtypes": [
@@ -13418,7 +13424,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {W} or {U} to your mana pool.\n{W}{U}: Azorius Keyrune becomes a 2/2 white and blue Bird artifact creature with flying until end of turn.",
@@ -13529,15 +13535,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If there are no creature cards in any graveyard when Bonehoard’s living weapon ability resolves, the Germ will be 0/0 and put into its owner’s graveyard."
+          "text": "If there are no creature cards in any graveyard when Bonehoard's living weapon ability resolves, the Germ will be 0/0 and put into its owner's graveyard."
         },
         {
           "date": "2011-06-01",
-          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won’t increase the bonus granted by Bonehoard, however briefly."
+          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won't increase the bonus granted by Bonehoard, however briefly."
         },
         {
           "date": "2011-06-01",
-          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won’t get an additional bonus from the other creature."
+          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won't get an additional bonus from the other creature."
         }
       ],
       "subtypes": [
@@ -13641,15 +13647,15 @@
       "rulings": [
         {
           "date": "2014-11-07",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even if your commander is in a hidden zone (such as your hand or your library) or if an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even if your commander is in a hidden zone (such as your hand or your library) or if an effect changes your commander's color."
         },
         {
           "date": "2014-11-07",
-          "text": "If your commander has no colors in its color identity, Commander’s Sphere produces no mana."
+          "text": "If your commander has no colors in its color identity, Commander's Sphere produces no mana."
         },
         {
           "date": "2014-11-07",
-          "text": "In formats other than Commander, Commander’s Sphere produces no mana."
+          "text": "In formats other than Commander, Commander's Sphere produces no mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
@@ -13804,11 +13810,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you control any creatures as the triggered ability resolves, you must sacrifice one. You can’t choose to sacrifice Eldrazi Monument instead. You sacrifice the Monument only if you had no creatures to sacrifice."
+          "text": "If you control any creatures as the triggered ability resolves, you must sacrifice one. You can't choose to sacrifice Eldrazi Monument instead. You sacrifice the Monument only if you had no creatures to sacrifice."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "text": "Creatures you control get +1/+1 and have flying and indestructible.\nAt the beginning of your upkeep, sacrifice a creature. If you can't, sacrifice Eldrazi Monument.",
@@ -13857,7 +13863,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -13877,7 +13883,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Green spells you cast cost {1} less to cast.",
@@ -14040,7 +14046,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You are not allowed to “unequip” equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won’t be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
+          "text": "You are not allowed to \"unequip\" equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won't be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
         }
       ],
       "subtypes": [
@@ -14417,7 +14423,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -14693,7 +14699,7 @@
         },
         {
           "date": "2013-10-17",
-          "text": "If no players control at least two more lands than you when the ability resolves, you’ll still search and shuffle your library."
+          "text": "If no players control at least two more lands than you when the ability resolves, you'll still search and shuffle your library."
         }
       ],
       "text": "{T}, Exile Surveyor's Scope: Search your library for up to X basic land cards, where X is the number of players who control at least two more lands than you. Put those cards onto the battlefield, then shuffle your library.",
@@ -14746,7 +14752,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can’t be the target of spells and abilities you control."
+          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can't be the target of spells and abilities you control."
         }
       ],
       "subtypes": [
@@ -14892,7 +14898,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Thousand-Year Elixir doesn’t actually grant haste to creatures you control, nor does it let you attack with them as though they had haste."
+          "text": "Thousand-Year Elixir doesn't actually grant haste to creatures you control, nor does it let you attack with them as though they had haste."
         }
       ],
       "text": "You may activate abilities of creatures you control as though those creatures had haste.\n{1}, {T}: Untap target creature.",
@@ -14947,7 +14953,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If Thunderstaff is untapped, it prevents 1 damage from each creature, each time it would deal combat damage to you. So if three creatures with double strike attack you and aren’t blocked, Thunderstaff will prevent a total of 6 damage."
+          "text": "If Thunderstaff is untapped, it prevents 1 damage from each creature, each time it would deal combat damage to you. So if three creatures with double strike attack you and aren't blocked, Thunderstaff will prevent a total of 6 damage."
         }
       ],
       "text": "As long as Thunderstaff is untapped, if a creature would deal combat damage to you, prevent 1 of that damage.\n{2}, {T}: Attacking creatures get +1/+0 until end of turn.",
@@ -15385,15 +15391,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander's color."
         },
         {
           "date": "2011-09-22",
-          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower’s ability produces no mana."
+          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower's ability produces no mana."
         },
         {
           "date": "2011-09-22",
-          "text": "In formats other than Commander, Command Tower’s ability produces no mana."
+          "text": "In formats other than Commander, Command Tower's ability produces no mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color in your commander's color identity.",
@@ -15578,11 +15584,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Faerie Conclave enters the battlefield tapped.\n{T}: Add {U} to your mana pool.\n{1}{U}: Faerie Conclave becomes a 2/1 blue Faerie creature with flying until end of turn. It's still a land.",
@@ -15740,15 +15746,15 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won’t get to search for a land card."
+          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won't get to search for a land card."
         },
         {
           "date": "2011-09-22",
-          "text": "If the targeted land is an illegal target by the time Ghost Quarter’s ability resolves, it will be countered and none of its effects will happen. The land’s controller won’t get to search for a basic land card."
+          "text": "If the targeted land is an illegal target by the time Ghost Quarter's ability resolves, it will be countered and none of its effects will happen. The land's controller won't get to search for a basic land card."
         },
         {
           "date": "2013-07-01",
-          "text": "The target land’s controller gets to search for a basic land card even if that land wasn’t destroyed by Ghost Quarter’s ability. This may happen because the land has indestructible or because it was regenerated."
+          "text": "The target land's controller gets to search for a basic land card even if that land wasn't destroyed by Ghost Quarter's ability. This may happen because the land has indestructible or because it was regenerated."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it onto the battlefield, then shuffle his or her library.",
@@ -15978,11 +15984,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The creature card returned to your hand is chosen at random as the ability resolves. If any player responds to the ability, that player won’t yet know what card will be returned."
+          "text": "The creature card returned to your hand is chosen at random as the ability resolves. If any player responds to the ability, that player won't yet know what card will be returned."
         },
         {
           "date": "2011-01-22",
-          "text": "Because the ability doesn’t target any creature card, any creature card put into the graveyard in response to that ability may be returned to your hand."
+          "text": "Because the ability doesn't target any creature card, any creature card put into the graveyard in response to that ability may be returned to your hand."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{3}, {T}, Sacrifice Haunted Fengraf: Return a creature card at random from your graveyard to your hand.",
@@ -16307,19 +16313,19 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "The “number of times it’s been cast from the command zone” includes the most recent time. For example, the first time you cast your commander from the command zone in a game, if you spent mana from Opal Palace’s last ability to do so, it will enter the battlefield with a +1/+1 counter."
+          "text": "The \"number of times it's been cast from the command zone\" includes the most recent time. For example, the first time you cast your commander from the command zone in a game, if you spent mana from Opal Palace's last ability to do so, it will enter the battlefield with a +1/+1 counter."
         },
         {
           "date": "2013-10-17",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even if your commander is in a hidden zone (like the hand or library) or an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even if your commander is in a hidden zone (like the hand or library) or an effect changes your commander's color."
         },
         {
           "date": "2013-10-17",
-          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Opal Palace’s last ability produces no mana."
+          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Opal Palace's last ability produces no mana."
         },
         {
           "date": "2013-10-17",
-          "text": "In formats other than Commander, Opal Palace’s last ability produces no mana."
+          "text": "In formats other than Commander, Opal Palace's last ability produces no mana."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add to your mana pool one mana of any color in your commander's color identity. If you spend this mana to cast your commander, it enters the battlefield with a number of additional +1/+1 counters on it equal to the number of times it's been cast from the command zone this game.",
@@ -16374,11 +16380,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Oran-Rief’s third ability cares about permanents’ characteristics at the time the ability resolves, not their characteristics at the time they entered the battlefield. For example, if a blue creature enters the battlefield, then is turned green by a spell or ability, then Oran-Rief’s second ability resolves, you’ll put a +1/+1 counter on that creature."
+          "text": "Oran-Rief's third ability cares about permanents' characteristics at the time the ability resolves, not their characteristics at the time they entered the battlefield. For example, if a blue creature enters the battlefield, then is turned green by a spell or ability, then Oran-Rief's second ability resolves, you'll put a +1/+1 counter on that creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Oran-Rief’s second ability affects all permanents that are green creatures that entered the battlefield this turn, not just the ones you control."
+          "text": "Oran-Rief's second ability affects all permanents that are green creatures that entered the battlefield this turn, not just the ones you control."
         }
       ],
       "text": "Oran-Rief, the Vastwood enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{T}: Put a +1/+1 counter on each green creature that entered the battlefield this turn.",

--- a/json/CMD.json
+++ b/json/CMD.json
@@ -92,15 +92,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -424,23 +424,23 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "During your turn, Angelic Arbiter’s abilities have no effect on the game."
+          "text": "During your turn, Angelic Arbiter's abilities have no effect on the game."
         },
         {
           "date": "2010-08-15",
-          "text": "During an opponent’s turn, that opponent may either cast spells or attack with creatures, but not both (assuming that Angelic Arbiter is on the battlefield for the entirety of that turn). The player may perform other actions, such as activating abilities and playing lands."
+          "text": "During an opponent's turn, that opponent may either cast spells or attack with creatures, but not both (assuming that Angelic Arbiter is on the battlefield for the entirety of that turn). The player may perform other actions, such as activating abilities and playing lands."
         },
         {
           "date": "2010-08-15",
-          "text": "If Angelic Arbiter leaves the battlefield during an opponent’s turn, its abilities cease to affect the game. For example, if an opponent casts Doom Blade to destroy Angelic Arbiter, that player may then attack with creatures."
+          "text": "If Angelic Arbiter leaves the battlefield during an opponent's turn, its abilities cease to affect the game. For example, if an opponent casts Doom Blade to destroy Angelic Arbiter, that player may then attack with creatures."
         },
         {
           "date": "2010-08-15",
-          "text": "If Angelic Arbiter enters the battlefield during an opponent’s turn, its abilities take actions that player performed earlier in the turn into account, even though it wasn’t on the battlefield at the time. For example, if an opponent casts a spell, then you use Leyline of Anticipation’s ability to cast Angelic Arbiter as though it had flash, that player won’t be able to attack with creatures that turn."
+          "text": "If Angelic Arbiter enters the battlefield during an opponent's turn, its abilities take actions that player performed earlier in the turn into account, even though it wasn't on the battlefield at the time. For example, if an opponent casts a spell, then you use Leyline of Anticipation's ability to cast Angelic Arbiter as though it had flash, that player won't be able to attack with creatures that turn."
         },
         {
           "date": "2010-08-15",
-          "text": "Angelic Arbiter’s last ability applies if an opponent attacked with at least one creature during the current turn."
+          "text": "Angelic Arbiter's last ability applies if an opponent attacked with at least one creature during the current turn."
         }
       ],
       "subtypes": [
@@ -536,7 +536,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "In other multiplayer formats, each player’s life total is set to the highest life total within his or her range of influence. These changes happen at the same time. For example, if each player has a range of influence of one, and the players in the game are Alice (4 life), Barry (8 life), Carrie (11 life), and Doug (7 life), in that order, then Alice’s life total will become 8 and Barry and Doug’s life totals will each become 11."
+          "text": "In other multiplayer formats, each player's life total is set to the highest life total within his or her range of influence. These changes happen at the same time. For example, if each player has a range of influence of one, and the players in the game are Alice (4 life), Barry (8 life), Carrie (11 life), and Doug (7 life), in that order, then Alice's life total will become 8 and Barry and Doug's life totals will each become 11."
         },
         {
           "date": "2010-06-15",
@@ -624,7 +624,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Archangel of Strife’s second and third abilities are linked. Similarly, its second and fourth abilities are linked. The bonus a player’s creatures get depends only on the choice that player made when Archangel of Strife entered the battlefield."
+          "text": "Archangel of Strife's second and third abilities are linked. Similarly, its second and fourth abilities are linked. The bonus a player's creatures get depends only on the choice that player made when Archangel of Strife entered the battlefield."
         },
         {
           "date": "2011-09-22",
@@ -632,7 +632,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Archangel of Strife’s bonuses apply immediately. Depending on your choice, Archangel of Strife will enter the battlefield as either a 9/6 or 6/9 creature."
+          "text": "Archangel of Strife's bonuses apply immediately. Depending on your choice, Archangel of Strife will enter the battlefield as either a 9/6 or 6/9 creature."
         },
         {
           "date": "2011-09-22",
@@ -825,11 +825,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
+          "text": "A creature \"shares a color\" with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
         },
         {
           "date": "2005-10-01",
-          "text": "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+          "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
         },
         {
           "date": "2005-10-01",
@@ -915,7 +915,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, this ability triggers once at the beginning of each team’s upkeep."
+          "text": "In a Two-Headed Giant game, this ability triggers once at the beginning of each team's upkeep."
         }
       ],
       "subtypes": [
@@ -1086,7 +1086,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, the first ability triggers once during each team’s upkeep."
+          "text": "In a Two-Headed Giant game, the first ability triggers once during each team's upkeep."
         }
       ],
       "text": "At the beginning of each upkeep, put a strife counter on Crescendo of War.\nAttacking creatures get +1/+0 for each strife counter on Crescendo of War.\nBlocking creatures you control get +1/+0 for each strife counter on Crescendo of War.",
@@ -1170,7 +1170,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "False Prophet only exiles creatures, which means only creature permanents which are on the battlefield. It won’t exile itself since it is already in the graveyard."
+          "text": "False Prophet only exiles creatures, which means only creature permanents which are on the battlefield. It won't exile itself since it is already in the graveyard."
         }
       ],
       "subtypes": [
@@ -1270,7 +1270,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -1356,31 +1356,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy all nontoken creatures.",
@@ -1466,7 +1466,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "When paying Jötun Grunt’s cumulative upkeep, you may choose a different graveyard for each age counter. For example, if it has three age counters on it, you may put four cards from your graveyard on the bottom of your library and two cards from your opponent’s graveyard on the bottom of his or her library. However, you can’t put five cards from your graveyard on the bottom of your library and one card from your opponent’s graveyard on the bottom of his or her library."
+          "text": "When paying Jötun Grunt's cumulative upkeep, you may choose a different graveyard for each age counter. For example, if it has three age counters on it, you may put four cards from your graveyard on the bottom of your library and two cards from your opponent's graveyard on the bottom of his or her library. However, you can't put five cards from your graveyard on the bottom of your library and one card from your opponent's graveyard on the bottom of his or her library."
         }
       ],
       "subtypes": [
@@ -1719,11 +1719,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If Martyr’s Bond and other nonland permanents are put into the graveyard from the battlefield at the same time, Martyr’s Bond will trigger for itself and each of those other nonland permanents."
+          "text": "If Martyr's Bond and other nonland permanents are put into the graveyard from the battlefield at the same time, Martyr's Bond will trigger for itself and each of those other nonland permanents."
         },
         {
           "date": "2011-09-22",
-          "text": "Each opponent must sacrifice only one permanent for each trigger, even if the nonland permanent you controlled that went to the graveyard had multiple types. For example, if an artifact creature you control is put into a graveyard from the battlefield, each opponent sacrifices exactly one artifact or creature, and that permanent doesn’t need to be an artifact creature."
+          "text": "Each opponent must sacrifice only one permanent for each trigger, even if the nonland permanent you controlled that went to the graveyard had multiple types. For example, if an artifact creature you control is put into a graveyard from the battlefield, each opponent sacrifices exactly one artifact or creature, and that permanent doesn't need to be an artifact creature."
         }
       ],
       "text": "Whenever Martyr's Bond or another nonland permanent you control is put into a graveyard from the battlefield, each opponent sacrifices a permanent that shares a card type with it.",
@@ -2076,11 +2076,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -2252,11 +2252,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature’s controller won’t search for a basic land card."
+          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature's controller won't search for a basic land card."
         },
         {
           "date": "2017-03-14",
-          "text": "The controller of the exiled creature isn’t required to search his or her library for a basic land. If that player doesn’t, the player won’t shuffle his or her library."
+          "text": "The controller of the exiled creature isn't required to search his or her library for a basic land. If that player doesn't, the player won't shuffle his or her library."
         }
       ],
       "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
@@ -2421,11 +2421,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The last ability works only if Prison Term is already on the battlefield. You may move it from the creature it’s currently enchanting onto the new creature."
+          "text": "The last ability works only if Prison Term is already on the battlefield. You may move it from the creature it's currently enchanting onto the new creature."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -2516,7 +2516,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there’s only one legal target. If it’s cast at a time other than its controller’s main phase and a second target is chosen, nothing will happen to that target."
+          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there's only one legal target. If it's cast at a time other than its controller's main phase and a second target is chosen, nothing will happen to that target."
         }
       ],
       "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
@@ -2952,7 +2952,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t activate this ability unless a single opponent has at least two cards in their graveyard to target."
+          "text": "You can't activate this ability unless a single opponent has at least two cards in their graveyard to target."
         }
       ],
       "subtypes": [
@@ -3385,7 +3385,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -3673,7 +3673,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The creatures can’t attack until you start a turn with them under your control. So you can’t swap and then attack."
+          "text": "The creatures can't attack until you start a turn with them under your control. So you can't swap and then attack."
         },
         {
           "date": "2004-10-04",
@@ -3768,7 +3768,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a card a player reveals this way is the card that particular player named, he or she must put it into his or her hand. Otherwise, he or she must put it on the bottom of his or her library, even if it’s the card a different player named. In no cases can a player leave the revealed card on top of his or her library."
+          "text": "If a card a player reveals this way is the card that particular player named, he or she must put it into his or her hand. Otherwise, he or she must put it on the bottom of his or her library, even if it's the card a different player named. In no cases can a player leave the revealed card on top of his or her library."
         }
       ],
       "subtypes": [
@@ -3859,7 +3859,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -4044,7 +4044,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Each pile may contain from zero to five cards; they don’t have to be split “evenly.”"
+          "text": "Each pile may contain from zero to five cards; they don't have to be split \"evenly.\""
         }
       ],
       "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
@@ -4122,15 +4122,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -4227,7 +4227,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If Fog Bank blocks a creature with trample, that creature’s controller must assign 2 damage to Fog Bank (assuming it’s blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
+          "text": "If Fog Bank blocks a creature with trample, that creature's controller must assign 2 damage to Fog Bank (assuming it's blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
         }
       ],
       "subtypes": [
@@ -4318,11 +4318,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Gomazoa’s ability can be activated any time its controller has priority. It doesn’t need to be blocking any creatures."
+          "text": "Gomazoa's ability can be activated any time its controller has priority. It doesn't need to be blocking any creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "If Gomazoa isn’t blocking a creature at the time its ability resolves, only Gomazoa is put on top of its owner’s library, and only that player shuffles his or her library."
+          "text": "If Gomazoa isn't blocking a creature at the time its ability resolves, only Gomazoa is put on top of its owner's library, and only that player shuffles his or her library."
         }
       ],
       "subtypes": [
@@ -4571,7 +4571,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The card-drawing part of the effect is not optional. A player can’t choose to draw fewer than X cards."
+          "text": "The card-drawing part of the effect is not optional. A player can't choose to draw fewer than X cards."
         }
       ],
       "text": "Join forces — Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.",
@@ -4930,7 +4930,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -5025,11 +5025,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The creature returns to the opponent when the “until end of turn” effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
+          "text": "The creature returns to the opponent when the \"until end of turn\" effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command's effect ends, or because a spell or ability causes another player to gain control of it."
         }
       ],
       "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature gains haste until end of turn. When you lose control of the creature, tap it.",
@@ -5273,7 +5273,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Riddlekeeper doesn’t impose a cost to attack. Creatures can attack you or a planeswalker you control even if their controller has no cards left in his or her library."
+          "text": "Riddlekeeper doesn't impose a cost to attack. Creatures can attack you or a planeswalker you control even if their controller has no cards left in his or her library."
         }
       ],
       "subtypes": [
@@ -5362,11 +5362,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "You decide whether or not to add that much {C} to your mana pool as the delayed triggered ability resolves at the beginning of your next main phase. You don’t decide before then."
+          "text": "You decide whether or not to add that much {C} to your mana pool as the delayed triggered ability resolves at the beginning of your next main phase. You don't decide before then."
         },
         {
           "date": "2007-10-01",
-          "text": "You can’t add just some of the mana to your mana pool. You either add all the mana to your mana pool or none of it."
+          "text": "You can't add just some of the mana to your mana pool. You either add all the mana to your mana pool or none of it."
         }
       ],
       "text": "Counter target spell. Clash with an opponent. If you win, at the beginning of your next main phase, you may add an amount of {C} to your mana pool equal to that spell's converted mana cost. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -5610,15 +5610,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If a commander is countered this way, it will be put on the bottom of its owner’s library."
+          "text": "If a commander is countered this way, it will be put on the bottom of its owner's library."
         },
         {
           "date": "2011-09-22",
-          "text": "If the spell is an illegal target when Spell Crumple tries to resolve, it will be countered and none of its effects will happen. Spell Crumple will be put into its owner’s graveyard."
+          "text": "If the spell is an illegal target when Spell Crumple tries to resolve, it will be countered and none of its effects will happen. Spell Crumple will be put into its owner's graveyard."
         },
         {
           "date": "2011-09-22",
-          "text": "If the targeted spell can’t be countered, it won’t be put onto the bottom of its owner’s library. Spell Crumple will still be put on the bottom of its owner’s library."
+          "text": "If the targeted spell can't be countered, it won't be put onto the bottom of its owner's library. Spell Crumple will still be put on the bottom of its owner's library."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, put it on the bottom of its owner's library instead of into that player's graveyard. Put Spell Crumple on the bottom of its owner's library.",
@@ -5774,7 +5774,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "While Trench Gorger’s ability is on the stack, it’s on the battlefield as a 6/6."
+          "text": "While Trench Gorger's ability is on the stack, it's on the battlefield as a 6/6."
         },
         {
           "date": "2011-09-22",
@@ -5782,7 +5782,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "After the ability resolves, Trench Gorger’s power and toughness won’t change if one of the exiled cards leaves exile."
+          "text": "After the ability resolves, Trench Gorger's power and toughness won't change if one of the exiled cards leaves exile."
         }
       ],
       "subtypes": [
@@ -5873,7 +5873,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If either land becomes an illegal target (or leaves the battlefield) before the ability resolves, the exchange won’t happen. There’s no way for you to gain a land without losing another one in the process."
+          "text": "If either land becomes an illegal target (or leaves the battlefield) before the ability resolves, the exchange won't happen. There's no way for you to gain a land without losing another one in the process."
         }
       ],
       "subtypes": [
@@ -6123,11 +6123,11 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If you don’t win the clash, the targeted creature always goes to its owner’s hand. If you win the clash, you choose whether the creature goes to its owner’s hand or the top of its owner’s library."
+          "text": "If you don't win the clash, the targeted creature always goes to its owner's hand. If you win the clash, you choose whether the creature goes to its owner's hand or the top of its owner's library."
         },
         {
           "date": "2007-10-01",
-          "text": "If you clash with the owner of the targeted creature and win, the owner of the creature decides where to put to card revealed during the clash before you decide whether to put the creature on top of that library. You know the player’s decision before you make your decision."
+          "text": "If you clash with the owner of the targeted creature and win, the owner of the creature decides where to put to card revealed during the clash before you decide whether to put the creature on top of that library. You know the player's decision before you make your decision."
         }
       ],
       "text": "Clash with an opponent, then return target creature to its owner's hand. If you win, you may put that creature on top of its owner's library instead. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -6457,7 +6457,8 @@
         "ARC",
         "CMD",
         "PD3",
-        "CN2"
+        "CN2",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -6651,15 +6652,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners’ graveyards at the same time, Butcher of Malakir’s triggered ability will trigger that many times."
+          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners' graveyards at the same time, Butcher of Malakir's triggered ability will trigger that many times."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers’ abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
+          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers' abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player’s Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player’s Butcher to trigger, and so on."
+          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player's Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player's Butcher to trigger, and so on."
         }
       ],
       "subtypes": [
@@ -7006,11 +7007,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you put Dread Cacodemon directly onto the battlefield from your hand, perhaps because of Kaalia of the Vast’s ability, its ability won’t trigger."
+          "text": "If you put Dread Cacodemon directly onto the battlefield from your hand, perhaps because of Kaalia of the Vast's ability, its ability won't trigger."
         },
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -7181,11 +7182,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon’s triggered ability will trigger."
+          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon's triggered ability will trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "You can target any player with Extractor Demon’s triggered ability. The target doesn’t have to be the controller of the creature that left the battlefield."
+          "text": "You can target any player with Extractor Demon's triggered ability. The target doesn't have to be the controller of the creature that left the battlefield."
         }
       ],
       "subtypes": [
@@ -7377,11 +7378,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you’ll have to sacrifice Fleshbag Marauder."
+          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you'll have to sacrifice Fleshbag Marauder."
         },
         {
           "date": "2015-06-22",
-          "text": "As Fleshbag Marauder’s ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
+          "text": "As Fleshbag Marauder's ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
         }
       ],
       "subtypes": [
@@ -7476,7 +7477,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "You can cast this with zero targets. If you do, you’ll get to draw a card. However, if you cast this with at least one target and all of those targets become illegal, the spell will be countered and you won’t get to draw a card."
+          "text": "You can cast this with zero targets. If you do, you'll get to draw a card. However, if you cast this with at least one target and all of those targets become illegal, the spell will be countered and you won't get to draw a card."
         }
       ],
       "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
@@ -7617,6 +7618,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -7630,6 +7635,10 @@
         },
         {
           "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -7675,7 +7684,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -7765,7 +7774,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You must target six different creatures. If you can’t, you can’t cast Hex. If some of the creatures become illegal targets before the spell resolves, Hex will still destroy the rest of them."
+          "text": "You must target six different creatures. If you can't, you can't cast Hex. If some of the creatures become illegal targets before the spell resolves, Hex will still destroy the rest of them."
         }
       ],
       "text": "Destroy six target creatures.",
@@ -7852,7 +7861,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures which are sacrificed can’t be regenerated."
+          "text": "The creatures which are sacrificed can't be regenerated."
         },
         {
           "date": "2004-10-04",
@@ -7860,7 +7869,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
+          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
         }
       ],
       "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -8132,15 +8141,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast Nemesis Trap during your opponent’s declare attackers step, you’ll put the token onto the battlefield before the declare blockers step begins and you can block with it this combat. If you cast Nemesis Trap later in the combat phase a, you won’t be able to block with the token."
+          "text": "If you cast Nemesis Trap during your opponent's declare attackers step, you'll put the token onto the battlefield before the declare blockers step begins and you can block with it this combat. If you cast Nemesis Trap later in the combat phase a, you won't be able to block with the token."
         },
         {
           "date": "2010-03-01",
-          "text": "The token you put onto the battlefield copies exactly what was printed on the exiled creature and nothing more (unless it was copying something else or it was a token; see below). It doesn’t copy whether the exiled creature was tapped or untapped, whether it had any counters on it or Auras attached to it, or any non-copy effects that changed its power, toughness, types, color, or so on. For example, if Nemesis Trap targets an animated Celestial Colonnade, the token you put onto the battlefield will be a Celestial Colonnade that’s just a land. (Because of this, Nemesis Trap has received minor errata to specify that you put a token, not a “creature token,” onto the battlefield.)"
+          "text": "The token you put onto the battlefield copies exactly what was printed on the exiled creature and nothing more (unless it was copying something else or it was a token; see below). It doesn't copy whether the exiled creature was tapped or untapped, whether it had any counters on it or Auras attached to it, or any non-copy effects that changed its power, toughness, types, color, or so on. For example, if Nemesis Trap targets an animated Celestial Colonnade, the token you put onto the battlefield will be a Celestial Colonnade that's just a land. (Because of this, Nemesis Trap has received minor errata to specify that you put a token, not a \"creature token,\" onto the battlefield.)"
         },
         {
           "date": "2010-03-01",
@@ -8156,11 +8165,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "Any enters-the-battlefield abilities of the exiled creature will trigger when the token is put onto the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the exiled creature will trigger when the token is put onto the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2010-03-01",
-          "text": "If the targeted creature is an illegal target by the time Nemesis Trap resolves, the entire spell is countered. You won’t get a token."
+          "text": "If the targeted creature is an illegal target by the time Nemesis Trap resolves, the entire spell is countered. You won't get a token."
         }
       ],
       "subtypes": [
@@ -8184,27 +8193,27 @@
       "foreignNames": [
         {
           "language": "French",
-          "name": "Noctœil le profanateur",
+          "name": "Nezumi Graverobber",
           "multiverseid": 261415
         },
         {
           "language": "German",
-          "name": "Nachtauge der Schänder",
+          "name": "Nezumi Graverobber",
           "multiverseid": 260430
         },
         {
           "language": "Italian",
-          "name": "Occhi-della-Notte il Profanatore",
+          "name": "Nezumi Graverobber",
           "multiverseid": 262052
         },
         {
           "language": "Japanese",
-          "name": "冒涜する者、夜目",
+          "name": "Nezumi Graverobber",
           "multiverseid": 261734
         },
         {
           "language": "Spanish",
-          "name": "Ojos nocturnos el profanador",
+          "name": "Nezumi Graverobber",
           "multiverseid": 260748
         }
       ],
@@ -8273,27 +8282,27 @@
       "foreignNames": [
         {
           "language": "French",
-          "name": "Noctœil le profanateur",
+          "name": "Nezumi Graverobber",
           "multiverseid": 261415
         },
         {
           "language": "German",
-          "name": "Nachtauge der Schänder",
+          "name": "Nezumi Graverobber",
           "multiverseid": 260430
         },
         {
           "language": "Italian",
-          "name": "Occhi-della-Notte il Profanatore",
+          "name": "Nezumi Graverobber",
           "multiverseid": 262052
         },
         {
           "language": "Japanese",
-          "name": "冒涜する者、夜目",
+          "name": "Nezumi Graverobber",
           "multiverseid": 261734
         },
         {
           "language": "Spanish",
-          "name": "Ojos nocturnos el profanador",
+          "name": "Nezumi Graverobber",
           "multiverseid": 260748
         }
       ],
@@ -8430,7 +8439,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Patron of the Nezumi’s ability triggers even if an event puts this and multiple other permanents into the graveyard at the same time (Wrath of God, gang blocks, etc.)"
+          "text": "Patron of the Nezumi's ability triggers even if an event puts this and multiple other permanents into the graveyard at the same time (Wrath of God, gang blocks, etc.)"
         }
       ],
       "subtypes": [
@@ -8613,7 +8622,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -8715,19 +8724,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
+          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -8816,7 +8825,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, each member of the opposing team will be able to see the other’s hand before deciding what to discard. If each member discards a card with the same converted mana cost, each player will lose that much life, resulting in the team losing life equal to twice that converted mana cost."
+          "text": "In a Two-Headed Giant game, each member of the opposing team will be able to see the other's hand before deciding what to discard. If each member discards a card with the same converted mana cost, each player will lose that much life, resulting in the team losing life equal to twice that converted mana cost."
         }
       ],
       "subtypes": [
@@ -8897,7 +8906,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the chosen player leaves the game, Sewer Nemesis’s power and toughness each become 0. Unless another effect is raising its toughness above 0, it will be put into its owner’s graveyard as a state-based action."
+          "text": "If the chosen player leaves the game, Sewer Nemesis's power and toughness each become 0. Unless another effect is raising its toughness above 0, it will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -9233,7 +9242,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Checks the number of cards in your graveyard when it starts resolving. You may drop below seven cards during resolution, but that won’t stop it from resolving."
+          "text": "Checks the number of cards in your graveyard when it starts resolving. You may drop below seven cards during resolution, but that won't stop it from resolving."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.\nThreshold — Return that card from your graveyard to the battlefield instead if seven or more cards are in your graveyard.",
@@ -9825,7 +9834,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The timestamp for the “in your graveyard” ability is set at the time that this card goes to your graveyard, regardless of whether you control a Mountain at that time."
+          "text": "The timestamp for the \"in your graveyard\" ability is set at the time that this card goes to your graveyard, regardless of whether you control a Mountain at that time."
         }
       ],
       "subtypes": [
@@ -9995,11 +10004,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2011-09-22",
-          "text": "If there are multiple combat phases in a turn, creatures must attack only in the first one in which they’re able to."
+          "text": "If there are multiple combat phases in a turn, creatures must attack only in the first one in which they're able to."
         }
       ],
       "subtypes": [
@@ -10248,7 +10257,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player’s library this way, that player shuffles before revealing the top card of that library."
+          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player's library this way, that player shuffles before revealing the top card of that library."
         },
         {
           "date": "2011-09-22",
@@ -10260,7 +10269,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the revealed card is a permanent card but can’t enter the battlefield (perhaps because it’s an Aura with nothing to enchant), it remains on top of that library."
+          "text": "If the revealed card is a permanent card but can't enter the battlefield (perhaps because it's an Aura with nothing to enchant), it remains on top of that library."
         },
         {
           "date": "2011-09-22",
@@ -10351,7 +10360,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Mountaincycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Mountaincycling doesn't allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -10459,11 +10468,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
+          "text": "A creature \"shares a color\" with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
         },
         {
           "date": "2005-10-01",
-          "text": "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+          "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
         },
         {
           "date": "2005-10-01",
@@ -10560,7 +10569,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The number of targets you choose for Comet Storm is one more than the number of times it’s kicked. First you declare how many times you’re going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you’ll kick the spell and the time you choose the targets."
+          "text": "The number of targets you choose for Comet Storm is one more than the number of times it's kicked. First you declare how many times you're going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you'll kick the spell and the time you choose the targets."
         },
         {
           "date": "2010-03-01",
@@ -10568,7 +10577,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you’re kicking the spell twice. You’ll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
+          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you're kicking the spell twice. You'll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
         },
         {
           "date": "2010-03-01",
@@ -10654,7 +10663,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If Death by Dragons resolves, the player who’s targeted is the only one who won’t put a Dragon token onto the battlefield."
+          "text": "If Death by Dragons resolves, the player who's targeted is the only one who won't put a Dragon token onto the battlefield."
         }
       ],
       "text": "Each player other than target player creates a 5/5 red Dragon creature token with flying.",
@@ -10832,11 +10841,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -11533,11 +11542,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The controller of Magmatic Force when its ability triggers always chooses the target, even when the ability triggers during another player’s upkeep."
+          "text": "The controller of Magmatic Force when its ability triggers always chooses the target, even when the ability triggers during another player's upkeep."
         },
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, this ability triggers once at the beginning of each team’s upkeep."
+          "text": "In a Two-Headed Giant game, this ability triggers once at the beginning of each team's upkeep."
         }
       ],
       "subtypes": [
@@ -11791,7 +11800,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Punishing Fire’s triggered ability triggers only if it’s already in your graveyard at the time an opponent gains life. For example, you can cast it in response to a spell or ability that will cause an opponent to gain life. In that case, Punishing Fire will resolve first, so it will be in the graveyard by the time the opponent gains life. However, if you wait until an opponent actually gains life and then cast Punishing Fire, you won’t be able to return it to your hand at that time."
+          "text": "Punishing Fire's triggered ability triggers only if it's already in your graveyard at the time an opponent gains life. For example, you can cast it in response to a spell or ability that will cause an opponent to gain life. In that case, Punishing Fire will resolve first, so it will be in the graveyard by the time the opponent gains life. However, if you wait until an opponent actually gains life and then cast Punishing Fire, you won't be able to return it to your hand at that time."
         },
         {
           "date": "2009-10-01",
@@ -11799,7 +11808,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Punishing Fire has left your graveyard by the time its triggered ability resolves, you may still pay {R}, but you won’t return it to your hand. This is true even if Punishing Fire has left your graveyard and returned to it by the time its triggered ability resolves."
+          "text": "If Punishing Fire has left your graveyard by the time its triggered ability resolves, you may still pay {R}, but you won't return it to your hand. This is true even if Punishing Fire has left your graveyard and returned to it by the time its triggered ability resolves."
         }
       ],
       "text": "Punishing Fire deals 2 damage to target creature or player.\nWhenever an opponent gains life, you may pay {R}. If you do, return Punishing Fire from your graveyard to your hand.",
@@ -11893,7 +11902,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -12148,7 +12157,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -12156,19 +12165,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -12250,27 +12259,27 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If your opponent controls a Stranglehold and an effect says “You may search your library . . . If you do, shuffle your library,” you can’t choose to search, so you won’t shuffle."
+          "text": "If your opponent controls a Stranglehold and an effect says \"You may search your library . . . If you do, shuffle your library,\" you can't choose to search, so you won't shuffle."
         },
         {
           "date": "2011-09-22",
-          "text": "If your opponent controls a Stranglehold and an effect says “Search your library . . . Then shuffle your library,” the search effect fails, but you will still have to shuffle."
+          "text": "If your opponent controls a Stranglehold and an effect says \"Search your library . . . Then shuffle your library,\" the search effect fails, but you will still have to shuffle."
         },
         {
           "date": "2011-09-22",
-          "text": "Since opponents can’t search libraries, they won’t be able to find any cards in a library. The effect applies to all opponents and all libraries, including your library. If a spell or ability’s effect has other parts that don’t depend on searching for or finding cards, they will still work normally."
+          "text": "Since opponents can't search libraries, they won't be able to find any cards in a library. The effect applies to all opponents and all libraries, including your library. If a spell or ability's effect has other parts that don't depend on searching for or finding cards, they will still work normally."
         },
         {
           "date": "2011-09-22",
-          "text": "Effects that tell an opponent to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word “search” will fail."
+          "text": "Effects that tell an opponent to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word \"search\" will fail."
         },
         {
           "date": "2011-09-22",
-          "text": "An “extra turn” means a turn created by a spell or ability. It doesn’t refer to a turn taken in a sanctioned tournament after the time limit for the round has expired."
+          "text": "An \"extra turn\" means a turn created by a spell or ability. It doesn't refer to a turn taken in a sanctioned tournament after the time limit for the round has expired."
         },
         {
           "date": "2011-09-22",
-          "text": "If an opponent’s extra turn is created while Stranglehold is on the battlefield, but Stranglehold leaves the battlefield before that turn would begin, that opponent takes the extra turn as normal."
+          "text": "If an opponent's extra turn is created while Stranglehold is on the battlefield, but Stranglehold leaves the battlefield before that turn would begin, that opponent takes the extra turn as normal."
         }
       ],
       "text": "Your opponents can't search libraries.\nIf an opponent would begin an extra turn, that player skips that turn instead.",
@@ -12515,19 +12524,19 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Wild Ricochet can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Wild Ricochet can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2013-07-01",
-          "text": "When Wild Ricochet resolves, it creates a copy of a spell. You control the copy. The controller of the original spell retains control of that spell. The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. The copy resolves before the original spell."
+          "text": "When Wild Ricochet resolves, it creates a copy of a spell. You control the copy. The controller of the original spell retains control of that spell. The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. The copy resolves before the original spell."
         },
         {
           "date": "2013-07-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2013-07-01",
-          "text": "If the spell Wild Ricochet copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Wild Ricochet copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2013-07-01",
@@ -12535,11 +12544,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Wild Ricochet, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Wild Ricochet, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2013-07-01",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
@@ -12883,7 +12892,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -12990,7 +12999,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"‘I have arrived,' bellowed Brawn, and the plane shuddered.\"\n—Scroll of Beginnings",
+      "flavor": "\"'I have arrived,' bellowed Brawn, and the plane shuddered.\"\n—Scroll of Beginnings",
       "foreignNames": [
         {
           "language": "French",
@@ -13140,11 +13149,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -13152,7 +13161,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A spell or ability destroys a permanent only if that spell or ability specifically contains the word “destroy” in its text. If a spell or ability an opponent controls exiles a noncreature permanent you control, causes you to sacrifice a noncreature permanent, removes all loyalty counters from a planeswalker you control, or causes an ability you control to trigger (and then that ability destroys a permanent you control), Cobra Trap’s alternative cost condition hasn’t been met."
+          "text": "A spell or ability destroys a permanent only if that spell or ability specifically contains the word \"destroy\" in its text. If a spell or ability an opponent controls exiles a noncreature permanent you control, causes you to sacrifice a noncreature permanent, removes all loyalty counters from a planeswalker you control, or causes an ability you control to trigger (and then that ability destroys a permanent you control), Cobra Trap's alternative cost condition hasn't been met."
         }
       ],
       "subtypes": [
@@ -13573,7 +13582,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Forestcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Forestcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -13859,7 +13868,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Although the targeted player doesn’t need to find a basic land card if he or she doesn’t want to, that player must shuffle his or her library."
+          "text": "Although the targeted player doesn't need to find a basic land card if he or she doesn't want to, that player must shuffle his or her library."
         }
       ],
       "subtypes": [
@@ -14031,15 +14040,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You create the Saproling tokens, even if Fists of Ironwood enters the battlefield attached to another player’s creature."
+          "text": "You create the Saproling tokens, even if Fists of Ironwood enters the battlefield attached to another player's creature."
         },
         {
           "date": "2017-03-14",
-          "text": "The Saproling tokens aren’t created until after Fists of Ironwood is on the battlefield, so you can’t cast Fists of Ironwood on one of those tokens."
+          "text": "The Saproling tokens aren't created until after Fists of Ironwood is on the battlefield, so you can't cast Fists of Ironwood on one of those tokens."
         },
         {
           "date": "2017-03-14",
-          "text": "If the target creature is an illegal target when Fists of Ironwood tries to resolve, Fists of Ironwood will be countered and won’t enter the battlefield. You won’t create Saproling tokens."
+          "text": "If the target creature is an illegal target when Fists of Ironwood tries to resolve, Fists of Ironwood will be countered and won't enter the battlefield. You won't create Saproling tokens."
         }
       ],
       "subtypes": [
@@ -14133,11 +14142,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two lands. They don’t have to be tapped."
+          "text": "The first ability can target any two lands. They don't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "The third ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "The third ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -14397,15 +14406,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -14488,7 +14497,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The damage dealt by Hydra Omnivore as a result of its triggered ability is not combat damage (and doesn’t cause the ability to trigger again)."
+          "text": "The damage dealt by Hydra Omnivore as a result of its triggered ability is not combat damage (and doesn't cause the ability to trigger again)."
         }
       ],
       "subtypes": [
@@ -14580,7 +14589,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If an effect says that an opponent can’t gain life, you can’t have that player gain life to pay Invigorate’s alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost’s action is replaced with nothing."
+          "text": "If an effect says that an opponent can't gain life, you can't have that player gain life to pay Invigorate's alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost's action is replaced with nothing."
         }
       ],
       "text": "If you control a Forest, rather than pay Invigorate's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
@@ -14769,7 +14778,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -14865,7 +14874,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -15310,7 +15319,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. No +1/+1 counter will be put on Scavenging Ooze and you won’t gain life. Notably, this means that if you activate Scavenging Ooze’s ability multiple times targeting the same creature card, only the first instance of the ability to resolve will have any effect."
+          "text": "If the target card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. No +1/+1 counter will be put on Scavenging Ooze and you won't gain life. Notably, this means that if you activate Scavenging Ooze's ability multiple times targeting the same creature card, only the first instance of the ability to resolve will have any effect."
         }
       ],
       "subtypes": [
@@ -15402,19 +15411,19 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "As the token is created, it checks the printed values of the Spawnwrithe it’s copying — or, if the Spawnwrithe whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the Spawnwrithe, nor will it copy other effects that have changed Spawnwrithe’s power, toughness, types, color, or so on. Normally, this means the token will simply be a Spawnwrithe. But if any copy effects have affected that Spawnwrithe, they’re taken into account."
+          "text": "As the token is created, it checks the printed values of the Spawnwrithe it's copying — or, if the Spawnwrithe whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the Spawnwrithe, nor will it copy other effects that have changed Spawnwrithe's power, toughness, types, color, or so on. Normally, this means the token will simply be a Spawnwrithe. But if any copy effects have affected that Spawnwrithe, they're taken into account."
         },
         {
           "date": "2008-05-01",
-          "text": "If Spawnwrithe’s ability triggers, then Spawnwrithe becomes a copy of another creature before its ability resolves (due to Mirrorweave, perhaps), the token will be a copy of whatever creature the Spawnwrithe is currently a copy of. At the end of the turn, Spawnwrithe will revert back to what it was, but the token will stay as it is."
+          "text": "If Spawnwrithe's ability triggers, then Spawnwrithe becomes a copy of another creature before its ability resolves (due to Mirrorweave, perhaps), the token will be a copy of whatever creature the Spawnwrithe is currently a copy of. At the end of the turn, Spawnwrithe will revert back to what it was, but the token will stay as it is."
         },
         {
           "date": "2008-05-01",
-          "text": "If a copy effect such as Mirrorweave causes some other creature to become a copy of Spawnwrithe, then that creature deals combat damage to a player, the token that’s put onto the battlefield is simply a copy of Spawnwrithe."
+          "text": "If a copy effect such as Mirrorweave causes some other creature to become a copy of Spawnwrithe, then that creature deals combat damage to a player, the token that's put onto the battlefield is simply a copy of Spawnwrithe."
         },
         {
           "date": "2008-05-01",
-          "text": "A token created by a Cemetery Puca that’s copying a Spawnwrithe will be a Spawnwrithe with the Cemetery Puca ability."
+          "text": "A token created by a Cemetery Puca that's copying a Spawnwrithe will be a Spawnwrithe with the Cemetery Puca ability."
         }
       ],
       "subtypes": [
@@ -16251,7 +16260,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The triggered ability triggers only when a creature spell is cast, after costs are paid. The counter put on Animar for each creature spell cast won’t affect the cost of that creature spell, only future ones."
+          "text": "The triggered ability triggers only when a creature spell is cast, after costs are paid. The counter put on Animar for each creature spell cast won't affect the cost of that creature spell, only future ones."
         },
         {
           "date": "2011-09-22",
@@ -16259,7 +16268,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the creature spell is countered, you’ll still put a +1/+1 counter on Animar."
+          "text": "If the creature spell is countered, you'll still put a +1/+1 counter on Animar."
         }
       ],
       "subtypes": [
@@ -16433,7 +16442,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -16521,7 +16530,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "While Basandra, Battle Seraph is on the battlefield, players can’t cast any spells during the combat phase, including permanent spells with flash."
+          "text": "While Basandra, Battle Seraph is on the battlefield, players can't cast any spells during the combat phase, including permanent spells with flash."
         },
         {
           "date": "2011-09-22",
@@ -16529,7 +16538,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -16894,7 +16903,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -16902,11 +16911,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Create a 5/5 blue and red Elemental creature token with flying.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -16995,15 +17004,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Chorus of the Conclave’s ability works only while it’s on the battlefield, so you can’t use it to put +1/+1 counters on itself."
+          "text": "Chorus of the Conclave's ability works only while it's on the battlefield, so you can't use it to put +1/+1 counters on itself."
         },
         {
           "date": "2005-10-01",
-          "text": "Chorus of the Conclave’s ability applies to creature spells only as they’re being cast. You can’t pay mana to put counters on creatures being put onto the battlefield by an effect."
+          "text": "Chorus of the Conclave's ability applies to creature spells only as they're being cast. You can't pay mana to put counters on creatures being put onto the battlefield by an effect."
         },
         {
           "date": "2005-10-01",
-          "text": "Chorus of the Conclave’s ability combines well with the convoke mechanic, effectively letting you tap creatures to put +1/+1 counters on the creature with convoke that you’re casting, if you choose to do so."
+          "text": "Chorus of the Conclave's ability combines well with the convoke mechanic, effectively letting you tap creatures to put +1/+1 counters on the creature with convoke that you're casting, if you choose to do so."
         }
       ],
       "subtypes": [
@@ -17175,7 +17184,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The number of cards in your hand is checked at the beginning of your upkeep before you have the opportunity to cast spells and activate abilities. If you have seven or more cards in your hand at that time, Damia’s last ability won’t trigger."
+          "text": "The number of cards in your hand is checked at the beginning of your upkeep before you have the opportunity to cast spells and activate abilities. If you have seven or more cards in your hand at that time, Damia's last ability won't trigger."
         },
         {
           "date": "2011-09-22",
@@ -17183,11 +17192,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "When Damia’s triggered ability tries to resolve, if you have seven or more cards in your hand, it will have no effect. If you have fewer than seven cards in your hand, you’ll determine the difference and draw that many cards."
+          "text": "When Damia's triggered ability tries to resolve, if you have seven or more cards in your hand, it will have no effect. If you have fewer than seven cards in your hand, you'll determine the difference and draw that many cards."
         },
         {
           "date": "2011-09-22",
-          "text": "Effects can modify the number of cards you’ll draw. For example, if you have four cards in your hand and control Thought Reflection (“If you would draw a card, draw two cards instead.”), you’ll draw six cards."
+          "text": "Effects can modify the number of cards you'll draw. For example, if you have four cards in your hand and control Thought Reflection (\"If you would draw a card, draw two cards instead.\"), you'll draw six cards."
         }
       ],
       "subtypes": [
@@ -17367,11 +17376,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This ability doesn’t target a card. It will determine which card is returned to your hand as it resolves. If there’s a tie, you choose which of the tied cards to return to your hand at that time."
+          "text": "This ability doesn't target a card. It will determine which card is returned to your hand as it resolves. If there's a tie, you choose which of the tied cards to return to your hand at that time."
         },
         {
           "date": "2008-08-01",
-          "text": "If the creature card has “*” in its power or toughness, the ability that defines “*” works in all zones."
+          "text": "If the creature card has \"*\" in its power or toughness, the ability that defines \"*\" works in all zones."
         }
       ],
       "subtypes": [
@@ -17464,7 +17473,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you already control the targeted permanent when the ability resolves, you still need to choose whether or not to apply the effect. If you choose to apply it, the permanent untaps and gains haste. If you don’t, it doesn’t."
+          "text": "If you already control the targeted permanent when the ability resolves, you still need to choose whether or not to apply the effect. If you choose to apply it, the permanent untaps and gains haste. If you don't, it doesn't."
         }
       ],
       "subtypes": [
@@ -17560,7 +17569,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -17572,7 +17581,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -17661,7 +17670,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric’s ability to trigger. The creature’s controller chooses whether to draw a card."
+          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric's ability to trigger. The creature's controller chooses whether to draw a card."
         },
         {
           "date": "2011-09-22",
@@ -17765,7 +17774,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If all chosen targets are illegal as Electrolyze tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt and you won’t draw a card."
+          "text": "If all chosen targets are illegal as Electrolyze tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt and you won't draw a card."
         }
       ],
       "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
@@ -18019,7 +18028,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -18284,7 +18293,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -18296,7 +18305,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -18471,11 +18480,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "After Intet leaves the battlefield, if a card exiled this way is still exiled, you may still look at it. You won’t be able to play it, though."
+          "text": "After Intet leaves the battlefield, if a card exiled this way is still exiled, you may still look at it. You won't be able to play it, though."
         },
         {
           "date": "2007-02-01",
-          "text": "Once you play a card this way, it leaves the Exile zone and goes to the stack. You won’t be able to play it again."
+          "text": "Once you play a card this way, it leaves the Exile zone and goes to the stack. You won't be able to play it again."
         }
       ],
       "subtypes": [
@@ -18655,15 +18664,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Kaalia’s ability doesn’t trigger if it attacks a planeswalker."
+          "text": "Kaalia's ability doesn't trigger if it attacks a planeswalker."
         },
         {
           "date": "2011-09-22",
-          "text": "The creature card is already tapped and attacking as it’s put onto the battlefield. Any abilities that trigger when a creature becomes tapped or when a creature attacks won’t trigger for that card."
+          "text": "The creature card is already tapped and attacking as it's put onto the battlefield. Any abilities that trigger when a creature becomes tapped or when a creature attacks won't trigger for that card."
         },
         {
           "date": "2011-09-22",
-          "text": "If the opponent Kaalia attacked is no longer in the game when its ability resolves, you may put an Angel, Demon, or Dragon creature card onto the battlefield tapped, but it won’t be attacking anyone and it won’t be an attacking creature."
+          "text": "If the opponent Kaalia attacked is no longer in the game when its ability resolves, you may put an Angel, Demon, or Dragon creature card onto the battlefield tapped, but it won't be attacking anyone and it won't be an attacking creature."
         }
       ],
       "subtypes": [
@@ -18754,27 +18763,27 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If Karador is your commander, calculate any cost increases, including the one based on the number of times you’ve cast Karador from the command zone, before considering Karador’s cost-reduction ability."
+          "text": "If Karador is your commander, calculate any cost increases, including the one based on the number of times you've cast Karador from the command zone, before considering Karador's cost-reduction ability."
         },
         {
           "date": "2011-09-22",
-          "text": "If you somehow cast Karador from a graveyard, its cost-reduction ability won’t count itself."
+          "text": "If you somehow cast Karador from a graveyard, its cost-reduction ability won't count itself."
         },
         {
           "date": "2011-09-22",
-          "text": "Although Karador’s second ability allows you to cast one creature card from your graveyard on each of your turns, it doesn’t change when you can cast that card. Unless it has flash, the creature card must be cast during one of your main phases when the stack is empty."
+          "text": "Although Karador's second ability allows you to cast one creature card from your graveyard on each of your turns, it doesn't change when you can cast that card. Unless it has flash, the creature card must be cast during one of your main phases when the stack is empty."
         },
         {
           "date": "2011-09-22",
-          "text": "Karador’s second ability doesn’t affect the costs you need to pay to cast that creature spell."
+          "text": "Karador's second ability doesn't affect the costs you need to pay to cast that creature spell."
         },
         {
           "date": "2011-09-22",
-          "text": "Karador’s first ability functions on the stack. Karador’s second ability functions only on the battlefield."
+          "text": "Karador's first ability functions on the stack. Karador's second ability functions only on the battlefield."
         },
         {
           "date": "2011-09-22",
-          "text": "If you cast a creature card from your graveyard, then Karador leaves the battlefield, then returns to the battlefield, you may cast another creature card from your graveyard that turn. If you didn’t cast a creature card from your graveyard while Karador was on the battlefield the first time, you may still cast only one creature card from your graveyard when it returns to the battlefield."
+          "text": "If you cast a creature card from your graveyard, then Karador leaves the battlefield, then returns to the battlefield, you may cast another creature card from your graveyard that turn. If you didn't cast a creature card from your graveyard while Karador was on the battlefield the first time, you may still cast only one creature card from your graveyard when it returns to the battlefield."
         }
       ],
       "subtypes": [
@@ -18973,15 +18982,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You choose attackers and make blocking assignments regardless of whether it’s your turn and regardless of whether the creatures are attacking you. Your choices must be legal within the normal rules for attacking and blocking."
+          "text": "You choose attackers and make blocking assignments regardless of whether it's your turn and regardless of whether the creatures are attacking you. Your choices must be legal within the normal rules for attacking and blocking."
         },
         {
           "date": "2006-01-01",
-          "text": "You can decide that a creature won’t block."
+          "text": "You can decide that a creature won't block."
         },
         {
           "date": "2008-04-01",
-          "text": "If the defending player controls a planeswalker, the person who cast Master Warcraft first chooses the complete group of creatures that are going to attack. Then, for each of those creatures, the active player chooses who or what it’s going to attack."
+          "text": "If the defending player controls a planeswalker, the person who cast Master Warcraft first chooses the complete group of creatures that are going to attack. Then, for each of those creatures, the active player chooses who or what it's going to attack."
         },
         {
           "date": "2013-09-20",
@@ -19067,7 +19076,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can’t choose to exile just one creature card."
+          "text": "You can't choose to exile just one creature card."
         },
         {
           "date": "2011-09-22",
@@ -19079,7 +19088,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Treat The Mimeoplasm as though it were the creature card it’s copying entering the battlefield. Any “As [this card] enters the battlefield,” “[This card] enters the battlefield with,” and “When [this card] enters the battlefield” abilities of that creature card will work."
+          "text": "Treat The Mimeoplasm as though it were the creature card it's copying entering the battlefield. Any \"As [this card] enters the battlefield,\" \"[This card] enters the battlefield with,\" and \"When [this card] enters the battlefield\" abilities of that creature card will work."
         },
         {
           "date": "2011-09-22",
@@ -19183,7 +19192,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target creature or enchantment.",
@@ -19273,7 +19282,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the targeted card is removed from the graveyard before the ability resolves, the ability is countered. You won’t get a Saproling token."
+          "text": "If the targeted card is removed from the graveyard before the ability resolves, the ability is countered. You won't get a Saproling token."
         }
       ],
       "text": "{2}: Exile target creature card from a graveyard. Create a 1/1 green Saproling creature token.",
@@ -19293,7 +19302,7 @@
         "Blue",
         "Red"
       ],
-      "flavor": "\"Your body is a delicate instrument that tells me truths. These devices help me ‘tune' that instrument.\"",
+      "flavor": "\"Your body is a delicate instrument that tells me truths. These devices help me 'tune' that instrument.\"",
       "foreignNames": [
         {
           "language": "French",
@@ -19353,15 +19362,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You may choose a value for X that’s greater than the creature’s toughness. Its controller will draw that many cards."
+          "text": "You may choose a value for X that's greater than the creature's toughness. Its controller will draw that many cards."
         },
         {
           "date": "2011-09-22",
-          "text": "The effect is not optional. The creature’s controller can’t choose to draw fewer than X cards."
+          "text": "The effect is not optional. The creature's controller can't choose to draw fewer than X cards."
         },
         {
           "date": "2011-09-22",
-          "text": "If the creature is an illegal target when Nin’s ability tries to resolve, it will be countered and none of its effects will happen. No player will draw cards."
+          "text": "If the creature is an illegal target when Nin's ability tries to resolve, it will be countered and none of its effects will happen. No player will draw cards."
         },
         {
           "date": "2011-09-22",
@@ -19997,11 +20006,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the spell that caused Riku’s first ability to trigger has left the stack by the time the ability resolves, you can still pay {U}{R}. If you do, you’ll copy the spell as it last existed on the stack."
+          "text": "If the spell that caused Riku's first ability to trigger has left the stack by the time the ability resolves, you can still pay {U}{R}. If you do, you'll copy the spell as it last existed on the stack."
         },
         {
           "date": "2011-09-22",
-          "text": "Riku’s first ability triggers whenever you cast any instant or sorcery spell, regardless of whether that spell has targets."
+          "text": "Riku's first ability triggers whenever you cast any instant or sorcery spell, regardless of whether that spell has targets."
         },
         {
           "date": "2011-09-22",
@@ -20009,23 +20018,23 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the copied spell is modal (that is, it says “Choose one —” or the like), the copy has the same mode as the original spell. You can’t choose a different one."
+          "text": "If the copied spell is modal (that is, it says \"Choose one —\" or the like), the copy has the same mode as the original spell. You can't choose a different one."
         },
         {
           "date": "2011-09-22",
-          "text": "You can’t pay any additional costs for the copy. However, effects based on any additional costs paid for the original spell are copied as though those same costs were paid for the copy. Notably, if the original spell was kicked (or kicked a certain number of times), the copy will also be kicked (or kicked that many times)."
+          "text": "You can't pay any additional costs for the copy. However, effects based on any additional costs paid for the original spell are copied as though those same costs were paid for the copy. Notably, if the original spell was kicked (or kicked a certain number of times), the copy will also be kicked (or kicked that many times)."
         },
         {
           "date": "2011-09-22",
-          "text": "If the creature that caused Riku’s second ability to trigger has already left the battlefield by the time the ability resolves, you can still pay {G}{U}. If you do, you’ll still put a token onto the battlefield. That token has the copiable values of the characteristics of that creature as it last existed on the battlefield."
+          "text": "If the creature that caused Riku's second ability to trigger has already left the battlefield by the time the ability resolves, you can still pay {G}{U}. If you do, you'll still put a token onto the battlefield. That token has the copiable values of the characteristics of that creature as it last existed on the battlefield."
         },
         {
           "date": "2011-09-22",
-          "text": "As the token is created, it checks the printed values of the creature it’s copying, as well as any copy effects that have been applied to it."
+          "text": "As the token is created, it checks the printed values of the creature it's copying, as well as any copy effects that have been applied to it."
         },
         {
           "date": "2011-09-22",
-          "text": "The copiable values of the token’s characteristics are the same as the copiable values of the characteristics of the creature it’s copying."
+          "text": "The copiable values of the token's characteristics are the same as the copiable values of the characteristics of the creature it's copying."
         },
         {
           "date": "2011-09-22",
@@ -20123,15 +20132,15 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If, during your declare attackers step, Ruhan is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under your control continuously since your turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having Ruhan attack the chosen player, you aren’t forced to pay that cost, so it doesn’t have to attack that player in that case either."
+          "text": "If, during your declare attackers step, Ruhan is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under your control continuously since your turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having Ruhan attack the chosen player, you aren't forced to pay that cost, so it doesn't have to attack that player in that case either."
         },
         {
           "date": "2011-09-22",
-          "text": "If Ruhan isn’t forced to attack the chosen player for one of the above reasons but can still attack, you may choose to have Ruhan attack another player, attack a planeswalker, or not attack at all."
+          "text": "If Ruhan isn't forced to attack the chosen player for one of the above reasons but can still attack, you may choose to have Ruhan attack another player, attack a planeswalker, or not attack at all."
         },
         {
           "date": "2011-09-22",
-          "text": "If your turn has multiple combat phases, Ruhan’s ability triggers at the beginning of each of them. Ignore any choices made during previous combat phases."
+          "text": "If your turn has multiple combat phases, Ruhan's ability triggers at the beginning of each of them. Ignore any choices made during previous combat phases."
         }
       ],
       "subtypes": [
@@ -20499,15 +20508,15 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Sigil Captain’s ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless the creature that enters the battlefield under your control is 1/1, and (2) the ability will do nothing unless that creature is still 1/1 at the time the ability resolves."
+          "text": "Sigil Captain's ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless the creature that enters the battlefield under your control is 1/1, and (2) the ability will do nothing unless that creature is still 1/1 at the time the ability resolves."
         },
         {
           "date": "2009-05-01",
-          "text": "For that reason, two Sigil Captains don’t work well together. When a 1/1 creature enters the battlefield under your control, the abilities of both Sigil Captains will trigger. When the first resolves, two +1/+1 counters are put on the 1/1 creature. When the second resolves, it will do nothing because the creature that entered the battlefield is now 3/3."
+          "text": "For that reason, two Sigil Captains don't work well together. When a 1/1 creature enters the battlefield under your control, the abilities of both Sigil Captains will trigger. When the first resolves, two +1/+1 counters are put on the 1/1 creature. When the second resolves, it will do nothing because the creature that entered the battlefield is now 3/3."
         },
         {
           "date": "2009-05-01",
-          "text": "Sigil Captain’s ability checks a creature’s initial power and toughness upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it’s on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, changing its power and toughness to 1/1 with a spell, activated ability, or triggered ability won’t allow this ability to trigger; it’s too late by then."
+          "text": "Sigil Captain's ability checks a creature's initial power and toughness upon being put on the battlefield, so it will take into account counters that it enters the battlefield with and static abilities that may give it a continuous power boost once it's on the battlefield (such as the one on Glorious Anthem). After the creature is already on the battlefield, changing its power and toughness to 1/1 with a spell, activated ability, or triggered ability won't allow this ability to trigger; it's too late by then."
         },
         {
           "date": "2009-05-01",
@@ -20692,19 +20701,19 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The counters that remain on Skullbriar as it changes zones aren’t “placed” on Skullbriar. Effects like Doubling Season’s and Melira, Sylvok Outcast’s won’t affect those counters."
+          "text": "The counters that remain on Skullbriar as it changes zones aren't \"placed\" on Skullbriar. Effects like Doubling Season's and Melira, Sylvok Outcast's won't affect those counters."
         },
         {
           "date": "2011-09-22",
-          "text": "Counters that adjust power and/or toughness affect Skullbriar’s power and/or toughness in zones other than the battlefield. For example, a Skullbriar in the command zone with a +1/+1 counter on it will be 2/2."
+          "text": "Counters that adjust power and/or toughness affect Skullbriar's power and/or toughness in zones other than the battlefield. For example, a Skullbriar in the command zone with a +1/+1 counter on it will be 2/2."
         },
         {
           "date": "2011-09-22",
-          "text": "Effects that last “for as long as that creature has a [kind of] counter on it,” such as Aven Mimeomancer’s, stop applying to Skullbriar once it leaves the battlefield. Even though Skullbriar retains the counters, it becomes a new object with no relation to its last existence in its previous zone."
+          "text": "Effects that last \"for as long as that creature has a [kind of] counter on it,\" such as Aven Mimeomancer's, stop applying to Skullbriar once it leaves the battlefield. Even though Skullbriar retains the counters, it becomes a new object with no relation to its last existence in its previous zone."
         },
         {
           "date": "2011-09-22",
-          "text": "Skullbriar’s last ability only works if it has that ability in the zone it’s moving from. For example, with Yixlid Jailer (“Cards in graveyards lose all abilities”) on the battlefield, a Skullbriar with a counter on it in a graveyard loses that counter when it’s put onto the battlefield. Conversely, that Skullbriar moving from the graveyard to the battlefield would retain that counter if Humility (“All creatures lose all abilities and are 1/1”) were on the battlefield; if Skullbriar then left the battlefield with Humility still on the battlefield, it would lose the counter."
+          "text": "Skullbriar's last ability only works if it has that ability in the zone it's moving from. For example, with Yixlid Jailer (\"Cards in graveyards lose all abilities\") on the battlefield, a Skullbriar with a counter on it in a graveyard loses that counter when it's put onto the battlefield. Conversely, that Skullbriar moving from the graveyard to the battlefield would retain that counter if Humility (\"All creatures lose all abilities and are 1/1\") were on the battlefield; if Skullbriar then left the battlefield with Humility still on the battlefield, it would lose the counter."
         },
         {
           "date": "2011-09-22",
@@ -20804,7 +20813,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If another effect would prevent Szadek’s combat damage from being dealt to the defending player or replace it with something else, that player chooses which effect applies first. For example, the player can choose to first have Mending Hands prevent 4 of the damage and then apply Szadek’s ability so that it gets only one counter."
+          "text": "If another effect would prevent Szadek's combat damage from being dealt to the defending player or replace it with something else, that player chooses which effect applies first. For example, the player can choose to first have Mending Hands prevent 4 of the damage and then apply Szadek's ability so that it gets only one counter."
         }
       ],
       "subtypes": [
@@ -20899,7 +20908,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The creature card is chosen at random from among creature cards in the target opponent’s graveyard as the ability resolves. Players can respond to the ability knowing the targeted player, but they won’t know which creature card is about to enter the battlefield."
+          "text": "The creature card is chosen at random from among creature cards in the target opponent's graveyard as the ability resolves. Players can respond to the ability knowing the targeted player, but they won't know which creature card is about to enter the battlefield."
         }
       ],
       "subtypes": [
@@ -21187,7 +21196,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -21199,7 +21208,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -21299,15 +21308,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "You can return a land card to your hand with Vengeful Rebirth. It just won’t deal any damage to the targeted creature or player if you do."
+          "text": "You can return a land card to your hand with Vengeful Rebirth. It just won't deal any damage to the targeted creature or player if you do."
         },
         {
           "date": "2009-05-01",
-          "text": "If the targeted creature or player becomes an illegal target but the targeted card in your graveyard doesn’t, Vengeful Rebirth will still return that card from your graveyard to your hand, but it won’t deal any damage. Vengeful Rebirth will then be exiled."
+          "text": "If the targeted creature or player becomes an illegal target but the targeted card in your graveyard doesn't, Vengeful Rebirth will still return that card from your graveyard to your hand, but it won't deal any damage. Vengeful Rebirth will then be exiled."
         },
         {
           "date": "2009-05-01",
-          "text": "If the targeted card in your graveyard becomes an illegal target but the targeted creature or player doesn’t, Vengeful Rebirth won’t return that card to your hand and it won’t deal any damage (because you didn’t return a nonland card to your hand this way). Vengeful Rebirth will still be exiled, though."
+          "text": "If the targeted card in your graveyard becomes an illegal target but the targeted creature or player doesn't, Vengeful Rebirth won't return that card to your hand and it won't deal any damage (because you didn't return a nonland card to your hand this way). Vengeful Rebirth will still be exiled, though."
         },
         {
           "date": "2009-05-01",
@@ -21390,7 +21399,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Vish Kal’s last ability doesn’t deal damage. It doesn’t cause you to gain any life from its lifelink ability."
+          "text": "Vish Kal's last ability doesn't deal damage. It doesn't cause you to gain any life from its lifelink ability."
         }
       ],
       "subtypes": [
@@ -21580,11 +21589,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The ability doesn’t care why a card goes to your opponent’s graveyard — only that it does. The ability triggers when a card is put into your opponent’s graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player’s hand (a card is discarded), from the player’s library (from a Millstone-like effect), or from any other zone."
+          "text": "The ability doesn't care why a card goes to your opponent's graveyard — only that it does. The ability triggers when a card is put into your opponent's graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player's hand (a card is discarded), from the player's library (from a Millstone-like effect), or from any other zone."
         },
         {
           "date": "2005-10-01",
-          "text": "This ability triggers only on cards, so it won’t trigger when a token is put into your opponent’s graveyard."
+          "text": "This ability triggers only on cards, so it won't trigger when a token is put into your opponent's graveyard."
         }
       ],
       "subtypes": [
@@ -21850,19 +21859,19 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If you want to cast the targeted card, you cast it as part of the resolution of Wrexial’s triggered ability. Timing restrictions based on the card’s type are ignored. Other restrictions are not (such as “Cast [this card] only during your end step”)."
+          "text": "If you want to cast the targeted card, you cast it as part of the resolution of Wrexial's triggered ability. Timing restrictions based on the card's type are ignored. Other restrictions are not (such as \"Cast [this card] only during your end step\")."
         },
         {
           "date": "2010-03-01",
-          "text": "If you are unable to cast the targeted card (there are no legal targets for the spell, for example), nothing happens when the ability resolves, and the card remains in its owner’s graveyard."
+          "text": "If you are unable to cast the targeted card (there are no legal targets for the spell, for example), nothing happens when the ability resolves, and the card remains in its owner's graveyard."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. On the other hand, if the card has additional costs (such as kicker or multikicker), you may pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. On the other hand, if the card has additional costs (such as kicker or multikicker), you may pay those."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast the targeted card and it would be put into its owner’s graveyard from the stack for any reason (either because it resolves or because it’s countered), that card is exiled instead."
+          "text": "If you cast the targeted card and it would be put into its owner's graveyard from the stack for any reason (either because it resolves or because it's countered), that card is exiled instead."
         }
       ],
       "subtypes": [
@@ -21959,7 +21968,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If either the opponent or the permanent you control becomes an illegal target by the time Zedruu’s last ability tries to resolve, the ability does nothing."
+          "text": "If either the opponent or the permanent you control becomes an illegal target by the time Zedruu's last ability tries to resolve, the ability does nothing."
         }
       ],
       "subtypes": [
@@ -22275,7 +22284,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "It’s possible for a Champion’s Helm you control to be attached to a creature an opponent controls (if an opponent gains control of your equipped creature, for example). In this case, the creature couldn’t be the target of spells or abilities you control, as you are an opponent of the controller of the creature with hexproof."
+          "text": "It's possible for a Champion's Helm you control to be attached to a creature an opponent controls (if an opponent gains control of your equipped creature, for example). In this case, the creature couldn't be the target of spells or abilities you control, as you are an opponent of the controller of the creature with hexproof."
         }
       ],
       "subtypes": [
@@ -22600,7 +22609,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This works even if the opponent’s lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
+          "text": "This works even if the opponent's lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
         },
         {
           "date": "2004-10-04",
@@ -22608,19 +22617,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, take into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, take into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Fellwar Stone doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -23054,7 +23063,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You are not allowed to “unequip” equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won’t be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
+          "text": "You are not allowed to \"unequip\" equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won't be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
         }
       ],
       "subtypes": [
@@ -24363,15 +24372,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The color identity of your commander is set before the game begins and doesn’t change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander’s color."
+          "text": "The color identity of your commander is set before the game begins and doesn't change during the game, even your commander is in a hidden zone (like the hand or library) or an effect changes your commander's color."
         },
         {
           "date": "2011-09-22",
-          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower’s ability produces no mana."
+          "text": "If your commander is a card like Kozilek, Butcher of Truth that has no colors in its color identity, Command Tower's ability produces no mana."
         },
         {
           "date": "2011-09-22",
-          "text": "In formats other than Commander, Command Tower’s ability produces no mana."
+          "text": "In formats other than Commander, Command Tower's ability produces no mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color in your commander's color identity.",
@@ -24575,6 +24584,10 @@
       "imageName": "evolving wilds",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Battle for Zendikar Block",
           "legality": "Legal"
@@ -26040,15 +26053,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "While animated, Svogthos’s power and toughness changes each time a creature card enters or leaves its controller’s graveyard."
+          "text": "While animated, Svogthos's power and toughness changes each time a creature card enters or leaves its controller's graveyard."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with \"This creature's power and toughness are each equal to the number of creature cards in your graveyard.\" It's still a land.",

--- a/json/CN2.json
+++ b/json/CN2.json
@@ -84,27 +84,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -112,11 +112,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -124,7 +124,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -132,11 +132,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nWhenever a creature you control with the chosen name attacks, you may pay {W}. If you do, that creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
@@ -195,27 +195,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -223,11 +223,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -235,7 +235,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -243,11 +243,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nCreatures you control with the chosen name have \"When this creature dies, you may pay {B}. If you do, create a tapped 2/2 black Zombie creature token.\"",
@@ -303,15 +303,15 @@
         },
         {
           "date": "2016-08-23",
-          "text": "When Echoing Boon’s ability resolves, it creates a copy of the instant or sorcery spell. The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, before the original spell resolves but after players get a chance to cast spells and activate abilities."
+          "text": "When Echoing Boon's ability resolves, it creates a copy of the instant or sorcery spell. The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, before the original spell resolves but after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2016-08-23",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If you can’t choose a new legal target for one of the targets, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If you can't choose a new legal target for one of the targets, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2016-08-23",
-          "text": "If the spell being copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell being copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2016-08-23",
@@ -319,7 +319,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If the spell being copied has damage divided as it was cast, the division can’t be changed (although the targets receiving that damage still can)."
+          "text": "If the spell being copied has damage divided as it was cast, the division can't be changed (although the targets receiving that damage still can)."
         },
         {
           "date": "2016-08-23",
@@ -331,27 +331,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -359,11 +359,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -371,7 +371,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -379,11 +379,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nWhenever you cast an instant or sorcery spell, if it targets a creature you control with the chosen name, you may copy that spell and may choose new targets for the copy.",
@@ -439,27 +439,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nBefore drawing your opening hand, choose 1, 2, or 3.\nYou may spend mana as though it were mana of any color to cast creature spells with converted mana cost equal to the chosen number.",
@@ -518,27 +518,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -546,11 +546,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -558,7 +558,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -566,11 +566,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nWhenever a creature you control with the chosen name deals combat damage to a player, you may pay {U}. If you do, draw a card.",
@@ -622,7 +622,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The Goblin tokens can’t attack the turn they are put onto the battlefield."
+          "text": "The Goblin tokens can't attack the turn they are put onto the battlefield."
         },
         {
           "date": "2016-08-23",
@@ -630,27 +630,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nAt the beginning of your first upkeep, create a 1/2 white Soldier creature token with defender.\nAt the beginning of each other player's first upkeep, that player creates a 1/1 red Goblin creature token with \"This creature can't block.\"",
@@ -703,19 +703,19 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The first ability doesn’t change the mana cost or converted mana cost of any creature spell. It changes only the total cost you actually pay."
+          "text": "The first ability doesn't change the mana cost or converted mana cost of any creature spell. It changes only the total cost you actually pay."
         },
         {
           "date": "2016-08-23",
-          "text": "If you have more than one Hymn of the Wilds in the command zone, their abilities will each apply to the first creature spell you cast each turn. For example, if you have two, the first creature spell you cast each turn costs {2} less to cast. Subsequent creature spells won’t get a discount."
+          "text": "If you have more than one Hymn of the Wilds in the command zone, their abilities will each apply to the first creature spell you cast each turn. For example, if you have two, the first creature spell you cast each turn costs {2} less to cast. Subsequent creature spells won't get a discount."
         },
         {
           "date": "2016-08-23",
-          "text": "The ability can’t affect the amount of colored mana you pay for a spell. It reduces only the generic component of that mana cost."
+          "text": "The ability can't affect the amount of colored mana you pay for a spell. It reduces only the generic component of that mana cost."
         },
         {
           "date": "2016-08-23",
-          "text": "The first creature spell you cast each turn doesn’t necessarily have to be the first spell you cast. For example, you could cast an artifact spell and then cast a creature spell that would get the discount."
+          "text": "The first creature spell you cast each turn doesn't necessarily have to be the first spell you cast. For example, you could cast an artifact spell and then cast a creature spell that would get the discount."
         },
         {
           "date": "2016-08-23",
@@ -727,7 +727,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If the first creature spell you cast in a turn has {X} in its mana cost, you choose the value of X before calculating the spell’s total cost. For example, if the first creature spell you cast in a turn has a mana cost of {X}{G}, you could choose 1 as the value of X and pay {G} to cast the spell."
+          "text": "If the first creature spell you cast in a turn has {X} in its mana cost, you choose the value of X before calculating the spell's total cost. For example, if the first creature spell you cast in a turn has a mana cost of {X}{G}, you could choose 1 as the value of X and pay {G} to cast the spell."
         },
         {
           "date": "2016-08-23",
@@ -735,27 +735,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nThe first creature spell you cast each turn costs {1} less to cast.\nYou can't cast instant or sorcery spells.",
@@ -814,27 +814,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -842,11 +842,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -854,7 +854,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -862,11 +862,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nCreatures you control with the chosen name have \"{R}: This creature gets +1/+0 until end of turn.\"",
@@ -925,27 +925,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -953,11 +953,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -965,7 +965,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -973,11 +973,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nCreatures you control with the chosen name have \"At the beginning of combat on your turn, you may pay {G}. If you do, put a +1/+1 counter on this creature.\"",
@@ -1029,27 +1029,27 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Even though your starting hand size is five, nothing else about the pregame procedure changes. If you don’t take two or more mulligans in a multiplayer game, you won’t be able to “scry” before the game starts."
+          "text": "Even though your starting hand size is five, nothing else about the pregame procedure changes. If you don't take two or more mulligans in a multiplayer game, you won't be able to \"scry\" before the game starts."
         },
         {
           "date": "2016-08-23",
-          "text": "Unless an effect states otherwise, you are still limited to one land play on each of your turns. Activating the ability of Sovereign’s Realm multiple times on your turn has no additional benefit."
+          "text": "Unless an effect states otherwise, you are still limited to one land play on each of your turns. Activating the ability of Sovereign's Realm multiple times on your turn has no additional benefit."
         },
         {
           "date": "2016-08-23",
-          "text": "In Limited and Constructed events, “outside the game” means your sideboard. In Limited events, your sideboard is considered to have as many cards named Plains, Island, Swamp, Mountain, and Forest as needed. You don’t have to draft such cards."
+          "text": "In Limited and Constructed events, \"outside the game\" means your sideboard. In Limited events, your sideboard is considered to have as many cards named Plains, Island, Swamp, Mountain, and Forest as needed. You don't have to draft such cards."
         },
         {
           "date": "2016-08-23",
-          "text": "If you’re drafting with other sets and draft basic land cards other than the five mentioned above (including Wastes and the “Snow-Covered” versions of the typical basic lands), those cards will be in your sideboard and the activated ability of Sovereign’s Realm will allow you to play them. Also, invite me to your next draft—your group sounds rad."
+          "text": "If you're drafting with other sets and draft basic land cards other than the five mentioned above (including Wastes and the \"Snow-Covered\" versions of the typical basic lands), those cards will be in your sideboard and the activated ability of Sovereign's Realm will allow you to play them. Also, invite me to your next draft—your group sounds rad."
         },
         {
           "date": "2016-08-23",
-          "text": "The ability of Sovereign’s Realm doesn’t change when you can play lands. You can still only play them during your main phase, if the stack is empty, if you have priority, and if you have an available land play."
+          "text": "The ability of Sovereign's Realm doesn't change when you can play lands. You can still only play them during your main phase, if the stack is empty, if you have priority, and if you have an available land play."
         },
         {
           "date": "2016-08-23",
-          "text": "You can never play lands on another player’s turn. Activating the ability of Sovereign’s Realm during an opponent’s turn won’t allow you to play lands that turn."
+          "text": "You can never play lands on another player's turn. Activating the ability of Sovereign's Realm during an opponent's turn won't allow you to play lands that turn."
         },
         {
           "date": "2016-08-23",
@@ -1057,27 +1057,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nYour deck can't have basic land cards and your starting hand size is five.\nExile a card from your hand: This turn, you may play basic land cards from outside the game.\nBasic lands you control have \"{T}: Add one mana of any color to your mana pool.\"",
@@ -1133,7 +1133,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "The last ability of Summoner’s Bond will resolve before the creature spell that caused it to trigger."
+          "text": "The last ability of Summoner's Bond will resolve before the creature spell that caused it to trigger."
         },
         {
           "date": "2016-08-23",
@@ -1141,27 +1141,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -1169,11 +1169,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -1181,7 +1181,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -1189,11 +1189,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Double agenda (Start the game with this conspiracy face down in the command zone and secretly choose two different card names. You may turn this conspiracy face up any time and reveal those names.)\nWhenever you cast a creature spell with one of the chosen names, you may search your library for a creature card with the other chosen name, reveal it, put it into your hand, then shuffle your library.",
@@ -1250,7 +1250,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Weight Advantage’s ability doesn’t change any creature’s power. It changes only the value of the combat damage it assigns. All other rules and effects that check power or toughness use the real values."
+          "text": "Weight Advantage's ability doesn't change any creature's power. It changes only the value of the combat damage it assigns. All other rules and effects that check power or toughness use the real values."
         },
         {
           "date": "2016-08-23",
@@ -1258,27 +1258,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nEach creature you control assigns combat damage equal to its toughness rather than its power.",
@@ -1344,11 +1344,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Ballot Broker’s ability is cumulative. If you control two of them, you can vote up to three times."
+          "text": "Ballot Broker's ability is cumulative. If you control two of them, you can vote up to three times."
         },
         {
           "date": "2016-08-23",
-          "text": "The ability only affects spells and abilities that use the word “vote.” Other cards that involve choices, such as Archangel of Strife, are unaffected."
+          "text": "The ability only affects spells and abilities that use the word \"vote.\" Other cards that involve choices, such as Archangel of Strife, are unaffected."
         },
         {
           "date": "2016-08-23",
@@ -1418,11 +1418,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "For example, if you draft Custodi Peacekeeper as the third card in a draft round and then another one as the sixth card in a draft round, each Custodi Peacekeeper’s ability could tap a creature with power 6 or less."
+          "text": "For example, if you draft Custodi Peacekeeper as the third card in a draft round and then another one as the sixth card in a draft round, each Custodi Peacekeeper's ability could tap a creature with power 6 or less."
         },
         {
           "date": "2016-08-23",
-          "text": "If you gain control of a Custodi Peacekeeper, but you didn’t draft one, the highest noted number is considered to be 0. You can only use it to tap creatures with power 0 or less."
+          "text": "If you gain control of a Custodi Peacekeeper, but you didn't draft one, the highest noted number is considered to be 0. You can only use it to tap creatures with power 0 or less."
         }
       ],
       "subtypes": [
@@ -1488,15 +1488,15 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The value of X in the last ability is calculated in a similar fashion to how melee bonuses are calculated. It doesn’t matter if the creatures are still attacking or on the battlefield. It also doesn’t matter if the player you attacked is still in the game."
+          "text": "The value of X in the last ability is calculated in a similar fashion to how melee bonuses are calculated. It doesn't matter if the creatures are still attacking or on the battlefield. It also doesn't matter if the player you attacked is still in the game."
         },
         {
           "date": "2016-08-23",
-          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn’t matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn’t matter if the opponent you attacked is still in the game."
+          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn't matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn't matter if the opponent you attacked is still in the game."
         },
         {
           "date": "2016-08-23",
-          "text": "It doesn’t matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
+          "text": "It doesn't matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
         },
         {
           "date": "2016-08-23",
@@ -1504,7 +1504,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won’t count toward melee’s effect. Similarly, if a creature with melee enters the battlefield attacking, melee won’t trigger."
+          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won't count toward melee's effect. Similarly, if a creature with melee enters the battlefield attacking, melee won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -1574,11 +1574,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council’s dilemma card adds to the ultimate effect."
+          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council's dilemma card adds to the ultimate effect."
         },
         {
           "date": "2016-08-23",
-          "text": "The effects of each council’s dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
+          "text": "The effects of each council's dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
         },
         {
           "date": "2016-08-23",
@@ -1586,11 +1586,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature with an enters-the-battlefield council’s dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won’t generate an effect."
+          "text": "If a creature with an enters-the-battlefield council's dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won't generate an effect."
         },
         {
           "date": "2016-08-23",
@@ -1598,7 +1598,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Players can’t do anything between voting and finishing the resolution of the spell or ability that included the vote."
+          "text": "Players can't do anything between voting and finishing the resolution of the spell or ability that included the vote."
         }
       ],
       "subtypes": [
@@ -1664,11 +1664,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The creature card you reveal during the draft can be another Noble Banneret. That second Noble Banneret will then be face up for a future creature card to be revealed. If Noble Banneret is one of the names you noted, a Noble Banneret that’s the only creature you control will get +1/+1 and have lifelink."
+          "text": "The creature card you reveal during the draft can be another Noble Banneret. That second Noble Banneret will then be face up for a future creature card to be revealed. If Noble Banneret is one of the names you noted, a Noble Banneret that's the only creature you control will get +1/+1 and have lifelink."
         },
         {
           "date": "2016-08-23",
-          "text": "If you gain control of a Noble Banneret, but you didn’t draft one, there will be no applicable noted names. It won’t get +1/+1 or have lifelink."
+          "text": "If you gain control of a Noble Banneret, but you didn't draft one, there will be no applicable noted names. It won't get +1/+1 or have lifelink."
         }
       ],
       "subtypes": [
@@ -1734,27 +1734,27 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Palace Jailer’s two abilities can be put on the stack in either order. The last one to be put onto the stack will resolve first."
+          "text": "Palace Jailer's two abilities can be put on the stack in either order. The last one to be put onto the stack will resolve first."
         },
         {
           "date": "2016-08-23",
-          "text": "If you’re not the monarch as the second ability resolves, the creature will be exiled until there’s a new monarch and that player is one of your opponents. The creature won’t immediately return just because an opponent is the monarch."
+          "text": "If you're not the monarch as the second ability resolves, the creature will be exiled until there's a new monarch and that player is one of your opponents. The creature won't immediately return just because an opponent is the monarch."
         },
         {
           "date": "2016-08-23",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Counters on the exiled creature will cease to exist."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t return to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't return to the battlefield."
         },
         {
           "date": "2016-08-23",
-          "text": "Palace Jailer leaving the battlefield won’t cause the exiled creature to return. The game will continue to watch for the next time an opponent becomes the monarch."
+          "text": "Palace Jailer leaving the battlefield won't cause the exiled creature to return. The game will continue to watch for the next time an opponent becomes the monarch."
         },
         {
           "date": "2016-08-23",
-          "text": "The opponent that controlled the exiled card doesn’t have to be the same opponent that becomes the monarch in order to cause that card to return to the battlefield. Any opponent becoming the monarch will cause the card to return."
+          "text": "The opponent that controlled the exiled card doesn't have to be the same opponent that becomes the monarch in order to cause that card to return to the battlefield. Any opponent becoming the monarch will cause the card to return."
         },
         {
           "date": "2016-08-23",
@@ -1762,7 +1762,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "In some unusual cases, Palace Jailer’s owner will leave the game while not being the monarch. In this case, nothing happens immediately, but the exiled creature will return to the battlefield the next time one of that player’s opponents becomes the monarch."
+          "text": "In some unusual cases, Palace Jailer's owner will leave the game while not being the monarch. In this case, nothing happens immediately, but the exiled creature will return to the battlefield the next time one of that player's opponents becomes the monarch."
         },
         {
           "date": "2016-08-23",
@@ -1770,7 +1770,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -1845,7 +1845,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -1976,19 +1976,19 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Protector of the Crown’s last ability doesn’t depend on you being the monarch. It will create a redirection effect even if an opponent is the monarch."
+          "text": "Protector of the Crown's last ability doesn't depend on you being the monarch. It will create a redirection effect even if an opponent is the monarch."
         },
         {
           "date": "2016-08-23",
-          "text": "Applying this redirection effect doesn’t change whether the damage is combat damage."
+          "text": "Applying this redirection effect doesn't change whether the damage is combat damage."
         },
         {
           "date": "2016-08-23",
-          "text": "If you control both Protector of the Crown and a planeswalker, and noncombat damage would be dealt to you, you choose the order in which Protector of the Crown’s redirection effect and the planeswalker redirection effect apply. If damage is redirected to Protector of the Crown first, the planeswalker redirection effect won’t apply. If you apply the planeswalker redirection effect first, the controller of the damage source chooses whether the damage will be dealt to the planeswalker or ultimately to Protector of the Crown."
+          "text": "If you control both Protector of the Crown and a planeswalker, and noncombat damage would be dealt to you, you choose the order in which Protector of the Crown's redirection effect and the planeswalker redirection effect apply. If damage is redirected to Protector of the Crown first, the planeswalker redirection effect won't apply. If you apply the planeswalker redirection effect first, the controller of the damage source chooses whether the damage will be dealt to the planeswalker or ultimately to Protector of the Crown."
         },
         {
           "date": "2016-08-23",
-          "text": "If you control more than one Protector of the Crown, you choose which redirection effect to apply. You can’t divide damage dealt by one source. For example, if an attacking creature would deal 6 damage to you and you control two Protectors of the Crown, you may have that damage dealt to either of the Protectors. You can’t have 3 damage dealt to each one."
+          "text": "If you control more than one Protector of the Crown, you choose which redirection effect to apply. You can't divide damage dealt by one source. For example, if an attacking creature would deal 6 damage to you and you control two Protectors of the Crown, you may have that damage dealt to either of the Protectors. You can't have 3 damage dealt to each one."
         },
         {
           "date": "2016-08-23",
@@ -1996,7 +1996,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -2128,11 +2128,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Effects that increase or reduce the cost to cast a spell don’t affect that spell’s converted mana cost."
+          "text": "Effects that increase or reduce the cost to cast a spell don't affect that spell's converted mana cost."
         },
         {
           "date": "2016-08-23",
-          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell’s converted mana cost is the chosen number. For example, if the chosen number is 4, a noncreature spell with mana cost {X}{R}{R} couldn’t be cast with X equal to 2, but it could be cast with X equal to any other number."
+          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell's converted mana cost is the chosen number. For example, if the chosen number is 4, a noncreature spell with mana cost {X}{R}{R} couldn't be cast with X equal to 2, but it could be cast with X equal to any other number."
         }
       ],
       "subtypes": [
@@ -2256,7 +2256,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The last ability of Throne Warden checks to see if you’re the monarch as your end step begins. If you’re not, the ability won’t trigger at all. You won’t be able to do anything that would make you the monarch during your end step in time to have that ability trigger. The ability will also check to see if you’re the monarch as it tries to resolve. If you’re not the monarch at that time, the ability will have no effect."
+          "text": "The last ability of Throne Warden checks to see if you're the monarch as your end step begins. If you're not, the ability won't trigger at all. You won't be able to do anything that would make you the monarch during your end step in time to have that ability trigger. The ability will also check to see if you're the monarch as it tries to resolve. If you're not the monarch at that time, the ability will have no effect."
         },
         {
           "date": "2016-08-23",
@@ -2264,7 +2264,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -2335,11 +2335,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn’t matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn’t matter if the opponent you attacked is still in the game."
+          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn't matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn't matter if the opponent you attacked is still in the game."
         },
         {
           "date": "2016-08-23",
-          "text": "It doesn’t matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
+          "text": "It doesn't matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
         },
         {
           "date": "2016-08-23",
@@ -2347,7 +2347,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won’t count toward melee’s effect. Similarly, if a creature with melee enters the battlefield attacking, melee won’t trigger."
+          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won't count toward melee's effect. Similarly, if a creature with melee enters the battlefield attacking, melee won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -2416,19 +2416,19 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "If you have more than one Arcane Savant in your deck, you may reveal any number of them and exile that many instant or sorcery cards you drafted that aren’t in your deck."
+          "text": "If you have more than one Arcane Savant in your deck, you may reveal any number of them and exile that many instant or sorcery cards you drafted that aren't in your deck."
         },
         {
           "date": "2016-08-23",
-          "text": "As Arcane Savant’s last ability resolves, if there are multiple cards you exiled with cards named Arcane Savant, you choose one of them to copy."
+          "text": "As Arcane Savant's last ability resolves, if there are multiple cards you exiled with cards named Arcane Savant, you choose one of them to copy."
         },
         {
           "date": "2016-08-23",
-          "text": "The copy is created in and cast from exile. You cast the copy during the resolution of Arcane Savant’s last ability. You ignore any timing restrictions based on the card type of the card you copied. However, you must still follow any other timing restrictions, such as “Cast [this spell] only during combat.”"
+          "text": "The copy is created in and cast from exile. You cast the copy during the resolution of Arcane Savant's last ability. You ignore any timing restrictions based on the card type of the card you copied. However, you must still follow any other timing restrictions, such as \"Cast [this spell] only during combat.\""
         },
         {
           "date": "2016-08-23",
-          "text": "You can’t pay any alternative costs the card has. You can pay additional costs, and if the spell has any mandatory additional costs, you must pay those."
+          "text": "You can't pay any alternative costs the card has. You can pay additional costs, and if the spell has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2016-08-23",
@@ -2499,7 +2499,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Attacking a planeswalker isn’t the same thing as attacking a player. Both Canal Courier and the other creature must attack different players for the last ability to trigger."
+          "text": "Attacking a planeswalker isn't the same thing as attacking a player. Both Canal Courier and the other creature must attack different players for the last ability to trigger."
         },
         {
           "date": "2016-08-23",
@@ -2507,7 +2507,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -2577,23 +2577,23 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "If, during a player’s declare attackers step, a creature that player controls that’s been goaded is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack a player, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature that player controls that's been goaded is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack a player, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-08-23",
-          "text": "If the creature doesn’t meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can’t attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
+          "text": "If the creature doesn't meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can't attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
         },
         {
           "date": "2016-08-23",
-          "text": "Being goaded isn’t an ability the creature has. Once it’s been goaded, it must attack as detailed above even if it loses all abilities."
+          "text": "Being goaded isn't an ability the creature has. Once it's been goaded, it must attack as detailed above even if it loses all abilities."
         },
         {
           "date": "2016-08-23",
-          "text": "Attacking with a goaded creature doesn’t cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
+          "text": "Attacking with a goaded creature doesn't cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn’t goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
+          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn't goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
         }
       ],
       "subtypes": [
@@ -2658,7 +2658,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Expropriate doesn’t target any of the permanents you gain control of. You could choose a permanent with hexproof, for example. (Hey, money talks.)"
+          "text": "Expropriate doesn't target any of the permanents you gain control of. You could choose a permanent with hexproof, for example. (Hey, money talks.)"
         },
         {
           "date": "2016-08-23",
@@ -2666,11 +2666,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council’s dilemma card adds to the ultimate effect."
+          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council's dilemma card adds to the ultimate effect."
         },
         {
           "date": "2016-08-23",
-          "text": "The effects of each council’s dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
+          "text": "The effects of each council's dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
         },
         {
           "date": "2016-08-23",
@@ -2678,11 +2678,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature with an enters-the-battlefield council’s dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won’t generate an effect."
+          "text": "If a creature with an enters-the-battlefield council's dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won't generate an effect."
         },
         {
           "date": "2016-08-23",
@@ -2690,7 +2690,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Players can’t do anything between voting and finishing the resolution of the spell or ability that included the vote."
+          "text": "Players can't do anything between voting and finishing the resolution of the spell or ability that included the vote."
         }
       ],
       "text": "Council's dilemma — Starting with you, each player votes for time or money. For each time vote, take an extra turn after this one. For each money vote, choose a permanent owned by the voter and gain control of it. Exile Expropriate.",
@@ -2755,7 +2755,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If another player controls Ballot Broker, that player first takes his or her “normal” vote with you choosing the result, then that player decides whether he or she is taking the additional vote. If there is an additional vote, you again choose the result."
+          "text": "If another player controls Ballot Broker, that player first takes his or her \"normal\" vote with you choosing the result, then that player decides whether he or she is taking the additional vote. If there is an additional vote, you again choose the result."
         }
       ],
       "text": "You choose how each player votes this turn.\nDraw a card.",
@@ -2816,7 +2816,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Once a player has put a card into his or her pile of drafted cards, it’s too late to turn Illusionary Informant face down to look at that card. As a courtesy, you should alert the player as soon as he or she is passed the booster pack."
+          "text": "Once a player has put a card into his or her pile of drafted cards, it's too late to turn Illusionary Informant face down to look at that card. As a courtesy, you should alert the player as soon as he or she is passed the booster pack."
         }
       ],
       "subtypes": [
@@ -2883,23 +2883,23 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "If, during a player’s declare attackers step, a creature that player controls that’s been goaded is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack a player, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature that player controls that's been goaded is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack a player, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-08-23",
-          "text": "If the creature doesn’t meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can’t attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
+          "text": "If the creature doesn't meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can't attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
         },
         {
           "date": "2016-08-23",
-          "text": "Being goaded isn’t an ability the creature has. Once it’s been goaded, it must attack as detailed above even if it loses all abilities."
+          "text": "Being goaded isn't an ability the creature has. Once it's been goaded, it must attack as detailed above even if it loses all abilities."
         },
         {
           "date": "2016-08-23",
-          "text": "Attacking with a goaded creature doesn’t cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
+          "text": "Attacking with a goaded creature doesn't cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn’t goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
+          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn't goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
         }
       ],
       "subtypes": [
@@ -2965,11 +2965,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The last ability of Keeper of Keys checks to see if you’re the monarch as your upkeep begins. If you’re not, the ability won’t trigger at all. You won’t be able to do anything that would make you the monarch during your upkeep in time to have that ability trigger. The ability will also check to see if you’re the monarch as it tries to resolve. If you’re not the monarch at that time, the ability will have no effect."
+          "text": "The last ability of Keeper of Keys checks to see if you're the monarch as your upkeep begins. If you're not, the ability won't trigger at all. You won't be able to do anything that would make you the monarch during your upkeep in time to have that ability trigger. The ability will also check to see if you're the monarch as it tries to resolve. If you're not the monarch at that time, the ability will have no effect."
         },
         {
           "date": "2016-08-23",
-          "text": "The last ability of Keeper of Keys will affect all creatures you control that turn, even if they weren’t on the battlefield or weren’t creatures as the ability resolved."
+          "text": "The last ability of Keeper of Keys will affect all creatures you control that turn, even if they weren't on the battlefield or weren't creatures as the ability resolved."
         },
         {
           "date": "2016-08-23",
@@ -2977,7 +2977,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -3048,11 +3048,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council’s dilemma card adds to the ultimate effect."
+          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council's dilemma card adds to the ultimate effect."
         },
         {
           "date": "2016-08-23",
-          "text": "The effects of each council’s dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
+          "text": "The effects of each council's dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
         },
         {
           "date": "2016-08-23",
@@ -3060,11 +3060,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature with an enters-the-battlefield council’s dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won’t generate an effect."
+          "text": "If a creature with an enters-the-battlefield council's dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won't generate an effect."
         },
         {
           "date": "2016-08-23",
@@ -3072,7 +3072,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Players can’t do anything between voting and finishing the resolution of the spell or ability that included the vote."
+          "text": "Players can't do anything between voting and finishing the resolution of the spell or ability that included the vote."
         }
       ],
       "subtypes": [
@@ -3196,7 +3196,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Typically, the next player will set aside the card he or she intends to draft, you’ll make your guess, then the card will be revealed. You can make your guess before the player drafts a card to make things weird more interesting."
+          "text": "Typically, the next player will set aside the card he or she intends to draft, you'll make your guess, then the card will be revealed. You can make your guess before the player drafts a card to make things weird more interesting."
         },
         {
           "date": "2016-08-23",
@@ -3267,7 +3267,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Stunt Double copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Stunt Double copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2016-08-23",
@@ -3279,15 +3279,15 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If the chosen creature is a token, Stunt Double copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Stunt Double isn’t a token."
+          "text": "If the chosen creature is a token, Stunt Double copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Stunt Double isn't a token."
         },
         {
           "date": "2016-08-23",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Stunt Double enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Stunt Double enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2016-08-23",
-          "text": "If Stunt Double somehow enters the battlefield at the same time as another creature, it can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Stunt Double somehow enters the battlefield at the same time as another creature, it can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2016-08-23",
@@ -3360,17 +3360,17 @@
         },
         {
           "date": "2016-08-23",
-          "text": "After you draft a card at random, look at it to determine whether it needs to be revealed as it’s drafted or drafted face up. If it does, follow its instructions as normal."
+          "text": "After you draft a card at random, look at it to determine whether it needs to be revealed as it's drafted or drafted face up. If it does, follow its instructions as normal."
         },
         {
           "date": "2016-08-23",
-          "text": "If you have more than one face-up Archdemon of Paliano, keep track of the number of cards you’ve drafted at random for each one. Each card you draft at random counts toward the demands of all your Archdemons. While you’re doing this, consider carefully why the Archdemon seems to favor you."
+          "text": "If you have more than one face-up Archdemon of Paliano, keep track of the number of cards you've drafted at random for each one. Each card you draft at random counts toward the demands of all your Archdemons. While you're doing this, consider carefully why the Archdemon seems to favor you."
         }
       ],
       "subtypes": [
         "Demon"
       ],
-      "text": "Draft Archdemon of Paliano face up. \nAs long as Archdemon of Paliano is face up during the draft, you can't look at booster packs and must draft cards at random. After you draft three cards this way, turn Archdemon of Paliano face down. (You may look at cards as you draft them.)\nFlying",
+      "text": "Draft Archdemon of Paliano face up.\nAs long as Archdemon of Paliano is face up during the draft, you can't look at booster packs and must draft cards at random. After you draft three cards this way, turn Archdemon of Paliano face down. (You may look at cards as you draft them.)\nFlying",
       "toughness": "4",
       "type": "Creature — Demon",
       "types": [
@@ -3437,11 +3437,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council’s dilemma card adds to the ultimate effect."
+          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council's dilemma card adds to the ultimate effect."
         },
         {
           "date": "2016-08-23",
-          "text": "The effects of each council’s dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
+          "text": "The effects of each council's dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
         },
         {
           "date": "2016-08-23",
@@ -3449,11 +3449,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature with an enters-the-battlefield council’s dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won’t generate an effect."
+          "text": "If a creature with an enters-the-battlefield council's dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won't generate an effect."
         },
         {
           "date": "2016-08-23",
@@ -3461,7 +3461,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Players can’t do anything between voting and finishing the resolution of the spell or ability that included the vote."
+          "text": "Players can't do anything between voting and finishing the resolution of the spell or ability that included the vote."
         }
       ],
       "text": "Council's dilemma — Starting with you, each player votes for death or taxes. Each opponent sacrifices a creature for each death vote and discards a card for each taxes vote.",
@@ -3527,7 +3527,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -3600,7 +3600,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If the player who controlled Deadly Designs as its last ability triggered doesn’t control it as that ability resolves, Deadly Designs won’t be sacrificed. However, if it’s still on the battlefield and has five or more plot counters on it, its last ability will immediately trigger again."
+          "text": "If the player who controlled Deadly Designs as its last ability triggered doesn't control it as that ability resolves, Deadly Designs won't be sacrificed. However, if it's still on the battlefield and has five or more plot counters on it, its last ability will immediately trigger again."
         }
       ],
       "text": "{2}: Put a plot counter on Deadly Designs. Any player may activate this ability.\nWhen there are five or more plot counters on Deadly Designs, sacrifice it. If you do, destroy up to two target creatures.",
@@ -3662,7 +3662,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The last ability of Garrulous Sycophant checks to see if you’re the monarch as your end step begins. If you’re not, the ability won’t trigger at all. You won’t be able to do anything that would make you the monarch during your end step in time to have that ability trigger. The ability will also check to see if you’re the monarch as it tries to resolve. If you’re not the monarch at that time, the ability will have no effect."
+          "text": "The last ability of Garrulous Sycophant checks to see if you're the monarch as your end step begins. If you're not, the ability won't trigger at all. You won't be able to do anything that would make you the monarch during your end step in time to have that ability trigger. The ability will also check to see if you're the monarch as it tries to resolve. If you're not the monarch at that time, the ability will have no effect."
         },
         {
           "date": "2016-08-23",
@@ -3670,7 +3670,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -3744,7 +3744,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -3813,23 +3813,23 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If you draft another Regicide, any additional colors chosen will count for each Regicide you’ve drafted."
+          "text": "If you draft another Regicide, any additional colors chosen will count for each Regicide you've drafted."
         },
         {
           "date": "2016-08-23",
-          "text": "The target creature can be colors that weren’t chosen as long as it’s also one or more colors that were. For example, if the chosen colors were red, white, and green, Regicide could target a creature that’s white and black."
+          "text": "The target creature can be colors that weren't chosen as long as it's also one or more colors that were. For example, if the chosen colors were red, white, and green, Regicide could target a creature that's white and black."
         },
         {
           "date": "2016-08-23",
-          "text": "Regicide can’t target colorless creatures."
+          "text": "Regicide can't target colorless creatures."
         },
         {
           "date": "2016-08-23",
-          "text": "If a card would allow you to cast a Regicide but you didn’t draft one, you won’t be able to cast it because you won’t be able to choose a legal target."
+          "text": "If a card would allow you to cast a Regicide but you didn't draft one, you won't be able to cast it because you won't be able to choose a legal target."
         },
         {
           "date": "2016-08-23",
-          "text": "If you copy or gain control of a Regicide that’s already on the stack but you didn’t draft one, you won’t be able to choose a new target and Regicide will be countered as it tries to resolve. The target creature won’t be destroyed. On the other hand, if you did draft a Regicide, use the set of colors chosen as you drafted cards named Regicide when choosing a new target (if applicable) or determining if the resolving Regicide’s target is legal."
+          "text": "If you copy or gain control of a Regicide that's already on the stack but you didn't draft one, you won't be able to choose a new target and Regicide will be countered as it tries to resolve. The target creature won't be destroyed. On the other hand, if you did draft a Regicide, use the set of colors chosen as you drafted cards named Regicide when choosing a new target (if applicable) or determining if the resolving Regicide's target is legal."
         }
       ],
       "text": "Reveal Regicide as you draft it. The player to your right chooses a color, you choose another color, then the player to your left chooses a third color.\nDestroy target creature that's one or more of the colors chosen as you drafted cards named Regicide.",
@@ -3890,7 +3890,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Once Sinuous Vermin has been legally blocked by one creature, activating the monstrosity ability to give it menace won’t change or undo that block."
+          "text": "Once Sinuous Vermin has been legally blocked by one creature, activating the monstrosity ability to give it menace won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -3956,7 +3956,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "If a Smuggler Captain enters the battlefield under your control, but you didn’t draft one, there will be no applicable noted names. You may search and shuffle your library, but you can’t find any cards."
+          "text": "If a Smuggler Captain enters the battlefield under your control, but you didn't draft one, there will be no applicable noted names. You may search and shuffle your library, but you can't find any cards."
         }
       ],
       "subtypes": [
@@ -4027,7 +4027,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -4101,31 +4101,31 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Besmirch can target any creature, including one you already control or one that’s untapped."
+          "text": "Besmirch can target any creature, including one you already control or one that's untapped."
         },
         {
           "date": "2016-08-23",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2016-08-23",
-          "text": "If, during a player’s declare attackers step, a creature that player controls that’s been goaded is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack a player, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature that player controls that's been goaded is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack a player, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-08-23",
-          "text": "If the creature doesn’t meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can’t attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
+          "text": "If the creature doesn't meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can't attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
         },
         {
           "date": "2016-08-23",
-          "text": "Being goaded isn’t an ability the creature has. Once it’s been goaded, it must attack as detailed above even if it loses all abilities."
+          "text": "Being goaded isn't an ability the creature has. Once it's been goaded, it must attack as detailed above even if it loses all abilities."
         },
         {
           "date": "2016-08-23",
-          "text": "Attacking with a goaded creature doesn’t cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
+          "text": "Attacking with a goaded creature doesn't cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn’t goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
+          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn't goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
         }
       ],
       "text": "Until end of turn, gain control of target creature and it gains haste. Untap and goad that creature. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
@@ -4187,7 +4187,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Crown-Hunter Hireling can attack only the monarch or a planeswalker controlled by the monarch. This check is done only as attackers are declared. After that point, Crown-Hunter Hireling won’t be removed from combat if that player ceases to be the monarch."
+          "text": "Crown-Hunter Hireling can attack only the monarch or a planeswalker controlled by the monarch. This check is done only as attackers are declared. After that point, Crown-Hunter Hireling won't be removed from combat if that player ceases to be the monarch."
         },
         {
           "date": "2016-08-23",
@@ -4195,7 +4195,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -4266,11 +4266,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn’t matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn’t matter if the opponent you attacked is still in the game."
+          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn't matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn't matter if the opponent you attacked is still in the game."
         },
         {
           "date": "2016-08-23",
-          "text": "It doesn’t matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
+          "text": "It doesn't matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
         },
         {
           "date": "2016-08-23",
@@ -4278,7 +4278,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won’t count toward melee’s effect. Similarly, if a creature with melee enters the battlefield attacking, melee won’t trigger."
+          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won't count toward melee's effect. Similarly, if a creature with melee enters the battlefield attacking, melee won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -4351,7 +4351,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If you somehow cast, copy, or gain control of Garbage Fire but you didn’t draft one, the highest noted number is considered to be 0, so Garbage Fire won’t deal any damage."
+          "text": "If you somehow cast, copy, or gain control of Garbage Fire but you didn't draft one, the highest noted number is considered to be 0, so Garbage Fire won't deal any damage."
         }
       ],
       "text": "Reveal Garbage Fire as you draft it and note how many cards you've drafted this draft round, including Garbage Fire.\nGarbage Fire deals damage to target creature equal to the highest number you noted for cards named Garbage Fire.",
@@ -4413,23 +4413,23 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "If, during a player’s declare attackers step, a creature that player controls that’s been goaded is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack a player, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature that player controls that's been goaded is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack a player, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-08-23",
-          "text": "If the creature doesn’t meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can’t attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
+          "text": "If the creature doesn't meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can't attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
         },
         {
           "date": "2016-08-23",
-          "text": "Being goaded isn’t an ability the creature has. Once it’s been goaded, it must attack as detailed above even if it loses all abilities."
+          "text": "Being goaded isn't an ability the creature has. Once it's been goaded, it must attack as detailed above even if it loses all abilities."
         },
         {
           "date": "2016-08-23",
-          "text": "Attacking with a goaded creature doesn’t cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
+          "text": "Attacking with a goaded creature doesn't cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn’t goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
+          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn't goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
         }
       ],
       "subtypes": [
@@ -4500,7 +4500,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If you exile a land card this way, you can’t play it."
+          "text": "If you exile a land card this way, you can't play it."
         },
         {
           "date": "2016-08-23",
@@ -4508,27 +4508,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If you don’t cast the card, it will remain in exile."
+          "text": "If you don't cast the card, it will remain in exile."
         },
         {
           "date": "2016-08-23",
-          "text": "If, during a player’s declare attackers step, a creature that player controls that’s been goaded is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack a player, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature that player controls that's been goaded is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack a player, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-08-23",
-          "text": "If the creature doesn’t meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can’t attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
+          "text": "If the creature doesn't meet any of the above exceptions and can attack, it must attack a player other than the controller of the spell or ability that goaded it if able. It the creature can't attack any of those players but could otherwise attack, it must attack an opposing planeswalker (controlled by any opponent) or the player that goaded it."
         },
         {
           "date": "2016-08-23",
-          "text": "Being goaded isn’t an ability the creature has. Once it’s been goaded, it must attack as detailed above even if it loses all abilities."
+          "text": "Being goaded isn't an ability the creature has. Once it's been goaded, it must attack as detailed above even if it loses all abilities."
         },
         {
           "date": "2016-08-23",
-          "text": "Attacking with a goaded creature doesn’t cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
+          "text": "Attacking with a goaded creature doesn't cause it to stop being goaded. If there is an additional combat phase that turn, or if another player gains control of it before it stops being goaded, it must attack again if able."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn’t goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
+          "text": "If a creature you control has been goaded by multiple opponents, it must attack one of your opponents that hasn't goaded it, as that fulfills the maximum number of goad requirements. If a creature you control has been goaded by each of your opponents, you choose which opponent it attacks."
         }
       ],
       "subtypes": [
@@ -4538,7 +4538,7 @@
       "supertypes": [
         "Legendary"
       ],
-      "text": "Whenever a creature you control deals combat damage to a player, choose one —\n• Goad target creature that player controls. \n• Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast it.",
+      "text": "Whenever a creature you control deals combat damage to a player, choose one —\n• Goad target creature that player controls.\n• Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
       "toughness": "2",
       "type": "Legendary Creature — Goblin Rogue",
       "types": [
@@ -4597,11 +4597,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn’t matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn’t matter if the opponent you attacked is still in the game."
+          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn't matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn't matter if the opponent you attacked is still in the game."
         },
         {
           "date": "2016-08-23",
-          "text": "It doesn’t matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
+          "text": "It doesn't matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
         },
         {
           "date": "2016-08-23",
@@ -4609,7 +4609,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won’t count toward melee’s effect. Similarly, if a creature with melee enters the battlefield attacking, melee won’t trigger."
+          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won't count toward melee's effect. Similarly, if a creature with melee enters the battlefield attacking, melee won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -4682,7 +4682,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If Pyretic Hunter enters the battlefield under your control, but you didn’t draft one, the highest noted number is considered to be 0. It will enter with zero +1/+1 counters and will be put into its owner’s graveyard (unless something else is raising its toughness)."
+          "text": "If Pyretic Hunter enters the battlefield under your control, but you didn't draft one, the highest noted number is considered to be 0. It will enter with zero +1/+1 counters and will be put into its owner's graveyard (unless something else is raising its toughness)."
         }
       ],
       "subtypes": [
@@ -4748,7 +4748,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The last ability of Skyline Despot checks to see if you’re the monarch as your upkeep begins. If you’re not, the ability won’t trigger at all. You won’t be able to do anything that would make you the monarch during your upkeep in time to have that ability trigger. The ability will also check to see if you’re the monarch as it tries to resolve. If you’re not the monarch at that time, the ability will have no effect."
+          "text": "The last ability of Skyline Despot checks to see if you're the monarch as your upkeep begins. If you're not, the ability won't trigger at all. You won't be able to do anything that would make you the monarch during your upkeep in time to have that ability trigger. The ability will also check to see if you're the monarch as it tries to resolve. If you're not the monarch at that time, the ability will have no effect."
         },
         {
           "date": "2016-08-23",
@@ -4756,7 +4756,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -4880,11 +4880,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Unlike the other two cards with this style of ability (Arcane Savant and Caller of the Untamed), if you have more than one Volatile Chimera in your deck, you need only reveal one of them because you can exile as many creature cards that aren’t in your deck as you want, with a minimum of three. If you do reveal more than one Volatile Chimera before shuffling, you’ll have to exile at least three creature cards for each of them."
+          "text": "Unlike the other two cards with this style of ability (Arcane Savant and Caller of the Untamed), if you have more than one Volatile Chimera in your deck, you need only reveal one of them because you can exile as many creature cards that aren't in your deck as you want, with a minimum of three. If you do reveal more than one Volatile Chimera before shuffling, you'll have to exile at least three creature cards for each of them."
         },
         {
           "date": "2016-08-23",
-          "text": "The copy effect created by the activated ability doesn’t have a duration. It will last until Volatile Chimera leaves the battlefield or another copy effect overwrites it."
+          "text": "The copy effect created by the activated ability doesn't have a duration. It will last until Volatile Chimera leaves the battlefield or another copy effect overwrites it."
         },
         {
           "date": "2016-08-23",
@@ -4962,11 +4962,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If a card you remove requires you to reveal it as you draft it, do so and follow any additional instructions it may have related to drafting it. However, if a card you remove instructs you to draft it face up, it has no effect while face up and can’t be turned face down to use an ability."
+          "text": "If a card you remove requires you to reveal it as you draft it, do so and follow any additional instructions it may have related to drafting it. However, if a card you remove instructs you to draft it face up, it has no effect while face up and can't be turned face down to use an ability."
         },
         {
           "date": "2016-08-23",
-          "text": "Some cards allow you to exile other cards you’ve drafted that aren’t in your deck before the game starts. Cards you removed from the draft with Animus of Predation can’t be exiled this way because they aren’t in your card pool."
+          "text": "Some cards allow you to exile other cards you've drafted that aren't in your deck before the game starts. Cards you removed from the draft with Animus of Predation can't be exiled this way because they aren't in your card pool."
         },
         {
           "date": "2016-08-23",
@@ -5035,7 +5035,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Players decide whether or not they’re discarding a card in turn order. Each player will know if previous players are discarding, but not what they are discarding. All cards to be discarded are set aside, then revealed and discarded simultaneously. Similarly, all basic land cards searched for are set aside, then revealed simultaneously."
+          "text": "Players decide whether or not they're discarding a card in turn order. Each player will know if previous players are discarding, but not what they are discarding. All cards to be discarded are set aside, then revealed and discarded simultaneously. Similarly, all basic land cards searched for are set aside, then revealed simultaneously."
         }
       ],
       "subtypes": [
@@ -5101,11 +5101,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "If you have more than one Caller of the Untamed in your deck, you may reveal any number of them and exile that many creature cards you drafted that aren’t in your deck. You’ll choose which one to copy at the time you choose the value of X while activating the ability."
+          "text": "If you have more than one Caller of the Untamed in your deck, you may reveal any number of them and exile that many creature cards you drafted that aren't in your deck. You'll choose which one to copy at the time you choose the value of X while activating the ability."
         },
         {
           "date": "2016-08-23",
-          "text": "If there is an {X} in the mana cost of the exiled creature card, that X is 0. Don’t confuse it with the {X} in the activation cost of Caller of the Untamed’s ability."
+          "text": "If there is an {X} in the mana cost of the exiled creature card, that X is 0. Don't confuse it with the {X} in the activation cost of Caller of the Untamed's ability."
         }
       ],
       "subtypes": [
@@ -5232,7 +5232,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Entourage of Trest checks if you’re the monarch only as blockers are declared. If it blocks two attacking creatures, another player becoming the monarch won’t change or undo that block."
+          "text": "Entourage of Trest checks if you're the monarch only as blockers are declared. If it blocks two attacking creatures, another player becoming the monarch won't change or undo that block."
         },
         {
           "date": "2016-08-23",
@@ -5240,7 +5240,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -5310,11 +5310,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn’t matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn’t matter if the opponent you attacked is still in the game."
+          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn't matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn't matter if the opponent you attacked is still in the game."
         },
         {
           "date": "2016-08-23",
-          "text": "It doesn’t matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
+          "text": "It doesn't matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
         },
         {
           "date": "2016-08-23",
@@ -5322,7 +5322,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won’t count toward melee’s effect. Similarly, if a creature with melee enters the battlefield attacking, melee won’t trigger."
+          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won't count toward melee's effect. Similarly, if a creature with melee enters the battlefield attacking, melee won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -5391,14 +5391,14 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "You can turn more than one Leovold’s Operative face down to draft additional cards from one booster pack. However, for each Leovold’s Operative you turn face down, you will skip drafting a card from an additional future booster pack. For example, if you turn three Leovold’s Operatives face down as you draft a card from a booster pack, you may draft three additional cards from that booster pack. You then won’t draft a card from the next three booster packs you are passed (and/or open)."
+          "text": "You can turn more than one Leovold's Operative face down to draft additional cards from one booster pack. However, for each Leovold's Operative you turn face down, you will skip drafting a card from an additional future booster pack. For example, if you turn three Leovold's Operatives face down as you draft a card from a booster pack, you may draft three additional cards from that booster pack. You then won't draft a card from the next three booster packs you are passed (and/or open)."
         }
       ],
       "subtypes": [
         "Elf",
         "Rogue"
       ],
-      "text": "Draft Leovold's Operative face up. \nAs you draft a card, you may draft an additional card from that booster pack. If you do, turn Leovold's Operative face down, then pass the next booster pack without drafting a card from it. (You may look at that booster pack.)",
+      "text": "Draft Leovold's Operative face up.\nAs you draft a card, you may draft an additional card from that booster pack. If you do, turn Leovold's Operative face down, then pass the next booster pack without drafting a card from it. (You may look at that booster pack.)",
       "toughness": "2",
       "type": "Creature — Elf Rogue",
       "types": [
@@ -5458,11 +5458,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn’t matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn’t matter if the opponent you attacked is still in the game."
+          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn't matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn't matter if the opponent you attacked is still in the game."
         },
         {
           "date": "2016-08-23",
-          "text": "It doesn’t matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
+          "text": "It doesn't matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
         },
         {
           "date": "2016-08-23",
@@ -5470,7 +5470,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won’t count toward melee’s effect. Similarly, if a creature with melee enters the battlefield attacking, melee won’t trigger."
+          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won't count toward melee's effect. Similarly, if a creature with melee enters the battlefield attacking, melee won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -5541,11 +5541,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council’s dilemma card adds to the ultimate effect."
+          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council's dilemma card adds to the ultimate effect."
         },
         {
           "date": "2016-08-23",
-          "text": "The effects of each council’s dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
+          "text": "The effects of each council's dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
         },
         {
           "date": "2016-08-23",
@@ -5553,11 +5553,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature with an enters-the-battlefield council’s dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won’t generate an effect."
+          "text": "If a creature with an enters-the-battlefield council's dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won't generate an effect."
         },
         {
           "date": "2016-08-23",
@@ -5565,7 +5565,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Players can’t do anything between voting and finishing the resolution of the spell or ability that included the vote."
+          "text": "Players can't do anything between voting and finishing the resolution of the spell or ability that included the vote."
         }
       ],
       "subtypes": [
@@ -5630,7 +5630,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Regal Behemoth’s last ability is a triggered mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Regal Behemoth's last ability is a triggered mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2016-08-23",
@@ -5638,7 +5638,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -5707,15 +5707,15 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The new creature’s power is compared to the power of each other creature on the battlefield as the first ability resolves. If another creature has the same or higher power than the new creature’s power, no one may draw a card."
+          "text": "The new creature's power is compared to the power of each other creature on the battlefield as the first ability resolves. If another creature has the same or higher power than the new creature's power, no one may draw a card."
         },
         {
           "date": "2016-08-23",
-          "text": "If the new creature isn’t on the battlefield as the first ability resolves, use its power when it left the battlefield to determine whether its controller may draw a card. Note that effects that reduced its power before it left the battlefield will apply."
+          "text": "If the new creature isn't on the battlefield as the first ability resolves, use its power when it left the battlefield to determine whether its controller may draw a card. Note that effects that reduced its power before it left the battlefield will apply."
         },
         {
           "date": "2016-08-23",
-          "text": "Selvala’s last ability is a mana ability. It doesn’t use the stack and can’t be responded to. If the greatest power among creatures you control is 0 or less at that time, no mana is added to your pool."
+          "text": "Selvala's last ability is a mana ability. It doesn't use the stack and can't be responded to. If the greatest power among creatures you control is 0 or less at that time, no mana is added to your pool."
         }
       ],
       "subtypes": [
@@ -5787,15 +5787,15 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Any abilities that trigger because of any of those cards entering the battlefield are put onto the stack at the same time, after Selvala’s Stampede finishes resolving. You choose the order that abilities you control go on the stack, followed by each other player in turn order choosing the order for abilities he or she controls. The last ability to be put on the stack will resolve first."
+          "text": "Any abilities that trigger because of any of those cards entering the battlefield are put onto the stack at the same time, after Selvala's Stampede finishes resolving. You choose the order that abilities you control go on the stack, followed by each other player in turn order choosing the order for abilities he or she controls. The last ability to be put on the stack will resolve first."
         },
         {
           "date": "2016-08-23",
-          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council’s dilemma card adds to the ultimate effect."
+          "text": "Unlike the will of the council cards from the original Conspiracy set, where a majority of votes determined what happened, each vote made for a council's dilemma card adds to the ultimate effect."
         },
         {
           "date": "2016-08-23",
-          "text": "The effects of each council’s dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
+          "text": "The effects of each council's dilemma ability happen in the stated order. First the vote occurs, then the first effect, and finally the second effect."
         },
         {
           "date": "2016-08-23",
@@ -5803,11 +5803,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2016-08-23",
-          "text": "If a creature with an enters-the-battlefield council’s dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won’t generate an effect."
+          "text": "If a creature with an enters-the-battlefield council's dilemma ability leaves the battlefield before that ability resolves, players can still vote for any option that would put +1/+1 counters on that creature, even though—or perhaps especially because—those votes won't generate an effect."
         },
         {
           "date": "2016-08-23",
@@ -5815,7 +5815,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Players can’t do anything between voting and finishing the resolution of the spell or ability that included the vote."
+          "text": "Players can't do anything between voting and finishing the resolution of the spell or ability that included the vote."
         }
       ],
       "text": "Council's dilemma — Starting with you, each player votes for wild or free. Reveal cards from the top of your library until you reveal a creature card for each wild vote. Put those creature cards onto the battlefield, then shuffle the rest into your library. You may put a permanent card from your hand onto the battlefield for each free vote.",
@@ -5876,7 +5876,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The token that’s put onto the battlefield isn’t monstrous at first. If you activate the token’s ability, it will get counters, it will become monstrous, and a new token will be put onto the battlefield."
+          "text": "The token that's put onto the battlefield isn't monstrous at first. If you activate the token's ability, it will get counters, it will become monstrous, and a new token will be put onto the battlefield."
         }
       ],
       "subtypes": [
@@ -5944,11 +5944,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn’t matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn’t matter if the opponent you attacked is still in the game."
+          "text": "You determine the size of the bonus as the melee ability resolves. Count each opponent that you attacked with one or more creatures. It doesn't matter if the attacking creatures are still attacking or even if they are still on the battlefield. It also doesn't matter if the opponent you attacked is still in the game."
         },
         {
           "date": "2016-08-23",
-          "text": "It doesn’t matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
+          "text": "It doesn't matter how many creatures you attacked a player with, only that you attacked a player with at least one creature. For example, if you attack one player with Wings of the Guard and another player with five creatures, Wings of the Guard will get +2/+2 until end of turn."
         },
         {
           "date": "2016-08-23",
@@ -5956,7 +5956,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won’t count toward melee’s effect. Similarly, if a creature with melee enters the battlefield attacking, melee won’t trigger."
+          "text": "Creatures that enter the battlefield attacking were never declared as attackers, so they won't count toward melee's effect. Similarly, if a creature with melee enters the battlefield attacking, melee won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -6035,7 +6035,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "For the last ability, if you choose an artifact on the battlefield as the target, and that artifact is no longer on the battlefield as the ability tries to resolve, the ability will be countered and none of its effects will happen. You won’t get any tokens. This is true even if the card that represented that artifact is now in a graveyard. That card will be a different object than it was on the battlefield."
+          "text": "For the last ability, if you choose an artifact on the battlefield as the target, and that artifact is no longer on the battlefield as the ability tries to resolve, the ability will be countered and none of its effects will happen. You won't get any tokens. This is true even if the card that represented that artifact is now in a graveyard. That card will be a different object than it was on the battlefield."
         }
       ],
       "subtypes": [
@@ -6111,11 +6111,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "You choose whether or not to target a creature as you activate the first ability. If you chose a target creature, you choose whether to exile Kaya or that creature as the ability resolves. If you chose a creature and that creature is no longer a legal target as the ability tries to resolve, the ability is countered and none of its effects happen. You won’t exile Kaya or lose 2 life."
+          "text": "You choose whether or not to target a creature as you activate the first ability. If you chose a target creature, you choose whether to exile Kaya or that creature as the ability resolves. If you chose a creature and that creature is no longer a legal target as the ability tries to resolve, the ability is countered and none of its effects happen. You won't exile Kaya or lose 2 life."
         },
         {
           "date": "2016-08-23",
-          "text": "If you didn’t choose a target creature for the first ability, and Kaya isn’t on the battlefield as the ability resolves, you’ll just lose 2 life. No card will be exiled or returned to the battlefield."
+          "text": "If you didn't choose a target creature for the first ability, and Kaya isn't on the battlefield as the ability resolves, you'll just lose 2 life. No card will be exiled or returned to the battlefield."
         },
         {
           "date": "2016-08-23",
@@ -6197,7 +6197,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -6247,7 +6247,7 @@
       "legalities": [
         {
           "format": "Commander",
-          "legality": "Legal"
+          "legality": "Banned"
         },
         {
           "format": "Legacy",
@@ -6272,23 +6272,23 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "Your opponents can draw a maximum of one card on each player’s turn. Subsequent card draws are ignored."
+          "text": "Your opponents can draw a maximum of one card on each player's turn. Subsequent card draws are ignored."
         },
         {
           "date": "2016-08-23",
-          "text": "If an opponent hasn’t drawn any cards in a turn, and a spell or ability instructs a player to draw multiple cards, that player will just draw one card. However, if the draws are an optional cost to generate an additional effect (“[That player] may draw two cards. If he or she does, [effect]” or similar), the player can’t pay that cost in full and can’t draw any cards."
+          "text": "If an opponent hasn't drawn any cards in a turn, and a spell or ability instructs a player to draw multiple cards, that player will just draw one card. However, if the draws are an optional cost to generate an additional effect (\"[That player] may draw two cards. If he or she does, [effect]\" or similar), the player can't pay that cost in full and can't draw any cards."
         },
         {
           "date": "2016-08-23",
-          "text": "Leovold will “see” cards drawn by opponents earlier in the turn on the turn it enters the battlefield, although Leovold can’t affect cards drawn before it entered the battlefield. For example, if an opponent draws two cards, then Leovold enters the battlefield, that opponent can’t draw more cards that turn, but the two drawn cards are unaffected."
+          "text": "Leovold will \"see\" cards drawn by opponents earlier in the turn on the turn it enters the battlefield, although Leovold can't affect cards drawn before it entered the battlefield. For example, if an opponent draws two cards, then Leovold enters the battlefield, that opponent can't draw more cards that turn, but the two drawn cards are unaffected."
         },
         {
           "date": "2016-08-23",
-          "text": "Replacement effects can’t be used to replace draws that Leovold disallows."
+          "text": "Replacement effects can't be used to replace draws that Leovold disallows."
         },
         {
           "date": "2016-08-23",
-          "text": "If you and a permanent you control each become the target of the same spell or ability an opponent controls, Leovold’s ability will trigger twice."
+          "text": "If you and a permanent you control each become the target of the same spell or ability an opponent controls, Leovold's ability will trigger twice."
         }
       ],
       "subtypes": [
@@ -6361,7 +6361,7 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The last ability of Queen Marchesa (long may she reign) checks to see if an opponent is the monarch as your upkeep begins. If no opponent is the monarch, Queen Marchesa’s (long may she reign) ability won’t trigger at all. Queen Marchesa’s (long may she reign) ability will also check to see if an opponent is the monarch as it tries to resolve. If no opponent is the monarch at that time, Queen Marchesa’s (long may she reign) ability will have no effect."
+          "text": "The last ability of Queen Marchesa (long may she reign) checks to see if an opponent is the monarch as your upkeep begins. If no opponent is the monarch, Queen Marchesa's (long may she reign) ability won't trigger at all. Queen Marchesa's (long may she reign) ability will also check to see if an opponent is the monarch as it tries to resolve. If no opponent is the monarch at that time, Queen Marchesa's (long may she reign) ability will have no effect."
         },
         {
           "date": "2016-08-23",
@@ -6369,7 +6369,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -6436,15 +6436,15 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "The set of names the equipped creature has includes the names of all nonlegendary creature cards in the Oracle card reference, including the back faces of double-faced cards. Notably, the equipped creature won’t gain the names of tokens, such as Zombie, Goblin, and similar. It also won’t gain the names of noncreature cards that have become creatures, such as a Wandering Fumarole that has become a creature."
+          "text": "The set of names the equipped creature has includes the names of all nonlegendary creature cards in the Oracle card reference, including the back faces of double-faced cards. Notably, the equipped creature won't gain the names of tokens, such as Zombie, Goblin, and similar. It also won't gain the names of noncreature cards that have become creatures, such as a Wandering Fumarole that has become a creature."
         },
         {
           "date": "2016-08-23",
-          "text": "If you named any nonlegendary creature card for hidden agenda or draft abilities that refer to a creature on the battlefield, the equipped creature will have that name and will qualify for any relevant bonuses. For example, equipping Spy Kit to Noble Banneret will enable Noble Banneret’s last ability (as long as you noted a nonlegendary card name for it)."
+          "text": "If you named any nonlegendary creature card for hidden agenda or draft abilities that refer to a creature on the battlefield, the equipped creature will have that name and will qualify for any relevant bonuses. For example, equipping Spy Kit to Noble Banneret will enable Noble Banneret's last ability (as long as you noted a nonlegendary card name for it)."
         },
         {
           "date": "2016-08-23",
-          "text": "Some creature cards have abilities that function during the draft and additional abilities that refer to cards you exiled or information you noted with “cards named [this card’s name].” These abilities are linked, so equipping Spy Kit to such a creature won’t affect the set of cards it exiled or the information you noted."
+          "text": "Some creature cards have abilities that function during the draft and additional abilities that refer to cards you exiled or information you noted with \"cards named [this card's name].\" These abilities are linked, so equipping Spy Kit to such a creature won't affect the set of cards it exiled or the information you noted."
         }
       ],
       "subtypes": [
@@ -6504,7 +6504,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "Abilities that trigger whenever you “become the monarch” trigger only if you aren’t already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won’t trigger."
+          "text": "Abilities that trigger whenever you \"become the monarch\" trigger only if you aren't already the monarch. For example, if you are already the monarch as Custodi Lich enters the battlefield, its last ability won't trigger."
         },
         {
           "date": "2016-08-23",
@@ -6833,19 +6833,19 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "A permanent card is a card that could be put onto the battlefield. Specifically, it means an artifact, creature, enchantment, land, or planeswalker card (instant and sorcery cards aren’t permanent cards)."
+          "text": "A permanent card is a card that could be put onto the battlefield. Specifically, it means an artifact, creature, enchantment, land, or planeswalker card (instant and sorcery cards aren't permanent cards)."
         },
         {
           "date": "2012-07-01",
-          "text": "Permanent cards that were put into your graveyard from anywhere else, such as a card that was discarded, stay in the graveyard. Permanent cards that you gained control of and went to another player’s graveyard from the battlefield will likewise stay in the graveyard."
+          "text": "Permanent cards that were put into your graveyard from anywhere else, such as a card that was discarded, stay in the graveyard. Permanent cards that you gained control of and went to another player's graveyard from the battlefield will likewise stay in the graveyard."
         },
         {
           "date": "2012-07-01",
-          "text": "You choose what an Aura card put onto the battlefield this way will enchant. You can’t choose any permanent cards entering the battlefield at the same time as that Aura. If there’s nothing legal for the Aura to enchant, it stays in the graveyard."
+          "text": "You choose what an Aura card put onto the battlefield this way will enchant. You can't choose any permanent cards entering the battlefield at the same time as that Aura. If there's nothing legal for the Aura to enchant, it stays in the graveyard."
         },
         {
           "date": "2012-07-01",
-          "text": "Permanent spells that were countered earlier in the turn never entered the battlefield, so they won’t return to the battlefield because of Faith’s Reward."
+          "text": "Permanent spells that were countered earlier in the turn never entered the battlefield, so they won't return to the battlefield because of Faith's Reward."
         }
       ],
       "text": "Return to the battlefield all permanent cards in your graveyard that were put there from the battlefield this turn.",
@@ -6990,7 +6990,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -7060,7 +7060,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -7142,7 +7142,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You choose the color as Gods Willing resolves. Once the color is chosen, it’s too late for players to respond."
+          "text": "You choose the color as Gods Willing resolves. Once the color is chosen, it's too late for players to respond."
         },
         {
           "date": "2013-09-15",
@@ -7154,11 +7154,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Target creature you control gains protection from the color of your choice until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -7228,7 +7228,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Guardian of the Gateless’s last ability triggers only once when it’s declared as a blocker no matter how many creatures it’s blocking."
+          "text": "Guardian of the Gateless's last ability triggers only once when it's declared as a blocker no matter how many creatures it's blocking."
         }
       ],
       "subtypes": [
@@ -7303,7 +7303,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "You choose how the damage will be divided among the target creatures at the time you cast Hail of Arrows. Each target must be dealt at least 1 damage. If any of those creatures becomes an illegal target before Hail of Arrows resolves, the division of damage among the remaining creatures doesn’t change."
+          "text": "You choose how the damage will be divided among the target creatures at the time you cast Hail of Arrows. Each target must be dealt at least 1 damage. If any of those creatures becomes an illegal target before Hail of Arrows resolves, the division of damage among the remaining creatures doesn't change."
         }
       ],
       "text": "Hail of Arrows deals X damage divided as you choose among any number of target attacking creatures.",
@@ -7373,11 +7373,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "All creatures leave the battlefield simultaneously. They’re not destroyed; they’re just put on the bottom of their owners’ libraries. This includes token creatures, though they’ll cease to exist as soon as Hallowed Burial finishes resolving."
+          "text": "All creatures leave the battlefield simultaneously. They're not destroyed; they're just put on the bottom of their owners' libraries. This includes token creatures, though they'll cease to exist as soon as Hallowed Burial finishes resolving."
         },
         {
           "date": "2008-08-01",
-          "text": "Each player chooses the relative order of the cards he or she is putting on the bottom of his or her library, regardless of who controlled them while they were on the battlefield. Players don’t reveal this order to other players."
+          "text": "Each player chooses the relative order of the cards he or she is putting on the bottom of his or her library, regardless of who controlled them while they were on the battlefield. Players don't reveal this order to other players."
         }
       ],
       "text": "Put all creatures on the bottom of their owners' libraries.",
@@ -7448,15 +7448,15 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Removing an attacking creature from combat doesn’t untap that creature."
+          "text": "Removing an attacking creature from combat doesn't untap that creature."
         },
         {
           "date": "2011-01-22",
-          "text": "Removing a blocking creature from combat doesn’t cause the creature it was blocking to become unblocked. If no other creatures are blocking that attacking creature, it won’t assign combat damage (unless it has trample)."
+          "text": "Removing a blocking creature from combat doesn't cause the creature it was blocking to become unblocked. If no other creatures are blocking that attacking creature, it won't assign combat damage (unless it has trample)."
         },
         {
           "date": "2011-01-22",
-          "text": "If there are multiple combat phases in a turn, a creature that’s been removed from combat can still attack or block in future combat phases that turn."
+          "text": "If there are multiple combat phases in a turn, a creature that's been removed from combat can still attack or block in future combat phases that turn."
         }
       ],
       "subtypes": [
@@ -7530,15 +7530,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -7678,7 +7678,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can attach this to an opponent’s creature, and all damage done to you is instead done to their creature."
+          "text": "You can attach this to an opponent's creature, and all damage done to you is instead done to their creature."
         },
         {
           "date": "2004-10-04",
@@ -8030,7 +8030,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You must target two creatures you control as you cast Windborne Charge. If you can’t (because you control just one creature, perhaps), you can’t cast the spell."
+          "text": "You must target two creatures you control as you cast Windborne Charge. If you can't (because you control just one creature, perhaps), you can't cast the spell."
         }
       ],
       "text": "Two target creatures you control each get +2/+2 and gain flying until end of turn.",
@@ -8514,7 +8514,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The card is put onto the battlefield, but any effects that check if the original card was “cast from your hand” will not trigger or otherwise consider the card to have been cast from your hand. The card was put onto the battlefield by the effect of Desertion instead."
+          "text": "The card is put onto the battlefield, but any effects that check if the original card was \"cast from your hand\" will not trigger or otherwise consider the card to have been cast from your hand. The card was put onto the battlefield by the effect of Desertion instead."
         },
         {
           "date": "2004-10-04",
@@ -8522,7 +8522,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then this card’s ability does not put the card onto the battlefield. The spell continues to resolve as normal."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then this card's ability does not put the card onto the battlefield. The spell continues to resolve as normal."
         }
       ],
       "text": "Counter target spell. If an artifact or creature spell is countered this way, put that card onto the battlefield under your control instead of into its owner's graveyard.",
@@ -8736,11 +8736,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Fleeting Distraction resolves, the spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target by the time Fleeting Distraction resolves, the spell is countered. You won't draw a card."
         },
         {
           "date": "2012-05-01",
-          "text": "If the targeted creature is an illegal target when Fleeting Distraction tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target when Fleeting Distraction tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
@@ -8810,7 +8810,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Any enters-the-battlefield abilities of the copied creature trigger when the creature tokens enter the battlefield. The creature tokens also have any “this enters the battlefield with” or “as this enters the battlefield” abilities that the copied creature has."
+          "text": "Any enters-the-battlefield abilities of the copied creature trigger when the creature tokens enter the battlefield. The creature tokens also have any \"this enters the battlefield with\" or \"as this enters the battlefield\" abilities that the copied creature has."
         },
         {
           "date": "2007-02-01",
@@ -8818,7 +8818,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If Followed Footsteps and the enchanted creature leave the battlefield simultaneously (say via Upheaval or Akroma’s Vengence somehow cast in response to the triggered ability), then a token copy of the creature that was enchanted when it was last on the battlefield is created. If Followed Foosteps did not enchant a creature when last on the battlefield as it went to the graveyard as a state-based action when the enchanted creature left the battlefield in response to the trigger, then no copy will get created."
+          "text": "If Followed Footsteps and the enchanted creature leave the battlefield simultaneously (say via Upheaval or Akroma's Vengence somehow cast in response to the triggered ability), then a token copy of the creature that was enchanted when it was last on the battlefield is created. If Followed Foosteps did not enchant a creature when last on the battlefield as it went to the graveyard as a state-based action when the enchanted creature left the battlefield in response to the trigger, then no copy will get created."
         }
       ],
       "subtypes": [
@@ -8839,7 +8839,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"The cathars have their swords, the inquisitors their axes. I prefer the ‘diplomatic' approach.\"\n—Terhold, archmage of Drunau",
+      "flavor": "\"The cathars have their swords, the inquisitors their axes. I prefer the 'diplomatic' approach.\"\n—Terhold, archmage of Drunau",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -9116,7 +9116,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "You may target any permanent with the ability, including Merfolk Skyscout itself or a permanent that’s already untapped."
+          "text": "You may target any permanent with the ability, including Merfolk Skyscout itself or a permanent that's already untapped."
         }
       ],
       "subtypes": [
@@ -9294,7 +9294,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -9374,11 +9374,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -9734,7 +9734,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -9885,11 +9885,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If the creature was already tapped when Vertigo Spawn blocked it, that creature still won’t untap during its controller’s next untap step."
+          "text": "If the creature was already tapped when Vertigo Spawn blocked it, that creature still won't untap during its controller's next untap step."
         },
         {
           "date": "2006-02-01",
-          "text": "If two Vertigo Spawns block the same creature, both abilities trigger, but each only affects the creature during its controller’s next untap step. The creature can untap during its controller’s untap step following that one."
+          "text": "If two Vertigo Spawns block the same creature, both abilities trigger, but each only affects the creature during its controller's next untap step. The creature can untap during its controller's untap step following that one."
         }
       ],
       "subtypes": [
@@ -9964,7 +9964,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -10137,7 +10137,8 @@
         "ARC",
         "CMD",
         "PD3",
-        "CN2"
+        "CN2",
+        "MPS_AKH"
       ],
       "rarity": "Mythic Rare",
       "rulings": [
@@ -10584,7 +10585,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Farbog Boneflinger’s ability is mandatory. If it’s the only creature on the battlefield, you must choose it as the target and give it -2/-2 until end of turn."
+          "text": "Farbog Boneflinger's ability is mandatory. If it's the only creature on the battlefield, you must choose it as the target and give it -2/-2 until end of turn."
         }
       ],
       "subtypes": [
@@ -10724,11 +10725,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you’ll have to sacrifice Fleshbag Marauder."
+          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you'll have to sacrifice Fleshbag Marauder."
         },
         {
           "date": "2015-06-22",
-          "text": "As Fleshbag Marauder’s ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
+          "text": "As Fleshbag Marauder's ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
         }
       ],
       "subtypes": [
@@ -11086,15 +11087,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -11371,7 +11372,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Only creatures controlled by the player when Public Execution resolves will get -2/-0. Creatures that enter the battlefield under that player’s control or that the player gains control of later in the turn are unaffected."
+          "text": "Only creatures controlled by the player when Public Execution resolves will get -2/-0. Creatures that enter the battlefield under that player's control or that the player gains control of later in the turn are unaffected."
         },
         {
           "date": "2012-07-01",
@@ -11379,7 +11380,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the target creature regenerates or has indestructible, each other creature controlled by that creature’s controller will still get -2/-0."
+          "text": "If the target creature regenerates or has indestructible, each other creature controlled by that creature's controller will still get -2/-0."
         }
       ],
       "text": "Destroy target creature an opponent controls. Each other creature that player controls gets -2/-0 until end of turn.",
@@ -11470,7 +11471,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -11541,7 +11542,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If one or more creatures an opponent controls are put into the graveyard at the same time as Sangromancer, Sangromancer’s first ability will trigger that many times."
+          "text": "If one or more creatures an opponent controls are put into the graveyard at the same time as Sangromancer, Sangromancer's first ability will trigger that many times."
         }
       ],
       "subtypes": [
@@ -11824,7 +11825,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If the creature doesn’t die that turn, the delayed triggered ability will simply cease to exist. It won’t trigger on a future turn."
+          "text": "If the creature doesn't die that turn, the delayed triggered ability will simply cease to exist. It won't trigger on a future turn."
         }
       ],
       "text": "Burn Away deals 6 damage to target creature. When that creature dies this turn, exile all cards from its controller's graveyard.",
@@ -11892,7 +11893,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t acquire the Ante cards. They are considered still “in the game” as are cards in the library and the graveyard."
+          "text": "Can't acquire the Ante cards. They are considered still \"in the game\" as are cards in the library and the graveyard."
         },
         {
           "date": "2007-05-01",
@@ -11904,15 +11905,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Can’t acquire cards that are phased out."
+          "text": "Can't acquire cards that are phased out."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t acquire exiled cards because those cards are still in one of the game’s zones."
+          "text": "You can't acquire exiled cards because those cards are still in one of the game's zones."
         },
         {
           "date": "2009-10-01",
-          "text": "In a sanctioned event, a card that’s “outside the game” is one that’s in your sideboard. In an unsanctioned event, you may choose any card from your collection."
+          "text": "In a sanctioned event, a card that's \"outside the game\" is one that's in your sideboard. In an unsanctioned event, you may choose any card from your collection."
         }
       ],
       "text": "You may choose a sorcery card you own from outside the game, reveal that card, and put it into your hand. Exile Burning Wish.",
@@ -11984,11 +11985,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The instant or sorcery card returned to your hand is chosen at random as the triggered ability resolves. If any player responds to the ability, that player won’t yet know what card will be returned."
+          "text": "The instant or sorcery card returned to your hand is chosen at random as the triggered ability resolves. If any player responds to the ability, that player won't yet know what card will be returned."
         },
         {
           "date": "2011-09-22",
-          "text": "Because the first ability doesn’t target the instant or sorcery card, any instants or sorceries put into your graveyard in response to that ability may be returned to your hand."
+          "text": "Because the first ability doesn't target the instant or sorcery card, any instants or sorceries put into your graveyard in response to that ability may be returned to your hand."
         }
       ],
       "subtypes": [
@@ -12133,15 +12134,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Ember Beast can’t attack or block unless another creature is also assigned to attack or block at the same time. Notably, two Ember Beasts can attack or block together."
+          "text": "Ember Beast can't attack or block unless another creature is also assigned to attack or block at the same time. Notably, two Ember Beasts can attack or block together."
         },
         {
           "date": "2013-01-24",
-          "text": "Once Ember Beast has been declared as an attacker or blocker, it doesn’t matter what happens to the other creature(s)."
+          "text": "Once Ember Beast has been declared as an attacker or blocker, it doesn't matter what happens to the other creature(s)."
         },
         {
           "date": "2013-01-24",
-          "text": "Other creatures assigned to attack alongside Ember Beast don’t have to attack the same player or planeswalker. Other creatures assigned to block alongside Ember Beast don’t have to block the same creature as Ember Beast."
+          "text": "Other creatures assigned to attack alongside Ember Beast don't have to attack the same player or planeswalker. Other creatures assigned to block alongside Ember Beast don't have to block the same creature as Ember Beast."
         }
       ],
       "subtypes": [
@@ -12221,7 +12222,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -12370,7 +12371,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You divide the damage as you put Gang of Devils’s triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
+          "text": "You divide the damage as you put Gang of Devils's triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
         }
       ],
       "subtypes": [
@@ -12454,7 +12455,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade’s ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
         }
       ],
       "subtypes": [
@@ -12532,11 +12533,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The power of the targeted creature is checked both as you target it and as the ability resolves. After the ability resolves, the creature can’t be blocked that turn even if its power becomes greater than 2."
+          "text": "The power of the targeted creature is checked both as you target it and as the ability resolves. After the ability resolves, the creature can't be blocked that turn even if its power becomes greater than 2."
         },
         {
           "date": "2010-06-15",
-          "text": "The ability doesn’t grant an ability to the targeted creature. Rather, it affects the game rules and states something that’s now true about that creature. After the ability resolves, the creature can’t be blocked that turn even if it loses all abilities."
+          "text": "The ability doesn't grant an ability to the targeted creature. Rather, it affects the game rules and states something that's now true about that creature. After the ability resolves, the creature can't be blocked that turn even if it loses all abilities."
         }
       ],
       "subtypes": [
@@ -12674,7 +12675,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Guttersnipe’s ability resolves and Guttersnipe deals damage before the instant or sorcery spell resolves."
+          "text": "Guttersnipe's ability resolves and Guttersnipe deals damage before the instant or sorcery spell resolves."
         }
       ],
       "subtypes": [
@@ -12960,15 +12961,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -13044,7 +13045,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an instant or sorcery spell, Kiln Fiend’s ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an instant or sorcery spell, Kiln Fiend's ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         }
       ],
       "subtypes": [
@@ -13190,23 +13191,23 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If blockers have already been declared when Stoneshock Giant’s last ability resolves, those blocks won’t change or become undone."
+          "text": "If blockers have already been declared when Stoneshock Giant's last ability resolves, those blocks won't change or become undone."
         },
         {
           "date": "2013-09-15",
-          "text": "Your opponents can’t assign any creature without flying to block that turn, even if that creature had flying or wasn’t on the battlefield under one of your opponent’s control when Stoneshock Giant’s ability resolved."
+          "text": "Your opponents can't assign any creature without flying to block that turn, even if that creature had flying or wasn't on the battlefield under one of your opponent's control when Stoneshock Giant's ability resolved."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -13312,6 +13313,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -13357,7 +13362,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Because discarding a card is an additional cost, you can’t cast Tormenting Voice if you have no other cards in hand."
+          "text": "Because discarding a card is an additional cost, you can't cast Tormenting Voice if you have no other cards in hand."
         }
       ],
       "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
@@ -13435,7 +13440,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
@@ -13443,7 +13448,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you’ve declared attackers usually won’t do anything."
+          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you've declared attackers usually won't do anything."
         }
       ],
       "text": "Attacking creatures get +2/+0 until end of turn.",
@@ -13517,7 +13522,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast Twin Bolt with two targets and one of those targets becomes illegal before Twin Bolt resolves, the remaining legal target will be dealt 1 damage. You can’t change the original division of damage."
+          "text": "If you cast Twin Bolt with two targets and one of those targets becomes illegal before Twin Bolt resolves, the remaining legal target will be dealt 1 damage. You can't change the original division of damage."
         }
       ],
       "text": "Twin Bolt deals 2 damage divided as you choose among one or two target creatures and/or players.",
@@ -13591,7 +13596,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent’s controller won’t get a Beast token."
+          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent's controller won't get a Beast token."
         },
         {
           "date": "2013-07-01",
@@ -13956,11 +13961,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Copperhorn Scout’s ability resolves, you’ll untap each other creature you control regardless of whether that creature was attacking."
+          "text": "As Copperhorn Scout's ability resolves, you'll untap each other creature you control regardless of whether that creature was attacking."
         },
         {
           "date": "2011-01-01",
-          "text": "Untapping an attacking creature doesn’t cause it to stop attacking."
+          "text": "Untapping an attacking creature doesn't cause it to stop attacking."
         }
       ],
       "subtypes": [
@@ -14259,15 +14264,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You can target a creature you don’t control or that otherwise couldn’t attack that turn."
+          "text": "You can target a creature you don't control or that otherwise couldn't attack that turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Irresistible Prey resolves, the spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target by the time Irresistible Prey resolves, the spell is countered. You won't draw a card."
         },
         {
           "date": "2010-06-15",
-          "text": "The creature affected by Irresistible Prey doesn’t have to attack that turn."
+          "text": "The creature affected by Irresistible Prey doesn't have to attack that turn."
         },
         {
           "date": "2010-06-15",
@@ -14275,7 +14280,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If there are multiple combat phases in a turn, the affected creature must be blocked only in the first one in which it’s able to be blocked."
+          "text": "If there are multiple combat phases in a turn, the affected creature must be blocked only in the first one in which it's able to be blocked."
         }
       ],
       "text": "Target creature must be blocked this turn if able.\nDraw a card.",
@@ -14416,7 +14421,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
@@ -14487,7 +14492,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Converted mana cost takes into account only the mana symbols printed in the upper right corner of the card. Manaplasm doesn’t care about additional costs, alternative costs, cost-reduction effects, or what you actually paid to cast the spell."
+          "text": "Converted mana cost takes into account only the mana symbols printed in the upper right corner of the card. Manaplasm doesn't care about additional costs, alternative costs, cost-reduction effects, or what you actually paid to cast the spell."
         },
         {
           "date": "2008-10-01",
@@ -14567,15 +14572,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -14742,7 +14747,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -14976,15 +14981,15 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2014-04-26",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2014-04-26",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -15059,7 +15064,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The value of X is determined only as Strength in Numbers resolves. It won’t change later in the turn if the number of attacking creatures changes."
+          "text": "The value of X is determined only as Strength in Numbers resolves. It won't change later in the turn if the number of attacking creatures changes."
         }
       ],
       "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of attacking creatures.",
@@ -15132,7 +15137,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -15288,7 +15293,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "The game checks the power and toughness of the creature that just entered the battlefield as it exists on the battlefield. That might mean it’s impossible to get another copy of that same card. For example, a Triskelion on the battlefield is 4/4, but a Triskelion in your library is 1/1. The power and toughness might also have been affected while the triggered ability was on the stack (such as with Giant Growth, Sudden Death, or Ovinize)."
+          "text": "The game checks the power and toughness of the creature that just entered the battlefield as it exists on the battlefield. That might mean it's impossible to get another copy of that same card. For example, a Triskelion on the battlefield is 4/4, but a Triskelion in your library is 1/1. The power and toughness might also have been affected while the triggered ability was on the stack (such as with Giant Growth, Sudden Death, or Ovinize)."
         },
         {
           "date": "2007-02-01",
@@ -15373,7 +15378,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Once the ability resolves, the bonus won’t change even if the number of attacking creatures you control does."
+          "text": "Once the ability resolves, the bonus won't change even if the number of attacking creatures you control does."
         }
       ],
       "subtypes": [
@@ -15524,11 +15529,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Carnage Gladiator’s ability triggers whenever any creature blocks, regardless of who controls that creature or which creature it blocked."
+          "text": "Carnage Gladiator's ability triggers whenever any creature blocks, regardless of who controls that creature or which creature it blocked."
         },
         {
           "date": "2017-03-14",
-          "text": "If a creature can block multiple creatures and does so, Carnage Gladiator’s ability triggers only once."
+          "text": "If a creature can block multiple creatures and does so, Carnage Gladiator's ability triggers only once."
         }
       ],
       "subtypes": [
@@ -15682,7 +15687,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "The triggered ability won’t be affected if the spell that caused it to trigger is countered."
+          "text": "The triggered ability won't be affected if the spell that caused it to trigger is countered."
         }
       ],
       "subtypes": [
@@ -15762,7 +15767,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The cards put into hands this way are not “drawn.” For example, you couldn’t reveal a card with miracle put into your hand this way (but it also won’t count as the first card you’ve drawn this turn either)."
+          "text": "The cards put into hands this way are not \"drawn.\" For example, you couldn't reveal a card with miracle put into your hand this way (but it also won't count as the first card you've drawn this turn either)."
         }
       ],
       "subtypes": [
@@ -15909,7 +15914,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "The creature doesn’t enter the battlefield with a +1/+1 counter on it. It enters the battlefield, then the ability triggers. If either that creature or Juniper Order Ranger leaves the battlefield before the ability resolves, the remaining creature will still get a +1/+1 counter."
+          "text": "The creature doesn't enter the battlefield with a +1/+1 counter on it. It enters the battlefield, then the ability triggers. If either that creature or Juniper Order Ranger leaves the battlefield before the ability resolves, the remaining creature will still get a +1/+1 counter."
         }
       ],
       "subtypes": [
@@ -16061,11 +16066,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2013-09-15",
-          "text": "The last ability affects creatures that are already attacking when it resolves. Activating it before combat won’t affect any creatures that attack later that turn."
+          "text": "The last ability affects creatures that are already attacking when it resolves. Activating it before combat won't affect any creatures that attack later that turn."
         }
       ],
       "subtypes": [
@@ -16582,23 +16587,23 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They’ll still work."
+          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They'll still work."
         },
         {
           "date": "2004-12-01",
-          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can’t prevent you from losing the game)."
+          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can't prevent you from losing the game)."
         },
         {
           "date": "2009-10-01",
-          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn’t matter whether you have 0 or less life, you’re forced to draw a card while your library is empty, you have ten or more poison counters, you’re dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
+          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn't matter whether you have 0 or less life, you're forced to draw a card while your library is empty, you have ten or more poison counters, you're dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
         },
         {
           "date": "2009-10-01",
-          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you’re penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
+          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you're penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
         },
         {
           "date": "2009-10-01",
-          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can’t lose the game and the opposing team can’t win the game."
+          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can't lose the game and the opposing team can't win the game."
         }
       ],
       "subtypes": [
@@ -16807,11 +16812,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}: Dread Statuary becomes a 4/2 Golem artifact creature until end of turn. It's still a land.",
@@ -16839,6 +16844,10 @@
       "imageName": "evolving wilds",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Battle for Zendikar Block",
           "legality": "Legal"
@@ -16969,23 +16978,23 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-02-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there are more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there are more than one, consider them in any possible order."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Exotic Orchard doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Lands that produce mana based only on what other lands “could produce” won’t help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent’s Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent’s Reflecting Pool can each produce {G} because your opponent’s Exotic Orchard can produce {G}."
+          "text": "Lands that produce mana based only on what other lands \"could produce\" won't help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent's Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent's Reflecting Pool can each produce {G} because your opponent's Exotic Orchard can produce {G}."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -17050,7 +17059,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Activating the second ability of Rogue’s Passage after a creature has become blocked won’t cause it to become unblocked."
+          "text": "Activating the second ability of Rogue's Passage after a creature has become blocked won't cause it to become unblocked."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}, {T}: Target creature can't be blocked this turn.",
@@ -17188,11 +17197,11 @@
       "rulings": [
         {
           "date": "2016-08-23",
-          "text": "You choose whether or not to target a creature as you activate the first ability. If you chose a target creature, you choose whether to exile Kaya or that creature as the ability resolves. If you chose a creature and that creature is no longer a legal target as the ability tries to resolve, the ability is countered and none of its effects happen. You won’t exile Kaya or lose 2 life."
+          "text": "You choose whether or not to target a creature as you activate the first ability. If you chose a target creature, you choose whether to exile Kaya or that creature as the ability resolves. If you chose a creature and that creature is no longer a legal target as the ability tries to resolve, the ability is countered and none of its effects happen. You won't exile Kaya or lose 2 life."
         },
         {
           "date": "2016-08-23",
-          "text": "If you didn’t choose a target creature for the first ability, and Kaya isn’t on the battlefield as the ability resolves, you’ll just lose 2 life. No card will be exiled or returned to the battlefield."
+          "text": "If you didn't choose a target creature for the first ability, and Kaya isn't on the battlefield as the ability resolves, you'll just lose 2 life. No card will be exiled or returned to the battlefield."
         },
         {
           "date": "2016-08-23",

--- a/json/CNS.json
+++ b/json/CNS.json
@@ -90,27 +90,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nYour minimum deck size is reduced by five.",
@@ -164,11 +164,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "The effect of Backup Plan is cumulative. If you have two in your command zone to start the game, you’ll draw three hands of seven cards and shuffle all but one of them into your library."
+          "text": "The effect of Backup Plan is cumulative. If you have two in your command zone to start the game, you'll draw three hands of seven cards and shuffle all but one of them into your library."
         },
         {
           "date": "2014-05-29",
-          "text": "If, through a combination of Backup Plan and/or other conspiracies, you have fewer cards in your deck than you must draw as the game begins, you’ll lose the game when state-based actions are checked during the upkeep of the first turn."
+          "text": "If, through a combination of Backup Plan and/or other conspiracies, you have fewer cards in your deck than you must draw as the game begins, you'll lose the game when state-based actions are checked during the upkeep of the first turn."
         },
         {
           "date": "2016-08-23",
@@ -176,27 +176,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nDraw an additional hand of seven cards as the game begins. Before taking mulligans, shuffle all but one of your hands into your library.",
@@ -249,7 +249,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "The second ability can’t reduce the colored mana requirement of a spell."
+          "text": "The second ability can't reduce the colored mana requirement of a spell."
         },
         {
           "date": "2014-05-29",
@@ -265,27 +265,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -293,11 +293,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -305,7 +305,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -313,11 +313,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nSpells with the chosen name you cast cost {1} less to cast.",
@@ -370,19 +370,19 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "You must turn Double Stroke face up before you cast the spell with the chosen name to have Double Stroke’s second ability trigger."
+          "text": "You must turn Double Stroke face up before you cast the spell with the chosen name to have Double Stroke's second ability trigger."
         },
         {
           "date": "2014-05-29",
-          "text": "When the ability resolves, it creates a copy of the spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When the ability resolves, it creates a copy of the spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2014-05-29",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-05-29",
-          "text": "If the spell being copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell being copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2014-05-29",
@@ -390,7 +390,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Effects based on any additional costs that were paid for the original spell will be copied as though those same costs were paid for the copy. For example, if a player exiles three cards from his or her graveyard to cast Skeletal Scrying, and you copy it, the copy will also cause you to draw three cards and lose 3 life (but you won’t exile any cards from your graveyard)."
+          "text": "Effects based on any additional costs that were paid for the original spell will be copied as though those same costs were paid for the copy. For example, if a player exiles three cards from his or her graveyard to cast Skeletal Scrying, and you copy it, the copy will also cause you to draw three cards and lose 3 life (but you won't exile any cards from your graveyard)."
         },
         {
           "date": "2016-08-23",
@@ -398,27 +398,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -426,11 +426,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -438,7 +438,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -446,11 +446,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nWhenever you cast an instant or sorcery spell with the chosen name, you may copy it. You may choose new targets for the copy.",
@@ -507,27 +507,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -535,11 +535,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -547,7 +547,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -555,11 +555,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nCreatures you control with the chosen name have haste.",
@@ -616,27 +616,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -644,11 +644,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -656,7 +656,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -664,11 +664,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nWhenever you cast an instant or sorcery spell with the chosen name, you may draw a card.",
@@ -725,27 +725,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nEach creature you control with the chosen name enters the battlefield with an additional +1/+1 counter on it.",
@@ -798,7 +798,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "If you have Power Play but aren’t the starting player (because another player also had Power Play), your place in the turn order is unaffected. If you’re sitting to the right of the starting player, you’re going last. Not all power plays bear fruit."
+          "text": "If you have Power Play but aren't the starting player (because another player also had Power Play), your place in the turn order is unaffected. If you're sitting to the right of the starting player, you're going last. Not all power plays bear fruit."
         },
         {
           "date": "2016-08-23",
@@ -806,27 +806,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nYou are the starting player. If multiple players would be the starting player, one of those players is chosen at random.",
@@ -883,27 +883,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -911,11 +911,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -923,7 +923,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -931,11 +931,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nWhenever a creature with the chosen name enters the battlefield under your control, you may search your library for any number of cards with that name, reveal them, put them into your hand, then shuffle your library.",
@@ -992,27 +992,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -1020,11 +1020,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -1032,7 +1032,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -1040,11 +1040,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nCreatures you control with the chosen name have \"{T}: Add one mana of any color to your mana pool.\"",
@@ -1102,27 +1102,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nAt the beginning of the first upkeep, create a 1/1 colorless Construct artifact creature token with defender.",
@@ -1179,27 +1179,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         },
         {
           "date": "2016-08-23",
@@ -1207,11 +1207,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that’s kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It’s important that each named card is clearly associated with only one of the conspiracies."
+          "text": "There are several ways to secretly name a card, including writing the name on a piece of paper that's kept with the face-down conspiracy. If you have multiple face-down conspiracies, you may name a different card for each one. It's important that each named card is clearly associated with only one of the conspiracies."
         },
         {
           "date": "2016-08-23",
-          "text": "You must name a Magic card. Notably, you can’t name a token (except in the unusual case that a token’s name matches the name of a card, such as Illusion)."
+          "text": "You must name a Magic card. Notably, you can't name a token (except in the unusual case that a token's name matches the name of a card, such as Illusion)."
         },
         {
           "date": "2016-08-23",
@@ -1219,7 +1219,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn’t use the stack and can’t be responded to. Once face up, the named card is revealed and the conspiracy’s abilities will affect the game."
+          "text": "As a special action, you may turn a face-down conspiracy face up. You may do so any time you have priority. This action doesn't use the stack and can't be responded to. Once face up, the named card is revealed and the conspiracy's abilities will affect the game."
         },
         {
           "date": "2016-08-23",
@@ -1227,11 +1227,11 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability’s trigger condition is met in order for it to trigger. Turning it face up afterward won’t have any effect."
+          "text": "A conspiracy with hidden agenda that has a triggered ability must be face up before that ability's trigger condition is met in order for it to trigger. Turning it face up afterward won't have any effect."
         },
         {
           "date": "2016-08-23",
-          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can’t bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
+          "text": "At the end of the game, you must reveal any face-down conspiracies you own in the command zone to all players. Notably, you can't bluff conspiracies with hidden agenda by putting other cards into the command zone face down as the game starts."
         }
       ],
       "text": "Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nYou may spend mana as though it were mana of any color to cast spells with the chosen name.",
@@ -1284,7 +1284,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Your card pool includes every card you drafted or received after the draft because of Deal Broker. It doesn’t include any cards removed from the draft with Cogwork Grinder."
+          "text": "Your card pool includes every card you drafted or received after the draft because of Deal Broker. It doesn't include any cards removed from the draft with Cogwork Grinder."
         },
         {
           "date": "2016-08-23",
@@ -1292,27 +1292,27 @@
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy doesn’t count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
+          "text": "A conspiracy doesn't count as a card in your deck for purposes of meeting minimum deck size requirements. (In most drafts, the minimum deck size is 40 cards.)"
         },
         {
           "date": "2016-08-23",
-          "text": "You don’t have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can’t put conspiracies into the command zone after this point."
+          "text": "You don't have to play with any conspiracy you draft. However, you have only one opportunity to put conspiracies into the command zone, as the game begins. You can't put conspiracies into the command zone after this point."
         },
         {
           "date": "2016-08-23",
-          "text": "You can look at any player’s face-up conspiracies at any time. You’ll also know how many face-down conspiracies a player has in the command zone, although you won’t know what they are."
+          "text": "You can look at any player's face-up conspiracies at any time. You'll also know how many face-down conspiracies a player has in the command zone, although you won't know what they are."
         },
         {
           "date": "2016-08-23",
-          "text": "A conspiracy’s static and triggered abilities function as long as that conspiracy is face-up in the command zone."
+          "text": "A conspiracy's static and triggered abilities function as long as that conspiracy is face-up in the command zone."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies are colorless, have no mana cost, and can’t be cast as spells."
+          "text": "Conspiracies are colorless, have no mana cost, and can't be cast as spells."
         },
         {
           "date": "2016-08-23",
-          "text": "Conspiracies aren’t legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
+          "text": "Conspiracies aren't legal for any sanctioned Constructed format, but may be included in other Limited formats, such as Cube Draft."
         }
       ],
       "text": "(Start the game with this conspiracy face up in the command zone.)\nAs long as every card in your card pool started the game in your library or in the command zone, lands you control have \"{T}: Add one mana of any color to your mana pool.\"",
@@ -1375,7 +1375,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "The ability is cumulative. For example, if you control two Brago’s Representatives, you’ll vote three times per vote."
+          "text": "The ability is cumulative. For example, if you control two Brago's Representatives, you'll vote three times per vote."
         },
         {
           "date": "2014-05-29",
@@ -1383,7 +1383,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "The ability only affects spells and abilities that use the word “vote.” Other cards that involve choices, such as Archangel of Strife, are unaffected."
+          "text": "The ability only affects spells and abilities that use the word \"vote.\" Other cards that involve choices, such as Archangel of Strife, are unaffected."
         }
       ],
       "subtypes": [
@@ -1450,11 +1450,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "The vote happens as the ability resolves. Until this happens, Council Guardian doesn’t have protection from any color. Spells and abilities may target Council Guardian as normal in response to its enters-the-battlefield ability, but not in response to the vote. Once players have started voting, it’s too late to respond."
+          "text": "The vote happens as the ability resolves. Until this happens, Council Guardian doesn't have protection from any color. Spells and abilities may target Council Guardian as normal in response to its enters-the-battlefield ability, but not in response to the vote. Once players have started voting, it's too late to respond."
         },
         {
           "date": "2014-05-29",
-          "text": "If Council Guardian is not on the battlefield when its ability resolves, the vote will still take place; it simply won’t have any effect. However, cards that care about voting (for example, Grudge Keeper) will still see the vote."
+          "text": "If Council Guardian is not on the battlefield when its ability resolves, the vote will still take place; it simply won't have any effect. However, cards that care about voting (for example, Grudge Keeper) will still see the vote."
         },
         {
           "date": "2014-05-29",
@@ -1462,7 +1462,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -1470,11 +1470,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "subtypes": [
@@ -1550,7 +1550,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -1558,11 +1558,15 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
+        },
+        {
+          "date": "2017-06-13",
+          "text": "If a choice has no votes, it can't have the most votes. If all choices have zero votes, the voting ability has no effect."
         }
       ],
       "text": "Will of the council — Starting with you, each player votes for a nonland permanent you don't control. Exile each permanent with the most votes or tied for most votes.",
@@ -1694,7 +1698,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -1702,11 +1706,15 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
+        },
+        {
+          "date": "2017-06-13",
+          "text": "If a choice has no votes, it can't have the most votes. If all choices have zero votes, the voting ability has no effect."
         }
       ],
       "subtypes": [
@@ -1899,11 +1907,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -1979,11 +1987,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -2059,7 +2067,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "The value of X is determined as the ability resolves. If, at that time, you control no artifacts, you won’t look at any cards."
+          "text": "The value of X is determined as the ability resolves. If, at that time, you control no artifacts, you won't look at any cards."
         }
       ],
       "subtypes": [
@@ -2133,7 +2141,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -2141,11 +2149,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "text": "Will of the council — Starting with you, each player votes for time or knowledge. If time gets more votes, take an extra turn after this one. If knowledge gets more votes or the vote is tied, draw three cards.",
@@ -2206,15 +2214,15 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "If duplication gets more votes, Split Decision creates a copy of the spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "If duplication gets more votes, Split Decision creates a copy of the spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2014-05-29",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-05-29",
-          "text": "If the spell being copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell being copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2014-05-29",
@@ -2222,7 +2230,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Effects based on any additional costs that were paid for the original spell will be copied as though those same costs were paid for the copy. For example, if a player exiles three cards from his or her graveyard to cast Skeletal Scrying, and you copy it, the copy will also cause you to draw three cards and lose 3 life (but you won’t exile any cards from your graveyard)."
+          "text": "Effects based on any additional costs that were paid for the original spell will be copied as though those same costs were paid for the copy. For example, if a player exiles three cards from his or her graveyard to cast Skeletal Scrying, and you copy it, the copy will also cause you to draw three cards and lose 3 life (but you won't exile any cards from your graveyard)."
         },
         {
           "date": "2014-05-29",
@@ -2230,7 +2238,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -2238,11 +2246,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "text": "Will of the council — Choose target instant or sorcery spell. Starting with you, each player votes for denial or duplication. If denial gets more votes, counter the spell. If duplication gets more votes or the vote is tied, copy the spell. You may choose new targets for the copy.",
@@ -2311,7 +2319,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -2319,11 +2327,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "text": "Will of the council — Starting with you, each player votes for sickness or psychosis. If sickness gets more votes, creatures your opponents control get -2/-2 until end of turn. If psychosis gets more votes or the vote is tied, each opponent discards two cards.",
@@ -2453,19 +2461,19 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "The spell or ability that caused you to vote will finish resolving before Grudge Keeper’s ability is put on the stack. The ability will be put on the stack even if the results of the vote cause Grudge Keeper to leave the battlefield."
+          "text": "The spell or ability that caused you to vote will finish resolving before Grudge Keeper's ability is put on the stack. The ability will be put on the stack even if the results of the vote cause Grudge Keeper to leave the battlefield."
         },
         {
           "date": "2014-05-29",
-          "text": "If one of your opponents has additional votes because of Brago’s Representative, and that player votes for more than one choice you didn’t vote for, that player will lose only 2 life."
+          "text": "If one of your opponents has additional votes because of Brago's Representative, and that player votes for more than one choice you didn't vote for, that player will lose only 2 life."
         },
         {
           "date": "2014-05-29",
-          "text": "If you have additional votes because of Brago’s Representative, and you vote for more than one choice, an opponent will lose 2 life only if he or she voted for none of those choices."
+          "text": "If you have additional votes because of Brago's Representative, and you vote for more than one choice, an opponent will lose 2 life only if he or she voted for none of those choices."
         },
         {
           "date": "2014-05-29",
-          "text": "Grudge Keeper’s ability considers only the vote that caused it to trigger, not any previous votes, even if they were caused by the same permanent."
+          "text": "Grudge Keeper's ability considers only the vote that caused it to trigger, not any previous votes, even if they were caused by the same permanent."
         }
       ],
       "subtypes": [
@@ -2606,7 +2614,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -2614,11 +2622,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "text": "Will of the council — Starting with you, each player votes for death or torture. If death gets more votes, each opponent sacrifices a creature. If torture gets more votes or the vote is tied, each opponent loses 4 life.",
@@ -2681,11 +2689,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -2761,11 +2769,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -2851,7 +2859,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "The player on your right can choose the Ogre that Grenzo’s Rebuttal creates."
+          "text": "The player on your right can choose the Ogre that Grenzo's Rebuttal creates."
         }
       ],
       "text": "Create a 4/4 red Ogre creature token. Starting with you, each player chooses an artifact, a creature, and a land from among the permanents controlled by the player to his or her left. Destroy each permanent chosen this way.",
@@ -2913,23 +2921,23 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "If the target land hasn’t been under its controller’s control continuously since the beginning of his or her most recent turn, that land won’t be able to attack and its {T} abilities can’t be activated. In most cases, that means it will no longer be able to be tapped for mana that turn."
+          "text": "If the target land hasn't been under its controller's control continuously since the beginning of his or her most recent turn, that land won't be able to attack and its {T} abilities can't be activated. In most cases, that means it will no longer be able to be tapped for mana that turn."
         },
         {
           "date": "2014-05-29",
-          "text": "This doesn’t count as a creature entering the battlefield. The land was already on the battlefield; it only changed types."
+          "text": "This doesn't count as a creature entering the battlefield. The land was already on the battlefield; it only changed types."
         },
         {
           "date": "2014-05-29",
-          "text": "Ignition Team’s ability doesn’t affect the land’s name or any other types, subtypes, or supertypes (such as basic or legendary) the land may have. The land will also keep any abilities it had."
+          "text": "Ignition Team's ability doesn't affect the land's name or any other types, subtypes, or supertypes (such as basic or legendary) the land may have. The land will also keep any abilities it had."
         },
         {
           "date": "2014-05-29",
-          "text": "Effects that modify power and/or toughness without setting them to a specific value (like the one created by Giant Growth), power and toughness changes from counters, and effects that switch a creature’s power and toughness will continue to apply. This may happen if the land was already a creature when the ability resolved."
+          "text": "Effects that modify power and/or toughness without setting them to a specific value (like the one created by Giant Growth), power and toughness changes from counters, and effects that switch a creature's power and toughness will continue to apply. This may happen if the land was already a creature when the ability resolved."
         },
         {
           "date": "2014-05-29",
-          "text": "Copies of the affected land won’t be 4/4 red Elemental creatures. For example, if the target land is a basic Mountain, a copy of that creature would just be a basic Mountain."
+          "text": "Copies of the affected land won't be 4/4 red Elemental creatures. For example, if the target land is a basic Mountain, a copy of that creature would just be a basic Mountain."
         }
       ],
       "subtypes": [
@@ -2997,15 +3005,15 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Scourge of the Throne’s ability has an intervening “if” clause. It must be attacking the player with the most life or tied with the most life both when it’s declared as an attacker and as it starts to resolve for it to have any effect. If, at either time, the player isn’t the one with the most life or tied for the most life, the ability will have no effect. Notably, this is different than how dethrone works. (Dethrone checks only once to see if the ability triggers.)"
+          "text": "Scourge of the Throne's ability has an intervening \"if\" clause. It must be attacking the player with the most life or tied with the most life both when it's declared as an attacker and as it starts to resolve for it to have any effect. If, at either time, the player isn't the one with the most life or tied for the most life, the ability will have no effect. Notably, this is different than how dethrone works. (Dethrone checks only once to see if the ability triggers.)"
         },
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -3080,11 +3088,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -3217,7 +3225,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "If Realm Seekers enters the battlefield directly from a player’s hand without being cast, it counts itself when determining the value of X."
+          "text": "If Realm Seekers enters the battlefield directly from a player's hand without being cast, it counts itself when determining the value of X."
         },
         {
           "date": "2014-05-29",
@@ -3350,7 +3358,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "If Selvala’s Enforcer leaves the battlefield before its ability resolves, the top card of each library will still be revealed and drawn, although no +1/+1 counters will be placed."
+          "text": "If Selvala's Enforcer leaves the battlefield before its ability resolves, the top card of each library will still be revealed and drawn, although no +1/+1 counters will be placed."
         },
         {
           "date": "2014-05-29",
@@ -3426,7 +3434,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Brago’s last ability exiles and returns all the targets during the combat damage step, after combat damage is dealt. You can’t target any creature that didn’t survive combat."
+          "text": "Brago's last ability exiles and returns all the targets during the combat damage step, after combat damage is dealt. You can't target any creature that didn't survive combat."
         },
         {
           "date": "2016-06-08",
@@ -3434,7 +3442,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you exile an Aura with Brago’s last ability, the Aura’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything (so it could be attached to a permanent with shroud, for example), but the Aura’s enchant ability restricts what it can be attached to. The Aura can’t enter the battlefield enchanting a permanent that enters the battlefield at the same time. If the Aura can’t legally be attached to anything, it remains exiled."
+          "text": "If you exile an Aura with Brago's last ability, the Aura's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything (so it could be attached to a permanent with shroud, for example), but the Aura's enchant ability restricts what it can be attached to. The Aura can't enter the battlefield enchanting a permanent that enters the battlefield at the same time. If the Aura can't legally be attached to anything, it remains exiled."
         }
       ],
       "subtypes": [
@@ -3507,19 +3515,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The targeted player draws two cards and discards two cards all while Dack’s first ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+          "text": "The targeted player draws two cards and discards two cards all while Dack's first ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability of Dack’s emblem will resolve before the spell that caused it to trigger."
+          "text": "The ability of Dack's emblem will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "The effect of Dack’s second ability and the effect of the emblem’s ability last indefinitely. You won’t lose control of the permanents if Dack leaves the battlefield."
+          "text": "The effect of Dack's second ability and the effect of the emblem's ability last indefinitely. You won't lose control of the permanents if Dack leaves the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "If you gain control of a permanent, and you leave the game, the control-changing effect will end. Unless there’s another control-changing effect affecting that permanent, it will return to its owner’s control."
+          "text": "If you gain control of a permanent, and you leave the game, the control-changing effect will end. Unless there's another control-changing effect affecting that permanent, it will return to its owner's control."
         },
         {
           "date": "2016-06-08",
@@ -3591,15 +3599,15 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Haste and dethrone are part of the copiable values of Dack’s Duplicate. If another creature enters the battlefield as or becomes a copy of Dack’s Duplicate, it will copy whatever Dack’s Duplicate is copying and have haste and dethrone."
+          "text": "Haste and dethrone are part of the copiable values of Dack's Duplicate. If another creature enters the battlefield as or becomes a copy of Dack's Duplicate, it will copy whatever Dack's Duplicate is copying and have haste and dethrone."
         },
         {
           "date": "2014-05-29",
-          "text": "The ability of Dack’s Duplicate doesn’t target the creature."
+          "text": "The ability of Dack's Duplicate doesn't target the creature."
         },
         {
           "date": "2014-05-29",
-          "text": "Dack’s Duplicate copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below), except it will have haste and dethrone. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Dack's Duplicate copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below), except it will have haste and dethrone. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2014-05-29",
@@ -3607,31 +3615,31 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If the chosen creature is copying something else (for example, if the chosen creature is another Dack’s Duplicate), then Dack’s Duplicate enters the battlefield as whatever the chosen creature is copying. It will have haste and dethrone."
+          "text": "If the chosen creature is copying something else (for example, if the chosen creature is another Dack's Duplicate), then Dack's Duplicate enters the battlefield as whatever the chosen creature is copying. It will have haste and dethrone."
         },
         {
           "date": "2014-05-29",
-          "text": "If the chosen creature is a token, Dack’s Duplicate copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Dack’s Duplicate is not a token, even when copying one."
+          "text": "If the chosen creature is a token, Dack's Duplicate copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Dack's Duplicate is not a token, even when copying one."
         },
         {
           "date": "2014-05-29",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Dack’s Duplicate enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Dack's Duplicate enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2014-05-29",
-          "text": "If Dack’s Duplicate somehow enters the battlefield at the same time as another creature, Dack’s Duplicate can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Dack's Duplicate somehow enters the battlefield at the same time as another creature, Dack's Duplicate can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2014-05-29",
-          "text": "You can choose to not copy anything. In that case, Dack’s Duplicate enters the battlefield as a 0/0 Shapeshifter creature, and will probably die almost immediately, when state-based actions are next performed."
+          "text": "You can choose to not copy anything. In that case, Dack's Duplicate enters the battlefield as a 0/0 Shapeshifter creature, and will probably die almost immediately, when state-based actions are next performed."
         },
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -3708,7 +3716,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Deathreap Ritual’s ability has an intervening “if” clause, so a creature must have died before the end step begins in order for the ability to trigger. Notably, this means that the trigger won’t be on the stack for you to respond to by destroying a creature."
+          "text": "Deathreap Ritual's ability has an intervening \"if\" clause, so a creature must have died before the end step begins in order for the ability to trigger. Notably, this means that the trigger won't be on the stack for you to respond to by destroying a creature."
         },
         {
           "date": "2014-05-29",
@@ -3778,7 +3786,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Extract from Darkness doesn’t target a creature card. You choose which card you’re putting onto the battlefield as it resolves. You can choose any creature card in a graveyard at that time, including one just put into a graveyard by Extract from Darkness. If there are no creature cards in graveyards at that time, Extract from Darkness simply finishes resolving."
+          "text": "Extract from Darkness doesn't target a creature card. You choose which card you're putting onto the battlefield as it resolves. You can choose any creature card in a graveyard at that time, including one just put into a graveyard by Extract from Darkness. If there are no creature cards in graveyards at that time, Extract from Darkness simply finishes resolving."
         }
       ],
       "text": "Each player puts the top two cards of his or her library into his or her graveyard. Then put a creature card from a graveyard onto the battlefield under your control.",
@@ -3907,11 +3915,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Compare Grenzo’s power when the ability resolves with the power of the creature card in your graveyard to determine if you put it onto the battlefield. If Grenzo isn’t on the battlefield at this time, use its power from when it was last on the battlefield."
+          "text": "Compare Grenzo's power when the ability resolves with the power of the creature card in your graveyard to determine if you put it onto the battlefield. If Grenzo isn't on the battlefield at this time, use its power from when it was last on the battlefield."
         },
         {
           "date": "2014-05-29",
-          "text": "If the card you put into your graveyard isn’t a creature card or it’s a creature card with power greater than Grenzo’s power, it stays in your graveyard."
+          "text": "If the card you put into your graveyard isn't a creature card or it's a creature card with power greater than Grenzo's power, it stays in your graveyard."
         }
       ],
       "subtypes": [
@@ -3989,7 +3997,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -3997,11 +4005,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "subtypes": [
@@ -4076,7 +4084,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If the creature card leaves the graveyard before the delayed triggered ability resolves, that card won’t return to the battlefield, even if it’s back in the graveyard when the delayed triggered ability resolves."
+          "text": "If the creature card leaves the graveyard before the delayed triggered ability resolves, that card won't return to the battlefield, even if it's back in the graveyard when the delayed triggered ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -4084,11 +4092,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -4169,11 +4177,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -4253,11 +4261,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Selvala’s parley ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Selvala's parley ability is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-05-29",
-          "text": "If you activate Selvala’s ability while casting a spell, and you discover you can’t produce enough mana to pay that spell’s costs, the spell is reversed. The spell returns to whatever zone you were casting it from. You may reverse other mana abilities you activated while casting the spell, but Selvala’s ability can’t be reversed. Whatever mana that ability produced will be in your mana pool and each player will have drawn a card."
+          "text": "If you activate Selvala's ability while casting a spell, and you discover you can't produce enough mana to pay that spell's costs, the spell is reversed. The spell returns to whatever zone you were casting it from. You may reverse other mana abilities you activated while casting the spell, but Selvala's ability can't be reversed. Whatever mana that ability produced will be in your mana pool and each player will have drawn a card."
         },
         {
           "date": "2014-05-29",
@@ -4392,11 +4400,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "When casting a card this way, ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "When casting a card this way, ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2014-05-29",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2014-05-29",
@@ -4404,33 +4412,33 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If Aether Searcher leaves the battlefield before its ability resolves, you’ll still be able to search for the named card and cast it."
+          "text": "If Aether Searcher leaves the battlefield before its ability resolves, you'll still be able to search for the named card and cast it."
         },
         {
           "date": "2014-05-29",
-          "text": "If the card you draft after Aether Searcher is a land card, you won’t be able to play that land using Aether Searcher’s ability."
+          "text": "If the card you draft after Aether Searcher is a land card, you won't be able to play that land using Aether Searcher's ability."
         },
         {
           "date": "2014-05-29",
-          "text": "If Aether Searcher is the last card you draft in any draft round other than the last one, you’ll reveal the first card you draft in the following draft round and note its name."
+          "text": "If Aether Searcher is the last card you draft in any draft round other than the last one, you'll reveal the first card you draft in the following draft round and note its name."
         },
         {
           "date": "2014-05-29",
-          "text": "If Aether Searcher is the last card you draft, there won’t be a noted name. You can still search your hand and/or library when it enters the battlefield, but you won’t cast any card this way unless you also drafted an Aether Searcher and noted a card then."
+          "text": "If Aether Searcher is the last card you draft, there won't be a noted name. You can still search your hand and/or library when it enters the battlefield, but you won't cast any card this way unless you also drafted an Aether Searcher and noted a card then."
         },
         {
           "date": "2014-05-29",
-          "text": "If an Aether Searcher owned by another player enters the battlefield under your control, you can search for a card you’ve named while drafting a card named Aether Searcher, not a card named by its owner. Unless you also drafted a card named Aether Searcher, you won’t cast a card."
+          "text": "If an Aether Searcher owned by another player enters the battlefield under your control, you can search for a card you've named while drafting a card named Aether Searcher, not a card named by its owner. Unless you also drafted a card named Aether Searcher, you won't cast a card."
         },
         {
           "date": "2014-05-29",
-          "text": "You cast the card before shuffling your library (if it was searched). In some very rare cases, you may need to take actions involving your library while casting the card. For example, if it has an additional cost and you activate Deranged Assistant’s ability (“{T}, Put the top card of your library into your graveyard: Add {C} to your mana pool.”) to pay for it, you must maintain the order of your library while you search it."
+          "text": "You cast the card before shuffling your library (if it was searched). In some very rare cases, you may need to take actions involving your library while casting the card. For example, if it has an additional cost and you activate Deranged Assistant's ability (\"{T}, Put the top card of your library into your graveyard: Add {C} to your mana pool.\") to pay for it, you must maintain the order of your library while you search it."
         }
       ],
       "subtypes": [
         "Construct"
       ],
-      "text": "Reveal Aether Searcher as you draft it. Reveal the next card you draft and note its name. \nWhen Aether Searcher enters the battlefield, you may search your hand and/or library for a card with a name noted as you drafted cards named Aether Searcher. You may cast it without paying its mana cost. If you searched your library this way, shuffle it.",
+      "text": "Reveal Aether Searcher as you draft it. Reveal the next card you draft and note its name.\nWhen Aether Searcher enters the battlefield, you may search your hand and/or library for a card with a name noted as you drafted cards named Aether Searcher. You may cast it without paying its mana cost. If you searched your library this way, shuffle it.",
       "toughness": "4",
       "type": "Artifact Creature — Construct",
       "types": [
@@ -4485,11 +4493,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "You choose the order the cards in that booster pack are drafted. In many cases this won’t matter, but it could be relevant if one of the cards cares about when it was drafted or what the next card you draft is."
+          "text": "You choose the order the cards in that booster pack are drafted. In many cases this won't matter, but it could be relevant if one of the cards cares about when it was drafted or what the next card you draft is."
         },
         {
           "date": "2014-05-29",
-          "text": "The second ability of Agent of Acquisitions works only if you’re drafting a card. For example, if you’ve already used one Agent of Acquisitions in a draft round, you can’t use a second Agent of Acquisitions later in that same draft round."
+          "text": "The second ability of Agent of Acquisitions works only if you're drafting a card. For example, if you've already used one Agent of Acquisitions in a draft round, you can't use a second Agent of Acquisitions later in that same draft round."
         }
       ],
       "subtypes": [
@@ -4623,7 +4631,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -4631,11 +4639,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "text": "Will of the council — At the beginning of your upkeep, starting with you, each player votes for carnage or homage. If carnage gets more votes, sacrifice Coercive Portal and destroy all nonland permanents. If homage gets more votes or the vote is tied, draw a card.",
@@ -4691,19 +4699,19 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "You still draft the card that you remove. This may matter if an ability refers to “the next card you draft” or similar. If that card instructs you to draft it face up, do so, then turn it face down as you remove it. If that card instructs you to reveal it as you draft it and then perform additional actions, perform those actions before turning the card face down and removing it from the draft."
+          "text": "You still draft the card that you remove. This may matter if an ability refers to \"the next card you draft\" or similar. If that card instructs you to draft it face up, do so, then turn it face down as you remove it. If that card instructs you to reveal it as you draft it and then perform additional actions, perform those actions before turning the card face down and removing it from the draft."
         },
         {
           "date": "2014-05-29",
-          "text": "A card that is removed from the draft isn’t in any player’s card pool. That card can’t be played in any games associated with that draft."
+          "text": "A card that is removed from the draft isn't in any player's card pool. That card can't be played in any games associated with that draft."
         },
         {
           "date": "2014-05-29",
-          "text": "You can’t remove cards from the draft that you’ve already drafted. Only cards drafted after you draft Cogwork Grinder may be removed this way."
+          "text": "You can't remove cards from the draft that you've already drafted. Only cards drafted after you draft Cogwork Grinder may be removed this way."
         },
         {
           "date": "2014-05-29",
-          "text": "If you draft multiple Cogwork Grinders, the value for X will be the same for each of them. It doesn’t matter that some of the removed cards may have been removed before you drafted the second Cogwork Grinder, for example."
+          "text": "If you draft multiple Cogwork Grinders, the value for X will be the same for each of them. It doesn't matter that some of the removed cards may have been removed before you drafted the second Cogwork Grinder, for example."
         },
         {
           "date": "2014-05-29",
@@ -4711,7 +4719,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If a Cogwork Grinder owned by another player enters the battlefield under your control, the number of counters it enters with will be based on the number of cards you’ve removed from the draft with Cogwork Grinders, not the number its owner removed. Unless you also drafted Cogwork Grinder, this will be 0."
+          "text": "If a Cogwork Grinder owned by another player enters the battlefield under your control, the number of counters it enters with will be based on the number of cards you've removed from the draft with Cogwork Grinders, not the number its owner removed. Unless you also drafted Cogwork Grinder, this will be 0."
         }
       ],
       "subtypes": [
@@ -4843,11 +4851,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "If you are the next person to draft from the booster pack (perhaps because of Cogwork Librarian), the first ability doesn’t do anything."
+          "text": "If you are the next person to draft from the booster pack (perhaps because of Cogwork Librarian), the first ability doesn't do anything."
         },
         {
           "date": "2014-05-29",
-          "text": "You may look at the card even if it’s removed from the draft face down by Cogwork Grinder."
+          "text": "You may look at the card even if it's removed from the draft face down by Cogwork Grinder."
         }
       ],
       "subtypes": [
@@ -4909,15 +4917,15 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "If your draft is breaking up into multiple games, you and the noted player(s) aren’t required to be in the same game."
+          "text": "If your draft is breaking up into multiple games, you and the noted player(s) aren't required to be in the same game."
         },
         {
           "date": "2014-05-29",
-          "text": "If the noted player isn’t in the game, Cogwork Tracker’s last ability won’t do anything, although it must still attack each turn if able. This is also true if there is no noted player because Cogwork Tracker was the first card drafted from a booster pack."
+          "text": "If the noted player isn't in the game, Cogwork Tracker's last ability won't do anything, although it must still attack each turn if able. This is also true if there is no noted player because Cogwork Tracker was the first card drafted from a booster pack."
         },
         {
           "date": "2014-05-29",
-          "text": "If the last ability doesn’t apply, you choose which player or planeswalker Cogwork Tracker attacks."
+          "text": "If the last ability doesn't apply, you choose which player or planeswalker Cogwork Tracker attacks."
         },
         {
           "date": "2014-05-29",
@@ -4925,7 +4933,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If, during your declare attackers step, Cogwork Tracker is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under your control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, you’re not forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Cogwork Tracker is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under your control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, you're not forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -4987,23 +4995,23 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "You may reveal Deal Broker itself for its second ability. If you do, and you accept another player’s offer, that player won’t be able to use the second ability to offer another exchange."
+          "text": "You may reveal Deal Broker itself for its second ability. If you do, and you accept another player's offer, that player won't be able to use the second ability to offer another exchange."
         },
         {
           "date": "2014-05-29",
-          "text": "When you use Deal Broker’s second ability, after you reveal your card, each other player chooses up to one card from his or her card pool, then all those chosen cards are revealed simultaneously."
+          "text": "When you use Deal Broker's second ability, after you reveal your card, each other player chooses up to one card from his or her card pool, then all those chosen cards are revealed simultaneously."
         },
         {
           "date": "2014-05-29",
-          "text": "If you accept a player’s offer, the card you revealed becomes part of that player’s card pool and the other offered card becomes part of your card pool."
+          "text": "If you accept a player's offer, the card you revealed becomes part of that player's card pool and the other offered card becomes part of your card pool."
         },
         {
           "date": "2014-05-29",
-          "text": "The cards exchanged this way aren’t drafted. They can’t be removed from the draft by Cogwork Grinder, for example."
+          "text": "The cards exchanged this way aren't drafted. They can't be removed from the draft by Cogwork Grinder, for example."
         },
         {
           "date": "2014-05-29",
-          "text": "If either card involved in the exchange has any information noted for it, that information stays with the exchanged card, not the player who initially drafted it. Any abilities that refer to actions taken as you drafted the card (or similar) now refer to the card’s new owner, even though that player wasn’t the person who actually drafted the card."
+          "text": "If either card involved in the exchange has any information noted for it, that information stays with the exchanged card, not the player who initially drafted it. Any abilities that refer to actions taken as you drafted the card (or similar) now refer to the card's new owner, even though that player wasn't the person who actually drafted the card."
         },
         {
           "date": "2014-05-29",
@@ -5015,7 +5023,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If your draft is breaking up into multiple games, the exchange happens before it’s known who will be playing in each game."
+          "text": "If your draft is breaking up into multiple games, the exchange happens before it's known who will be playing in each game."
         }
       ],
       "subtypes": [
@@ -5081,7 +5089,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "To add a booster pack to the draft, first pass the booster pack that contained Lore Seeker to the next player. Then open the new booster pack, draft a card, and pass the new booster pack in the same direction. Then you’ll receive the booster pack you would’ve received had you not added a booster pack, and the draft round will continue. The added booster pack will last a few picks longer than the rest of the booster packs opened that draft round."
+          "text": "To add a booster pack to the draft, first pass the booster pack that contained Lore Seeker to the next player. Then open the new booster pack, draft a card, and pass the new booster pack in the same direction. Then you'll receive the booster pack you would've received had you not added a booster pack, and the draft round will continue. The added booster pack will last a few picks longer than the rest of the booster packs opened that draft round."
         },
         {
           "date": "2014-05-29",
@@ -5089,7 +5097,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If you use Agent of Acquisitions to draft a booster pack containing Lore Seeker, and you wish to add a booster pack to the draft, first draft each remaining card from the Lore Seeker booster pack. Then open the new booster pack. You may look at the cards in that pack, but you can’t draft any cards from it. You’ll pass the new booster pack as normal. That was very generous of you."
+          "text": "If you use Agent of Acquisitions to draft a booster pack containing Lore Seeker, and you wish to add a booster pack to the draft, first draft each remaining card from the Lore Seeker booster pack. Then open the new booster pack. You may look at the cards in that pack, but you can't draft any cards from it. You'll pass the new booster pack as normal. That was very generous of you."
         }
       ],
       "subtypes": [
@@ -5220,11 +5228,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If you use Whispergear Sneak during the first draft round to look at an unopened booster pack, the owner of that booster pack doesn’t have to “open” that booster pack for the next draft round, although he or she may do so."
+          "text": "If you use Whispergear Sneak during the first draft round to look at an unopened booster pack, the owner of that booster pack doesn't have to \"open\" that booster pack for the next draft round, although he or she may do so."
         },
         {
           "date": "2014-05-29",
-          "text": "If you look at a booster pack that is being drafted during the current draft round, you may do so after a player has drafted a card from that booster pack and before the next player has been passed the cards. As a courtesy, you may inform the player currently looking at the booster pack that you’ll be looking at it next, before it’s passed to the next player."
+          "text": "If you look at a booster pack that is being drafted during the current draft round, you may do so after a player has drafted a card from that booster pack and before the next player has been passed the cards. As a courtesy, you may inform the player currently looking at the booster pack that you'll be looking at it next, before it's passed to the next player."
         }
       ],
       "subtypes": [
@@ -5286,7 +5294,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If you control Paliano, the High City but you didn’t draft a card named Paliano, the High City, its second ability won’t add mana to your mana pool. Notably, Paliano won’t produce colorless mana."
+          "text": "If you control Paliano, the High City but you didn't draft a card named Paliano, the High City, its second ability won't add mana to your mana pool. Notably, Paliano won't produce colorless mana."
         }
       ],
       "supertypes": [
@@ -5642,7 +5650,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If a token is exiled this way, it ceases to exist and won’t return to the battlefield."
+          "text": "If a token is exiled this way, it ceases to exist and won't return to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -5650,11 +5658,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything (so it could be attached to a permanent with shroud, for example), but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything (so it could be attached to a permanent with shroud, for example), but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled."
         },
         {
           "date": "2016-06-08",
-          "text": "If Glimmerpoint Stag somehow enters the battlefield during a turn’s end step, the exiled card won’t be returned to the battlefield until the beginning of the following turn’s end step."
+          "text": "If Glimmerpoint Stag somehow enters the battlefield during a turn's end step, the exiled card won't be returned to the battlefield until the beginning of the following turn's end step."
         }
       ],
       "subtypes": [
@@ -5732,7 +5740,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-03-01",
@@ -5740,15 +5748,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon and the land it’s enchanting are destroyed at the same time (due to Akroma’s Vengeance, for example), the Zendikon’s last ability will still trigger."
+          "text": "If a Zendikon and the land it's enchanting are destroyed at the same time (due to Akroma's Vengeance, for example), the Zendikon's last ability will still trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon’s last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
+          "text": "If a Zendikon's last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
         }
       ],
       "subtypes": [
@@ -6161,7 +6169,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If Pride Guardian gains the ability to block additional creatures and does so, you’ll still gain only 3 life."
+          "text": "If Pride Guardian gains the ability to block additional creatures and does so, you'll still gain only 3 life."
         }
       ],
       "subtypes": [
@@ -6512,7 +6520,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If another creature with flying is dealt lethal damage at the same time as Soulcatcher, they’ll be destroyed at the same time. Soulcatcher’s ability won’t save it."
+          "text": "If another creature with flying is dealt lethal damage at the same time as Soulcatcher, they'll be destroyed at the same time. Soulcatcher's ability won't save it."
         }
       ],
       "subtypes": [
@@ -6675,7 +6683,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -6757,7 +6765,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"As my father taught, ‘Training will raise your shield to the blow, but courage fills the gaps the shield leaves open.'\"",
+      "flavor": "\"As my father taught, 'Training will raise your shield to the blow, but courage fills the gaps the shield leaves open.'\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -6938,11 +6946,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "Wakestone Gargoyle’s ability allows itself to attack."
+          "text": "Wakestone Gargoyle's ability allows itself to attack."
         },
         {
           "date": "2006-05-01",
-          "text": "Wakestone Gargoyle’s ability will affect creatures with defender that come under your control after the ability resolves but before you declare attackers (though those creatures still can’t attack unless they have haste)."
+          "text": "Wakestone Gargoyle's ability will affect creatures with defender that come under your control after the ability resolves but before you declare attackers (though those creatures still can't attack unless they have haste)."
         }
       ],
       "subtypes": [
@@ -7025,7 +7033,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If one target permanent becomes an illegal target, the other will be returned to its owner’s hand. If both targets become illegal, Aether Tradewinds will be countered."
+          "text": "If one target permanent becomes an illegal target, the other will be returned to its owner's hand. If both targets become illegal, Aether Tradewinds will be countered."
         }
       ],
       "text": "Return target permanent you control and target permanent you don't control to their owners' hands.",
@@ -7390,7 +7398,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -7609,7 +7617,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Each pile may contain from zero to five cards; they don’t have to be split “evenly.”"
+          "text": "Each pile may contain from zero to five cards; they don't have to be split \"evenly.\""
         }
       ],
       "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
@@ -7750,7 +7758,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "The affected land loses its existing land types and any abilities printed on it. It becomes the chosen basic land type and now has the ability to tap to add one mana of the appropriate color to your mana pool. Grixis Illusionist’s ability doesn’t change the affected land’s name or whether it’s legendary or basic."
+          "text": "The affected land loses its existing land types and any abilities printed on it. It becomes the chosen basic land type and now has the ability to tap to add one mana of the appropriate color to your mana pool. Grixis Illusionist's ability doesn't change the affected land's name or whether it's legendary or basic."
         }
       ],
       "subtypes": [
@@ -7981,7 +7989,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -8213,7 +8221,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “If you do” means “If you search”."
+          "text": "The \"If you do\" means \"If you search\"."
         }
       ],
       "subtypes": [
@@ -8421,15 +8429,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "An activated ability has a “Cost: Effect” format. Look for the colon. A triggered ability starts with “when”, “whenever”, or “at”."
+          "text": "An activated ability has a \"Cost: Effect\" format. Look for the colon. A triggered ability starts with \"when\", \"whenever\", or \"at\"."
         },
         {
           "date": "2004-10-04",
-          "text": "Turn-based actions and special actions like the normal card draw, combat damage, or turning a face-down creature face up can’t be targeted."
+          "text": "Turn-based actions and special actions like the normal card draw, combat damage, or turning a face-down creature face up can't be targeted."
         },
         {
           "date": "2004-10-04",
-          "text": "It can target delayed triggered abilities. For example, a card that says “Whenever a player cycles a card, you may exile target creature. If you do, return that creature to the battlefield at the beginning of the end step.” triggers when a player cycles a card and creates a delayed trigger that happens at the beginning of the end step. You can choose to target the “at the beginning of the end step” trigger when it is placed on the stack at end of turn."
+          "text": "It can target delayed triggered abilities. For example, a card that says \"Whenever a player cycles a card, you may exile target creature. If you do, return that creature to the battlefield at the beginning of the end step.\" triggers when a player cycles a card and creates a delayed trigger that happens at the beginning of the end step. You can choose to target the \"at the beginning of the end step\" trigger when it is placed on the stack at end of turn."
         }
       ],
       "text": "Counter target activated or triggered ability. (Mana abilities can't be targeted.)",
@@ -9076,11 +9084,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player’s previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
+          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player's previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says that a player can’t lose life, that player can’t exchange life totals with a player who has a lower life total; in that case, the exchange won’t happen."
+          "text": "If an effect says that a player can't lose life, that player can't exchange life totals with a player who has a lower life total; in that case, the exchange won't happen."
         }
       ],
       "subtypes": [
@@ -9307,7 +9315,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “cast from your hand” if you cast it as a spell from your hand. Putting it onto the battlefield from your hand using a spell or ability will cause you to lose the game."
+          "text": "It is only considered \"cast from your hand\" if you cast it as a spell from your hand. Putting it onto the battlefield from your hand using a spell or ability will cause you to lose the game."
         },
         {
           "date": "2013-07-01",
@@ -9944,7 +9952,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2016-06-08",
@@ -10109,11 +10117,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The card will return to the battlefield under your control only if it’s still in the graveyard when Unhallowed Pact’s ability resolves. If it’s not (perhaps because an ability like undying has already returned it to the battlefield), nothing happens."
+          "text": "The card will return to the battlefield under your control only if it's still in the graveyard when Unhallowed Pact's ability resolves. If it's not (perhaps because an ability like undying has already returned it to the battlefield), nothing happens."
         },
         {
           "date": "2012-05-01",
-          "text": "If Unhallowed Pact is enchanting a token creature, that creature can’t return to the battlefield."
+          "text": "If Unhallowed Pact is enchanting a token creature, that creature can't return to the battlefield."
         }
       ],
       "subtypes": [
@@ -10193,7 +10201,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If all loyalty counters are removed from a planeswalker, that planeswalker is put into its owner’s graveyard as a state-based action."
+          "text": "If all loyalty counters are removed from a planeswalker, that planeswalker is put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -10269,19 +10277,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You must choose two targets. You can’t cast Victimize targeting only one creature card."
+          "text": "You must choose two targets. You can't cast Victimize targeting only one creature card."
         },
         {
           "date": "2016-06-08",
-          "text": "The creature you sacrifice isn’t chosen until Victimize resolves. You can’t return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
+          "text": "The creature you sacrifice isn't chosen until Victimize resolves. You can't return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
         },
         {
           "date": "2016-06-08",
-          "text": "As Victimize resolves, you must sacrifice a creature if able. You can’t change your mind and choose not to sacrifice anything."
+          "text": "As Victimize resolves, you must sacrifice a creature if able. You can't change your mind and choose not to sacrifice anything."
         },
         {
           "date": "2016-06-08",
-          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you’ll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won’t sacrifice a creature."
+          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you'll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won't sacrifice a creature."
         },
         {
           "date": "2016-06-08",
@@ -10727,7 +10735,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Mountaincycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Mountaincycling doesn't allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -11168,11 +11176,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The creature’s controller still decides which player or planeswalker the creature attacks."
+          "text": "The creature's controller still decides which player or planeswalker the creature attacks."
         },
         {
           "date": "2011-01-22",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -11790,7 +11798,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
@@ -11798,7 +11806,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you’ve declared attackers usually won’t do anything."
+          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you've declared attackers usually won't do anything."
         }
       ],
       "text": "Attacking creatures get +2/+0 until end of turn.",
@@ -12009,7 +12017,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Volcanic Fallout can be targeted by spells that try to counter it (such as Countersquall). Those spells will still resolve, but the part of their effect that would counter Volcanic Fallout won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Volcanic Fallout can be targeted by spells that try to counter it (such as Countersquall). Those spells will still resolve, but the part of their effect that would counter Volcanic Fallout won't do anything. Any other effects those spells have will work as normal."
         }
       ],
       "text": "Volcanic Fallout can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
@@ -12085,11 +12093,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "The “can’t block” effect applies to each of the targeted creatures — and only those creatures — even if Wrap in Flames deals no damage to one or more of them (due to a prevention effect, for example) or Wrap in Flames deals damage to a different creature (due to a redirection effect)."
+          "text": "The \"can't block\" effect applies to each of the targeted creatures — and only those creatures — even if Wrap in Flames deals no damage to one or more of them (due to a prevention effect, for example) or Wrap in Flames deals damage to a different creature (due to a redirection effect)."
         },
         {
           "date": "2010-06-15",
-          "text": "If any of the targeted creatures is an illegal target by the time Wrap in Flames resolves, it won’t be dealt damage and will be able to block. The other targeted creatures will still be affected."
+          "text": "If any of the targeted creatures is an illegal target by the time Wrap in Flames resolves, it won't be dealt damage and will be able to block. The other targeted creatures will still be affected."
         }
       ],
       "text": "Wrap in Flames deals 1 damage to each of up to three target creatures. Those creatures can't block this turn.",
@@ -12234,11 +12242,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Copperhorn Scout’s ability resolves, you’ll untap each other creature you control regardless of whether that creature was attacking."
+          "text": "As Copperhorn Scout's ability resolves, you'll untap each other creature you control regardless of whether that creature was attacking."
         },
         {
           "date": "2011-01-01",
-          "text": "Untapping an attacking creature doesn’t cause it to stop attacking."
+          "text": "Untapping an attacking creature doesn't cause it to stop attacking."
         }
       ],
       "subtypes": [
@@ -12380,7 +12388,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If Elephant Guide enchants an opponent’s creature, you get the Elephant when that creature dies."
+          "text": "If Elephant Guide enchants an opponent's creature, you get the Elephant when that creature dies."
         }
       ],
       "subtypes": [
@@ -12453,7 +12461,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Forestcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Forestcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -12871,7 +12879,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The damage dealt by Hydra Omnivore as a result of its triggered ability is not combat damage (and doesn’t cause the ability to trigger again)."
+          "text": "The damage dealt by Hydra Omnivore as a result of its triggered ability is not combat damage (and doesn't cause the ability to trigger again)."
         }
       ],
       "subtypes": [
@@ -13012,7 +13020,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the targeted artifact or enchantment is an illegal target when Nature’s Claim tries to resolve, the entire spell is countered. No one gains any life."
+          "text": "If the targeted artifact or enchantment is an illegal target when Nature's Claim tries to resolve, the entire spell is countered. No one gains any life."
         }
       ],
       "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
@@ -13729,7 +13737,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If a targeted permanent has indestructible or regenerates, its controller won’t get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner’s graveyard, its controller won’t get an Elephant token for it."
+          "text": "If a targeted permanent has indestructible or regenerates, its controller won't get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner's graveyard, its controller won't get an Elephant token for it."
         }
       ],
       "subtypes": [
@@ -13944,7 +13952,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "While Basandra, Battle Seraph is on the battlefield, players can’t cast any spells during the combat phase, including permanent spells with flash."
+          "text": "While Basandra, Battle Seraph is on the battlefield, players can't cast any spells during the combat phase, including permanent spells with flash."
         },
         {
           "date": "2011-09-22",
@@ -13952,7 +13960,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -14029,7 +14037,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You no longer need four distinct targets for Decimate. If the spell or ability uses the word target in multiple places, the same object or player can be chosen once for each instance of the word “target.” For example, you could choose Tree of Tales for both the artifact and the land. You still need a legal target enchantment and creature as well."
+          "text": "You no longer need four distinct targets for Decimate. If the spell or ability uses the word target in multiple places, the same object or player can be chosen once for each instance of the word \"target.\" For example, you could choose Tree of Tales for both the artifact and the land. You still need a legal target enchantment and creature as well."
         }
       ],
       "text": "Destroy target artifact, target creature, target enchantment, and target land.",
@@ -14103,11 +14111,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "This creature becomes an exact copy of a copied card, except that it also has Dimir Doppelganger’s activated ability. If it becomes a copy of a different creature card, the new copy will overwrite the old copy."
+          "text": "This creature becomes an exact copy of a copied card, except that it also has Dimir Doppelganger's activated ability. If it becomes a copy of a different creature card, the new copy will overwrite the old copy."
         },
         {
           "date": "2005-10-01",
-          "text": "A permanent’s ability that refers to cards the creature exiled (such as Sisters of Stone Death’s third ability) only affects cards exiled by other abilities intrinsic to that permanent (such as Sisters of Stone Death’s second ability). Suppose that (a) Dimir Doppelganger copies Arc-Slogger, (b) its “deal 2 damage” ability is activated, and then (c) it copies Sisters of Stone Death. Creatures exiled by Arc-Slogger’s ability can’t be returned with Sisters of Stone Death’s ability."
+          "text": "A permanent's ability that refers to cards the creature exiled (such as Sisters of Stone Death's third ability) only affects cards exiled by other abilities intrinsic to that permanent (such as Sisters of Stone Death's second ability). Suppose that (a) Dimir Doppelganger copies Arc-Slogger, (b) its \"deal 2 damage\" ability is activated, and then (c) it copies Sisters of Stone Death. Creatures exiled by Arc-Slogger's ability can't be returned with Sisters of Stone Death's ability."
         }
       ],
       "subtypes": [
@@ -14180,7 +14188,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric’s ability to trigger. The creature’s controller chooses whether to draw a card."
+          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric's ability to trigger. The creature's controller chooses whether to draw a card."
         },
         {
           "date": "2011-09-22",
@@ -14405,7 +14413,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target creature or enchantment.",
@@ -14868,7 +14876,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If the creature you put onto the battlefield can’t be equipped by Deathrender (due to protection from artifacts, for example), the creature enters the battlefield but Deathrender remains unattached."
+          "text": "If the creature you put onto the battlefield can't be equipped by Deathrender (due to protection from artifacts, for example), the creature enters the battlefield but Deathrender remains unattached."
         }
       ],
       "subtypes": [
@@ -15448,11 +15456,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The controller of Vedalken Orrery can cast nonland artifact, creature, enchantment, and sorcery cards any time he or she could cast an instant. This includes on other players’ turns and during the upkeep step, draw step, combat phase, and end step."
+          "text": "The controller of Vedalken Orrery can cast nonland artifact, creature, enchantment, and sorcery cards any time he or she could cast an instant. This includes on other players' turns and during the upkeep step, draw step, combat phase, and end step."
         },
         {
           "date": "2010-06-15",
-          "text": "This applies only to casting spells. It does not, for example, change when you may activate abilities that can only be activated “any time you could cast a sorcery”."
+          "text": "This applies only to casting spells. It does not, for example, change when you may activate abilities that can only be activated \"any time you could cast a sorcery\"."
         }
       ],
       "text": "You may cast spells as though they had flash.",
@@ -15517,11 +15525,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The second ability doesn’t cause the equipped creature to lose defender. It just lets it attack."
+          "text": "The second ability doesn't cause the equipped creature to lose defender. It just lets it attack."
         },
         {
           "date": "2010-06-15",
-          "text": "If the equipped creature doesn’t have defender, the second ability simply doesn’t affect it."
+          "text": "If the equipped creature doesn't have defender, the second ability simply doesn't affect it."
         }
       ],
       "subtypes": [
@@ -15716,7 +15724,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Any change to a land’s type or splicing of text into a land can affect the types of mana a land can produce."
+          "text": "Any change to a land's type or splicing of text into a land can affect the types of mana a land can produce."
         },
         {
           "date": "2008-05-01",
@@ -15724,15 +15732,15 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Reflecting Pool checks the effects of all mana-producing abilities of lands you control, but it doesn’t check their costs. For example, Vivid Crag says “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If you control Vivid Crag and Reflecting Pool, you can tap Reflecting Pool for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Reflecting Pool checks the effects of all mana-producing abilities of lands you control, but it doesn't check their costs. For example, Vivid Crag says \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If you control Vivid Crag and Reflecting Pool, you can tap Reflecting Pool for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2008-05-01",
-          "text": "Reflecting Pool doesn’t care about any restrictions or riders your lands put on the mana they produce, such as Pillar of the Paruns and Hall of the Bandit Lord do. It just cares about types of mana."
+          "text": "Reflecting Pool doesn't care about any restrictions or riders your lands put on the mana they produce, such as Pillar of the Paruns and Hall of the Bandit Lord do. It just cares about types of mana."
         },
         {
           "date": "2008-05-01",
-          "text": "Multiple Reflecting Pools won’t help each other produce mana. If you control a Reflecting Pool, and all other lands you control either lack mana abilities or are other Reflecting Pools, you may still activate Reflecting Pool’s ability — it just won’t produce any mana."
+          "text": "Multiple Reflecting Pools won't help each other produce mana. If you control a Reflecting Pool, and all other lands you control either lack mana abilities or are other Reflecting Pools, you may still activate Reflecting Pool's ability — it just won't produce any mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any type that a land you control could produce.",

--- a/json/CON.json
+++ b/json/CON.json
@@ -443,11 +443,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         },
         {
           "date": "2009-02-01",
-          "text": "Aven Trailblazer’s second ability is a “characteristic-defining ability.” It applies at all times in all zones."
+          "text": "Aven Trailblazer's second ability is a \"characteristic-defining ability.\" It applies at all times in all zones."
         }
       ],
       "subtypes": [
@@ -557,7 +557,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Lands are colorless (even if their frames have some colored elements to them). You can’t target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
+          "text": "Lands are colorless (even if their frames have some colored elements to them). You can't target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
         }
       ],
       "text": "Exile target black or red permanent.",
@@ -861,7 +861,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -1067,7 +1067,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "“Noncombat damage” is damage dealt as the result of a spell or ability. (In unusual cases involving a card like Words of War, noncombat damage can also be dealt as the result of a turn-based action.)"
+          "text": "\"Noncombat damage\" is damage dealt as the result of a spell or ability. (In unusual cases involving a card like Words of War, noncombat damage can also be dealt as the result of a turn-based action.)"
         }
       ],
       "text": "Prevent all noncombat damage that would be dealt to creatures you control.",
@@ -1173,11 +1173,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "You do what the spell says in order. If X is 5 or more, you’ll put the Soldier tokens onto the battlefield, then you’ll destroy all other creatures."
+          "text": "You do what the spell says in order. If X is 5 or more, you'll put the Soldier tokens onto the battlefield, then you'll destroy all other creatures."
         },
         {
           "date": "2009-02-01",
-          "text": "No one can cast spells or activate abilities between the time the Soldier tokens are put onto the battlefield and the time all other creatures are destroyed. For example, you can’t sacrifice one of those Soldier tokens to regenerate a Skeletal Kathari."
+          "text": "No one can cast spells or activate abilities between the time the Soldier tokens are put onto the battlefield and the time all other creatures are destroyed. For example, you can't sacrifice one of those Soldier tokens to regenerate a Skeletal Kathari."
         }
       ],
       "text": "Create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures.",
@@ -1278,19 +1278,19 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The “intervening ‘if’ clause” means that (1) the ability won’t trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
+          "text": "The \"intervening 'if' clause\" means that (1) the ability won't trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
         },
         {
           "date": "2009-02-01",
-          "text": "Normally, when a token is created by this ability, it will simply be a Mirror-Sigil Sergeant, so it’ll also have the token-creating ability. (See the other ruling for weird exceptions.) At the beginning of your next upkeep, if you still control the original Sergeant, the token copy, and a blue permanent, you’ll get two more token copies; the turn after that you’ll get four; then eight; and so on."
+          "text": "Normally, when a token is created by this ability, it will simply be a Mirror-Sigil Sergeant, so it'll also have the token-creating ability. (See the other ruling for weird exceptions.) At the beginning of your next upkeep, if you still control the original Sergeant, the token copy, and a blue permanent, you'll get two more token copies; the turn after that you'll get four; then eight; and so on."
         },
         {
           "date": "2009-02-01",
-          "text": "Here’s the detailed version of what happens. As the token is created, it checks the printed values of the Mirror-Sigil Sergeant it’s copying — or, if the Mirror-Sigil Sergeant whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the Mirror-Sigil Sergeant, nor will it copy other effects that have changed Mirror-Sigil Sergeant’s power, toughness, types, color, or so on."
+          "text": "Here's the detailed version of what happens. As the token is created, it checks the printed values of the Mirror-Sigil Sergeant it's copying — or, if the Mirror-Sigil Sergeant whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the Mirror-Sigil Sergeant, nor will it copy other effects that have changed Mirror-Sigil Sergeant's power, toughness, types, color, or so on."
         },
         {
           "date": "2009-02-01",
-          "text": "If Mirror-Sigil Sergeant has left the battlefield by the time its triggered ability resolves, you’ll still put a token onto the battlefield. That token has the copiable values of the characteristics of Mirror-Sigil Sergeant as it last existed on the battlefield."
+          "text": "If Mirror-Sigil Sergeant has left the battlefield by the time its triggered ability resolves, you'll still put a token onto the battlefield. That token has the copiable values of the characteristics of Mirror-Sigil Sergeant as it last existed on the battlefield."
         },
         {
           "date": "2009-02-01",
@@ -1403,7 +1403,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If either ability is activated after blockers have been declared, it won’t cause those blocks to change."
+          "text": "If either ability is activated after blockers have been declared, it won't cause those blocks to change."
         },
         {
           "date": "2009-02-01",
@@ -1517,15 +1517,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "When Paragon of the Amesha’s activated ability resolves, Paragon of the Amesha will gain flying and lifelink in addition to its other abilities. However, becoming an Angel will make it lose all other creature types. It will no longer be a Human or a Knight."
+          "text": "When Paragon of the Amesha's activated ability resolves, Paragon of the Amesha will gain flying and lifelink in addition to its other abilities. However, becoming an Angel will make it lose all other creature types. It will no longer be a Human or a Knight."
         },
         {
           "date": "2009-02-01",
-          "text": "If Paragon of the Amesha gains flying after blockers have been declared, it won’t cause those blocks to change."
+          "text": "If Paragon of the Amesha gains flying after blockers have been declared, it won't cause those blocks to change."
         },
         {
           "date": "2009-10-01",
-          "text": "You can activate Paragon of the Amesha’s ability more than once during a turn. The second time it resolves, it will get another +3/+3 and gain another instance of lifelink. However, multiple instances of lifelink are redundant so you won’t gain extra life from the new one."
+          "text": "You can activate Paragon of the Amesha's ability more than once during a turn. The second time it resolves, it will get another +3/+3 and gain another instance of lifelink. However, multiple instances of lifelink on the same creature are redundant so you won't gain extra life from the new one."
         }
       ],
       "subtypes": [
@@ -1638,11 +1638,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature’s controller won’t search for a basic land card."
+          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature's controller won't search for a basic land card."
         },
         {
           "date": "2017-03-14",
-          "text": "The controller of the exiled creature isn’t required to search his or her library for a basic land. If that player doesn’t, the player won’t shuffle his or her library."
+          "text": "The controller of the exiled creature isn't required to search his or her library for a basic land. If that player doesn't, the player won't shuffle his or her library."
         }
       ],
       "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
@@ -1743,7 +1743,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The “intervening ‘if’ clause” means that (1) the ability won’t trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
+          "text": "The \"intervening 'if' clause\" means that (1) the ability won't trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
         }
       ],
       "subtypes": [
@@ -1950,11 +1950,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can’t play an Aura spell intending to enchant the Angel that will be created as a result."
+          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can't play an Aura spell intending to enchant the Angel that will be created as a result."
         },
         {
           "date": "2009-02-01",
-          "text": "Casting Sigil of the Empty Throne won’t trigger its own ability. It has to be on the battlefield for its ability to work."
+          "text": "Casting Sigil of the Empty Throne won't trigger its own ability. It has to be on the battlefield for its ability to work."
         }
       ],
       "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
@@ -2154,7 +2154,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "This ability triggers and resolves before “until end of turn” effects have worn off."
+          "text": "This ability triggers and resolves before \"until end of turn\" effects have worn off."
         }
       ],
       "subtypes": [
@@ -2462,7 +2462,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "Controlled Instincts can enchant only a creature that’s red or green. If at any time the enchanted creature is neither red nor green, Controlled Instincts is put into its owner’s graveyard as a state-based action."
+          "text": "Controlled Instincts can enchant only a creature that's red or green. If at any time the enchanted creature is neither red nor green, Controlled Instincts is put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -2662,7 +2662,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "When Esperzoa’s ability resolves, if you control no other artifacts, you’ll have to return Esperzoa itself."
+          "text": "When Esperzoa's ability resolves, if you control no other artifacts, you'll have to return Esperzoa itself."
         }
       ],
       "subtypes": [
@@ -3080,7 +3080,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "The affected land loses its existing land types and any abilities printed on it. It becomes the chosen basic land type and now has the ability to tap to add one mana of the appropriate color to your mana pool. Grixis Illusionist’s ability doesn’t change the affected land’s name or whether it’s legendary or basic."
+          "text": "The affected land loses its existing land types and any abilities printed on it. It becomes the chosen basic land type and now has the ability to tap to add one mana of the appropriate color to your mana pool. Grixis Illusionist's ability doesn't change the affected land's name or whether it's legendary or basic."
         }
       ],
       "subtypes": [
@@ -3290,7 +3290,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Returning an artifact you control to its owner’s hand is part of the cost of Master Transmuter’s activated ability. Paying a cost can’t be responded to (with Naturalize, for example)."
+          "text": "Returning an artifact you control to its owner's hand is part of the cost of Master Transmuter's activated ability. Paying a cost can't be responded to (with Naturalize, for example)."
         },
         {
           "date": "2009-02-01",
@@ -3405,7 +3405,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The “intervening ‘if’ clause” means that (1) the ability won’t trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
+          "text": "The \"intervening 'if' clause\" means that (1) the ability won't trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
         }
       ],
       "subtypes": [
@@ -3705,7 +3705,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If there are no creature cards in the targeted opponent’s library, that player will put his or her entire library into his or her graveyard."
+          "text": "If there are no creature cards in the targeted opponent's library, that player will put his or her entire library into his or her graveyard."
         }
       ],
       "text": "Target opponent reveals cards from the top of his or her library until he or she reveals a creature card. That player puts all noncreature cards revealed this way into his or her graveyard, then you put the creature card onto the battlefield under your control.",
@@ -3807,7 +3807,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -3884,6 +3884,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -4041,7 +4045,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "If you control a white permanent, View from Above moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don’t control a white permanent, View from Above is put into the graveyard from the stack as normal."
+          "text": "If you control a white permanent, View from Above moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don't control a white permanent, View from Above is put into the graveyard from the stack as normal."
         },
         {
           "date": "2009-02-01",
@@ -4162,7 +4166,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
@@ -4264,7 +4268,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -4376,11 +4380,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Corrupted Roots can enchant only a Forest or a Plains. It checks the enchanted land’s subtypes, not its name. If at any time the enchanted land is neither a Forest nor a Plains (due to Unstable Frontier’s ability, perhaps), Corrupted Roots is put into its owner’s graveyard as a state-based action."
+          "text": "Corrupted Roots can enchant only a Forest or a Plains. It checks the enchanted land's subtypes, not its name. If at any time the enchanted land is neither a Forest nor a Plains (due to Unstable Frontier's ability, perhaps), Corrupted Roots is put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2009-02-01",
-          "text": "Corrupted Roots doesn’t care why the enchanted land becomes tapped. If that land changes from being untapped to being tapped for any reason, the ability will trigger."
+          "text": "Corrupted Roots doesn't care why the enchanted land becomes tapped. If that land changes from being untapped to being tapped for any reason, the ability will trigger."
         }
       ],
       "subtypes": [
@@ -4492,7 +4496,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Target creature gets -1/-1 until end of turn for each basic land type among lands you control.",
@@ -4698,11 +4702,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon’s triggered ability will trigger."
+          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon's triggered ability will trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "You can target any player with Extractor Demon’s triggered ability. The target doesn’t have to be the controller of the creature that left the battlefield."
+          "text": "You can target any player with Extractor Demon's triggered ability. The target doesn't have to be the controller of the creature that left the battlefield."
         }
       ],
       "subtypes": [
@@ -4811,11 +4815,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Fleshformer’s ability has only one target: the creature. If that creature becomes an illegal target by the time Fleshformer’s ability would resolve, the entire ability is countered. Fleshformer won’t get +2/+2 and won’t gain fear."
+          "text": "Fleshformer's ability has only one target: the creature. If that creature becomes an illegal target by the time Fleshformer's ability would resolve, the entire ability is countered. Fleshformer won't get +2/+2 and won't gain fear."
         },
         {
           "date": "2009-02-01",
-          "text": "Fleshformer can target itself with its ability. The result is that Fleshformer gains fear, since the +2/+2 and -2/-2 parts of the effect will balance each other out. (Fleshformer’s power and toughness will each momentarily go up by 2, in case anything cares about that.)"
+          "text": "Fleshformer can target itself with its ability. The result is that Fleshformer gains fear, since the +2/+2 and -2/-2 parts of the effect will balance each other out. (Fleshformer's power and toughness will each momentarily go up by 2, in case anything cares about that.)"
         }
       ],
       "subtypes": [
@@ -5123,7 +5127,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The “intervening ‘if’ clause” means that (1) the ability won’t trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
+          "text": "The \"intervening 'if' clause\" means that (1) the ability won't trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
         }
       ],
       "subtypes": [
@@ -5232,15 +5236,15 @@
         },
         {
           "date": "2009-02-01",
-          "text": "In a multiplayer game, if the chosen player leaves the game, Nyxathid’s second ability simply won’t do anything anymore."
+          "text": "In a multiplayer game, if the chosen player leaves the game, Nyxathid's second ability simply won't do anything anymore."
         },
         {
           "date": "2009-02-01",
-          "text": "Nyxathid’s two abilities are linked: The second one refers only to the player chosen by the first one. If another creature becomes a copy of Nyxathid (due to Mirrorweave, for example), the second ability won’t do anything because a player was never chosen as a result of the first ability. This is true even if a different ability allowed a player to be chosen as that creature entered the battlefield."
+          "text": "Nyxathid's two abilities are linked: The second one refers only to the player chosen by the first one. If another creature becomes a copy of Nyxathid (due to Mirrorweave, for example), the second ability won't do anything because a player was never chosen as a result of the first ability. This is true even if a different ability allowed a player to be chosen as that creature entered the battlefield."
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell or ability causes the chosen player to draw cards and then discard cards, Nyxathid’s power and toughness changes accordingly as that spell or ability is resolving. For example, if the chosen player has five cards in hand and a spell causes that player to draw two cards then discard two cards, Nyxathid will start out as 2/2, then become 1/1, 0/0, and finally 2/2. This is because cards are always drawn one at a time, but multiple cards may be discarded at once. Although Nyxathid momentarily had 0 toughness while that spell was resolving, it isn’t put into its owner’s graveyard as a state-based action because state-based actions aren’t checked until the spell has finished resolving."
+          "text": "If a spell or ability causes the chosen player to draw cards and then discard cards, Nyxathid's power and toughness changes accordingly as that spell or ability is resolving. For example, if the chosen player has five cards in hand and a spell causes that player to draw two cards then discard two cards, Nyxathid will start out as 2/2, then become 1/1, 0/0, and finally 2/2. This is because cards are always drawn one at a time, but multiple cards may be discarded at once. Although Nyxathid momentarily had 0 toughness while that spell was resolving, it isn't put into its owner's graveyard as a state-based action because state-based actions aren't checked until the spell has finished resolving."
         }
       ],
       "subtypes": [
@@ -5445,7 +5449,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "When Rotting Rats’s enters-the-battlefield ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order does the same, then all cards are discarded at the same time. No one sees what the other players are discarding before deciding which card to discard."
+          "text": "When Rotting Rats's enters-the-battlefield ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order does the same, then all cards are discarded at the same time. No one sees what the other players are discarding before deciding which card to discard."
         }
       ],
       "subtypes": [
@@ -5746,11 +5750,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The “intervening ‘if’ clause” means that (1) the ability won’t trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
+          "text": "The \"intervening 'if' clause\" means that (1) the ability won't trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
         },
         {
           "date": "2009-02-01",
-          "text": "This ability isn’t optional. When Sedraxis Alchemist enters the battlefield, if you control a blue permanent and no other player controls a nonland permanent, you’ll have to target a nonland permanent you control."
+          "text": "This ability isn't optional. When Sedraxis Alchemist enters the battlefield, if you control a blue permanent and no other player controls a nonland permanent, you'll have to target a nonland permanent you control."
         }
       ],
       "subtypes": [
@@ -5863,7 +5867,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Target player discards a card for each basic land type among lands you control.",
@@ -5963,7 +5967,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Wretched Banquet may target any creature. The creature’s power is checked only as Wretched Banquet resolves. If another creature has less power than the targeted creature at that time, Wretched Banquet does nothing."
+          "text": "Wretched Banquet may target any creature. The creature's power is checked only as Wretched Banquet resolves. If another creature has less power than the targeted creature at that time, Wretched Banquet does nothing."
         }
       ],
       "text": "Destroy target creature if it has the least power or is tied for least power among creatures on the battlefield.",
@@ -6168,11 +6172,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "Banefire can be targeted by spells that try to counter it (such as Countersquall) regardless of what the value of X is. If X is 5 or more, those spells will still resolve, but the part of their effect that would counter Banefire won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Banefire can be targeted by spells that try to counter it (such as Countersquall) regardless of what the value of X is. If X is 5 or more, those spells will still resolve, but the part of their effect that would counter Banefire won't do anything. Any other effects those spells have will work as normal."
         },
         {
           "date": "2009-02-01",
-          "text": "Banefire’s ability won’t prevent it from being countered by the game rules if its target has become an illegal target."
+          "text": "Banefire's ability won't prevent it from being countered by the game rules if its target has become an illegal target."
         }
       ],
       "text": "Banefire deals X damage to target creature or player.\nIf X is 5 or more, Banefire can't be countered by spells or abilities and the damage can't be prevented.",
@@ -6273,11 +6277,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The “intervening ‘if’ clause” means that (1) the ability won’t trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
+          "text": "The \"intervening 'if' clause\" means that (1) the ability won't trigger at all unless you control a permanent of the specified color, and (2) the ability will do nothing unless you control a permanent of the specified color at the time it resolves."
         },
         {
           "date": "2009-02-01",
-          "text": "A permanent that’s both black and green will allow both abilities to trigger (as will separate black permanents and green permanents, of course)."
+          "text": "A permanent that's both black and green will allow both abilities to trigger (as will separate black permanents and green permanents, of course)."
         }
       ],
       "subtypes": [
@@ -6487,7 +6491,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "Dark Temper has a self-replacement effect, which applies before other prevention or replacement effects would. If you control a black permanent as Dark Temper resolves, it doesn’t deal damage at all (so damage prevention or redirection effects would have no effect); it simply destroys the targeted creature."
+          "text": "Dark Temper has a self-replacement effect, which applies before other prevention or replacement effects would. If you control a black permanent as Dark Temper resolves, it doesn't deal damage at all (so damage prevention or redirection effects would have no effect); it simply destroys the targeted creature."
         }
       ],
       "text": "Dark Temper deals 2 damage to target creature. If you control a black permanent, destroy the creature instead.",
@@ -6593,15 +6597,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "When Dragonsoul Knight’s activated ability resolves, Dragonsoul Knight will gain flying and trample in addition to its other abilities. However, becoming a Dragon will make it lose all other creature types. It will no longer be a Human or a Knight."
+          "text": "When Dragonsoul Knight's activated ability resolves, Dragonsoul Knight will gain flying and trample in addition to its other abilities. However, becoming a Dragon will make it lose all other creature types. It will no longer be a Human or a Knight."
         },
         {
           "date": "2009-02-01",
-          "text": "If Dragonsoul Knight gains flying after blockers have been declared, it won’t cause those blocks to change."
+          "text": "If Dragonsoul Knight gains flying after blockers have been declared, it won't cause those blocks to change."
         },
         {
           "date": "2009-02-01",
-          "text": "You can activate Dragonsoul Knight’s ability more than once during a turn. The second time it resolves, it will probably have no visible effect other than giving Dragonsoul Knight another +5/+3."
+          "text": "You can activate Dragonsoul Knight's ability more than once during a turn. The second time it resolves, it will probably have no visible effect other than giving Dragonsoul Knight another +5/+3."
         }
       ],
       "subtypes": [
@@ -6714,7 +6718,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -6827,7 +6831,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "You don’t count how many +1/+1 counters are on Goblin Razerunners until its triggered ability resolves."
+          "text": "You don't count how many +1/+1 counters are on Goblin Razerunners until its triggered ability resolves."
         },
         {
           "date": "2009-02-01",
@@ -7359,7 +7363,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "Any permanent that’s both an artifact and a creature is a legal target for Molten Frame."
+          "text": "Any permanent that's both an artifact and a creature is a legal target for Molten Frame."
         }
       ],
       "text": "Destroy target artifact creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
@@ -7460,11 +7464,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "After Quenchable Fire resolves, the targeted player becomes able to perform a special action of paying {U}. This action may be performed any time the player has priority, and it doesn’t use the stack. It may be performed only once, and only before your next upkeep begins. If the player has performed the action by then, the “deal an additional 3 damage” ability won’t trigger. Otherwise, it will. If it triggers, the player can’t stop it by paying {U}."
+          "text": "After Quenchable Fire resolves, the targeted player becomes able to perform a special action of paying {U}. This action may be performed any time the player has priority, and it doesn't use the stack. It may be performed only once, and only before your next upkeep begins. If the player has performed the action by then, the \"deal an additional 3 damage\" ability won't trigger. Otherwise, it will. If it triggers, the player can't stop it by paying {U}."
         },
         {
           "date": "2009-02-01",
-          "text": "Quenchable Fire’s delayed triggered ability (and the special action of paying {U}) will affect the player who was targeted by the spell, even if the original 3 damage is prevented or redirected to a different creature or player."
+          "text": "Quenchable Fire's delayed triggered ability (and the special action of paying {U}) will affect the player who was targeted by the spell, even if the original 3 damage is prevented or redirected to a different creature or player."
         }
       ],
       "text": "Quenchable Fire deals 3 damage to target player. It deals an additional 3 damage to that player at the beginning of your next upkeep step unless he or she pays {U} before that step.",
@@ -7668,7 +7672,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "As long as at least one permanent you control is the specified color, the ability will “work” and grant this creature the bonus. Otherwise, it won’t have the bonus."
+          "text": "As long as at least one permanent you control is the specified color, the ability will \"work\" and grant this creature the bonus. Otherwise, it won't have the bonus."
         },
         {
           "date": "2009-02-01",
@@ -7882,7 +7886,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Volcanic Fallout can be targeted by spells that try to counter it (such as Countersquall). Those spells will still resolve, but the part of their effect that would counter Volcanic Fallout won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Volcanic Fallout can be targeted by spells that try to counter it (such as Countersquall). Those spells will still resolve, but the part of their effect that would counter Volcanic Fallout won't do anything. Any other effects those spells have will work as normal."
         }
       ],
       "text": "Volcanic Fallout can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
@@ -7987,7 +7991,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "“The number of Goblins it devoured” means “The number of Goblins sacrificed as a result of its devour ability as it entered the battlefield.” For each creature that Voracious Dragon devoured, this ability checks its creature type as it last existed on the battlefield to see if it was a Goblin at that time."
+          "text": "\"The number of Goblins it devoured\" means \"The number of Goblins sacrificed as a result of its devour ability as it entered the battlefield.\" For each creature that Voracious Dragon devoured, this ability checks its creature type as it last existed on the battlefield to see if it was a Goblin at that time."
         }
       ],
       "subtypes": [
@@ -8100,7 +8104,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -8210,7 +8214,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Casting Worldheart Phoenix from your graveyard by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
+          "text": "Casting Worldheart Phoenix from your graveyard by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
         },
         {
           "date": "2009-02-01",
@@ -8218,7 +8222,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "As soon as you start to cast Worldheart Phoenix from your graveyard, the card moves onto the stack. At that point, it’s too late for an opponent to prevent you from casting it by removing it from your graveyard."
+          "text": "As soon as you start to cast Worldheart Phoenix from your graveyard, the card moves onto the stack. At that point, it's too late for an opponent to prevent you from casting it by removing it from your graveyard."
         }
       ],
       "subtypes": [
@@ -8422,15 +8426,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "As long as at least one permanent you control is the specified color, the ability will “work” and grant this creature the bonus. Otherwise, it won’t have the bonus."
+          "text": "As long as at least one permanent you control is the specified color, the ability will \"work\" and grant this creature the bonus. Otherwise, it won't have the bonus."
         },
         {
           "date": "2009-02-01",
-          "text": "Whether Cliffrunner Behemoth has haste matters only when attackers are declared. Once it’s been declared as an attacker, it doesn’t matter if it loses haste."
+          "text": "Whether Cliffrunner Behemoth has haste matters only when attackers are declared. Once it's been declared as an attacker, it doesn't matter if it loses haste."
         },
         {
           "date": "2009-02-01",
-          "text": "Whether Cliffrunner Behemoth has lifelink matters only when it deals damage (that is, at the point when its combat damage resolves, or at the point when a spell or ability that causes it to deal damage resolves). For example, if your only white permanent is a creature that receives lethal damage at the same time Cliffrunner Behemoth deals damage, the lifelink ability will still apply and you’ll gain life."
+          "text": "Whether Cliffrunner Behemoth has lifelink matters only when it deals damage (that is, at the point when its combat damage resolves, or at the point when a spell or ability that causes it to deal damage resolves). For example, if your only white permanent is a creature that receives lethal damage at the same time Cliffrunner Behemoth deals damage, the lifelink ability will still apply and you'll gain life."
         }
       ],
       "subtypes": [
@@ -8538,7 +8542,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "When the ability resolves, it gives the +3/+3 bonus to the source of the ability and each other creature that shares a name with that source, even if that source isn’t actually named Cylian Sunsinger. This could happen if Skill Borrower gains this ability, or if Cylian Sunsinger’s name is changed (due to Mirrorweave, perhaps) before the ability resolves."
+          "text": "When the ability resolves, it gives the +3/+3 bonus to the source of the ability and each other creature that shares a name with that source, even if that source isn't actually named Cylian Sunsinger. This could happen if Skill Borrower gains this ability, or if Cylian Sunsinger's name is changed (due to Mirrorweave, perhaps) before the ability resolves."
         },
         {
           "date": "2009-02-01",
@@ -8648,7 +8652,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "As long as at least one permanent you control is the specified color, the ability will “work” and grant this creature the bonus. Otherwise, it won’t have the bonus."
+          "text": "As long as at least one permanent you control is the specified color, the ability will \"work\" and grant this creature the bonus. Otherwise, it won't have the bonus."
         },
         {
           "date": "2009-02-01",
@@ -8961,11 +8965,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         },
         {
           "date": "2009-02-01",
-          "text": "Matca Rioters’ ability is a “characteristic-defining ability.” It applies at all times in all zones."
+          "text": "Matca Rioters' ability is a \"characteristic-defining ability.\" It applies at all times in all zones."
         }
       ],
       "subtypes": [
@@ -9078,7 +9082,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
@@ -9179,7 +9183,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "“Protection from artifacts” means the following: -- Nacatl Savage can't be blocked by artifact creatures. -- Nacatl Savage can't be equipped. It also can't be enchanted by Auras that have somehow become artifacts in addition to enchantments. -- Nacatl Savage can't be targeted by abilities from artifact sources. -- All damage that would be dealt to Nacatl Savage by artifact sources is prevented."
+          "text": "\"Protection from artifacts\" means the following: -- Nacatl Savage can't be blocked by artifact creatures. -- Nacatl Savage can't be equipped. It also can't be enchanted by Auras that have somehow become artifacts in addition to enchantments. -- Nacatl Savage can't be targeted by abilities from artifact sources. -- All damage that would be dealt to Nacatl Savage by artifact sources is prevented."
         }
       ],
       "subtypes": [
@@ -9389,7 +9393,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If Paleoloth and another creature with power 5 or greater enter the battlefield under your control at the same time, Paleoloth’s triggered ability will trigger."
+          "text": "If Paleoloth and another creature with power 5 or greater enter the battlefield under your control at the same time, Paleoloth's triggered ability will trigger."
         }
       ],
       "subtypes": [
@@ -9695,7 +9699,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "You don’t have to find all four cards."
+          "text": "You don't have to find all four cards."
         },
         {
           "date": "2009-02-01",
@@ -9703,7 +9707,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "You may find “dual lands” with Shard Convergence. The Plains card you find, for example, can have a second subtype. What subtypes it has won’t impact what other cards you can find. For example, you may find a Hallowed Fountain (which has subtypes Plains and Island) as the Plains card, and another Hallowed Fountain as the Island card."
+          "text": "You may find \"dual lands\" with Shard Convergence. The Plains card you find, for example, can have a second subtype. What subtypes it has won't impact what other cards you can find. For example, you may find a Hallowed Fountain (which has subtypes Plains and Island) as the Plains card, and another Hallowed Fountain as the Island card."
         }
       ],
       "text": "Search your library for a Plains card, an Island card, a Swamp card, and a Mountain card. Reveal those cards and put them into your hand. Then shuffle your library.",
@@ -9803,7 +9807,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Soul’s Majesty’s only target is the creature. If that creature becomes an illegal target by the time Soul’s Majesty would resolve, the entire spell is countered. You won’t draw any cards."
+          "text": "Soul's Majesty's only target is the creature. If that creature becomes an illegal target by the time Soul's Majesty would resolve, the entire spell is countered. You won't draw any cards."
         }
       ],
       "text": "Draw cards equal to the power of target creature you control.",
@@ -9911,7 +9915,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Create a 1/1 green Saproling creature token for each basic land type among lands you control.",
@@ -10016,7 +10020,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -10128,7 +10132,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -10551,15 +10555,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Blood Tyrant’s second ability causes each player to lose 1 life, including you. Blood Tyrant will count each player’s life loss, including yours, when determining how many +1/+1 counters it gets."
+          "text": "Blood Tyrant's second ability causes each player to lose 1 life, including you. Blood Tyrant will count each player's life loss, including yours, when determining how many +1/+1 counters it gets."
         },
         {
           "date": "2009-02-01",
-          "text": "Blood Tyrant’s third ability will trigger no matter how a player loses the game: due to a state-based action (as a result of having a life total of 0 or less, trying to draw a card from an empty library, or having ten poison counters), a spell or ability that says that player loses the game, a concession, or a game loss awarded by a judge."
+          "text": "Blood Tyrant's third ability will trigger no matter how a player loses the game: due to a state-based action (as a result of having a life total of 0 or less, trying to draw a card from an empty library, or having ten poison counters), a spell or ability that says that player loses the game, a concession, or a game loss awarded by a judge."
         },
         {
           "date": "2009-02-01",
-          "text": "In a multiplayer game using the limited range of influence option (such as a Grand Melee game), if a spell or ability says that you win the game, it instead causes all of your opponents within your range of influence to lose the game. This is another way by which Blood Tyrant’s third ability can trigger."
+          "text": "In a multiplayer game using the limited range of influence option (such as a Grand Melee game), if a spell or ability says that you win the game, it instead causes all of your opponents within your range of influence to lose the game. This is another way by which Blood Tyrant's third ability can trigger."
         }
       ],
       "subtypes": [
@@ -10893,11 +10897,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "You don’t have to find all five cards."
+          "text": "You don't have to find all five cards."
         },
         {
           "date": "2009-02-01",
-          "text": "You may find multicolored cards with Conflux. The white card you find, for example, can be any number of colors, as long as white is one of them. What colors it is won’t impact what other cards you can find. For example, you may find a white-blue card as the white card and another white-blue card as the blue card."
+          "text": "You may find multicolored cards with Conflux. The white card you find, for example, can be any number of colors, as long as white is one of them. What colors it is won't impact what other cards you can find. For example, you may find a white-blue card as the white card and another white-blue card as the blue card."
         }
       ],
       "text": "Search your library for a white card, a blue card, a black card, a red card, and a green card. Reveal those cards and put them into your hand. Then shuffle your library.",
@@ -11314,19 +11318,19 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         },
         {
           "date": "2009-02-01",
-          "text": "You do what the spell says in order, so you’ll put a new basic land card onto the battlefield before you determine the value of X."
+          "text": "You do what the spell says in order, so you'll put a new basic land card onto the battlefield before you determine the value of X."
         },
         {
           "date": "2009-02-01",
-          "text": "Exploding Borders will still deal damage even if you don’t put a land card onto the battlefield."
+          "text": "Exploding Borders will still deal damage even if you don't put a land card onto the battlefield."
         },
         {
           "date": "2009-02-01",
-          "text": "Exploding Borders has only one target: the player. If that player becomes an illegal target by the time Exploding Borders would resolve, the entire spell is countered. You won’t get to search for a basic land card."
+          "text": "Exploding Borders has only one target: the player. If that player becomes an illegal target by the time Exploding Borders would resolve, the entire spell is countered. You won't get to search for a basic land card."
         }
       ],
       "text": "Domain — Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library. Exploding Borders deals X damage to target player, where X is the number of basic land types among lands you control.",
@@ -11747,7 +11751,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "Creatures with bribery counters on them can’t be declared as attackers or blockers. However, if a bribery counter is put on a creature that’s already been declared as an attacker or blocker, that creature will continue to attack or block that combat."
+          "text": "Creatures with bribery counters on them can't be declared as attackers or blockers. However, if a bribery counter is put on a creature that's already been declared as an attacker or blocker, that creature will continue to attack or block that combat."
         }
       ],
       "subtypes": [
@@ -11860,7 +11864,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Hellkite Hatchling has flying and trample if at least one creature was sacrificed as a result of the Hatchling’s devour ability as it entered the battlefield. It retains those abilities even if its +1/+1 counters are somehow removed."
+          "text": "Hellkite Hatchling has flying and trample if at least one creature was sacrificed as a result of the Hatchling's devour ability as it entered the battlefield. It retains those abilities even if its +1/+1 counters are somehow removed."
         },
         {
           "date": "2009-02-01",
@@ -11971,7 +11975,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "After blockers have been declared, activating the second ability won’t cause those blocks to change."
+          "text": "After blockers have been declared, activating the second ability won't cause those blocks to change."
         }
       ],
       "subtypes": [
@@ -12081,15 +12085,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The activated ability’s cost checks the land’s subtype, not its name. You can sacrifice a nonbasic land this way as long as it has the subtype Forest or Plains."
+          "text": "The activated ability's cost checks the land's subtype, not its name. You can sacrifice a nonbasic land this way as long as it has the subtype Forest or Plains."
         },
         {
           "date": "2009-02-01",
-          "text": "Sacrificing a Forest or Plains is part of the cost of Knight of the Reliquary’s activated ability. Assuming that sacrificing the land puts it into your graveyard, Knight of the Reliquary’s first ability will immediately give it an additional +1/+1 when that cost is paid because there’ll be a new land card in your graveyard. Paying a cost can’t be responded to (with Shock, for example)."
+          "text": "Sacrificing a Forest or Plains is part of the cost of Knight of the Reliquary's activated ability. Assuming that sacrificing the land puts it into your graveyard, Knight of the Reliquary's first ability will immediately give it an additional +1/+1 when that cost is paid because there'll be a new land card in your graveyard. Paying a cost can't be responded to (with Shock, for example)."
         },
         {
           "date": "2009-02-01",
-          "text": "Knight of the Reliquary’s activated ability lets you find any land card, not just a basic land card."
+          "text": "Knight of the Reliquary's activated ability lets you find any land card, not just a basic land card."
         }
       ],
       "subtypes": [
@@ -12307,11 +12311,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If you want to cast a card this way, you cast it as part of the resolution of Maelstrom Angel’s triggered ability. Timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other casting restrictions are not (such as “Cast [this card] only before attackers are declared”)."
+          "text": "If you want to cast a card this way, you cast it as part of the resolution of Maelstrom Angel's triggered ability. Timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other casting restrictions are not (such as \"Cast [this card] only before attackers are declared\")."
         },
         {
           "date": "2009-02-01",
-          "text": "If you cast a card this way, you’re casting it as a spell. It can be countered."
+          "text": "If you cast a card this way, you're casting it as a spell. It can be countered."
         },
         {
           "date": "2009-02-01",
@@ -12319,7 +12323,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. However, you can pay optional additional costs, such as conspire, and you must still pay mandatory additional costs, such as the one on Goldmeadow Stalwart."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. However, you can pay optional additional costs, such as conspire, and you must still pay mandatory additional costs, such as the one on Goldmeadow Stalwart."
         }
       ],
       "subtypes": [
@@ -12433,11 +12437,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "For a player’s life total to become 10, what actually happens is that the player gains or loses the appropriate amount of life. For example, if the targeted player’s life total is 4 when this ability resolves, it will cause that player to gain 6 life; alternately, if the targeted player’s life total is 17 when this ability resolves, it will cause that player to lose 7 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For a player's life total to become 10, what actually happens is that the player gains or loses the appropriate amount of life. For example, if the targeted player's life total is 4 when this ability resolves, it will cause that player to gain 6 life; alternately, if the targeted player's life total is 17 when this ability resolves, it will cause that player to lose 7 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, this ability basically causes the team’s life total to become 10, but only the targeted player is considered to have actually gained or lost life."
+          "text": "In a Two-Headed Giant game, this ability basically causes the team's life total to become 10, but only the targeted player is considered to have actually gained or lost life."
         }
       ],
       "subtypes": [
@@ -12665,7 +12669,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "You don’t check Meglonoth’s power until its triggered ability resolves."
+          "text": "You don't check Meglonoth's power until its triggered ability resolves."
         },
         {
           "date": "2009-02-01",
@@ -12890,7 +12894,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If the damage from Nicol Bolas’s third ability is prevented or redirected, the rest of the effect will still happen. Specifically, the number of cards discarded and permanents sacrificed isn’t tied to the amount of damage dealt."
+          "text": "If the damage from Nicol Bolas's third ability is prevented or redirected, the rest of the effect will still happen. Specifically, the number of cards discarded and permanents sacrificed isn't tied to the amount of damage dealt."
         },
         {
           "date": "2012-07-01",
@@ -13008,11 +13012,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "“Protection from everything” means the following: Progenitus can’t be blocked, Progenitus can’t be enchanted or equipped, Progenitus can’t be the target of spells or abilities, and all damage that would be dealt to Progenitus is prevented."
+          "text": "\"Protection from everything\" means the following: Progenitus can't be blocked, Progenitus can't be enchanted or equipped, Progenitus can't be the target of spells or abilities, and all damage that would be dealt to Progenitus is prevented."
         },
         {
           "date": "2009-02-01",
-          "text": "Progenitus can still be affected by effects that don’t target it or deal damage to it (such as Day of Judgment)."
+          "text": "Progenitus can still be affected by effects that don't target it or deal damage to it (such as Day of Judgment)."
         }
       ],
       "subtypes": [
@@ -13542,11 +13546,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If Sludge Strider and another artifact enter the battlefield under your control at the same time, Sludge Strider’s triggered ability will trigger. Similarly, if Sludge Strider and another artifact you control leave the battlefield at the same time, Sludge Strider’s triggered ability will trigger."
+          "text": "If Sludge Strider and another artifact enter the battlefield under your control at the same time, Sludge Strider's triggered ability will trigger. Similarly, if Sludge Strider and another artifact you control leave the battlefield at the same time, Sludge Strider's triggered ability will trigger."
         },
         {
           "date": "2009-02-01",
-          "text": "If an artifact creature with 0 toughness enters the battlefield under your control, Sludge Strider’s ability will trigger a total of twice: Once when that creature enters the battlefield, and once when it’s put into a graveyard. Both abilities will be put on the stack after the state-based action check that puts the 0-toughness creature into the graveyard is finished."
+          "text": "If an artifact creature with 0 toughness enters the battlefield under your control, Sludge Strider's ability will trigger a total of twice: Once when that creature enters the battlefield, and once when it's put into a graveyard. Both abilities will be put on the stack after the state-based action check that puts the 0-toughness creature into the graveyard is finished."
         }
       ],
       "subtypes": [
@@ -13761,7 +13765,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Suicidal Charge’s ability affects only the creatures your opponents control at the time it resolves. If another creature comes under the control of one of those players by the time that turn’s combat step begins, it won’t have to attack."
+          "text": "Suicidal Charge's ability affects only the creatures your opponents control at the time it resolves. If another creature comes under the control of one of those players by the time that turn's combat step begins, it won't have to attack."
         }
       ],
       "text": "Sacrifice Suicidal Charge: Creatures your opponents control get -1/-1 until end of turn. Those creatures attack this turn if able.",
@@ -13864,7 +13868,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "This ability checks the targeted creature’s power only at the time the ability is activated and at the time it resolves. The regeneration shield it creates will work no matter what that creature’s power is at the time it would be destroyed."
+          "text": "This ability checks the targeted creature's power only at the time the ability is activated and at the time it resolves. The regeneration shield it creates will work no matter what that creature's power is at the time it would be destroyed."
         }
       ],
       "subtypes": [
@@ -14857,7 +14861,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -15049,11 +15053,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Mana produced by Ancient Ziggurat can be spent on any part of a creature spell’s total cost. This includes additional costs (such as kicker) and alternative costs (such as evoke or Worldheart Phoenix’s alternative cost)."
+          "text": "Mana produced by Ancient Ziggurat can be spent on any part of a creature spell's total cost. This includes additional costs (such as kicker) and alternative costs (such as evoke or Worldheart Phoenix's alternative cost)."
         },
         {
           "date": "2009-02-01",
-          "text": "Mana produced by Ancient Ziggurat can’t be spent on activated abilities that put a creature card directly onto the battlefield, such as unearth or ninjutsu."
+          "text": "Mana produced by Ancient Ziggurat can't be spent on activated abilities that put a creature card directly onto the battlefield, such as unearth or ninjutsu."
         }
       ],
       "text": "{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell.",
@@ -15149,23 +15153,23 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-02-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there are more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there are more than one, consider them in any possible order."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Exotic Orchard doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Lands that produce mana based only on what other lands “could produce” won’t help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent’s Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent’s Reflecting Pool can each produce {G} because your opponent’s Exotic Orchard can produce {G}."
+          "text": "Lands that produce mana based only on what other lands \"could produce\" won't help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent's Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent's Reflecting Pool can each produce {G} because your opponent's Exotic Orchard can produce {G}."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -15262,7 +15266,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you’ll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you'll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\n{T}: Add {C} to your mana pool.",
@@ -15451,7 +15455,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "The affected land loses its existing land types and any abilities printed on it. It becomes the chosen basic land type and now has the ability to tap to add one mana of the appropriate color to your mana pool. Unstable Frontier’s ability doesn’t change the affected land’s name or whether it’s legendary or basic."
+          "text": "The affected land loses its existing land types and any abilities printed on it. It becomes the chosen basic land type and now has the ability to tap to add one mana of the appropriate color to your mana pool. Unstable Frontier's ability doesn't change the affected land's name or whether it's legendary or basic."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}: Target land you control becomes the basic land type of your choice until end of turn.",

--- a/json/CPK.json
+++ b/json/CPK.json
@@ -639,7 +639,7 @@
         "KTK"
       ],
       "rarity": "Special",
-      "source": "CP1-Magic 2015",
+      "source": "CP2-Fate Reforged",
       "text": "At the beginning of your upkeep, look at the top two cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.",
       "type": "Enchantment",
       "types": [

--- a/json/CSP.json
+++ b/json/CSP.json
@@ -130,7 +130,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Adarkar Valkyrie’s ability can target a token creature, but since token creatures cease to exist when they leave the battlefield, it won’t be returned to the battlefield."
+          "text": "Adarkar Valkyrie's ability can target a token creature, but since token creatures cease to exist when they leave the battlefield, it won't be returned to the battlefield."
         }
       ],
       "subtypes": [
@@ -338,11 +338,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Cover of Winter’s replacement effect prevents combat damage creatures would deal to you and to attacking or blocking creatures you control."
+          "text": "Cover of Winter's replacement effect prevents combat damage creatures would deal to you and to attacking or blocking creatures you control."
         },
         {
           "date": "2006-07-15",
-          "text": "If multiple creatures would deal combat damage to you and your creatures at the same time, this prevents X of the damage that would be dealt by each of them. This prevention is applied creature by creature. For example, if Cover of Winter has two age counters and you’re being attacked by an unblocked 1/1 and an unblocked 4/4, this will prevent 2 of the combat damage that would be dealt by each one. All damage from the 1/1 is prevented and 2 damage from the 4/4 is prevented, meaning you’re dealt 2 damage."
+          "text": "If multiple creatures would deal combat damage to you and your creatures at the same time, this prevents X of the damage that would be dealt by each of them. This prevention is applied creature by creature. For example, if Cover of Winter has two age counters and you're being attacked by an unblocked 1/1 and an unblocked 4/4, this will prevent 2 of the combat damage that would be dealt by each one. All damage from the 1/1 is prevented and 2 damage from the 4/4 is prevented, meaning you're dealt 2 damage."
         },
         {
           "date": "2006-07-15",
@@ -350,7 +350,7 @@
         },
         {
           "date": "2006-07-15",
-          "text": "If a creature’s combat damage is assigned to multiple recipients (for example, if it has trample and is blocked by two creatures, and damage is assigned to each of those creatures and to you), you decide how to divide the prevention effect. You may prevent damage that would be dealt to the first creature, the second creature, and/or you, as long as the total amount of that creature’s damage that would be prevented is X."
+          "text": "If a creature's combat damage is assigned to multiple recipients (for example, if it has trample and is blocked by two creatures, and damage is assigned to each of those creatures and to you), you decide how to divide the prevention effect. You may prevent damage that would be dealt to the first creature, the second creature, and/or you, as long as the total amount of that creature's damage that would be prevented is X."
         }
       ],
       "supertypes": [
@@ -656,11 +656,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Gelid Shackles doesn’t stop static abilities or triggered abilities from working. It also won’t prevent the creature from attacking unless the enchanted creature is given defender before attackers are declared."
+          "text": "Gelid Shackles doesn't stop static abilities or triggered abilities from working. It also won't prevent the creature from attacking unless the enchanted creature is given defender before attackers are declared."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -866,7 +866,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "When paying Jötun Grunt’s cumulative upkeep, you may choose a different graveyard for each age counter. For example, if it has three age counters on it, you may put four cards from your graveyard on the bottom of your library and two cards from your opponent’s graveyard on the bottom of his or her library. However, you can’t put five cards from your graveyard on the bottom of your library and one card from your opponent’s graveyard on the bottom of his or her library."
+          "text": "When paying Jötun Grunt's cumulative upkeep, you may choose a different graveyard for each age counter. For example, if it has three age counters on it, you may put four cards from your graveyard on the bottom of your library and two cards from your opponent's graveyard on the bottom of his or her library. However, you can't put five cards from your graveyard on the bottom of your library and one card from your opponent's graveyard on the bottom of his or her library."
         }
       ],
       "subtypes": [
@@ -1169,7 +1169,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -1564,15 +1564,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Each card that’s revealed to pay the cost remains revealed until the ability leaves the stack."
+          "text": "Each card that's revealed to pay the cost remains revealed until the ability leaves the stack."
         },
         {
           "date": "2006-07-15",
-          "text": "A card that’s already revealed for another cost or because of an effect can be revealed to pay this cost."
+          "text": "A card that's already revealed for another cost or because of an effect can be revealed to pay this cost."
         },
         {
           "date": "2006-07-15",
-          "text": "If one of the cards that’s revealed to pay the cost leaves its owner’s hand before the ability resolves, it stops being revealed, but the value of X is not affected."
+          "text": "If one of the cards that's revealed to pay the cost leaves its owner's hand before the ability resolves, it stops being revealed, but the value of X is not affected."
         }
       ],
       "subtypes": [
@@ -1971,19 +1971,19 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Paying the alternative cost doesn’t change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
+          "text": "Paying the alternative cost doesn't change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
         },
         {
           "date": "2006-07-15",
-          "text": "You may pay the alternative cost rather than the card’s mana cost. Any additional costs are paid as normal."
+          "text": "You may pay the alternative cost rather than the card's mana cost. Any additional costs are paid as normal."
         },
         {
           "date": "2006-07-15",
-          "text": "If you don’t have two cards of the right color in your hand, you can’t choose to cast the spell using the alternative cost."
+          "text": "If you don't have two cards of the right color in your hand, you can't choose to cast the spell using the alternative cost."
         },
         {
           "date": "2006-07-15",
-          "text": "You can’t exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
+          "text": "You can't exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
         }
       ],
       "text": "You may exile two white cards from your hand rather than pay Sunscour's mana cost.\nDestroy all creatures.",
@@ -2375,11 +2375,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "When paying Wall of Shards’ cumulative upkeep, you may choose a different opponent for each age counter, or you can choose the same opponent multiple times."
+          "text": "When paying Wall of Shards' cumulative upkeep, you may choose a different opponent for each age counter, or you can choose the same opponent multiple times."
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -2586,11 +2586,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Having an ice counter on Woolly Razorback doesn’t prevent combat damage that would be dealt to it."
+          "text": "Having an ice counter on Woolly Razorback doesn't prevent combat damage that would be dealt to it."
         },
         {
           "date": "2006-07-15",
-          "text": "The third time Woolly Razorback blocks, its last ice counter will be removed, meaning the combat damage it deals that combat won’t be prevented."
+          "text": "The third time Woolly Razorback blocks, its last ice counter will be removed, meaning the combat damage it deals that combat won't be prevented."
         }
       ],
       "subtypes": [
@@ -2798,11 +2798,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Arcum Dagsson’s ability targets an artifact creature, not the controller of one."
+          "text": "Arcum Dagsson's ability targets an artifact creature, not the controller of one."
         },
         {
           "date": "2006-07-15",
-          "text": "Arcum Dagsson’s ability can target any permanent that’s both an artifact and a creature, such as a Grizzly Bears while Mycosynth Lattice is on the battlefield."
+          "text": "Arcum Dagsson's ability can target any permanent that's both an artifact and a creature, such as a Grizzly Bears while Mycosynth Lattice is on the battlefield."
         }
       ],
       "subtypes": [
@@ -2911,15 +2911,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Balduvian Frostwaker’s effect has no duration. The snow land is a creature as long as it’s on the battlefield."
+          "text": "Balduvian Frostwaker's effect has no duration. The snow land is a creature as long as it's on the battlefield."
         },
         {
           "date": "2006-07-15",
-          "text": "If an affected land later loses the supertype snow, Balduvian Frostwaker’s effect doesn’t end. The land will remain a creature."
+          "text": "If an affected land later loses the supertype snow, Balduvian Frostwaker's effect doesn't end. The land will remain a creature."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -3023,15 +3023,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If you gain control of an instant or sorcery spell with Commandeer, it will still be put into its owner’s graveyard when it resolves."
+          "text": "If you gain control of an instant or sorcery spell with Commandeer, it will still be put into its owner's graveyard when it resolves."
         },
         {
           "date": "2006-07-15",
-          "text": "After Commandeer resolves, you control the targeted spell. Any instance of “you” in that spell’s text now refers to you, “an opponent” refers to one of your opponents, and so on. The change of control happens before new targets are chosen, so any targeting restrictions such as “target opponent” or “target creature you control” are now made in reference to you, not the spell’s original controller. You may either change those targets to be legal in reference to you, or, if those are the spell’s only targets, the spell will be countered on resolution for having illegal targets. When the spell resolves, any illegal targets are unaffected by it and you make all decisions the spell’s effect calls for."
+          "text": "After Commandeer resolves, you control the targeted spell. Any instance of \"you\" in that spell's text now refers to you, \"an opponent\" refers to one of your opponents, and so on. The change of control happens before new targets are chosen, so any targeting restrictions such as \"target opponent\" or \"target creature you control\" are now made in reference to you, not the spell's original controller. You may either change those targets to be legal in reference to you, or, if those are the spell's only targets, the spell will be countered on resolution for having illegal targets. When the spell resolves, any illegal targets are unaffected by it and you make all decisions the spell's effect calls for."
         },
         {
           "date": "2006-07-15",
-          "text": "You may change any of the targeted spell’s targets. If you change a target, you must choose a legal target for the spell. If you can’t, you must leave the target the same (even if that target is now illegal)."
+          "text": "You may change any of the targeted spell's targets. If you change a target, you must choose a legal target for the spell. If you can't, you must leave the target the same (even if that target is now illegal)."
         },
         {
           "date": "2006-07-15",
@@ -3039,19 +3039,19 @@
         },
         {
           "date": "2006-07-15",
-          "text": "You may pay the alternative cost rather than the card’s mana cost. Any additional costs are paid as normal."
+          "text": "You may pay the alternative cost rather than the card's mana cost. Any additional costs are paid as normal."
         },
         {
           "date": "2006-07-15",
-          "text": "If you don’t have two cards of the right color in your hand, you can’t choose to cast the spell using the alternative cost."
+          "text": "If you don't have two cards of the right color in your hand, you can't choose to cast the spell using the alternative cost."
         },
         {
           "date": "2006-07-15",
-          "text": "You can’t exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
+          "text": "You can't exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
         },
         {
           "date": "2007-02-01",
-          "text": "If you Commandeer a spell for which Buyback has been paid, the card returns to its owner’s hand."
+          "text": "If you Commandeer a spell for which Buyback has been paid, the card returns to its owner's hand."
         }
       ],
       "text": "You may exile two blue cards from your hand rather than pay Commandeer's mana cost.\nGain control of target noncreature spell. You may choose new targets for it. (If that spell is an artifact, enchantment, or planeswalker, the permanent enters the battlefield under your control.)",
@@ -3244,11 +3244,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If an opponent casts a spell with X in its mana cost, the converted mana cost of that spell takes the value of X into account. If you reveal a card with X in its mana cost, X is 0. For example, if your opponent casts Blaze with X=1, Counterbalance will counter that spell if you reveal a card with converted mana cost 2, but it won’t counter that spell if you reveal a Blaze of your own."
+          "text": "If an opponent casts a spell with X in its mana cost, the converted mana cost of that spell takes the value of X into account. If you reveal a card with X in its mana cost, X is 0. For example, if your opponent casts Blaze with X=1, Counterbalance will counter that spell if you reveal a card with converted mana cost 2, but it won't counter that spell if you reveal a Blaze of your own."
         },
         {
           "date": "2017-04-18",
-          "text": "If an opponent casts half of a split card (for example, Hit), it won’t be countered if you reveal that same split card. The converted mana cost of a split card is determined by the combined mana cost of its two halves, but the converted mana cost of Hit is determined using only that half’s mana cost."
+          "text": "If an opponent casts half of a split card (for example, Hit), it won't be countered if you reveal that same split card. The converted mana cost of a split card is determined by the combined mana cost of its two halves, but the converted mana cost of Hit is determined using only that half's mana cost."
         }
       ],
       "text": "Whenever an opponent casts a spell, you may reveal the top card of your library. If you do, counter that spell if it has the same converted mana cost as the revealed card.",
@@ -4152,15 +4152,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Each card that’s revealed to pay the cost remains revealed until the ability leaves the stack."
+          "text": "Each card that's revealed to pay the cost remains revealed until the ability leaves the stack."
         },
         {
           "date": "2006-07-15",
-          "text": "A card that’s already revealed for another cost or because of an effect can be revealed to pay this cost."
+          "text": "A card that's already revealed for another cost or because of an effect can be revealed to pay this cost."
         },
         {
           "date": "2006-07-15",
-          "text": "If one of the cards that’s revealed to pay the cost leaves its owner’s hand before the ability resolves, it stops being revealed, but the value of X is not affected."
+          "text": "If one of the cards that's revealed to pay the cost leaves its owner's hand before the ability resolves, it stops being revealed, but the value of X is not affected."
         }
       ],
       "subtypes": [
@@ -4361,7 +4361,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Rimefeather Owl’s last ability affects all permanents with ice counters on them, whether or not it put the ice counters on them."
+          "text": "Rimefeather Owl's last ability affects all permanents with ice counters on them, whether or not it put the ice counters on them."
         }
       ],
       "subtypes": [
@@ -4469,7 +4469,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -4962,11 +4962,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If you don’t draw a card because all the draws were replaced (with dredge, for example), you still have to put a card from your hand on top of your library."
+          "text": "If you don't draw a card because all the draws were replaced (with dredge, for example), you still have to put a card from your hand on top of your library."
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -5070,7 +5070,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Thermal Flux adds or removes the supertype snow from a permanent. Adding or removing a supertype doesn’t affect any other types, supertypes, or subtypes that permanent has."
+          "text": "Thermal Flux adds or removes the supertype snow from a permanent. Adding or removing a supertype doesn't affect any other types, supertypes, or subtypes that permanent has."
         }
       ],
       "text": "Choose one —\n• Target nonsnow permanent becomes snow until end of turn.\n• Target snow permanent isn't snow until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -5170,11 +5170,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If Vexing Sphinx has more age counters on it than you have cards in your hand, you can’t pay the upkeep and you must sacrifice it."
+          "text": "If Vexing Sphinx has more age counters on it than you have cards in your hand, you can't pay the upkeep and you must sacrifice it."
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -5279,7 +5279,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -6265,11 +6265,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Haakon can’t be cast from your hand. It can’t be cast from any zone other than your graveyard, even if an effect such as that of Spelljack or Muse Vessel would otherwise allow you to."
+          "text": "Haakon can't be cast from your hand. It can't be cast from any zone other than your graveyard, even if an effect such as that of Spelljack or Muse Vessel would otherwise allow you to."
         },
         {
           "date": "2006-07-15",
-          "text": "While Haakon is in your graveyard, you may cast it. This follows the normal rules and timing for casting a creature spell; the only difference is what zone Haakon is being cast from. The spell goes on the stack. You have to pay Haakon’s mana cost and any applicable additional costs. The same applies for Knight cards you cast from your graveyard while Haakon is on the battlefield."
+          "text": "While Haakon is in your graveyard, you may cast it. This follows the normal rules and timing for casting a creature spell; the only difference is what zone Haakon is being cast from. The spell goes on the stack. You have to pay Haakon's mana cost and any applicable additional costs. The same applies for Knight cards you cast from your graveyard while Haakon is on the battlefield."
         }
       ],
       "subtypes": [
@@ -6377,19 +6377,19 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "When Herald of Leshrac’s cumulative upkeep ability resolves, if its age counters outnumber the number of lands on the battlefield that you don’t control, you can’t pay its cumulative upkeep cost and must sacrifice it."
+          "text": "When Herald of Leshrac's cumulative upkeep ability resolves, if its age counters outnumber the number of lands on the battlefield that you don't control, you can't pay its cumulative upkeep cost and must sacrifice it."
         },
         {
           "date": "2006-07-15",
-          "text": "You must choose a different land you don’t control for each age counter on Herald of Leshrac. Otherwise, you’d try to gain control of a land you *do* control midway through paying the cost and need to back up."
+          "text": "You must choose a different land you don't control for each age counter on Herald of Leshrac. Otherwise, you'd try to gain control of a land you *do* control midway through paying the cost and need to back up."
         },
         {
           "date": "2006-07-15",
-          "text": "Herald of Leshrac’s leaves-the-battlefield ability affects all lands you control but don’t own, not just the ones you gained control of with Herald of Leshrac. For example, if you had gained control of an opponent’s land with Annex, its owner will regain control of that land. Annex will remain attached to it, but its effect will be overridden."
+          "text": "Herald of Leshrac's leaves-the-battlefield ability affects all lands you control but don't own, not just the ones you gained control of with Herald of Leshrac. For example, if you had gained control of an opponent's land with Annex, its owner will regain control of that land. Annex will remain attached to it, but its effect will be overridden."
         },
         {
           "date": "2013-04-15",
-          "text": "The cumulative upkeep trigger doesn’t target what you gain control of, and you don’t choose lands until the ability resolves. Your opponents can not tap lands in response to the choice, but they could respond to the ability by tapping any number of lands before you’ve made any choices."
+          "text": "The cumulative upkeep trigger doesn't target what you gain control of, and you don't choose lands until the ability resolves. Your opponents can not tap lands in response to the choice, but they could respond to the ability by tapping any number of lands before you've made any choices."
         }
       ],
       "subtypes": [
@@ -6685,15 +6685,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Each card that’s revealed to pay the cost remains revealed until the ability leaves the stack."
+          "text": "Each card that's revealed to pay the cost remains revealed until the ability leaves the stack."
         },
         {
           "date": "2006-07-15",
-          "text": "A card that’s already revealed for another cost or because of an effect can be revealed to pay this cost."
+          "text": "A card that's already revealed for another cost or because of an effect can be revealed to pay this cost."
         },
         {
           "date": "2006-07-15",
-          "text": "If one of the cards that’s revealed to pay the cost leaves its owner’s hand before the ability resolves, it stops being revealed, but the value of X is not affected."
+          "text": "If one of the cards that's revealed to pay the cost leaves its owner's hand before the ability resolves, it stops being revealed, but the value of X is not affected."
         }
       ],
       "subtypes": [
@@ -6798,7 +6798,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -7196,15 +7196,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "You may pay the alternative cost rather than the card’s mana cost. Any additional costs are paid as normal."
+          "text": "You may pay the alternative cost rather than the card's mana cost. Any additional costs are paid as normal."
         },
         {
           "date": "2006-07-15",
-          "text": "If you don’t have two cards of the right color in your hand, you can’t choose to cast the spell using the alternative cost."
+          "text": "If you don't have two cards of the right color in your hand, you can't choose to cast the spell using the alternative cost."
         },
         {
           "date": "2006-07-15",
-          "text": "You can’t exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
+          "text": "You can't exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
         }
       ],
       "text": "You may exile two black cards from your hand rather than pay Soul Spike's mana cost.\nSoul Spike deals 4 damage to target creature or player and you gain 4 life.",
@@ -7611,7 +7611,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Cards exiled with Void Maw that would go to the graveyard but have that replaced by an effect such as Leyline of the Void are considered new objects. They can not be used to activate Void Maw’s ability again."
+          "text": "Cards exiled with Void Maw that would go to the graveyard but have that replaced by an effect such as Leyline of the Void are considered new objects. They can not be used to activate Void Maw's ability again."
         }
       ],
       "subtypes": [
@@ -7716,7 +7716,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Zombie Musher can’t be blocked as long as defending player controls a snow land."
+          "text": "Zombie Musher can't be blocked as long as defending player controls a snow land."
         }
       ],
       "subtypes": [
@@ -7917,31 +7917,31 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Balduvian Warlord’s ability may be activated during any player’s turn."
+          "text": "Balduvian Warlord's ability may be activated during any player's turn."
         },
         {
           "date": "2006-07-15",
-          "text": "The targeted creature that’s removed from combat may then block the attacking creature that it was originally blocking. If so, that creature will no longer be unblocked."
+          "text": "The targeted creature that's removed from combat may then block the attacking creature that it was originally blocking. If so, that creature will no longer be unblocked."
         },
         {
           "date": "2006-07-15",
-          "text": "If an attacking creature becomes unblocked this way and remains unblocked, it will deal its combat damage to the defending player. Abilities that say “When this creature attacks and isn’t blocked” won’t trigger."
+          "text": "If an attacking creature becomes unblocked this way and remains unblocked, it will deal its combat damage to the defending player. Abilities that say \"When this creature attacks and isn't blocked\" won't trigger."
         },
         {
           "date": "2006-07-15",
-          "text": "If the targeted creature has a “When this creature blocks” ability, it will trigger when Balduvian Warlord’s ability resolves and the creature blocks again."
+          "text": "If the targeted creature has a \"When this creature blocks\" ability, it will trigger when Balduvian Warlord's ability resolves and the creature blocks again."
         },
         {
           "date": "2006-07-15",
-          "text": "If an attacking creature has an ability that triggers “When this creature becomes blocked,” it triggers when a creature blocks it due to the Warlord’s ability only if it was unblocked at that point."
+          "text": "If an attacking creature has an ability that triggers \"When this creature becomes blocked,\" it triggers when a creature blocks it due to the Warlord's ability only if it was unblocked at that point."
         },
         {
           "date": "2006-07-15",
-          "text": "If an attacking creature has a “When this creature becomes blocked by [a creature]” ability, it triggers when a creature blocks it due to the Warlord’s ability."
+          "text": "If an attacking creature has a \"When this creature becomes blocked by [a creature]\" ability, it triggers when a creature blocks it due to the Warlord's ability."
         },
         {
           "date": "2006-07-15",
-          "text": "The attacking creature will become unblocked only if the targeted creature was the only one that blocked it this combat, even if all the other creatures that were blocking it are no longer on the battlefield or are no longer blocking it (even those removed with other Balduvian Warlords’ abilities)."
+          "text": "The attacking creature will become unblocked only if the targeted creature was the only one that blocked it this combat, even if all the other creatures that were blocking it are no longer on the battlefield or are no longer blocking it (even those removed with other Balduvian Warlords' abilities)."
         }
       ],
       "subtypes": [
@@ -8046,11 +8046,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Braid of Fire is a very unusual card. “Add {R} to your mana pool” is a cost. This enchantment does nothing but add increasing amounts of mana to your mana pool during your upkeep."
+          "text": "Braid of Fire is a very unusual card. \"Add {R} to your mana pool\" is a cost. This enchantment does nothing but add increasing amounts of mana to your mana pool during your upkeep."
         },
         {
           "date": "2009-10-01",
-          "text": "Any of this mana that isn’t spent during your upkeep step will be removed before your draw step begins. You cannot save it to be spent on the card you will draw this turn."
+          "text": "Any of this mana that isn't spent during your upkeep step will be removed before your draw step begins. You cannot save it to be spent on the card you will draw this turn."
         }
       ],
       "text": "Cumulative upkeep—Add {R} to your mana pool. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
@@ -8246,7 +8246,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -8350,23 +8350,23 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If it’s somehow not a main phase when Fury of the Horde resolves, all it does is untap all creatures that attacked that turn. No new phases are created."
+          "text": "If it's somehow not a main phase when Fury of the Horde resolves, all it does is untap all creatures that attacked that turn. No new phases are created."
         },
         {
           "date": "2006-07-15",
-          "text": "Paying the alternative cost doesn’t change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
+          "text": "Paying the alternative cost doesn't change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
         },
         {
           "date": "2006-07-15",
-          "text": "You may pay the alternative cost rather than the card’s mana cost. Any additional costs are paid as normal."
+          "text": "You may pay the alternative cost rather than the card's mana cost. Any additional costs are paid as normal."
         },
         {
           "date": "2006-07-15",
-          "text": "If you don’t have two cards of the right color in your hand, you can’t choose to cast the spell using the alternative cost."
+          "text": "If you don't have two cards of the right color in your hand, you can't choose to cast the spell using the alternative cost."
         },
         {
           "date": "2006-07-15",
-          "text": "You can’t exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
+          "text": "You can't exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
         }
       ],
       "text": "You may exile two red cards from your hand rather than pay Fury of the Horde's mana cost.\nUntap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
@@ -8467,7 +8467,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If a spell or ability is cast or activated that would have Goblin Furrier deal damage to a snow creature, and Goblin Furrier leaves the battlefield before it resolves, the damage won’t be prevented."
+          "text": "If a spell or ability is cast or activated that would have Goblin Furrier deal damage to a snow creature, and Goblin Furrier leaves the battlefield before it resolves, the damage won't be prevented."
         }
       ],
       "subtypes": [
@@ -8677,11 +8677,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "After Greater Stone Spirit’s activated ability is activated, the affected creature gains an activated ability that only that creature’s controller can activate."
+          "text": "After Greater Stone Spirit's activated ability is activated, the affected creature gains an activated ability that only that creature's controller can activate."
         },
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don’t actually have Flying."
+          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don't actually have Flying."
         }
       ],
       "subtypes": [
@@ -8880,19 +8880,19 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "The coin flip rules have changed. You now win or lose a flip only if *you* flipped the coin. If your opponent loses a flip, that no longer means that you win that flip. Only coin flips caused by cards that say “win” and/or “lose” anywhere on them have a winner or loser."
+          "text": "The coin flip rules have changed. You now win or lose a flip only if *you* flipped the coin. If your opponent loses a flip, that no longer means that you win that flip. Only coin flips caused by cards that say \"win\" and/or \"lose\" anywhere on them have a winner or loser."
         },
         {
           "date": "2006-07-15",
-          "text": "If a spell or ability uses a coin flip to determine what happens on a heads result versus a tails result, the flipping player doesn’t call “heads” or “tails.” Such flips have no winner or loser."
+          "text": "If a spell or ability uses a coin flip to determine what happens on a heads result versus a tails result, the flipping player doesn't call \"heads\" or \"tails.\" Such flips have no winner or loser."
         },
         {
           "date": "2006-07-15",
-          "text": "When Karplusan Minotaur’s cumulative upkeep ability resolves, you either flip a number of coins equal to the number of age counters on it, or you sacrifice it. Once you start to flip, you can’t stop; you must continue until all flips are made. If you flip, you call heads or tails for each flip. Each time you’re right, the Minotaur’s second ability triggers. Each time you’re wrong, the Minotaur’s third ability triggers. The triggers wait until after you’re done flipping, then they all go on the stack in whatever order you choose. Each may have a different target."
+          "text": "When Karplusan Minotaur's cumulative upkeep ability resolves, you either flip a number of coins equal to the number of age counters on it, or you sacrifice it. Once you start to flip, you can't stop; you must continue until all flips are made. If you flip, you call heads or tails for each flip. Each time you're right, the Minotaur's second ability triggers. Each time you're wrong, the Minotaur's third ability triggers. The triggers wait until after you're done flipping, then they all go on the stack in whatever order you choose. Each may have a different target."
         },
         {
           "date": "2006-07-15",
-          "text": "The Minotaur’s last two abilities will trigger whenever you win or lose any coin flip. For example, if you cast Stitch in Time, one of the Minotaur’s abilities will trigger."
+          "text": "The Minotaur's last two abilities will trigger whenever you win or lose any coin flip. For example, if you cast Stitch in Time, one of the Minotaur's abilities will trigger."
         }
       ],
       "subtypes": [
@@ -9209,15 +9209,15 @@
         },
         {
           "date": "2006-07-15",
-          "text": "When you cast Lightning Storm, you immediately have a chance to activate its ability since you’ll have priority. If you don’t, and all other players pass, the spell will resolve. You won’t receive priority again — and thus won’t get another chance to activate its ability — unless someone else activates Lightning Storm’s activated ability, casts some other spell, or activates some other ability."
+          "text": "When you cast Lightning Storm, you immediately have a chance to activate its ability since you'll have priority. If you don't, and all other players pass, the spell will resolve. You won't receive priority again — and thus won't get another chance to activate its ability — unless someone else activates Lightning Storm's activated ability, casts some other spell, or activates some other ability."
         },
         {
           "date": "2006-07-15",
-          "text": "After an instance of Lightning Storm’s activated ability resolves, the active player (not Lightning Storm’s controller) receives priority."
+          "text": "After an instance of Lightning Storm's activated ability resolves, the active player (not Lightning Storm's controller) receives priority."
         },
         {
           "date": "2006-07-15",
-          "text": "When Lightning Storm’s activated ability resolves, if there are no other legal targets to choose for the Lightning Storm spell, you must leave the target the same, even if it’s now an illegal target."
+          "text": "When Lightning Storm's activated ability resolves, if there are no other legal targets to choose for the Lightning Storm spell, you must leave the target the same, even if it's now an illegal target."
         },
         {
           "date": "2006-07-15",
@@ -9323,7 +9323,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Each creature with at least one of those subtypes gets +2/+2 from Lovisa Coldeyes’ ability, regardless of how many of those subtypes it has. For example, a 3/3 Mistform Ultimus would become 5/5, not 9/9."
+          "text": "Each creature with at least one of those subtypes gets +2/+2 from Lovisa Coldeyes' ability, regardless of how many of those subtypes it has. For example, a 3/3 Mistform Ultimus would become 5/5, not 9/9."
         }
       ],
       "subtypes": [
@@ -9429,7 +9429,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "The damage is divided when Magmatic Core’s ability triggers. Increasing or decreasing the number of age counters on Magmatic Core after the ability triggers but before it resolves has no effect on the amount of damage that’s dealt."
+          "text": "The damage is divided when Magmatic Core's ability triggers. Increasing or decreasing the number of age counters on Magmatic Core after the ability triggers but before it resolves has no effect on the amount of damage that's dealt."
         },
         {
           "date": "2006-07-15",
@@ -9441,7 +9441,7 @@
         },
         {
           "date": "2006-07-15",
-          "text": "Magmatic Core’s effect is mandatory. At the end of your turn, if the only creatures on the battlefield are yours, you must have Magmatic Core deal damage to at least one of them."
+          "text": "Magmatic Core's effect is mandatory. At the end of your turn, if the only creatures on the battlefield are yours, you must have Magmatic Core deal damage to at least one of them."
         }
       ],
       "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nAt the beginning of your end step, Magmatic Core deals X damage divided as you choose among any number of target creatures, where X is the number of age counters on it.",
@@ -9542,15 +9542,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Each card that’s revealed to pay the cost remains revealed until the ability leaves the stack."
+          "text": "Each card that's revealed to pay the cost remains revealed until the ability leaves the stack."
         },
         {
           "date": "2006-07-15",
-          "text": "A card that’s already revealed for another cost or because of an effect can be revealed to pay this cost."
+          "text": "A card that's already revealed for another cost or because of an effect can be revealed to pay this cost."
         },
         {
           "date": "2006-07-15",
-          "text": "If one of the cards that’s revealed to pay the cost leaves its owner’s hand before the ability resolves, it stops being revealed, but the value of X is not affected."
+          "text": "If one of the cards that's revealed to pay the cost leaves its owner's hand before the ability resolves, it stops being revealed, but the value of X is not affected."
         }
       ],
       "subtypes": [
@@ -9857,7 +9857,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Rimescale Dragon’s last ability affects all permanents with ice counters on them, whether or not it put the ice counters on them."
+          "text": "Rimescale Dragon's last ability affects all permanents with ice counters on them, whether or not it put the ice counters on them."
         }
       ],
       "subtypes": [
@@ -10458,19 +10458,19 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Paying the alternative cost doesn’t change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
+          "text": "Paying the alternative cost doesn't change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
         },
         {
           "date": "2006-07-15",
-          "text": "You may pay the alternative cost rather than the card’s mana cost. Any additional costs are paid as normal."
+          "text": "You may pay the alternative cost rather than the card's mana cost. Any additional costs are paid as normal."
         },
         {
           "date": "2006-07-15",
-          "text": "If you don’t have two cards of the right color in your hand, you can’t choose to cast the spell using the alternative cost."
+          "text": "If you don't have two cards of the right color in your hand, you can't choose to cast the spell using the alternative cost."
         },
         {
           "date": "2006-07-15",
-          "text": "You can’t exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
+          "text": "You can't exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
         }
       ],
       "subtypes": [
@@ -10576,7 +10576,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -10987,7 +10987,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If a permanent is enchanted with an Aura such as Confiscate when Brooding Saurian’s ability resolves, the enchanted permanent’s owner will regain control of it. The Aura will not be removed. The Aura will still be controlled by its owner, but its effect will be overridden."
+          "text": "If a permanent is enchanted with an Aura such as Confiscate when Brooding Saurian's ability resolves, the enchanted permanent's owner will regain control of it. The Aura will not be removed. The Aura will still be controlled by its owner, but its effect will be overridden."
         }
       ],
       "subtypes": [
@@ -11290,7 +11290,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If Frostweb Spider blocks a creature with flying that’s just powerful enough to kill it, it will die before it can get the +1/+1 counter."
+          "text": "If Frostweb Spider blocks a creature with flying that's just powerful enough to kill it, it will die before it can get the +1/+1 counter."
         },
         {
           "date": "2006-07-15",
@@ -11400,7 +11400,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "The converted mana cost of the creature you find must be exactly equal to the number of age counters on Hibernation’s End."
+          "text": "The converted mana cost of the creature you find must be exactly equal to the number of age counters on Hibernation's End."
         }
       ],
       "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever you pay Hibernation's End's cumulative upkeep, you may search your library for a creature card with converted mana cost equal to the number of age counters on Hibernation's End and put it onto the battlefield. If you do, shuffle your library.",
@@ -11696,15 +11696,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Each card that’s revealed to pay the cost remains revealed until the ability leaves the stack."
+          "text": "Each card that's revealed to pay the cost remains revealed until the ability leaves the stack."
         },
         {
           "date": "2006-07-15",
-          "text": "A card that’s already revealed for another cost or because of an effect can be revealed to pay this cost."
+          "text": "A card that's already revealed for another cost or because of an effect can be revealed to pay this cost."
         },
         {
           "date": "2006-07-15",
-          "text": "If one of the cards that’s revealed to pay the cost leaves its owner’s hand before the ability resolves, it stops being revealed, but the value of X is not affected."
+          "text": "If one of the cards that's revealed to pay the cost leaves its owner's hand before the ability resolves, it stops being revealed, but the value of X is not affected."
         }
       ],
       "subtypes": [
@@ -12008,11 +12008,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Panglacial Wurm’s ability works only while you’re searching your own library. The effect that caused you to search needs to say “search” and “library,” and you need to be looking through your own library for this to work. Examples of effects that let you cast Panglacial Wurm are Rampant Growth and Gifts Ungiven. Examples of effects that don’t are Bribery and Sage Owl."
+          "text": "Panglacial Wurm's ability works only while you're searching your own library. The effect that caused you to search needs to say \"search\" and \"library,\" and you need to be looking through your own library for this to work. Examples of effects that let you cast Panglacial Wurm are Rampant Growth and Gifts Ungiven. Examples of effects that don't are Bribery and Sage Owl."
         },
         {
           "date": "2006-07-15",
-          "text": "Casting Panglacial Wurm while searching your library follows all the normal rules for casting a creature spell, except for timing (casting the Wurm this way always occurs during the resolution of another spell or ability) and what zone the Wurm is being cast from. The spell goes on the stack. You have to pay the Wurm’s mana cost and any applicable additional costs, which means you can activate mana abilities while you’re casting the Wurm while you’re searching your library."
+          "text": "Casting Panglacial Wurm while searching your library follows all the normal rules for casting a creature spell, except for timing (casting the Wurm this way always occurs during the resolution of another spell or ability) and what zone the Wurm is being cast from. The spell goes on the stack. You have to pay the Wurm's mana cost and any applicable additional costs, which means you can activate mana abilities while you're casting the Wurm while you're searching your library."
         },
         {
           "date": "2006-07-15",
@@ -12024,7 +12024,7 @@
         },
         {
           "date": "2006-07-15",
-          "text": "A Panglacial Wurm that you cast while searching your library can’t be found by the search effect."
+          "text": "A Panglacial Wurm that you cast while searching your library can't be found by the search effect."
         },
         {
           "date": "2006-07-15",
@@ -12229,7 +12229,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If the first creature targeted by Rimehorn Aurochs can’t block the second targeted creature (for example, because the second creature has flying and the first doesn’t, or because both creatures are controlled by the same player), the ability does nothing and the first creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "If the first creature targeted by Rimehorn Aurochs can't block the second targeted creature (for example, because the second creature has flying and the first doesn't, or because both creatures are controlled by the same player), the ability does nothing and the first creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2006-07-15",
@@ -12340,11 +12340,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Ronom Hulk can’t be targeted by snow spells (though there are no snow instants or sorceries) or abilities of snow sources, it can’t be enchanted by snow Auras, it can’t be equipped by snow Equipment (though there are none), it can’t be blocked by snow creatures, and all damage that would be dealt to it by snow sources is prevented."
+          "text": "Ronom Hulk can't be targeted by snow spells (though there are no snow instants or sorceries) or abilities of snow sources, it can't be enchanted by snow Auras, it can't be equipped by snow Equipment (though there are none), it can't be blocked by snow creatures, and all damage that would be dealt to it by snow sources is prevented."
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -12447,7 +12447,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If Shape of the Wiitigo leaves the battlefield but the creature doesn’t, the +1/+1 counters stay on the creature."
+          "text": "If Shape of the Wiitigo leaves the battlefield but the creature doesn't, the +1/+1 counters stay on the creature."
         }
       ],
       "subtypes": [
@@ -12550,19 +12550,19 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If no opponent controls a creature, you can’t pay the upkeep and must sacrifice Sheltering Ancient."
+          "text": "If no opponent controls a creature, you can't pay the upkeep and must sacrifice Sheltering Ancient."
         },
         {
           "date": "2006-07-15",
-          "text": "You may choose a different creature to put each counter on, but you can also choose the same creature multiple times. The creatures don’t have to be controlled by the same opponent."
+          "text": "You may choose a different creature to put each counter on, but you can also choose the same creature multiple times. The creatures don't have to be controlled by the same opponent."
         },
         {
           "date": "2006-07-15",
-          "text": "Creatures that can’t be the target of abilities can have +1/+1 counters put on them by Sheltering Ancient’s cumulative upkeep ability because it doesn’t target them. The same is true for creatures with protection from green or protection from any other quality Sheltering Ancient has."
+          "text": "Creatures that can't be the target of abilities can have +1/+1 counters put on them by Sheltering Ancient's cumulative upkeep ability because it doesn't target them. The same is true for creatures with protection from green or protection from any other quality Sheltering Ancient has."
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -12766,7 +12766,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If Sound the Call resolves while all graveyards are empty, first a 1/1 token is created, then the Sound the Call card is put into your graveyard, which makes the token 2/2. Although the token is momentarily 1/1, state-based actions aren’t checked until after the Sound the Call card used to create the token is in a graveyard. For example, if Night of Souls’ Betrayal is on the battlefield, the Wolf will momentarily be 0/0. By the time state-based actions are checked, it will be 1/1, so it will remain on the battlefield."
+          "text": "If Sound the Call resolves while all graveyards are empty, first a 1/1 token is created, then the Sound the Call card is put into your graveyard, which makes the token 2/2. Although the token is momentarily 1/1, state-based actions aren't checked until after the Sound the Call card used to create the token is in a graveyard. For example, if Night of Souls' Betrayal is on the battlefield, the Wolf will momentarily be 0/0. By the time state-based actions are checked, it will be 1/1, so it will remain on the battlefield."
         }
       ],
       "text": "Create a 1/1 green Wolf creature token. It has \"This creature gets +1/+1 for each card named Sound the Call in each graveyard.\"",
@@ -13064,15 +13064,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "You choose the mode when you put Blizzard Specter’s triggered ability on the stack."
+          "text": "You choose the mode when you put Blizzard Specter's triggered ability on the stack."
         },
         {
           "date": "2006-07-15",
-          "text": "If Blizzard Specter’s first mode is chosen, the defending player chooses the permanent to return to hand when the ability resolves."
+          "text": "If Blizzard Specter's first mode is chosen, the defending player chooses the permanent to return to hand when the ability resolves."
         },
         {
           "date": "2006-07-15",
-          "text": "Blizzard Specter’s second mode may be chosen even if the defending player’s hand is empty."
+          "text": "Blizzard Specter's second mode may be chosen even if the defending player's hand is empty."
         }
       ],
       "subtypes": [
@@ -13504,7 +13504,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "The creature doesn’t enter the battlefield with a +1/+1 counter on it. It enters the battlefield, then the ability triggers. If either that creature or Juniper Order Ranger leaves the battlefield before the ability resolves, the remaining creature will still get a +1/+1 counter."
+          "text": "The creature doesn't enter the battlefield with a +1/+1 counter on it. It enters the battlefield, then the ability triggers. If either that creature or Juniper Order Ranger leaves the battlefield before the ability resolves, the remaining creature will still get a +1/+1 counter."
         }
       ],
       "subtypes": [
@@ -13722,11 +13722,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "A noncreature source is a source that doesn’t have the type creature. If a creature card that’s not on the battlefield deals damage (for example, a cycled Gempalm Incinerator), Tamanoa’s ability won’t trigger."
+          "text": "A noncreature source is a source that doesn't have the type creature. If a creature card that's not on the battlefield deals damage (for example, a cycled Gempalm Incinerator), Tamanoa's ability won't trigger."
         },
         {
           "date": "2006-07-15",
-          "text": "Tamanoa’s ability triggers no matter who the recipient of the damage is: another player, a creature, or even you. If a noncreature source you control deals damage to you that drops your life total to 0 or less, you’ll lose the game before Tamanoa’s ability can resolve."
+          "text": "Tamanoa's ability triggers no matter who the recipient of the damage is: another player, a creature, or even you. If a noncreature source you control deals damage to you that drops your life total to 0 or less, you'll lose the game before Tamanoa's ability can resolve."
         }
       ],
       "subtypes": [
@@ -13834,15 +13834,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Vanish into Memory cares about the creature’s power just before it left the battlefield and its toughness just after it returns to the battlefield. For example, if you target a 2/2 creature with two +1/+1 counters on it, you’ll draw four cards, then when it returns to the battlefield without any counters on it, you’ll discard two cards."
+          "text": "Vanish into Memory cares about the creature's power just before it left the battlefield and its toughness just after it returns to the battlefield. For example, if you target a 2/2 creature with two +1/+1 counters on it, you'll draw four cards, then when it returns to the battlefield without any counters on it, you'll discard two cards."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature exiled with Vanish into Memory never returns to the battlefield (because it was a token creature, for example), you don’t discard any cards."
+          "text": "If the creature exiled with Vanish into Memory never returns to the battlefield (because it was a token creature, for example), you don't discard any cards."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature exiled with Vanish into Memory isn’t a creature card (for example, a crewed Vehicle), that card will still be returned to the battlefield, but not as a creature. Since the card returned to the battlefield has no toughness, you discard no cards."
+          "text": "If the creature exiled with Vanish into Memory isn't a creature card (for example, a crewed Vehicle), that card will still be returned to the battlefield, but not as a creature. Since the card returned to the battlefield has no toughness, you discard no cards."
         }
       ],
       "text": "Exile target creature. You draw cards equal to that creature's power. At the beginning of your next upkeep, return that card to the battlefield under its owner's control. If you do, discard cards equal to that creature's toughness.",
@@ -14050,7 +14050,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "An Aura put onto the battlefield without being cast doesn’t target anything, so it could be attached to a permanent with shroud or hexproof. However, the Aura’s enchant ability restricts what it can be attached to."
+          "text": "An Aura put onto the battlefield without being cast doesn't target anything, so it could be attached to a permanent with shroud or hexproof. However, the Aura's enchant ability restricts what it can be attached to."
         }
       ],
       "subtypes": [
@@ -14243,19 +14243,19 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "You can see the cards that are exiled with Jester’s Scepter, but no one else can."
+          "text": "You can see the cards that are exiled with Jester's Scepter, but no one else can."
         },
         {
           "date": "2006-07-15",
-          "text": "Because the cards that are exiled are not hidden to you, you can choose which one to put into its owner’s graveyard when you activate the second ability."
+          "text": "Because the cards that are exiled are not hidden to you, you can choose which one to put into its owner's graveyard when you activate the second ability."
         },
         {
           "date": "2006-07-15",
-          "text": "When Jester’s Scepter’s second ability is activated, any of the exiled cards may be put into its owner’s graveyard, and any spell may be targeted, whether or not the card and the spell have the same name. If they don’t have the same name, the effect does nothing. The spell’s controller and the owner of the card put into a graveyard this way may be different."
+          "text": "When Jester's Scepter's second ability is activated, any of the exiled cards may be put into its owner's graveyard, and any spell may be targeted, whether or not the card and the spell have the same name. If they don't have the same name, the effect does nothing. The spell's controller and the owner of the card put into a graveyard this way may be different."
         },
         {
           "date": "2006-07-15",
-          "text": "If half of a split card is cast (for example, Hit), and you put one of those split cards into its owner’s graveyard with Jester’s Scepter (for example, Hit/Run), the spell is countered."
+          "text": "If half of a split card is cast (for example, Hit), and you put one of those split cards into its owner's graveyard with Jester's Scepter (for example, Hit/Run), the spell is countered."
         }
       ],
       "text": "When Jester's Scepter enters the battlefield, exile the top five cards of target player's library face down. You may look at those cards for as long as they remain exiled.\n{2}, {T}, Put a card exiled with Jester's Scepter into its owner's graveyard: Counter target spell if it has the same name as that card.",
@@ -14632,7 +14632,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "When Phyrexian Soulgorger’s cumulative upkeep ability resolves, you must either sacrifice a different creature for each age counter on Phyrexian Soulgorger or sacrifice it. You may also sacrifice it as part of its own upkeep payment."
+          "text": "When Phyrexian Soulgorger's cumulative upkeep ability resolves, you must either sacrifice a different creature for each age counter on Phyrexian Soulgorger or sacrifice it. You may also sacrifice it as part of its own upkeep payment."
         }
       ],
       "subtypes": [
@@ -14733,7 +14733,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If you cast a spell that already has ripple (such as Surging Flame, which has ripple 4) while Thrumming Stone is on the battlefield, both ripple abilities will trigger separately. Assuming you choose to do all “you may” actions, when the first instance of ripple resolves, you reveal the top four cards of your library, cast all Surging Flames, and put the rest of the cards on the bottom of your library. Any new Surging Flames are on the stack on top of the other instance of ripple, so they’ll resolve next. Each of them also has two instances of ripple, which trigger separately, and the process continues until the ripple abilities don’t reveal any Surging Flames."
+          "text": "If you cast a spell that already has ripple (such as Surging Flame, which has ripple 4) while Thrumming Stone is on the battlefield, both ripple abilities will trigger separately. Assuming you choose to do all \"you may\" actions, when the first instance of ripple resolves, you reveal the top four cards of your library, cast all Surging Flames, and put the rest of the cards on the bottom of your library. Any new Surging Flames are on the stack on top of the other instance of ripple, so they'll resolve next. Each of them also has two instances of ripple, which trigger separately, and the process continues until the ripple abilities don't reveal any Surging Flames."
         },
         {
           "date": "2006-07-15",
@@ -15022,7 +15022,7 @@
         },
         {
           "date": "2006-07-15",
-          "text": "Dark Depths’s last ability is a state trigger. It will not trigger again while the ability is on the stack, but if the ability is countered and Dark Depths is still on the battlefield with no ice counters on it, it will trigger again immediately."
+          "text": "Dark Depths's last ability is a state trigger. It will not trigger again while the ability is on the stack, but if the ability is countered and Dark Depths is still on the battlefield with no ice counters on it, it will trigger again immediately."
         }
       ],
       "supertypes": [
@@ -15391,7 +15391,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If the card isn’t snow, you can’t reveal it. If the card is snow, you don’t have to reveal it. An unrevealed card stays on top of your library."
+          "text": "If the card isn't snow, you can't reveal it. If the card is snow, you don't have to reveal it. An unrevealed card stays on top of your library."
         }
       ],
       "supertypes": [
@@ -15583,7 +15583,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -15591,11 +15591,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -15698,7 +15698,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -15706,11 +15706,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -15813,7 +15813,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -15821,11 +15821,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -15928,7 +15928,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -15936,11 +15936,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -16043,7 +16043,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -16051,11 +16051,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [

--- a/json/CST.json
+++ b/json/CST.json
@@ -4329,6 +4329,296 @@
       ],
       "mciNumber": "49",
       "name": "Plains",
+      "number": "370",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "RQS",
+        "pARL",
+        "MIR",
+        "ITP",
+        "5ED",
+        "POR",
+        "pPRE",
+        "TMP",
+        "pJGP",
+        "PO2",
+        "UGL",
+        "pALP",
+        "USG",
+        "ATH",
+        "6ED",
+        "PTK",
+        "pGRU",
+        "S99",
+        "MMQ",
+        "BRB",
+        "pELP",
+        "S00",
+        "INV",
+        "7ED",
+        "ODY",
+        "ONS",
+        "8ED",
+        "MRD",
+        "CHK",
+        "UNH",
+        "9ED",
+        "RAV",
+        "CST",
+        "TSP",
+        "10E",
+        "MED",
+        "LRW",
+        "SHM",
+        "ALA",
+        "DDC",
+        "M10",
+        "HOP",
+        "ME3",
+        "ZEN",
+        "H09",
+        "DDE",
+        "ROE",
+        "ARC",
+        "M11",
+        "DDF",
+        "SOM",
+        "MBS",
+        "DDG",
+        "NPH",
+        "CMD",
+        "M12",
+        "DDH",
+        "ISD",
+        "DDI",
+        "AVR",
+        "PC2",
+        "M13",
+        "RTR",
+        "DDK",
+        "M14",
+        "DDL",
+        "THS",
+        "C13",
+        "MD1",
+        "M15",
+        "DDN",
+        "KTK",
+        "C14",
+        "DD3_DVD",
+        "FRF",
+        "DDO",
+        "DTK",
+        "TPR",
+        "ORI",
+        "DDP",
+        "BFZ",
+        "C15",
+        "DDQ",
+        "SOI",
+        "KLD",
+        "C16",
+        "PCA",
+        "AKH",
+        "CMA",
+        "E01",
+        "HOU"
+      ],
+      "rarity": "Basic Land",
+      "source": "Kjeldoran Cunning Theme Deck",
+      "subtypes": [
+        "Plains"
+      ],
+      "supertypes": [
+        "Basic"
+      ],
+      "type": "Basic Land — Plains",
+      "types": [
+        "Land"
+      ],
+      "watermark": "White"
+    },
+    {
+      "artist": "Christopher Rush",
+      "colorIdentity": [
+        "W"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "平原"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "平原"
+        },
+        {
+          "language": "French",
+          "name": "Plaine"
+        },
+        {
+          "language": "German",
+          "name": "Ebene"
+        },
+        {
+          "language": "Italian",
+          "name": "Pianura"
+        },
+        {
+          "language": "Japanese",
+          "name": "平地"
+        },
+        {
+          "language": "Korean",
+          "name": "들"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Planície"
+        },
+        {
+          "language": "Russian",
+          "name": "Равнина"
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura"
+        }
+      ],
+      "id": "0ecaefe22a017fe93ba5761dcea5e293538ddf67",
+      "imageName": "plains3",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Battle for Zendikar Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Invasion Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kaladesh Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kamigawa Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Lorwyn-Shadowmoor Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Scars of Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Theros Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Un-Sets",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        },
+        {
+          "format": "Zendikar Block",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "50",
+      "name": "Plains",
       "number": "371",
       "printings": [
         "LEA",
@@ -4734,296 +5024,6 @@
       "watermark": "Blue"
     },
     {
-      "artist": "Christopher Rush",
-      "colorIdentity": [
-        "W"
-      ],
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "平原"
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "平原"
-        },
-        {
-          "language": "French",
-          "name": "Plaine"
-        },
-        {
-          "language": "German",
-          "name": "Ebene"
-        },
-        {
-          "language": "Italian",
-          "name": "Pianura"
-        },
-        {
-          "language": "Japanese",
-          "name": "平地"
-        },
-        {
-          "language": "Korean",
-          "name": "들"
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície"
-        },
-        {
-          "language": "Russian",
-          "name": "Равнина"
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura"
-        }
-      ],
-      "id": "0ecaefe22a017fe93ba5761dcea5e293538ddf67",
-      "imageName": "plains3",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Amonkhet Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Battle for Zendikar Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Invasion Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kaladesh Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kamigawa Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Khans of Tarkir Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Lorwyn-Shadowmoor Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Scars of Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shadows over Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shards of Alara Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Theros Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Un-Sets",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        },
-        {
-          "format": "Zendikar Block",
-          "legality": "Legal"
-        }
-      ],
-      "mciNumber": "50",
-      "name": "Plains",
-      "number": "373",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ICE",
-        "RQS",
-        "pARL",
-        "MIR",
-        "ITP",
-        "5ED",
-        "POR",
-        "pPRE",
-        "TMP",
-        "pJGP",
-        "PO2",
-        "UGL",
-        "pALP",
-        "USG",
-        "ATH",
-        "6ED",
-        "PTK",
-        "pGRU",
-        "S99",
-        "MMQ",
-        "BRB",
-        "pELP",
-        "S00",
-        "INV",
-        "7ED",
-        "ODY",
-        "ONS",
-        "8ED",
-        "MRD",
-        "CHK",
-        "UNH",
-        "9ED",
-        "RAV",
-        "CST",
-        "TSP",
-        "10E",
-        "MED",
-        "LRW",
-        "SHM",
-        "ALA",
-        "DDC",
-        "M10",
-        "HOP",
-        "ME3",
-        "ZEN",
-        "H09",
-        "DDE",
-        "ROE",
-        "ARC",
-        "M11",
-        "DDF",
-        "SOM",
-        "MBS",
-        "DDG",
-        "NPH",
-        "CMD",
-        "M12",
-        "DDH",
-        "ISD",
-        "DDI",
-        "AVR",
-        "PC2",
-        "M13",
-        "RTR",
-        "DDK",
-        "M14",
-        "DDL",
-        "THS",
-        "C13",
-        "MD1",
-        "M15",
-        "DDN",
-        "KTK",
-        "C14",
-        "DD3_DVD",
-        "FRF",
-        "DDO",
-        "DTK",
-        "TPR",
-        "ORI",
-        "DDP",
-        "BFZ",
-        "C15",
-        "DDQ",
-        "SOI",
-        "KLD",
-        "C16",
-        "PCA",
-        "AKH",
-        "CMA",
-        "E01",
-        "HOU"
-      ],
-      "rarity": "Basic Land",
-      "source": "Kjeldoran Cunning Theme Deck",
-      "subtypes": [
-        "Plains"
-      ],
-      "supertypes": [
-        "Basic"
-      ],
-      "type": "Basic Land — Plains",
-      "types": [
-        "Land"
-      ],
-      "watermark": "White"
-    },
-    {
       "artist": "Anson Maddocks",
       "colorIdentity": [
         "U"
@@ -5196,6 +5196,294 @@
         }
       ],
       "mciNumber": "52",
+      "name": "Island",
+      "number": "373",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "RQS",
+        "pARL",
+        "MIR",
+        "ITP",
+        "5ED",
+        "POR",
+        "TMP",
+        "pJGP",
+        "PO2",
+        "UGL",
+        "pALP",
+        "USG",
+        "6ED",
+        "PTK",
+        "pGRU",
+        "S99",
+        "MMQ",
+        "BRB",
+        "pELP",
+        "S00",
+        "BTD",
+        "INV",
+        "7ED",
+        "ODY",
+        "ONS",
+        "8ED",
+        "MRD",
+        "CHK",
+        "UNH",
+        "9ED",
+        "RAV",
+        "CST",
+        "TSP",
+        "10E",
+        "MED",
+        "LRW",
+        "SHM",
+        "ALA",
+        "DD2",
+        "M10",
+        "HOP",
+        "ME3",
+        "ZEN",
+        "H09",
+        "DDE",
+        "ROE",
+        "DPA",
+        "ARC",
+        "M11",
+        "DDF",
+        "SOM",
+        "MBS",
+        "NPH",
+        "CMD",
+        "M12",
+        "DDH",
+        "ISD",
+        "DDI",
+        "AVR",
+        "PC2",
+        "M13",
+        "DDJ",
+        "RTR",
+        "M14",
+        "THS",
+        "C13",
+        "DDM",
+        "M15",
+        "DDN",
+        "KTK",
+        "C14",
+        "DD3_JVC",
+        "FRF",
+        "DDO",
+        "DTK",
+        "TPR",
+        "ORI",
+        "BFZ",
+        "C15",
+        "DDQ",
+        "SOI",
+        "KLD",
+        "C16",
+        "PCA",
+        "DDS",
+        "AKH",
+        "CMA",
+        "E01",
+        "HOU"
+      ],
+      "rarity": "Basic Land",
+      "source": "Kjeldoran Cunning Theme Deck",
+      "subtypes": [
+        "Island"
+      ],
+      "supertypes": [
+        "Basic"
+      ],
+      "type": "Basic Land — Island",
+      "types": [
+        "Land"
+      ],
+      "watermark": "Blue"
+    },
+    {
+      "artist": "Anson Maddocks",
+      "colorIdentity": [
+        "U"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "海岛"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "海島"
+        },
+        {
+          "language": "French",
+          "name": "Île"
+        },
+        {
+          "language": "German",
+          "name": "Insel"
+        },
+        {
+          "language": "Italian",
+          "name": "Isola"
+        },
+        {
+          "language": "Japanese",
+          "name": "島"
+        },
+        {
+          "language": "Korean",
+          "name": "섬"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Ilha"
+        },
+        {
+          "language": "Russian",
+          "name": "Остров"
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla"
+        }
+      ],
+      "id": "6ae68cc611826f8dea15d2b54ec66c9f91140938",
+      "imageName": "island3",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Battle for Zendikar Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Invasion Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kaladesh Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kamigawa Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Lorwyn-Shadowmoor Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Scars of Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Theros Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Un-Sets",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        },
+        {
+          "format": "Zendikar Block",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "53",
       "name": "Island",
       "number": "374",
       "printings": [
@@ -5605,294 +5893,6 @@
       "watermark": "Black"
     },
     {
-      "artist": "Anson Maddocks",
-      "colorIdentity": [
-        "U"
-      ],
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "海岛"
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "海島"
-        },
-        {
-          "language": "French",
-          "name": "Île"
-        },
-        {
-          "language": "German",
-          "name": "Insel"
-        },
-        {
-          "language": "Italian",
-          "name": "Isola"
-        },
-        {
-          "language": "Japanese",
-          "name": "島"
-        },
-        {
-          "language": "Korean",
-          "name": "섬"
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Ilha"
-        },
-        {
-          "language": "Russian",
-          "name": "Остров"
-        },
-        {
-          "language": "Spanish",
-          "name": "Isla"
-        }
-      ],
-      "id": "6ae68cc611826f8dea15d2b54ec66c9f91140938",
-      "imageName": "island3",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Amonkhet Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Battle for Zendikar Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Invasion Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kaladesh Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kamigawa Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Khans of Tarkir Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Lorwyn-Shadowmoor Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Scars of Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shadows over Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shards of Alara Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Theros Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Un-Sets",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        },
-        {
-          "format": "Zendikar Block",
-          "legality": "Legal"
-        }
-      ],
-      "mciNumber": "53",
-      "name": "Island",
-      "number": "376",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ICE",
-        "RQS",
-        "pARL",
-        "MIR",
-        "ITP",
-        "5ED",
-        "POR",
-        "TMP",
-        "pJGP",
-        "PO2",
-        "UGL",
-        "pALP",
-        "USG",
-        "6ED",
-        "PTK",
-        "pGRU",
-        "S99",
-        "MMQ",
-        "BRB",
-        "pELP",
-        "S00",
-        "BTD",
-        "INV",
-        "7ED",
-        "ODY",
-        "ONS",
-        "8ED",
-        "MRD",
-        "CHK",
-        "UNH",
-        "9ED",
-        "RAV",
-        "CST",
-        "TSP",
-        "10E",
-        "MED",
-        "LRW",
-        "SHM",
-        "ALA",
-        "DD2",
-        "M10",
-        "HOP",
-        "ME3",
-        "ZEN",
-        "H09",
-        "DDE",
-        "ROE",
-        "DPA",
-        "ARC",
-        "M11",
-        "DDF",
-        "SOM",
-        "MBS",
-        "NPH",
-        "CMD",
-        "M12",
-        "DDH",
-        "ISD",
-        "DDI",
-        "AVR",
-        "PC2",
-        "M13",
-        "DDJ",
-        "RTR",
-        "M14",
-        "THS",
-        "C13",
-        "DDM",
-        "M15",
-        "DDN",
-        "KTK",
-        "C14",
-        "DD3_JVC",
-        "FRF",
-        "DDO",
-        "DTK",
-        "TPR",
-        "ORI",
-        "BFZ",
-        "C15",
-        "DDQ",
-        "SOI",
-        "KLD",
-        "C16",
-        "PCA",
-        "DDS",
-        "AKH",
-        "CMA",
-        "E01",
-        "HOU"
-      ],
-      "rarity": "Basic Land",
-      "source": "Kjeldoran Cunning Theme Deck",
-      "subtypes": [
-        "Island"
-      ],
-      "supertypes": [
-        "Basic"
-      ],
-      "type": "Basic Land — Island",
-      "types": [
-        "Land"
-      ],
-      "watermark": "Blue"
-    },
-    {
       "artist": "Douglas Shuler",
       "colorIdentity": [
         "B"
@@ -6065,6 +6065,299 @@
         }
       ],
       "mciNumber": "55",
+      "name": "Swamp",
+      "number": "376",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "RQS",
+        "pARL",
+        "MIR",
+        "ITP",
+        "5ED",
+        "POR",
+        "TMP",
+        "pJGP",
+        "PO2",
+        "UGL",
+        "pALP",
+        "USG",
+        "ATH",
+        "6ED",
+        "PTK",
+        "pGRU",
+        "S99",
+        "MMQ",
+        "BRB",
+        "pELP",
+        "S00",
+        "BTD",
+        "INV",
+        "7ED",
+        "ODY",
+        "DKM",
+        "ONS",
+        "8ED",
+        "MRD",
+        "CHK",
+        "UNH",
+        "9ED",
+        "RAV",
+        "CST",
+        "TSP",
+        "10E",
+        "MED",
+        "LRW",
+        "SHM",
+        "ALA",
+        "DDC",
+        "M10",
+        "HOP",
+        "ME3",
+        "ZEN",
+        "DDD",
+        "H09",
+        "DDE",
+        "ROE",
+        "DPA",
+        "ARC",
+        "M11",
+        "SOM",
+        "MBS",
+        "NPH",
+        "CMD",
+        "M12",
+        "DDH",
+        "ISD",
+        "PD3",
+        "AVR",
+        "PC2",
+        "M13",
+        "DDJ",
+        "RTR",
+        "DDK",
+        "M14",
+        "THS",
+        "C13",
+        "DDM",
+        "MD1",
+        "M15",
+        "DDN",
+        "KTK",
+        "C14",
+        "DD3_DVD",
+        "DD3_GVL",
+        "FRF",
+        "DTK",
+        "TPR",
+        "ORI",
+        "DDP",
+        "BFZ",
+        "C15",
+        "DDQ",
+        "SOI",
+        "DDR",
+        "KLD",
+        "C16",
+        "PCA",
+        "AKH",
+        "CMA",
+        "E01",
+        "HOU"
+      ],
+      "rarity": "Basic Land",
+      "source": "Beyond the Grave Theme Deck",
+      "subtypes": [
+        "Swamp"
+      ],
+      "supertypes": [
+        "Basic"
+      ],
+      "type": "Basic Land — Swamp",
+      "types": [
+        "Land"
+      ],
+      "watermark": "Black"
+    },
+    {
+      "artist": "Douglas Shuler",
+      "colorIdentity": [
+        "B"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "沼泽"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "沼澤"
+        },
+        {
+          "language": "French",
+          "name": "Marais"
+        },
+        {
+          "language": "German",
+          "name": "Sumpf"
+        },
+        {
+          "language": "Italian",
+          "name": "Palude"
+        },
+        {
+          "language": "Japanese",
+          "name": "沼"
+        },
+        {
+          "language": "Korean",
+          "name": "늪"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pântano"
+        },
+        {
+          "language": "Russian",
+          "name": "Болото"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pantano"
+        }
+      ],
+      "id": "56b274f1477072f63827087a57cf589acd7d2adb",
+      "imageName": "swamp3",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Battle for Zendikar Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Invasion Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kaladesh Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kamigawa Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Lorwyn-Shadowmoor Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Scars of Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Theros Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Un-Sets",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        },
+        {
+          "format": "Zendikar Block",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "56",
       "name": "Swamp",
       "number": "377",
       "printings": [
@@ -6394,6 +6687,7 @@
         "BTD",
         "INV",
         "7ED",
+        "ODY",
         "DKM",
         "ONS",
         "8ED",
@@ -6477,299 +6771,6 @@
         "Land"
       ],
       "watermark": "Red"
-    },
-    {
-      "artist": "Douglas Shuler",
-      "colorIdentity": [
-        "B"
-      ],
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "沼泽"
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "沼澤"
-        },
-        {
-          "language": "French",
-          "name": "Marais"
-        },
-        {
-          "language": "German",
-          "name": "Sumpf"
-        },
-        {
-          "language": "Italian",
-          "name": "Palude"
-        },
-        {
-          "language": "Japanese",
-          "name": "沼"
-        },
-        {
-          "language": "Korean",
-          "name": "늪"
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano"
-        },
-        {
-          "language": "Russian",
-          "name": "Болото"
-        },
-        {
-          "language": "Spanish",
-          "name": "Pantano"
-        }
-      ],
-      "id": "56b274f1477072f63827087a57cf589acd7d2adb",
-      "imageName": "swamp3",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Amonkhet Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Battle for Zendikar Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Invasion Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kaladesh Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kamigawa Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Khans of Tarkir Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Lorwyn-Shadowmoor Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Scars of Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shadows over Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shards of Alara Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Theros Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Un-Sets",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        },
-        {
-          "format": "Zendikar Block",
-          "legality": "Legal"
-        }
-      ],
-      "mciNumber": "56",
-      "name": "Swamp",
-      "number": "379",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ICE",
-        "RQS",
-        "pARL",
-        "MIR",
-        "ITP",
-        "5ED",
-        "POR",
-        "TMP",
-        "pJGP",
-        "PO2",
-        "UGL",
-        "pALP",
-        "USG",
-        "ATH",
-        "6ED",
-        "PTK",
-        "pGRU",
-        "S99",
-        "MMQ",
-        "BRB",
-        "pELP",
-        "S00",
-        "BTD",
-        "INV",
-        "7ED",
-        "ODY",
-        "DKM",
-        "ONS",
-        "8ED",
-        "MRD",
-        "CHK",
-        "UNH",
-        "9ED",
-        "RAV",
-        "CST",
-        "TSP",
-        "10E",
-        "MED",
-        "LRW",
-        "SHM",
-        "ALA",
-        "DDC",
-        "M10",
-        "HOP",
-        "ME3",
-        "ZEN",
-        "DDD",
-        "H09",
-        "DDE",
-        "ROE",
-        "DPA",
-        "ARC",
-        "M11",
-        "SOM",
-        "MBS",
-        "NPH",
-        "CMD",
-        "M12",
-        "DDH",
-        "ISD",
-        "PD3",
-        "AVR",
-        "PC2",
-        "M13",
-        "DDJ",
-        "RTR",
-        "DDK",
-        "M14",
-        "THS",
-        "C13",
-        "DDM",
-        "MD1",
-        "M15",
-        "DDN",
-        "KTK",
-        "C14",
-        "DD3_DVD",
-        "DD3_GVL",
-        "FRF",
-        "DTK",
-        "TPR",
-        "ORI",
-        "DDP",
-        "BFZ",
-        "C15",
-        "DDQ",
-        "SOI",
-        "DDR",
-        "KLD",
-        "C16",
-        "PCA",
-        "AKH",
-        "CMA",
-        "E01",
-        "HOU"
-      ],
-      "rarity": "Basic Land",
-      "source": "Beyond the Grave Theme Deck",
-      "subtypes": [
-        "Swamp"
-      ],
-      "supertypes": [
-        "Basic"
-      ],
-      "type": "Basic Land — Swamp",
-      "types": [
-        "Land"
-      ],
-      "watermark": "Black"
     },
     {
       "artist": "Tom Wänerstrand",
@@ -6945,6 +6946,300 @@
       ],
       "mciNumber": "58",
       "name": "Mountain",
+      "number": "379",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "ARN",
+        "3ED",
+        "4ED",
+        "ICE",
+        "RQS",
+        "pARL",
+        "MIR",
+        "ITP",
+        "5ED",
+        "POR",
+        "TMP",
+        "pJGP",
+        "PO2",
+        "UGL",
+        "pALP",
+        "USG",
+        "ATH",
+        "6ED",
+        "PTK",
+        "pGRU",
+        "S99",
+        "MMQ",
+        "BRB",
+        "pELP",
+        "S00",
+        "BTD",
+        "INV",
+        "7ED",
+        "ODY",
+        "DKM",
+        "ONS",
+        "8ED",
+        "MRD",
+        "CHK",
+        "UNH",
+        "9ED",
+        "RAV",
+        "CST",
+        "TSP",
+        "10E",
+        "MED",
+        "LRW",
+        "EVG",
+        "SHM",
+        "ALA",
+        "DD2",
+        "M10",
+        "HOP",
+        "ME3",
+        "ZEN",
+        "H09",
+        "DDE",
+        "ROE",
+        "DPA",
+        "ARC",
+        "M11",
+        "SOM",
+        "PD2",
+        "MBS",
+        "DDG",
+        "NPH",
+        "CMD",
+        "M12",
+        "DDH",
+        "ISD",
+        "DDI",
+        "AVR",
+        "PC2",
+        "M13",
+        "DDJ",
+        "RTR",
+        "DDK",
+        "M14",
+        "DDL",
+        "THS",
+        "C13",
+        "M15",
+        "DDN",
+        "KTK",
+        "C14",
+        "DD3_EVG",
+        "DD3_JVC",
+        "FRF",
+        "DTK",
+        "TPR",
+        "ORI",
+        "DDP",
+        "BFZ",
+        "C15",
+        "SOI",
+        "KLD",
+        "C16",
+        "PCA",
+        "DDS",
+        "AKH",
+        "CMA",
+        "E01",
+        "HOU"
+      ],
+      "rarity": "Basic Land",
+      "source": "Beyond the Grave Theme Deck",
+      "subtypes": [
+        "Mountain"
+      ],
+      "supertypes": [
+        "Basic"
+      ],
+      "type": "Basic Land — Mountain",
+      "types": [
+        "Land"
+      ],
+      "watermark": "Red"
+    },
+    {
+      "artist": "Tom Wänerstrand",
+      "colorIdentity": [
+        "R"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "山脉"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈"
+        },
+        {
+          "language": "French",
+          "name": "Montagne"
+        },
+        {
+          "language": "German",
+          "name": "Gebirge"
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna"
+        },
+        {
+          "language": "Japanese",
+          "name": "山"
+        },
+        {
+          "language": "Korean",
+          "name": "산"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha"
+        },
+        {
+          "language": "Russian",
+          "name": "Гора"
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña"
+        }
+      ],
+      "id": "72910593af4a8bbf2460838c574bb532e23d951a",
+      "imageName": "mountain3",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Battle for Zendikar Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Invasion Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kaladesh Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kamigawa Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Lorwyn-Shadowmoor Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Scars of Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Theros Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Un-Sets",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        },
+        {
+          "format": "Zendikar Block",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "59",
+      "name": "Mountain",
       "number": "380",
       "printings": [
         "LEA",
@@ -6980,6 +7275,7 @@
         "BTD",
         "INV",
         "7ED",
+        "ODY",
         "DKM",
         "ONS",
         "8ED",
@@ -7357,299 +7653,6 @@
       "watermark": "Green"
     },
     {
-      "artist": "Tom Wänerstrand",
-      "colorIdentity": [
-        "R"
-      ],
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "山脉"
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "山脈"
-        },
-        {
-          "language": "French",
-          "name": "Montagne"
-        },
-        {
-          "language": "German",
-          "name": "Gebirge"
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna"
-        },
-        {
-          "language": "Japanese",
-          "name": "山"
-        },
-        {
-          "language": "Korean",
-          "name": "산"
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha"
-        },
-        {
-          "language": "Russian",
-          "name": "Гора"
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña"
-        }
-      ],
-      "id": "72910593af4a8bbf2460838c574bb532e23d951a",
-      "imageName": "mountain3",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Amonkhet Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Battle for Zendikar Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Invasion Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kaladesh Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kamigawa Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Khans of Tarkir Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Lorwyn-Shadowmoor Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Scars of Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shadows over Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shards of Alara Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Theros Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Un-Sets",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        },
-        {
-          "format": "Zendikar Block",
-          "legality": "Legal"
-        }
-      ],
-      "mciNumber": "59",
-      "name": "Mountain",
-      "number": "382",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "ARN",
-        "3ED",
-        "4ED",
-        "ICE",
-        "RQS",
-        "pARL",
-        "MIR",
-        "ITP",
-        "5ED",
-        "POR",
-        "TMP",
-        "pJGP",
-        "PO2",
-        "UGL",
-        "pALP",
-        "USG",
-        "ATH",
-        "6ED",
-        "PTK",
-        "pGRU",
-        "S99",
-        "MMQ",
-        "BRB",
-        "pELP",
-        "S00",
-        "BTD",
-        "INV",
-        "7ED",
-        "DKM",
-        "ONS",
-        "8ED",
-        "MRD",
-        "CHK",
-        "UNH",
-        "9ED",
-        "RAV",
-        "CST",
-        "TSP",
-        "10E",
-        "MED",
-        "LRW",
-        "EVG",
-        "SHM",
-        "ALA",
-        "DD2",
-        "M10",
-        "HOP",
-        "ME3",
-        "ZEN",
-        "H09",
-        "DDE",
-        "ROE",
-        "DPA",
-        "ARC",
-        "M11",
-        "SOM",
-        "PD2",
-        "MBS",
-        "DDG",
-        "NPH",
-        "CMD",
-        "M12",
-        "DDH",
-        "ISD",
-        "DDI",
-        "AVR",
-        "PC2",
-        "M13",
-        "DDJ",
-        "RTR",
-        "DDK",
-        "M14",
-        "DDL",
-        "THS",
-        "C13",
-        "M15",
-        "DDN",
-        "KTK",
-        "C14",
-        "DD3_EVG",
-        "DD3_JVC",
-        "FRF",
-        "DTK",
-        "TPR",
-        "ORI",
-        "DDP",
-        "BFZ",
-        "C15",
-        "SOI",
-        "KLD",
-        "C16",
-        "PCA",
-        "DDS",
-        "AKH",
-        "CMA",
-        "E01",
-        "HOU"
-      ],
-      "rarity": "Basic Land",
-      "source": "Beyond the Grave Theme Deck",
-      "subtypes": [
-        "Mountain"
-      ],
-      "supertypes": [
-        "Basic"
-      ],
-      "type": "Basic Land — Mountain",
-      "types": [
-        "Land"
-      ],
-      "watermark": "Red"
-    },
-    {
       "artist": "Pat Morrissey",
       "colorIdentity": [
         "G"
@@ -7823,7 +7826,7 @@
       ],
       "mciNumber": "61",
       "name": "Forest",
-      "number": "383",
+      "number": "382",
       "printings": [
         "LEA",
         "LEB",
@@ -8115,7 +8118,7 @@
       ],
       "mciNumber": "62",
       "name": "Forest",
-      "number": "385",
+      "number": "383",
       "printings": [
         "LEA",
         "LEB",

--- a/json/DD2.json
+++ b/json/DD2.json
@@ -73,7 +73,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than twenty cards in the targeted player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than twenty cards in the targeted player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "subtypes": [
@@ -144,15 +144,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Each card that’s revealed to pay the cost remains revealed until the ability leaves the stack."
+          "text": "Each card that's revealed to pay the cost remains revealed until the ability leaves the stack."
         },
         {
           "date": "2006-07-15",
-          "text": "A card that’s already revealed for another cost or because of an effect can be revealed to pay this cost."
+          "text": "A card that's already revealed for another cost or because of an effect can be revealed to pay this cost."
         },
         {
           "date": "2006-07-15",
-          "text": "If one of the cards that’s revealed to pay the cost leaves its owner’s hand before the ability resolves, it stops being revealed, but the value of X is not affected."
+          "text": "If one of the cards that's revealed to pay the cost leaves its owner's hand before the ability resolves, it stops being revealed, but the value of X is not affected."
         }
       ],
       "subtypes": [
@@ -583,7 +583,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are no other creatures on the battlefield when Man-o’-War enters the battlefield, its ability must target itself."
+          "text": "If there are no other creatures on the battlefield when Man-o'-War enters the battlefield, its ability must target itself."
         }
       ],
       "subtypes": [
@@ -652,7 +652,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -1010,7 +1010,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Guile’s second ability replaces “counter [a certain spell]” with “exile [a certain spell] and you may cast it without paying its mana cost.” You have the option to cast it immediately upon its exile. If you choose not to, it remains exiled and you don’t get another chance to cast it. If the spell or ability that tried to counter the spell has additional effects, it then continues to resolve."
+          "text": "Guile's second ability replaces \"counter [a certain spell]\" with \"exile [a certain spell] and you may cast it without paying its mana cost.\" You have the option to cast it immediately upon its exile. If you choose not to, it remains exiled and you don't get another chance to cast it. If the spell or ability that tried to counter the spell has additional effects, it then continues to resolve."
         },
         {
           "date": "2007-10-01",
@@ -1022,23 +1022,23 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a spell or ability you control attempts to counter a spell that can’t be countered, it doesn’t. Since the spell wouldn’t be countered, Guile’s ability has no effect on it. The spell will continue to resolve normally."
+          "text": "If a spell or ability you control attempts to counter a spell that can't be countered, it doesn't. Since the spell wouldn't be countered, Guile's ability has no effect on it. The spell will continue to resolve normally."
         },
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -1112,39 +1112,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1355,7 +1355,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Skipping the “next” step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player’s opponents will each skip their next two untap steps."
+          "text": "Skipping the \"next\" step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player's opponents will each skip their next two untap steps."
         }
       ],
       "subtypes": [
@@ -1489,39 +1489,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1592,44 +1592,40 @@
       "rarity": "Rare",
       "rulings": [
         {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "date": "2013-06-07",
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
-        },
-        {
-          "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1637,11 +1633,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 4—{U} (Rather than cast this card from your hand, pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nTarget player draws three cards.",
@@ -1988,7 +1984,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Each pile may contain from zero to five cards; they don’t have to be split “evenly.”"
+          "text": "Each pile may contain from zero to five cards; they don't have to be split \"evenly.\""
         }
       ],
       "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
@@ -2032,7 +2028,7 @@
         },
         {
           "format": "Vintage",
-          "legality": "Legal"
+          "legality": "Restricted"
         }
       ],
       "manaCost": "{4}{U}",
@@ -3329,7 +3325,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can’t choose a negative number."
+          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can't choose a negative number."
         }
       ],
       "subtypes": [
@@ -3532,19 +3528,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Soulbright Flamekin’s ability uses the stack and can be responded to. It’s not a mana ability because it has a target."
+          "text": "Soulbright Flamekin's ability uses the stack and can be responded to. It's not a mana ability because it has a target."
         },
         {
           "date": "2007-10-01",
-          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won’t count toward the total."
+          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won't count toward the total."
         },
         {
           "date": "2007-10-01",
-          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn’t matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don’t count towards the total. Neither does an ability that’s been countered."
+          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn't matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don't count towards the total. Neither does an ability that's been countered."
         },
         {
           "date": "2007-10-01",
-          "text": "You get the bonus only the third time the ability resolves. You won’t get the bonus the fourth, fifth, sixth, or any subsequent times."
+          "text": "You get the bonus only the third time the ability resolves. You won't get the bonus the fourth, fifth, sixth, or any subsequent times."
         }
       ],
       "subtypes": [
@@ -4038,7 +4034,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If Rakdos Pit Dragon loses double strike after first strike combat damage has been dealt, it won’t deal damage during the normal combat damage step."
+          "text": "If Rakdos Pit Dragon loses double strike after first strike combat damage has been dealt, it won't deal damage during the normal combat damage step."
         }
       ],
       "subtypes": [
@@ -4243,7 +4239,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Mountaincycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Mountaincycling doesn't allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -4328,23 +4324,23 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If a spell you control would deal damage to an opponent and that opponent controls a planeswalker, that opponent chooses which of your effects to apply first. — If that player chooses to apply Hostility’s effect first, the damage is prevented, you put some tokens onto the battlefield, and the planeswalker redirection effect is moot because there’s no damage to redirect. — If that player chooses to apply the planeswalker redirection effect first, you have a choice. You can redirect the damage to the planeswalker (in which case Hostility’s prevention effect is moot because nothing’s dealing damage to the player anymore) or you can have your spell continue to deal damage to the opponent. If you choose the latter, Hostility’s effect then applies, the damage is prevented, and you get the tokens."
+          "text": "If a spell you control would deal damage to an opponent and that opponent controls a planeswalker, that opponent chooses which of your effects to apply first. — If that player chooses to apply Hostility's effect first, the damage is prevented, you put some tokens onto the battlefield, and the planeswalker redirection effect is moot because there's no damage to redirect. — If that player chooses to apply the planeswalker redirection effect first, you have a choice. You can redirect the damage to the planeswalker (in which case Hostility's prevention effect is moot because nothing's dealing damage to the player anymore) or you can have your spell continue to deal damage to the opponent. If you choose the latter, Hostility's effect then applies, the damage is prevented, and you get the tokens."
         },
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -4556,7 +4552,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Regeneration abilities that would affect that creature can still be activated; they just won’t do anything. The creature can’t be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
+          "text": "Regeneration abilities that would affect that creature can still be activated; they just won't do anything. The creature can't be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
         }
       ],
       "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
@@ -4638,11 +4634,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Magma Jet deals 2 damage to target creature or player. Scry 2.",
@@ -4711,7 +4707,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -4798,11 +4794,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of the three targets must be different. If there aren’t three different legal targets available, you can’t cast the spell."
+          "text": "Each of the three targets must be different. If there aren't three different legal targets available, you can't cast the spell."
         },
         {
           "date": "2014-07-18",
-          "text": "If one or two of Cone of Flame’s targets are illegal when it resolves, you can’t change how much damage will be dealt to the remaining legal targets."
+          "text": "If one or two of Cone of Flame's targets are illegal when it resolves, you can't change how much damage will be dealt to the remaining legal targets."
         }
       ],
       "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
@@ -4951,7 +4947,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -4963,7 +4959,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -5088,7 +5084,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "It doesn’t matter how many cards you have in your hand when the ability resolves."
+          "text": "It doesn't matter how many cards you have in your hand when the ability resolves."
         }
       ],
       "text": "Keldon Megaliths enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\nHellbent — {1}{R}, {T}: Keldon Megaliths deals 1 damage to target creature or player. Activate this ability only if you have no cards in hand.",

--- a/json/DD3_DVD.json
+++ b/json/DD3_DVD.json
@@ -713,23 +713,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -1056,11 +1056,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Any Aura attached to the creature is put into its owner’s graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
+          "text": "Any Aura attached to the creature is put into its owner's graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
         },
         {
           "date": "2005-08-01",
-          "text": "If Otherworldly Journey is cast during an end step, the creature won’t return until the beginning of the next end step."
+          "text": "If Otherworldly Journey is cast during an end step, the creature won't return until the beginning of the next end step."
         }
       ],
       "subtypes": [
@@ -1276,11 +1276,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -1292,7 +1292,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         },
         {
           "date": "2012-07-01",
@@ -1357,11 +1357,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Faith’s Fetters doesn’t stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
+          "text": "Faith's Fetters doesn't stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -1538,7 +1538,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a white spell, Angel’s Feather’s ability triggers and is put on the stack on top of that spell. Angel’s Feather’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a white spell, Angel's Feather's ability triggers and is put on the stack on top of that spell. Angel's Feather's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a white spell, you may gain 1 life.",
@@ -2795,7 +2795,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “sacrifice a creature” effect is not targeted. It can affect creatures with protection from black, for example."
+          "text": "The \"sacrifice a creature\" effect is not targeted. It can affect creatures with protection from black, for example."
         },
         {
           "date": "2008-04-01",
@@ -3115,15 +3115,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         },
         {
           "date": "2013-06-07",
-          "text": "Notably, Stinkweed Imp’s ability isn’t deathtouch. It’s a triggered ability that triggers only on combat damage."
+          "text": "Notably, Stinkweed Imp's ability isn't deathtouch. It's a triggered ability that triggers only on combat damage."
         }
       ],
       "subtypes": [
@@ -3192,7 +3192,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A hybrid spell that’s black and another color is *not* a nonblack spell. Since it’s black, it can’t be nonblack!"
+          "text": "A hybrid spell that's black and another color is *not* a nonblack spell. Since it's black, it can't be nonblack!"
         }
       ],
       "subtypes": [
@@ -3567,7 +3567,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -3980,7 +3980,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t reveal the card to your opponent."
+          "text": "You don't reveal the card to your opponent."
         },
         {
           "date": "2004-10-04",
@@ -4002,7 +4002,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"Ha, banishment? Be merciful, say ‘death,'\nFor exile hath more terror in his look,\nMuch more than death.\"\n—William Shakespeare, Romeo and Juliet",
+      "flavor": "\"Ha, banishment? Be merciful, say 'death,'\nFor exile hath more terror in his look,\nMuch more than death.\"\n—William Shakespeare, Romeo and Juliet",
       "id": "3cc7250a0fa962a45e7f6629b067f63b7a7f5e12",
       "imageName": "dark banishing",
       "layout": "normal",
@@ -4187,7 +4187,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Barter in Blood doesn’t target any creatures and may be cast even if a player controls fewer than two creatures."
+          "text": "Barter in Blood doesn't target any creatures and may be cast even if a player controls fewer than two creatures."
         }
       ],
       "text": "Each player sacrifices two creatures.",
@@ -4305,11 +4305,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The power and toughness of the Demon token are set when Promise of Power resolves. They’re unaffected if the number of cards in your hand changes later."
+          "text": "The power and toughness of the Demon token are set when Promise of Power resolves. They're unaffected if the number of cards in your hand changes later."
         },
         {
           "date": "2004-12-01",
-          "text": "If you pay the entwine cost, you draw five cards, then lose five life, then put the Demon token onto the battlefield. The five cards you draw count toward the Demon’s power and toughness."
+          "text": "If you pay the entwine cost, you draw five cards, then lose five life, then put the Demon token onto the battlefield. The five cards you draw count toward the Demon's power and toughness."
         }
       ],
       "text": "Choose one —\n• You draw five cards and you lose 5 life.\n• Create an X/X black Demon creature token with flying, where X is the number of cards in your hand.\nEntwine {4} (Choose both if you pay the entwine cost.)",
@@ -4389,7 +4389,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -4464,7 +4464,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
@@ -4528,7 +4528,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a black spell, Demon’s Horn’s ability triggers and is put on the stack on top of that spell. Demon’s Horn’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a black spell, Demon's Horn's ability triggers and is put on the stack on top of that spell. Demon's Horn's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a black spell, you may gain 1 life.",

--- a/json/DD3_EVG.json
+++ b/json/DD3_EVG.json
@@ -55,7 +55,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -120,19 +120,19 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Paying the alternative cost doesn’t change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
+          "text": "Paying the alternative cost doesn't change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
         },
         {
           "date": "2006-07-15",
-          "text": "You may pay the alternative cost rather than the card’s mana cost. Any additional costs are paid as normal."
+          "text": "You may pay the alternative cost rather than the card's mana cost. Any additional costs are paid as normal."
         },
         {
           "date": "2006-07-15",
-          "text": "If you don’t have two cards of the right color in your hand, you can’t choose to cast the spell using the alternative cost."
+          "text": "If you don't have two cards of the right color in your hand, you can't choose to cast the spell using the alternative cost."
         },
         {
           "date": "2006-07-15",
-          "text": "You can’t exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
+          "text": "You can't exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
         }
       ],
       "subtypes": [
@@ -392,11 +392,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -665,7 +665,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Lys Alana Huntmaster’s ability will resolve before the Elf spell that caused it to trigger."
+          "text": "Lys Alana Huntmaster's ability will resolve before the Elf spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -845,7 +845,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf’s ability resolves. If Timberwatch Elf is still on the battlefield, it’ll count itself."
+          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf's ability resolves. If Timberwatch Elf is still on the battlefield, it'll count itself."
         }
       ],
       "subtypes": [
@@ -1153,7 +1153,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -2774,11 +2774,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander’s activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
+          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander's activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
         },
         {
           "date": "2016-06-08",
-          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -3077,7 +3077,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The target of the ability can’t be a creature with Protection from Creatures, with Protection from Goblins, or with Protection from Red."
+          "text": "The target of the ability can't be a creature with Protection from Creatures, with Protection from Goblins, or with Protection from Red."
         },
         {
           "date": "2008-10-01",
@@ -3089,11 +3089,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -3218,11 +3218,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type “Summon Goblin” and “Summon Goblins” also count. You can’t search for cards that have Goblin in the name but don’t have the creature type Goblin."
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
         }
       ],
       "subtypes": [
@@ -3300,7 +3300,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Let's play ‘sled.' Here's how it works: you're the sled.\"",
+      "flavor": "\"Let's play 'sled.' Here's how it works: you're the sled.\"",
       "id": "45c526905d3dab76489e8b74cec9ab6fd94fb274",
       "imageName": "goblin sledder",
       "layout": "normal",
@@ -3457,7 +3457,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If you don’t actually sacrifice the Goblin (because it was removed from the battlefield before the ability resolved, for example), no damage is dealt."
+          "text": "If you don't actually sacrifice the Goblin (because it was removed from the battlefield before the ability resolved, for example), no damage is dealt."
         }
       ],
       "subtypes": [
@@ -3533,7 +3533,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it’s too late to activate its ability before it’s destroyed."
+          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it's too late to activate its ability before it's destroyed."
         }
       ],
       "subtypes": [

--- a/json/DD3_GVL.json
+++ b/json/DD3_GVL.json
@@ -63,11 +63,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two lands. They don’t have to be tapped."
+          "text": "The first ability can target any two lands. They don't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "The third ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "The third ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -128,7 +128,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -535,7 +535,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability that returns a creature doesn’t target anything. You can return a creature with shroud or protection from green, for example. You don’t decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
+          "text": "The ability that returns a creature doesn't target anything. You can return a creature with shroud or protection from green, for example. You don't decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
         },
         {
           "date": "2004-10-04",
@@ -675,7 +675,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -798,11 +798,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -959,7 +959,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -1022,7 +1022,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature’s power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
+          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature's power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
         },
         {
           "date": "2007-10-01",
@@ -1030,7 +1030,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites previous effects that changed the enchanted creature’s creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
+          "text": "Lignify overwrites previous effects that changed the enchanted creature's creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
         },
         {
           "date": "2007-10-01",
@@ -1038,11 +1038,11 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a previous effect switched the creature’s power and toughness, that effect still applies (though it will apply to the creature’s new power and toughness)."
+          "text": "If a previous effect switched the creature's power and toughness, that effect still applies (though it will apply to the creature's new power and toughness)."
         },
         {
           "date": "2007-10-01",
-          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it’s applied before the creature loses the ability."
+          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it's applied before the creature loses the ability."
         },
         {
           "date": "2007-10-01",
@@ -1050,11 +1050,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will overwrite any previous effects that set the enchanted creature’s power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
+          "text": "Lignify will overwrite any previous effects that set the enchanted creature's power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature’s power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
+          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature's power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
         }
       ],
       "subtypes": [
@@ -1121,7 +1121,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -1184,7 +1184,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If Elephant Guide enchants an opponent’s creature, you get the Elephant when that creature dies."
+          "text": "If Elephant Guide enchants an opponent's creature, you get the Elephant when that creature dies."
         }
       ],
       "subtypes": [
@@ -1248,7 +1248,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If an effect says that an opponent can’t gain life, you can’t have that player gain life to pay Invigorate’s alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost’s action is replaced with nothing."
+          "text": "If an effect says that an opponent can't gain life, you can't have that player gain life to pay Invigorate's alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost's action is replaced with nothing."
         }
       ],
       "text": "If you control a Forest, rather than pay Invigorate's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
@@ -1304,7 +1304,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you’ve somehow manage to get a new arrowhead counter on the Arrows."
+          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you've somehow manage to get a new arrowhead counter on the Arrows."
         }
       ],
       "text": "Serrated Arrows enters the battlefield with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
@@ -1433,11 +1433,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-06-07",
-          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won’t be affected."
+          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won't be affected."
         }
       ],
       "text": "Choose one —\n• Untap all lands you control.\n• Until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
@@ -1564,7 +1564,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -1736,11 +1736,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
@@ -2828,7 +2828,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -3215,11 +3215,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you’ll have to sacrifice Fleshbag Marauder."
+          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you'll have to sacrifice Fleshbag Marauder."
         },
         {
           "date": "2015-06-22",
-          "text": "As Fleshbag Marauder’s ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
+          "text": "As Fleshbag Marauder's ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
         }
       ],
       "subtypes": [
@@ -3483,7 +3483,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Faerie Macabre’s second ability can be activated only while it’s in your hand. You can do this any time you could cast an instant."
+          "text": "Faerie Macabre's second ability can be activated only while it's in your hand. You can do this any time you could cast an instant."
         },
         {
           "date": "2008-05-01",
@@ -3676,7 +3676,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2016-06-08",
@@ -3754,7 +3754,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You may pay the cost of Skeletal Vampire’s activated abilities by sacrificing any Bat, not just a Bat token it created."
+          "text": "You may pay the cost of Skeletal Vampire's activated abilities by sacrificing any Bat, not just a Bat token it created."
         }
       ],
       "subtypes": [
@@ -3818,11 +3818,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -4244,7 +4244,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -4306,7 +4306,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won’t change later in the turn, even if the number of Swamps you control changes."
+          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won't change later in the turn, even if the number of Swamps you control changes."
         }
       ],
       "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
@@ -4377,19 +4377,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
+          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -4469,7 +4469,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -4537,11 +4537,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn’t start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
+          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn't start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         }
       ],
       "subtypes": [

--- a/json/DD3_JVC.json
+++ b/json/DD3_JVC.json
@@ -62,7 +62,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than twenty cards in the targeted player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than twenty cards in the targeted player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "subtypes": [
@@ -126,15 +126,15 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Each card that’s revealed to pay the cost remains revealed until the ability leaves the stack."
+          "text": "Each card that's revealed to pay the cost remains revealed until the ability leaves the stack."
         },
         {
           "date": "2006-07-15",
-          "text": "A card that’s already revealed for another cost or because of an effect can be revealed to pay this cost."
+          "text": "A card that's already revealed for another cost or because of an effect can be revealed to pay this cost."
         },
         {
           "date": "2006-07-15",
-          "text": "If one of the cards that’s revealed to pay the cost leaves its owner’s hand before the ability resolves, it stops being revealed, but the value of X is not affected."
+          "text": "If one of the cards that's revealed to pay the cost leaves its owner's hand before the ability resolves, it stops being revealed, but the value of X is not affected."
         }
       ],
       "subtypes": [
@@ -523,7 +523,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are no other creatures on the battlefield when Man-o’-War enters the battlefield, its ability must target itself."
+          "text": "If there are no other creatures on the battlefield when Man-o'-War enters the battlefield, its ability must target itself."
         }
       ],
       "subtypes": [
@@ -585,7 +585,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -908,7 +908,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Guile’s second ability replaces “counter [a certain spell]” with “exile [a certain spell] and you may cast it without paying its mana cost.” You have the option to cast it immediately upon its exile. If you choose not to, it remains exiled and you don’t get another chance to cast it. If the spell or ability that tried to counter the spell has additional effects, it then continues to resolve."
+          "text": "Guile's second ability replaces \"counter [a certain spell]\" with \"exile [a certain spell] and you may cast it without paying its mana cost.\" You have the option to cast it immediately upon its exile. If you choose not to, it remains exiled and you don't get another chance to cast it. If the spell or ability that tried to counter the spell has additional effects, it then continues to resolve."
         },
         {
           "date": "2007-10-01",
@@ -920,23 +920,23 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a spell or ability you control attempts to counter a spell that can’t be countered, it doesn’t. Since the spell wouldn’t be countered, Guile’s ability has no effect on it. The spell will continue to resolve normally."
+          "text": "If a spell or ability you control attempts to counter a spell that can't be countered, it doesn't. Since the spell wouldn't be countered, Guile's ability has no effect on it. The spell will continue to resolve normally."
         },
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -1003,39 +1003,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1225,7 +1225,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Skipping the “next” step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player’s opponents will each skip their next two untap steps."
+          "text": "Skipping the \"next\" step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player's opponents will each skip their next two untap steps."
         }
       ],
       "subtypes": [
@@ -1345,39 +1345,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1441,44 +1441,40 @@
       "rarity": "Rare",
       "rulings": [
         {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "date": "2013-06-07",
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
-        },
-        {
-          "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1486,11 +1482,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 4—{U} (Rather than cast this card from your hand, pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nTarget player draws three cards.",
@@ -1802,7 +1798,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Each pile may contain from zero to five cards; they don’t have to be split “evenly.”"
+          "text": "Each pile may contain from zero to five cards; they don't have to be split \"evenly.\""
         }
       ],
       "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
@@ -3027,7 +3023,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can’t choose a negative number."
+          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can't choose a negative number."
         }
       ],
       "subtypes": [
@@ -3209,19 +3205,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Soulbright Flamekin’s ability uses the stack and can be responded to. It’s not a mana ability because it has a target."
+          "text": "Soulbright Flamekin's ability uses the stack and can be responded to. It's not a mana ability because it has a target."
         },
         {
           "date": "2007-10-01",
-          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won’t count toward the total."
+          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won't count toward the total."
         },
         {
           "date": "2007-10-01",
-          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn’t matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don’t count towards the total. Neither does an ability that’s been countered."
+          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn't matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don't count towards the total. Neither does an ability that's been countered."
         },
         {
           "date": "2007-10-01",
-          "text": "You get the bonus only the third time the ability resolves. You won’t get the bonus the fourth, fifth, sixth, or any subsequent times."
+          "text": "You get the bonus only the third time the ability resolves. You won't get the bonus the fourth, fifth, sixth, or any subsequent times."
         }
       ],
       "subtypes": [
@@ -3666,7 +3662,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If Rakdos Pit Dragon loses double strike after first strike combat damage has been dealt, it won’t deal damage during the normal combat damage step."
+          "text": "If Rakdos Pit Dragon loses double strike after first strike combat damage has been dealt, it won't deal damage during the normal combat damage step."
         }
       ],
       "subtypes": [
@@ -3850,7 +3846,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Mountaincycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Mountaincycling doesn't allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -3928,23 +3924,23 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If a spell you control would deal damage to an opponent and that opponent controls a planeswalker, that opponent chooses which of your effects to apply first. — If that player chooses to apply Hostility’s effect first, the damage is prevented, you put some tokens onto the battlefield, and the planeswalker redirection effect is moot because there’s no damage to redirect. — If that player chooses to apply the planeswalker redirection effect first, you have a choice. You can redirect the damage to the planeswalker (in which case Hostility’s prevention effect is moot because nothing’s dealing damage to the player anymore) or you can have your spell continue to deal damage to the opponent. If you choose the latter, Hostility’s effect then applies, the damage is prevented, and you get the tokens."
+          "text": "If a spell you control would deal damage to an opponent and that opponent controls a planeswalker, that opponent chooses which of your effects to apply first. — If that player chooses to apply Hostility's effect first, the damage is prevented, you put some tokens onto the battlefield, and the planeswalker redirection effect is moot because there's no damage to redirect. — If that player chooses to apply the planeswalker redirection effect first, you have a choice. You can redirect the damage to the planeswalker (in which case Hostility's prevention effect is moot because nothing's dealing damage to the player anymore) or you can have your spell continue to deal damage to the opponent. If you choose the latter, Hostility's effect then applies, the damage is prevented, and you get the tokens."
         },
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -4135,7 +4131,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Regeneration abilities that would affect that creature can still be activated; they just won’t do anything. The creature can’t be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
+          "text": "Regeneration abilities that would affect that creature can still be activated; they just won't do anything. The creature can't be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
         }
       ],
       "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
@@ -4210,11 +4206,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Magma Jet deals 2 damage to target creature or player. Scry 2.",
@@ -4276,7 +4272,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -4356,11 +4352,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of the three targets must be different. If there aren’t three different legal targets available, you can’t cast the spell."
+          "text": "Each of the three targets must be different. If there aren't three different legal targets available, you can't cast the spell."
         },
         {
           "date": "2014-07-18",
-          "text": "If one or two of Cone of Flame’s targets are illegal when it resolves, you can’t change how much damage will be dealt to the remaining legal targets."
+          "text": "If one or two of Cone of Flame's targets are illegal when it resolves, you can't change how much damage will be dealt to the remaining legal targets."
         }
       ],
       "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
@@ -4495,7 +4491,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -4507,7 +4503,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -4618,7 +4614,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "It doesn’t matter how many cards you have in your hand when the ability resolves."
+          "text": "It doesn't matter how many cards you have in your hand when the ability resolves."
         }
       ],
       "text": "Keldon Megaliths enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\nHellbent — {1}{R}, {T}: Keldon Megaliths deals 1 damage to target creature or player. Activate this ability only if you have no cards in hand.",

--- a/json/DDC.json
+++ b/json/DDC.json
@@ -713,23 +713,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -1056,11 +1056,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Any Aura attached to the creature is put into its owner’s graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
+          "text": "Any Aura attached to the creature is put into its owner's graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
         },
         {
           "date": "2005-08-01",
-          "text": "If Otherworldly Journey is cast during an end step, the creature won’t return until the beginning of the next end step."
+          "text": "If Otherworldly Journey is cast during an end step, the creature won't return until the beginning of the next end step."
         }
       ],
       "subtypes": [
@@ -1276,11 +1276,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -1292,7 +1292,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         },
         {
           "date": "2012-07-01",
@@ -1357,11 +1357,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Faith’s Fetters doesn’t stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
+          "text": "Faith's Fetters doesn't stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -1538,7 +1538,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a white spell, Angel’s Feather’s ability triggers and is put on the stack on top of that spell. Angel’s Feather’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a white spell, Angel's Feather's ability triggers and is put on the stack on top of that spell. Angel's Feather's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a white spell, you may gain 1 life.",
@@ -2795,7 +2795,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “sacrifice a creature” effect is not targeted. It can affect creatures with protection from black, for example."
+          "text": "The \"sacrifice a creature\" effect is not targeted. It can affect creatures with protection from black, for example."
         },
         {
           "date": "2008-04-01",
@@ -3115,15 +3115,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         },
         {
           "date": "2013-06-07",
-          "text": "Notably, Stinkweed Imp’s ability isn’t deathtouch. It’s a triggered ability that triggers only on combat damage."
+          "text": "Notably, Stinkweed Imp's ability isn't deathtouch. It's a triggered ability that triggers only on combat damage."
         }
       ],
       "subtypes": [
@@ -3192,7 +3192,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A hybrid spell that’s black and another color is *not* a nonblack spell. Since it’s black, it can’t be nonblack!"
+          "text": "A hybrid spell that's black and another color is *not* a nonblack spell. Since it's black, it can't be nonblack!"
         }
       ],
       "subtypes": [
@@ -3567,7 +3567,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -3980,7 +3980,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t reveal the card to your opponent."
+          "text": "You don't reveal the card to your opponent."
         },
         {
           "date": "2004-10-04",
@@ -4002,7 +4002,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"Ha, banishment? Be merciful, say ‘death,'\nFor exile hath more terror in his look,\nMuch more than death.\"\n—William Shakespeare, Romeo and Juliet",
+      "flavor": "\"Ha, banishment? Be merciful, say 'death,'\nFor exile hath more terror in his look,\nMuch more than death.\"\n—William Shakespeare, Romeo and Juliet",
       "id": "4b895346ce167fef948ab2c403db894a191cdfcf",
       "imageName": "dark banishing",
       "layout": "normal",
@@ -4187,7 +4187,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Barter in Blood doesn’t target any creatures and may be cast even if a player controls fewer than two creatures."
+          "text": "Barter in Blood doesn't target any creatures and may be cast even if a player controls fewer than two creatures."
         }
       ],
       "text": "Each player sacrifices two creatures.",
@@ -4305,11 +4305,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The power and toughness of the Demon token are set when Promise of Power resolves. They’re unaffected if the number of cards in your hand changes later."
+          "text": "The power and toughness of the Demon token are set when Promise of Power resolves. They're unaffected if the number of cards in your hand changes later."
         },
         {
           "date": "2004-12-01",
-          "text": "If you pay the entwine cost, you draw five cards, then lose five life, then put the Demon token onto the battlefield. The five cards you draw count toward the Demon’s power and toughness."
+          "text": "If you pay the entwine cost, you draw five cards, then lose five life, then put the Demon token onto the battlefield. The five cards you draw count toward the Demon's power and toughness."
         }
       ],
       "text": "Choose one —\n• You draw five cards and you lose 5 life.\n• Create an X/X black Demon creature token with flying, where X is the number of cards in your hand.\nEntwine {4} (Choose both if you pay the entwine cost.)",
@@ -4389,7 +4389,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -4464,7 +4464,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
@@ -4528,7 +4528,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a black spell, Demon’s Horn’s ability triggers and is put on the stack on top of that spell. Demon’s Horn’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a black spell, Demon's Horn's ability triggers and is put on the stack on top of that spell. Demon's Horn's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a black spell, you may gain 1 life.",

--- a/json/DDD.json
+++ b/json/DDD.json
@@ -63,11 +63,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two lands. They don’t have to be tapped."
+          "text": "The first ability can target any two lands. They don't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "The third ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "The third ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -128,7 +128,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -535,7 +535,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability that returns a creature doesn’t target anything. You can return a creature with shroud or protection from green, for example. You don’t decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
+          "text": "The ability that returns a creature doesn't target anything. You can return a creature with shroud or protection from green, for example. You don't decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
         },
         {
           "date": "2004-10-04",
@@ -675,7 +675,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -798,11 +798,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -959,7 +959,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -1022,7 +1022,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature’s power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
+          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature's power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
         },
         {
           "date": "2007-10-01",
@@ -1030,7 +1030,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites previous effects that changed the enchanted creature’s creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
+          "text": "Lignify overwrites previous effects that changed the enchanted creature's creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
         },
         {
           "date": "2007-10-01",
@@ -1038,11 +1038,11 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a previous effect switched the creature’s power and toughness, that effect still applies (though it will apply to the creature’s new power and toughness)."
+          "text": "If a previous effect switched the creature's power and toughness, that effect still applies (though it will apply to the creature's new power and toughness)."
         },
         {
           "date": "2007-10-01",
-          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it’s applied before the creature loses the ability."
+          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it's applied before the creature loses the ability."
         },
         {
           "date": "2007-10-01",
@@ -1050,11 +1050,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will overwrite any previous effects that set the enchanted creature’s power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
+          "text": "Lignify will overwrite any previous effects that set the enchanted creature's power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature’s power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
+          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature's power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
         }
       ],
       "subtypes": [
@@ -1121,7 +1121,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -1184,7 +1184,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If Elephant Guide enchants an opponent’s creature, you get the Elephant when that creature dies."
+          "text": "If Elephant Guide enchants an opponent's creature, you get the Elephant when that creature dies."
         }
       ],
       "subtypes": [
@@ -1248,7 +1248,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If an effect says that an opponent can’t gain life, you can’t have that player gain life to pay Invigorate’s alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost’s action is replaced with nothing."
+          "text": "If an effect says that an opponent can't gain life, you can't have that player gain life to pay Invigorate's alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost's action is replaced with nothing."
         }
       ],
       "text": "If you control a Forest, rather than pay Invigorate's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
@@ -1304,7 +1304,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you’ve somehow manage to get a new arrowhead counter on the Arrows."
+          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you've somehow manage to get a new arrowhead counter on the Arrows."
         }
       ],
       "text": "Serrated Arrows enters the battlefield with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
@@ -1433,11 +1433,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-06-07",
-          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won’t be affected."
+          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won't be affected."
         }
       ],
       "text": "Choose one —\n• Untap all lands you control.\n• Until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
@@ -1564,7 +1564,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -1736,11 +1736,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
@@ -2828,7 +2828,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -3215,11 +3215,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you’ll have to sacrifice Fleshbag Marauder."
+          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you'll have to sacrifice Fleshbag Marauder."
         },
         {
           "date": "2015-06-22",
-          "text": "As Fleshbag Marauder’s ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
+          "text": "As Fleshbag Marauder's ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
         }
       ],
       "subtypes": [
@@ -3483,7 +3483,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Faerie Macabre’s second ability can be activated only while it’s in your hand. You can do this any time you could cast an instant."
+          "text": "Faerie Macabre's second ability can be activated only while it's in your hand. You can do this any time you could cast an instant."
         },
         {
           "date": "2008-05-01",
@@ -3676,7 +3676,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2016-06-08",
@@ -3754,7 +3754,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You may pay the cost of Skeletal Vampire’s activated abilities by sacrificing any Bat, not just a Bat token it created."
+          "text": "You may pay the cost of Skeletal Vampire's activated abilities by sacrificing any Bat, not just a Bat token it created."
         }
       ],
       "subtypes": [
@@ -3818,11 +3818,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -4244,7 +4244,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -4306,7 +4306,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won’t change later in the turn, even if the number of Swamps you control changes."
+          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won't change later in the turn, even if the number of Swamps you control changes."
         }
       ],
       "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
@@ -4377,19 +4377,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
+          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -4469,7 +4469,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -4537,11 +4537,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn’t start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
+          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn't start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         }
       ],
       "subtypes": [

--- a/json/DDE.json
+++ b/json/DDE.json
@@ -448,7 +448,7 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -1248,7 +1248,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You are not allowed to “unequip” equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won’t be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
+          "text": "You are not allowed to \"unequip\" equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won't be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
         }
       ],
       "subtypes": [
@@ -1313,11 +1313,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When damage is dealt to Phyrexian Totem, its triggered ability will trigger. A number of permanents equal to the amount of damage dealt will be sacrificed when the ability resolves. It doesn’t matter if Phyrexian Totem isn’t on the battlefield when the ability resolves, as long as Phyrexian Totem was a creature as it left the battlefield. If one of the permanents sacrificed is Phyrexian Totem itself, the requisite number of other permanents must still be sacrificed."
+          "text": "When damage is dealt to Phyrexian Totem, its triggered ability will trigger. A number of permanents equal to the amount of damage dealt will be sacrificed when the ability resolves. It doesn't matter if Phyrexian Totem isn't on the battlefield when the ability resolves, as long as Phyrexian Totem was a creature as it left the battlefield. If one of the permanents sacrificed is Phyrexian Totem itself, the requisite number of other permanents must still be sacrificed."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {B} to your mana pool.\n{2}{B}: Phyrexian Totem becomes a 5/5 black Horror artifact creature with trample until end of turn.\nWhenever Phyrexian Totem is dealt damage, if it's a creature, sacrifice that many permanents.",
@@ -1607,7 +1607,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t draw a card if this spell is countered."
+          "text": "You don't draw a card if this spell is countered."
         }
       ],
       "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
@@ -1847,7 +1847,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can pay 0 life if you want, but it’s not useful most of the time."
+          "text": "You can pay 0 life if you want, but it's not useful most of the time."
         }
       ],
       "text": "As Phyrexian Processor enters the battlefield, pay any amount of life.\n{4}, {T}: Create an X/X black Minion creature token, where X is the life paid as Phyrexian Processor entered the battlefield.",
@@ -1922,7 +1922,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -1989,7 +1989,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures which are sacrificed can’t be regenerated."
+          "text": "The creatures which are sacrificed can't be regenerated."
         },
         {
           "date": "2004-10-04",
@@ -1997,7 +1997,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
+          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
         }
       ],
       "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -3175,11 +3175,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This spell has a self-replacement in it . This means that if Urza’s Rage is kicked, the 3 damage is replaced with 10 unpreventable damage before any other replacements can be applied. For example, you can’t use Healing Salve to prevent the 3 damage before it gets changed."
+          "text": "This spell has a self-replacement in it . This means that if Urza's Rage is kicked, the 3 damage is replaced with 10 unpreventable damage before any other replacements can be applied. For example, you can't use Healing Salve to prevent the 3 damage before it gets changed."
         },
         {
           "date": "2004-10-04",
-          "text": "You can target this spell with spells and abilities, so you can change its target. Those spells and abilities just can’t counter it."
+          "text": "You can target this spell with spells and abilities, so you can change its target. Those spells and abilities just can't counter it."
         },
         {
           "date": "2004-10-04",
@@ -3191,7 +3191,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Counterspells can be cast that target it, but when they resolve they simply don’t counter it since it can’t be countered."
+          "text": "Counterspells can be cast that target it, but when they resolve they simply don't counter it since it can't be countered."
         }
       ],
       "text": "Kicker {8}{R} (You may pay an additional {8}{R} as you cast this spell.)\nUrza's Rage can't be countered by spells or abilities.\nUrza's Rage deals 3 damage to target creature or player. If Urza's Rage was kicked, instead it deals 10 damage to that creature or player and the damage can't be prevented.",
@@ -3583,19 +3583,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You choose whether to kick a spell as you cast it, and you pay that much along with the spell’s mana cost at the same time. Kicking a spell is always optional."
+          "text": "You choose whether to kick a spell as you cast it, and you pay that much along with the spell's mana cost at the same time. Kicking a spell is always optional."
         },
         {
           "date": "2017-03-14",
-          "text": "You can pay any particular kicker cost only once. You can’t pay it multiple times to get multiples of either triggered ability."
+          "text": "You can pay any particular kicker cost only once. You can't pay it multiple times to get multiples of either triggered ability."
         },
         {
           "date": "2017-03-14",
-          "text": "If Thornscape Battlemage is put onto the battlefield as the result of a spell or ability, there’s no opportunity to kick it."
+          "text": "If Thornscape Battlemage is put onto the battlefield as the result of a spell or ability, there's no opportunity to kick it."
         },
         {
           "date": "2017-03-14",
-          "text": "Kicker costs don’t change a spell’s mana cost or converted mana cost."
+          "text": "Kicker costs don't change a spell's mana cost or converted mana cost."
         }
       ],
       "subtypes": [
@@ -4143,7 +4143,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Counter target spell unless its controller pays {1} for each basic land type among lands you control.",
@@ -4224,7 +4224,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
@@ -4557,7 +4557,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -4641,7 +4641,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can’t pay this cost more than once to get a multiple effect."
+          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can't pay this cost more than once to get a multiple effect."
         },
         {
           "date": "2004-10-04",
@@ -4649,7 +4649,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
@@ -4717,11 +4717,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "While Armadillo Cloak’s last ability is similar to lifelink, it isn’t lifelink—it’s a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you’ll gain that much life for lifelink, and then Armadillo Cloak’s triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak’s triggered ability do trigger separately."
+          "text": "While Armadillo Cloak's last ability is similar to lifelink, it isn't lifelink—it's a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you'll gain that much life for lifelink, and then Armadillo Cloak's triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak's triggered ability do trigger separately."
         },
         {
           "date": "2016-06-08",
-          "text": "If Armadillo Cloak enchants a creature you don’t control, you’ll gain life when it deals damage, as long as that damage hasn’t already caused you to lose the game."
+          "text": "If Armadillo Cloak enchants a creature you don't control, you'll gain life when it deals damage, as long as that damage hasn't already caused you to lose the game."
         }
       ],
       "subtypes": [
@@ -4965,7 +4965,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — {3}, {T}: Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
@@ -5039,7 +5039,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Target player draws a card for each basic land type among lands he or she controls.",

--- a/json/DDF.json
+++ b/json/DDF.json
@@ -94,11 +94,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren’t permanents and don’t exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
+          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren't permanents and don't exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s a creature whose toughness is 0 or less, or if it’s an Aura that’s either unattached or attached to something illegal."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's a creature whose toughness is 0 or less, or if it's an Aura that's either unattached or attached to something illegal."
         }
       ],
       "subtypes": [
@@ -363,7 +363,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         }
       ],
       "subtypes": [
@@ -719,7 +719,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Kor Skyfisher’s triggered ability doesn’t target a permanent. You choose which one to return to its owner’s hand as the ability resolves. No one can respond to the choice."
+          "text": "Kor Skyfisher's triggered ability doesn't target a permanent. You choose which one to return to its owner's hand as the ability resolves. No one can respond to the choice."
         },
         {
           "date": "2017-03-14",
@@ -1068,7 +1068,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Kor Hookmaster’s ability can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Kor Hookmaster's ability can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -1091,7 +1091,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"We're now to dispense aid to any Mirran we see battling anything . . . ‘strange.' Regent's orders.\"\n—Ranya, skyhunter captain",
+      "flavor": "\"We're now to dispense aid to any Mirran we see battling anything . . . 'strange.' Regent's orders.\"\n—Ranya, skyhunter captain",
       "foreignNames": [
         {
           "language": "French",
@@ -1250,23 +1250,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -1454,31 +1454,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -1581,19 +1581,19 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner’s hand."
+          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner's hand."
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -1616,7 +1616,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"There's no ‘I' in ‘team,' but there's a ‘we' in ‘weapon.'\"",
+      "flavor": "\"There's no 'I' in 'team,' but there's a 'we' in 'weapon.'\"",
       "foreignNames": [
         {
           "language": "French",
@@ -1777,31 +1777,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -1896,31 +1896,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -2117,7 +2117,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -2304,7 +2304,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
         }
       ],
       "text": "Target creature gets +2/+2 and gains flying until end of turn.",
@@ -2638,7 +2638,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The second mode affects all creatures during the player’s next untap step, including creatures controlled by other players (who may have untapped because of Seedborn Muse, for example) and creatures that weren’t on the battlefield when Blinding Beam resolved."
+          "text": "The second mode affects all creatures during the player's next untap step, including creatures controlled by other players (who may have untapped because of Seedborn Muse, for example) and creatures that weren't on the battlefield when Blinding Beam resolved."
         }
       ],
       "text": "Choose one —\n• Tap two target creatures.\n• Creatures don't untap during target player's next untap step.\nEntwine {1} (Choose both if you pay the entwine cost.)",
@@ -4607,7 +4607,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "For the second ability, you choose the value of X when you activate it. You don’t look through your library until the ability resolves. (In other words, you can’t look through your library, decide what artifact card you want, and then determine what X is.) You can’t choose an X that’s greater than the number of loyalty counters on Tezzeret."
+          "text": "For the second ability, you choose the value of X when you activate it. You don't look through your library until the ability resolves. (In other words, you can't look through your library, decide what artifact card you want, and then determine what X is.) You can't choose an X that's greater than the number of loyalty counters on Tezzeret."
         },
         {
           "date": "2008-10-01",
@@ -4619,11 +4619,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -5045,7 +5045,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Steel Overseer is affected by its own ability (assuming that, by the time the ability resolves, you still control Steel Overseer and its types haven’t changed). You’ll put a +1/+1 counter on it, as well as on each other artifact creature you control."
+          "text": "Steel Overseer is affected by its own ability (assuming that, by the time the ability resolves, you still control Steel Overseer and its types haven't changed). You'll put a +1/+1 counter on it, as well as on each other artifact creature you control."
         }
       ],
       "subtypes": [
@@ -5213,7 +5213,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If Serrated Biskelion leaves the battlefield before its ability resolves, you’ll still put a -1/-1 counter on the targeted creature. If the target leaves the battlefield or otherwise becomes an illegal target before the ability resolves, the ability is countered and you won’t put a -1/-1 counter on Serrated Biskelion."
+          "text": "If Serrated Biskelion leaves the battlefield before its ability resolves, you'll still put a -1/-1 counter on the targeted creature. If the target leaves the battlefield or otherwise becomes an illegal target before the ability resolves, the ability is countered and you won't put a -1/-1 counter on Serrated Biskelion."
         }
       ],
       "subtypes": [
@@ -5306,7 +5306,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "When Esperzoa’s ability resolves, if you control no other artifacts, you’ll have to return Esperzoa itself."
+          "text": "When Esperzoa's ability resolves, if you control no other artifacts, you'll have to return Esperzoa itself."
         }
       ],
       "subtypes": [
@@ -5408,7 +5408,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Since Master of Etherium is an artifact itself, while it’s on the battlefield you will usually control at least one artifact."
+          "text": "Since Master of Etherium is an artifact itself, while it's on the battlefield you will usually control at least one artifact."
         }
       ],
       "subtypes": [
@@ -5766,11 +5766,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -6187,11 +6187,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it’ll be destroyed before you get a chance to activate its ability."
+          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it'll be destroyed before you get a chance to activate its ability."
         },
         {
           "date": "2010-08-15",
-          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won’t be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
+          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won't be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
         }
       ],
       "subtypes": [
@@ -6279,11 +6279,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus's other abilities."
         },
         {
           "date": "2011-09-22",
-          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus’s second activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus's second activated ability, not just ones created by Pentavus's other abilities."
         }
       ],
       "subtypes": [
@@ -6616,19 +6616,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Paying the activation cost of Elixir of Immortality’s ability doesn’t cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
+          "text": "Paying the activation cost of Elixir of Immortality's ability doesn't cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
         },
         {
           "date": "2011-09-22",
-          "text": "As the ability resolves, you’ll shuffle Elixir of Immortality into its owner’s library directly from the battlefield, if it’s still there."
+          "text": "As the ability resolves, you'll shuffle Elixir of Immortality into its owner's library directly from the battlefield, if it's still there."
         },
         {
           "date": "2011-09-22",
-          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you’ll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it’s anywhere else by that time, including in another player’s graveyard, it remains where it is and you shuffle just your graveyard into your library."
+          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you'll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it's anywhere else by that time, including in another player's graveyard, it remains where it is and you shuffle just your graveyard into your library."
         },
         {
           "date": "2011-09-22",
-          "text": "If you gain control of another player’s Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner’s library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
+          "text": "If you gain control of another player's Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner's library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
         }
       ],
       "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
@@ -6712,11 +6712,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -6724,11 +6724,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         },
         {
           "date": "2011-01-01",
-          "text": "Contagion Clasp’s first ability is mandatory. If you’re the only player who controls a creature, you must target one of them."
+          "text": "Contagion Clasp's first ability is mandatory. If you're the only player who controls a creature, you must target one of them."
         }
       ],
       "text": "When Contagion Clasp enters the battlefield, put a -1/-1 counter on target creature.\n{4}, {T}: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -7436,7 +7436,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Although Darksteel Citadel is an artifact, it can’t be cast as a spell. Playing it follows the normal rules for playing a land."
+          "text": "Although Darksteel Citadel is an artifact, it can't be cast as a spell. Playing it follows the normal rules for playing a land."
         }
       ],
       "text": "Indestructible\n{T}: Add {C} to your mana pool.",
@@ -7514,19 +7514,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Once turned into a creature, Mishra’s Factory’s last ability can target itself. If it’s already blocking, this won’t remove it from combat."
+          "text": "Once turned into a creature, Mishra's Factory's last ability can target itself. If it's already blocking, this won't remove it from combat."
         },
         {
           "date": "2016-06-08",
-          "text": "If you turn Mishra’s Factory into a creature but haven’t controlled it continuously since your most recent turn began, you won’t be able to activate its first or last ability."
+          "text": "If you turn Mishra's Factory into a creature but haven't controlled it continuously since your most recent turn began, you won't be able to activate its first or last ability."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
@@ -7687,11 +7687,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{6}: Stalking Stones becomes a 3/3 Elemental artifact creature that's still a land. (This effect lasts indefinitely.)",

--- a/json/DDG.json
+++ b/json/DDG.json
@@ -90,15 +90,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The activated ability’s cost checks the land’s subtype, not its name. You can sacrifice a nonbasic land this way as long as it has the subtype Forest or Plains."
+          "text": "The activated ability's cost checks the land's subtype, not its name. You can sacrifice a nonbasic land this way as long as it has the subtype Forest or Plains."
         },
         {
           "date": "2009-02-01",
-          "text": "Sacrificing a Forest or Plains is part of the cost of Knight of the Reliquary’s activated ability. Assuming that sacrificing the land puts it into your graveyard, Knight of the Reliquary’s first ability will immediately give it an additional +1/+1 when that cost is paid because there’ll be a new land card in your graveyard. Paying a cost can’t be responded to (with Shock, for example)."
+          "text": "Sacrificing a Forest or Plains is part of the cost of Knight of the Reliquary's activated ability. Assuming that sacrificing the land puts it into your graveyard, Knight of the Reliquary's first ability will immediately give it an additional +1/+1 when that cost is paid because there'll be a new land card in your graveyard. Paying a cost can't be responded to (with Shock, for example)."
         },
         {
           "date": "2009-02-01",
-          "text": "Knight of the Reliquary’s activated ability lets you find any land card, not just a basic land card."
+          "text": "Knight of the Reliquary's activated ability lets you find any land card, not just a basic land card."
         }
       ],
       "subtypes": [
@@ -185,23 +185,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -369,23 +369,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -555,11 +555,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Knight of the White Orchid’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
+          "text": "Knight of the White Orchid's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
         },
         {
           "date": "2015-06-22",
-          "text": "The Plains you search for doesn’t have to be basic. For example, you could put a Sacred Foundry onto the battlefield."
+          "text": "The Plains you search for doesn't have to be basic. For example, you could put a Sacred Foundry onto the battlefield."
         }
       ],
       "subtypes": [
@@ -1242,11 +1242,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage, damage from a source with deathtouch, and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage, damage from a source with deathtouch, and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If another Knight creature you control is dealt lethal damage, the creature isn’t destroyed, but the damage remains marked on it. If, at some point later in that turn, you no longer control Knight Exemplar or it loses its abilities, the other Knight creature will lose indestructible and will be destroyed."
+          "text": "If another Knight creature you control is dealt lethal damage, the creature isn't destroyed, but the damage remains marked on it. If, at some point later in that turn, you no longer control Knight Exemplar or it loses its abilities, the other Knight creature will lose indestructible and will be destroyed."
         },
         {
           "date": "2013-07-01",
@@ -1421,23 +1421,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -1845,7 +1845,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "The creature doesn’t enter the battlefield with a +1/+1 counter on it. It enters the battlefield, then the ability triggers. If either that creature or Juniper Order Ranger leaves the battlefield before the ability resolves, the remaining creature will still get a +1/+1 counter."
+          "text": "The creature doesn't enter the battlefield with a +1/+1 counter on it. It enters the battlefield, then the ability triggers. If either that creature or Juniper Order Ranger leaves the battlefield before the ability resolves, the remaining creature will still get a +1/+1 counter."
         }
       ],
       "subtypes": [
@@ -2007,27 +2007,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As you cast Harm’s Way, you target the creature or player that the redirected damage will be dealt to. As Harm’s Way resolves, you choose a source of damage. You never choose the original recipient of the damage; Harm’s Way will apply to whatever the chosen source tries to deal damage to, as long as it’s you or a permanent you control."
+          "text": "As you cast Harm's Way, you target the creature or player that the redirected damage will be dealt to. As Harm's Way resolves, you choose a source of damage. You never choose the original recipient of the damage; Harm's Way will apply to whatever the chosen source tries to deal damage to, as long as it's you or a permanent you control."
         },
         {
           "date": "2009-10-01",
-          "text": "Harm’s Way can affect damage that would be dealt to a planeswalker you control (as well as damage that would be dealt to you, or to a creature you control)."
+          "text": "Harm's Way can affect damage that would be dealt to a planeswalker you control (as well as damage that would be dealt to you, or to a creature you control)."
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen source would deal just 1 damage to you or a permanent you control, Harm’s Way’s effect will redirect that damage and still have a “shield” left for another 1 damage from that source later in the turn."
+          "text": "If the chosen source would deal just 1 damage to you or a permanent you control, Harm's Way's effect will redirect that damage and still have a \"shield\" left for another 1 damage from that source later in the turn."
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen source would simultaneously deal damage to multiple permanents you control (like Pyroclasm could) or to you and at least one permanent you control (like Earthquake could), Harm’s Way will redirect just 2 of that damage. It won’t redirect the next 2 damage that would be dealt to each recipient. You choose which 2 damage is redirected. If you like, you can choose to redirect 1 damage that would be dealt by the chosen source to each of two different recipients."
+          "text": "If the chosen source would simultaneously deal damage to multiple permanents you control (like Pyroclasm could) or to you and at least one permanent you control (like Earthquake could), Harm's Way will redirect just 2 of that damage. It won't redirect the next 2 damage that would be dealt to each recipient. You choose which 2 damage is redirected. If you like, you can choose to redirect 1 damage that would be dealt by the chosen source to each of two different recipients."
         },
         {
           "date": "2009-10-01",
-          "text": "After Harm’s Way resolves, it no longer checks to see if the targeted creature or player is a legal target. However, if that creature or player can’t be dealt damage at the time the chosen source would deal damage (perhaps because the creature is no longer on the battlefield or is no longer a creature, or because the player is no longer in the game), the damage can’t be redirected. It’s dealt to the original recipient."
+          "text": "After Harm's Way resolves, it no longer checks to see if the targeted creature or player is a legal target. However, if that creature or player can't be dealt damage at the time the chosen source would deal damage (perhaps because the creature is no longer on the battlefield or is no longer a creature, or because the player is no longer in the game), the damage can't be redirected. It's dealt to the original recipient."
         },
         {
           "date": "2009-10-01",
-          "text": "Harm’s Way has no effect on damage that’s already been dealt."
+          "text": "Harm's Way has no effect on damage that's already been dealt."
         }
       ],
       "text": "The next 2 damage that a source of your choice would deal to you and/or permanents you control this turn is dealt to target creature or player instead.",
@@ -2280,7 +2280,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
         }
       ],
       "text": "Target creature gets +2/+2 and gains flying until end of turn.",
@@ -2612,7 +2612,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the targeted creature becomes an illegal target by the time Sigil Blessing resolves, the entire spell will be countered. Your other creatures won’t get +1/+1."
+          "text": "If the targeted creature becomes an illegal target by the time Sigil Blessing resolves, the entire spell will be countered. Your other creatures won't get +1/+1."
         }
       ],
       "text": "Until end of turn, target creature you control gets +3/+3 and other creatures you control get +1/+1.",
@@ -2844,7 +2844,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide’s ability will trigger."
+          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide's ability will trigger."
         }
       ],
       "subtypes": [
@@ -2948,11 +2948,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -3254,11 +3254,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
@@ -6623,11 +6623,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -6788,7 +6788,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "“The number of Goblins it devoured” means “The number of Goblins sacrificed as a result of its devour ability as it entered the battlefield.” For each creature that Voracious Dragon devoured, this ability checks its creature type as it last existed on the battlefield to see if it was a Goblin at that time."
+          "text": "\"The number of Goblins it devoured\" means \"The number of Goblins sacrificed as a result of its devour ability as it entered the battlefield.\" For each creature that Voracious Dragon devoured, this ability checks its creature type as it last existed on the battlefield to see if it was a Goblin at that time."
         }
       ],
       "subtypes": [
@@ -7343,7 +7343,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a red spell, Dragon’s Claw’s ability triggers and is put on the stack on top of that spell. Dragon’s Claw’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a red spell, Dragon's Claw's ability triggers and is put on the stack on top of that spell. Dragon's Claw's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a red spell, you may gain 1 life.",
@@ -7581,7 +7581,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Punishing Fire’s triggered ability triggers only if it’s already in your graveyard at the time an opponent gains life. For example, you can cast it in response to a spell or ability that will cause an opponent to gain life. In that case, Punishing Fire will resolve first, so it will be in the graveyard by the time the opponent gains life. However, if you wait until an opponent actually gains life and then cast Punishing Fire, you won’t be able to return it to your hand at that time."
+          "text": "Punishing Fire's triggered ability triggers only if it's already in your graveyard at the time an opponent gains life. For example, you can cast it in response to a spell or ability that will cause an opponent to gain life. In that case, Punishing Fire will resolve first, so it will be in the graveyard by the time the opponent gains life. However, if you wait until an opponent actually gains life and then cast Punishing Fire, you won't be able to return it to your hand at that time."
         },
         {
           "date": "2009-10-01",
@@ -7589,7 +7589,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Punishing Fire has left your graveyard by the time its triggered ability resolves, you may still pay {R}, but you won’t return it to your hand. This is true even if Punishing Fire has left your graveyard and returned to it by the time its triggered ability resolves."
+          "text": "If Punishing Fire has left your graveyard by the time its triggered ability resolves, you may still pay {R}, but you won't return it to your hand. This is true even if Punishing Fire has left your graveyard and returned to it by the time its triggered ability resolves."
         }
       ],
       "text": "Punishing Fire deals 2 damage to target creature or player.\nWhenever an opponent gains life, you may pay {R}. If you do, return Punishing Fire from your graveyard to your hand.",
@@ -8205,11 +8205,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Only Shiv’s Embrace’s controller (who is not necessarily the enchanted creature’s controller) can activate its activated ability."
+          "text": "Only Shiv's Embrace's controller (who is not necessarily the enchanted creature's controller) can activate its activated ability."
         },
         {
           "date": "2010-08-15",
-          "text": "When Shiv’s Embrace’s activated ability resolves, the creature Shiv’s Embrace is enchanting at that time will get +1/+0 (regardless of what creature Shiv’s Embrace was enchanting when the ability was activated). If Shiv’s Embrace has left the battlefield by then, the creature it was enchanting at the time it left the battlefield will get +1/+0."
+          "text": "When Shiv's Embrace's activated ability resolves, the creature Shiv's Embrace is enchanting at that time will get +1/+0 (regardless of what creature Shiv's Embrace was enchanting when the ability was activated). If Shiv's Embrace has left the battlefield by then, the creature it was enchanting at the time it left the battlefield will get +1/+0."
         }
       ],
       "subtypes": [
@@ -8302,11 +8302,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of the three targets must be different. If there aren’t three different legal targets available, you can’t cast the spell."
+          "text": "Each of the three targets must be different. If there aren't three different legal targets available, you can't cast the spell."
         },
         {
           "date": "2014-07-18",
-          "text": "If one or two of Cone of Flame’s targets are illegal when it resolves, you can’t change how much damage will be dealt to the remaining legal targets."
+          "text": "If one or two of Cone of Flame's targets are illegal when it resolves, you can't change how much damage will be dealt to the remaining legal targets."
         }
       ],
       "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
@@ -8394,7 +8394,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -8488,7 +8488,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The amount of damage is locked in as you cast Jaws of Stone. It won’t change, even if the number of Mountains you control changes."
+          "text": "The amount of damage is locked in as you cast Jaws of Stone. It won't change, even if the number of Mountains you control changes."
         },
         {
           "date": "2008-05-01",

--- a/json/DDH.json
+++ b/json/DDH.json
@@ -90,11 +90,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target any permanent with Ajani Vengeant’s first ability. It doesn’t have to be tapped."
+          "text": "You may target any permanent with Ajani Vengeant's first ability. It doesn't have to be tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "The first ability tracks the permanent, but not its controller. If the permanent changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "The first ability tracks the permanent, but not its controller. If the permanent changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -359,7 +359,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Wild Nacatl’s abilities check for lands with the subtypes Mountain and Plains. Those lands don’t need to be named Mountain and Plains. Wild Nacatl will get both bonuses if those two subtypes are contained among the lands you control, even if they’re from the same land (such as Plateau or Sacred Foundry)."
+          "text": "Wild Nacatl's abilities check for lands with the subtypes Mountain and Plains. Those lands don't need to be named Mountain and Plains. Wild Nacatl will get both bonuses if those two subtypes are contained among the lands you control, even if they're from the same land (such as Plateau or Sacred Foundry)."
         }
       ],
       "subtypes": [
@@ -446,7 +446,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Loam Lion either gets +1/+2 or it doesn’t. It doesn’t get the bonus for each Forest you control."
+          "text": "Loam Lion either gets +1/+2 or it doesn't. It doesn't get the bonus for each Forest you control."
         }
       ],
       "subtypes": [
@@ -771,11 +771,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Soulmender or 8 life from Meditation Puzzle."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Soulmender or 8 life from Meditation Puzzle."
         },
         {
           "date": "2014-07-18",
-          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Ajani’s Pridemate’s ability will trigger twice. However, if a single creature you control with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
+          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Ajani's Pridemate's ability will trigger twice. However, if a single creature you control with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
         }
       ],
       "subtypes": [
@@ -949,7 +949,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -1384,7 +1384,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Even if the amount of damage dealt to Spitemare is enough to destroy it, Spitemare’s ability will trigger and it will deal the full amount of damage to the target."
+          "text": "Even if the amount of damage dealt to Spitemare is enough to destroy it, Spitemare's ability will trigger and it will deal the full amount of damage to the target."
         }
       ],
       "subtypes": [
@@ -1629,11 +1629,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -1641,7 +1641,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -1729,7 +1729,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If either ability is activated after blockers have been declared, it won’t cause those blocks to change."
+          "text": "If either ability is activated after blockers have been declared, it won't cause those blocks to change."
         },
         {
           "date": "2009-02-01",
@@ -1821,7 +1821,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If you return Firemane Angel from your graveyard to the battlefield during your upkeep before its life-gain ability resolves, you won’t gain 1 life. (Most of the time, players will let the triggered ability resolve before activating its activated ability.)"
+          "text": "If you return Firemane Angel from your graveyard to the battlefield during your upkeep before its life-gain ability resolves, you won't gain 1 life. (Most of the time, players will let the triggered ability resolve before activating its activated ability.)"
         },
         {
           "date": "2006-07-01",
@@ -1987,7 +1987,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
@@ -2144,7 +2144,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide’s ability will trigger."
+          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide's ability will trigger."
         }
       ],
       "subtypes": [
@@ -2228,7 +2228,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The triggered ability is on the Aura, not the creature. It triggers at the beginning of the upkeep of Recumbent Bliss’s controller, not the enchanted creature’s controller, and Recumbent Bliss’s controller will gain the life."
+          "text": "The triggered ability is on the Aura, not the creature. It triggers at the beginning of the upkeep of Recumbent Bliss's controller, not the enchanted creature's controller, and Recumbent Bliss's controller will gain the life."
         }
       ],
       "subtypes": [
@@ -2314,7 +2314,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Searing Meditation doesn’t care how much life you gain. It triggers just once for each life-gaining event, whether it’s 1 life from Firemane Angel or 15 life from Brightflame."
+          "text": "Searing Meditation doesn't care how much life you gain. It triggers just once for each life-gaining event, whether it's 1 life from Firemane Angel or 15 life from Brightflame."
         }
       ],
       "text": "Whenever you gain life, you may pay {2}. If you do, Searing Meditation deals 2 damage to target creature or player.",
@@ -2398,7 +2398,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Multiple instances of lifelink are redundant. If a creature with multiple instances of lifelink deals damage, its controller still only gains life equal to the damage dealt."
+          "text": "multiple instances of lifelink on the same creature are redundant. If a creature with multiple instances of lifelink deals damage, its controller still only gains life equal to the damage dealt."
         }
       ],
       "subtypes": [
@@ -2488,11 +2488,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -2581,7 +2581,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -2686,7 +2686,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature you control already has lifelink, Titanic Ultimatum will give it a second instance of lifelink; however, multiple instances of lifelink are redundant. You still only gain life equal to the amount of damage dealt, regardless of how many instances of lifelink the creature has."
+          "text": "If a creature you control already has lifelink, Titanic Ultimatum will give it a second instance of lifelink; however, multiple instances of lifelink on the same creature are redundant. You still only gain life equal to the amount of damage dealt, regardless of how many instances of lifelink the creature has."
         }
       ],
       "text": "Until end of turn, creatures you control get +5/+5 and gain first strike, lifelink, and trample.",
@@ -4419,7 +4419,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If the damage from Nicol Bolas’s third ability is prevented or redirected, the rest of the effect will still happen. Specifically, the number of cards discarded and permanents sacrificed isn’t tied to the amount of damage dealt."
+          "text": "If the damage from Nicol Bolas's third ability is prevented or redirected, the rest of the effect will still happen. Specifically, the number of cards discarded and permanents sacrificed isn't tied to the amount of damage dealt."
         },
         {
           "date": "2012-07-01",
@@ -4592,7 +4592,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -4612,7 +4612,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -4936,11 +4936,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Hellfire Mongrel’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless the opponent whose turn it is has two or fewer cards in hand as his or her upkeep starts, and (2) the ability will do nothing if that player has three or more cards in hand by the time it resolves."
+          "text": "Hellfire Mongrel's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless the opponent whose turn it is has two or fewer cards in hand as his or her upkeep starts, and (2) the ability will do nothing if that player has three or more cards in hand by the time it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "In a Two-Headed Giant game, this ability will potentially trigger twice at the beginning of the opposing team’s upkeep — once for each player on that team."
+          "text": "In a Two-Headed Giant game, this ability will potentially trigger twice at the beginning of the opposing team's upkeep — once for each player on that team."
         }
       ],
       "subtypes": [
@@ -5355,23 +5355,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -5643,7 +5643,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -5655,7 +5655,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -5746,7 +5746,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -5758,7 +5758,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -6227,11 +6227,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. If you can't choose legal targets for any of the modes, you can't cast the spell."
         },
         {
           "date": "2008-10-01",
-          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+          "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don't exist. You don't choose targets for those modes."
         },
         {
           "date": "2008-10-01",
@@ -6325,19 +6325,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player’s pool."
+          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player's pool."
         },
         {
           "date": "2004-10-04",
-          "text": "Icy Manipulator can’t be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
+          "text": "Icy Manipulator can't be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger “if the card becomes tapped” effects."
+          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger \"if the card becomes tapped\" effects."
         },
         {
           "date": "2004-10-04",
-          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use the Icy Manipulator."
+          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use the Icy Manipulator."
         },
         {
           "date": "2004-10-04",
@@ -6578,7 +6578,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you don’t control the targeted creature when the “at end of turn” ability resolves, it won’t be sacrificed. If it’s still on the battlefield but under another player’s control, the ability won’t try to have you sacrifice it again at the end of the turn after that."
+          "text": "If you don't control the targeted creature when the \"at end of turn\" ability resolves, it won't be sacrificed. If it's still on the battlefield but under another player's control, the ability won't try to have you sacrifice it again at the end of the turn after that."
         }
       ],
       "text": "Gain control of target creature. Untap that creature. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
@@ -6755,7 +6755,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Cruel Ultimatum’s only target is an opponent. You don’t choose which creature card in your graveyard you’ll return to your hand until Cruel Ultimatum resolves."
+          "text": "Cruel Ultimatum's only target is an opponent. You don't choose which creature card in your graveyard you'll return to your hand until Cruel Ultimatum resolves."
         },
         {
           "date": "2017-03-14",
@@ -6763,7 +6763,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If, as Cruel Ultimatum begins to resolve, your opponent’s life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent’s life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You’ll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
+          "text": "If, as Cruel Ultimatum begins to resolve, your opponent's life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent's life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You'll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
         }
       ],
       "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
@@ -6846,10 +6846,10 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The value chosen for X applies to each X in the spell’s effect. You pay {X} only once."
+          "text": "The value chosen for X applies to each X in the spell's effect. You pay {X} only once."
         }
       ],
-      "text": "Choose two —\n• Target player loses X life. \n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
+      "text": "Choose two —\n• Target player loses X life.\n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"

--- a/json/DDI.json
+++ b/json/DDI.json
@@ -70,7 +70,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren’t permanents and don’t exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
+          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren't permanents and don't exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
         },
         {
           "date": "2011-01-01",
@@ -78,7 +78,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If the first ability exiles a token, that token will cease to exist. It won’t return to the battlefield."
+          "text": "If the first ability exiles a token, that token will cease to exist. It won't return to the battlefield."
         },
         {
           "date": "2011-01-01",
@@ -86,19 +86,19 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Venser’s second ability doesn’t lock in what it applies to. That’s because the effect states a true thing about creatures, but doesn’t actually change the characteristics of those creatures. As a result, all creatures can’t be blocked that turn, including creatures you don’t control, creatures that weren’t on the battlefield at the time the ability resolved, and creatures that have lost all abilities."
+          "text": "Venser's second ability doesn't lock in what it applies to. That's because the effect states a true thing about creatures, but doesn't actually change the characteristics of those creatures. As a result, all creatures can't be blocked that turn, including creatures you don't control, creatures that weren't on the battlefield at the time the ability resolved, and creatures that have lost all abilities."
         },
         {
           "date": "2011-01-01",
-          "text": "Venser’s last ability creates an emblem with a triggered ability. The emblem is the source of the triggered ability. Because emblems are colorless, you can target permanents with protection from white or from blue, for example, with the triggered ability."
+          "text": "Venser's last ability creates an emblem with a triggered ability. The emblem is the source of the triggered ability. Because emblems are colorless, you can target permanents with protection from white or from blue, for example, with the triggered ability."
         },
         {
           "date": "2011-01-01",
-          "text": "Whenever you cast a spell, the emblem’s ability triggers and goes on the stack on top of it. It will resolve before the spell does."
+          "text": "Whenever you cast a spell, the emblem's ability triggers and goes on the stack on top of it. It will resolve before the spell does."
         },
         {
           "date": "2011-01-01",
-          "text": "If you control more than one such emblem, each one’s ability will trigger separately whenever you cast a spell."
+          "text": "If you control more than one such emblem, each one's ability will trigger separately whenever you cast a spell."
         }
       ],
       "subtypes": [
@@ -170,11 +170,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -302,7 +302,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -848,7 +848,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Galepowder Mage’s ability can target a creature controlled by any player. It’s not optional."
+          "text": "Galepowder Mage's ability can target a creature controlled by any player. It's not optional."
         },
         {
           "date": "2007-10-01",
@@ -1014,7 +1014,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -1022,11 +1022,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -1034,7 +1034,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -1104,7 +1104,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "You do the three different scry actions in sequence, in the order they’re printed on the card."
+          "text": "You do the three different scry actions in sequence, in the order they're printed on the card."
         }
       ],
       "subtypes": [
@@ -1178,7 +1178,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
         },
         {
           "date": "2007-02-01",
@@ -1190,7 +1190,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         }
       ],
       "subtypes": [
@@ -1334,7 +1334,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This ability isn’t targeted. You choose a permanent to return when the ability resolves. No one will be able to respond to the choice."
+          "text": "This ability isn't targeted. You choose a permanent to return when the ability resolves. No one will be able to respond to the choice."
         }
       ],
       "subtypes": [
@@ -1411,7 +1411,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -1550,7 +1550,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The second ability destroys each creature that’s tapped at the time it resolves, including creatures you control. If Sunblast Angel has become tapped by the time its ability resolves, it will be destroyed too."
+          "text": "The second ability destroys each creature that's tapped at the time it resolves, including creatures you control. If Sunblast Angel has become tapped by the time its ability resolves, it will be destroyed too."
         }
       ],
       "subtypes": [
@@ -1623,7 +1623,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "A pile can have no cards in it. In this case, you’ll choose whether to put all the revealed cards into your hand or into your graveyard."
+          "text": "A pile can have no cards in it. In this case, you'll choose whether to put all the revealed cards into your hand or into your graveyard."
         },
         {
           "date": "2011-09-22",
@@ -1631,7 +1631,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn’t target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
+          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn't target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
         }
       ],
       "subtypes": [
@@ -1708,11 +1708,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature’s controller won’t search for a basic land card."
+          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature's controller won't search for a basic land card."
         },
         {
           "date": "2017-03-14",
-          "text": "The controller of the exiled creature isn’t required to search his or her library for a basic land. If that player doesn’t, the player won’t shuffle his or her library."
+          "text": "The controller of the exiled creature isn't required to search his or her library for a basic land. If that player doesn't, the player won't shuffle his or her library."
         }
       ],
       "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
@@ -2042,11 +2042,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -2114,15 +2114,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage will prevent damage dealt to creatures that weren’t on the battlefield at the time it resolved."
+          "text": "Safe Passage will prevent damage dealt to creatures that weren't on the battlefield at the time it resolved."
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage doesn’t prevent damage that would be dealt to planeswalkers you control. Although it can’t prevent combat damage that would be dealt to your planeswalkers, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply Safe Passage’s prevention effect to that damage first, and there won’t be any damage to redirect."
+          "text": "Safe Passage doesn't prevent damage that would be dealt to planeswalkers you control. Although it can't prevent combat damage that would be dealt to your planeswalkers, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply Safe Passage's prevention effect to that damage first, and there won't be any damage to redirect."
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage has no effect on damage that’s already been dealt."
+          "text": "Safe Passage has no effect on damage that's already been dealt."
         }
       ],
       "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
@@ -2261,15 +2261,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Vanish into Memory cares about the creature’s power just before it left the battlefield and its toughness just after it returns to the battlefield. For example, if you target a 2/2 creature with two +1/+1 counters on it, you’ll draw four cards, then when it returns to the battlefield without any counters on it, you’ll discard two cards."
+          "text": "Vanish into Memory cares about the creature's power just before it left the battlefield and its toughness just after it returns to the battlefield. For example, if you target a 2/2 creature with two +1/+1 counters on it, you'll draw four cards, then when it returns to the battlefield without any counters on it, you'll discard two cards."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature exiled with Vanish into Memory never returns to the battlefield (because it was a token creature, for example), you don’t discard any cards."
+          "text": "If the creature exiled with Vanish into Memory never returns to the battlefield (because it was a token creature, for example), you don't discard any cards."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature exiled with Vanish into Memory isn’t a creature card (for example, a crewed Vehicle), that card will still be returned to the battlefield, but not as a creature. Since the card returned to the battlefield has no toughness, you discard no cards."
+          "text": "If the creature exiled with Vanish into Memory isn't a creature card (for example, a crewed Vehicle), that card will still be returned to the battlefield, but not as a creature. Since the card returned to the battlefield has no toughness, you discard no cards."
         }
       ],
       "text": "Exile target creature. You draw cards equal to that creature's power. At the beginning of your next upkeep, return that card to the battlefield under its owner's control. If you do, discard cards equal to that creature's toughness.",
@@ -2337,7 +2337,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "You gain the life whether or not the spell’s controller pays {X} and whether or not the spell is countered."
+          "text": "You gain the life whether or not the spell's controller pays {X} and whether or not the spell is countered."
         }
       ],
       "text": "Counter target spell unless its controller pays {X}. You gain X life.",
@@ -2457,7 +2457,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Flood Plain enters the battlefield tapped.\n{T}, Sacrifice Flood Plain: Search your library for a Plains or Island card and put it onto the battlefield. Then shuffle your library.",
@@ -4305,29 +4305,29 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren’t permanents and don’t exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
+          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren't permanents and don't exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
         },
         {
           "date": "2011-01-01",
-          "text": "Koth’s first ability can target any Mountain, including an untapped Mountain and/or a Mountain another player controls."
+          "text": "Koth's first ability can target any Mountain, including an untapped Mountain and/or a Mountain another player controls."
         },
         {
           "date": "2011-01-01",
-          "text": "If Koth’s first ability animates a Mountain that came under your control that turn, it will have “summoning sickness” and be unable to attack. It will also be unable to be tapped to activate an ability with the {T} symbol in its cost, such as the Mountain’s mana ability or the ability granted to it by Koth’s emblem."
+          "text": "If Koth's first ability animates a Mountain that came under your control that turn, it will have \"summoning sickness\" and be unable to attack. It will also be unable to be tapped to activate an ability with the {T} symbol in its cost, such as the Mountain's mana ability or the ability granted to it by Koth's emblem."
         },
         {
           "date": "2011-01-01",
-          "text": "Loyalty abilities can’t be mana abilities. Koth’s second ability uses the stack and can be countered or otherwise responded to. Like all loyalty abilities, it can be activated only once per turn, during your main phase, when the stack is empty, and only if no other loyalty abilities of this permanent have been activated this turn."
+          "text": "Loyalty abilities can't be mana abilities. Koth's second ability uses the stack and can be countered or otherwise responded to. Like all loyalty abilities, it can be activated only once per turn, during your main phase, when the stack is empty, and only if no other loyalty abilities of this permanent have been activated this turn."
         },
         {
           "date": "2011-01-01",
-          "text": "Koth’s emblem grants an activated ability to each Mountain you control at any given time for the rest of the game. It will continuously check which permanents you control are Mountains to determine what has the ability. For example, a Mountain that comes under your control later in the game will have the ability, while a Mountain you controlled at the time the emblem was created, but that later came under the control of another player, will no longer have the ability."
+          "text": "Koth's emblem grants an activated ability to each Mountain you control at any given time for the rest of the game. It will continuously check which permanents you control are Mountains to determine what has the ability. For example, a Mountain that comes under your control later in the game will have the ability, while a Mountain you controlled at the time the emblem was created, but that later came under the control of another player, will no longer have the ability."
         }
       ],
       "subtypes": [
         "Koth"
       ],
-      "text": "+1: Untap target Mountain. It becomes a 4/4 red Elemental creature until end of turn. It's still a land.\n−2: Add {R} to your mana pool for each Mountain you control.\n−5: You get an emblem with \"Mountains you control have ‘{T}: This land deals 1 damage to target creature or player.'\"",
+      "text": "+1: Untap target Mountain. It becomes a 4/4 red Elemental creature until end of turn. It's still a land.\n−2: Add {R} to your mana pool for each Mountain you control.\n−5: You get an emblem with \"Mountains you control have '{T}: This land deals 1 damage to target creature or player.'\"",
       "type": "Planeswalker — Koth",
       "types": [
         "Planeswalker"
@@ -4391,7 +4391,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -4599,7 +4599,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The blocked creature is returned to its owner’s hand at end of combat only if the blocked creature is still on the battlefield. It doesn’t matter whether Aether Membrane is on the battlefield."
+          "text": "The blocked creature is returned to its owner's hand at end of combat only if the blocked creature is still on the battlefield. It doesn't matter whether Aether Membrane is on the battlefield."
         }
       ],
       "subtypes": [
@@ -4800,7 +4800,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The timestamp for the “in your graveyard” ability is set at the time that this card goes to your graveyard, regardless of whether you control a Mountain at that time."
+          "text": "The timestamp for the \"in your graveyard\" ability is set at the time that this card goes to your graveyard, regardless of whether you control a Mountain at that time."
         }
       ],
       "subtypes": [
@@ -4871,7 +4871,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -5079,19 +5079,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the Giant’s power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
+          "text": "If the Giant's power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
         },
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stone Giant’s ability is activated during a turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. The targeted creature will be destroyed at that time."
+          "text": "If Stone Giant's ability is activated during a turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. The targeted creature will be destroyed at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it’s no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant’s power at that time."
+          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it's no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant's power at that time."
         }
       ],
       "subtypes": [
@@ -5162,7 +5162,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -5299,15 +5299,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When the third ability resolves, you must change the target if able. If you can’t choose a legal target for the spell when this ability resolves, that spell’s target doesn’t change."
+          "text": "When the third ability resolves, you must change the target if able. If you can't choose a legal target for the spell when this ability resolves, that spell's target doesn't change."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Torchling’s third ability, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Torchling's third ability, even if all but one of those targets has become illegal."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell has multiple targets, but it’s targeting Torchling with all of them (such as Seeds of Strength targeting Torchling three times), you can target that spell with Torchling’s third ability. In that case, you change all of those targets to the same new target, as long as it meets each of the spell’s targeting conditions."
+          "text": "If a spell has multiple targets, but it's targeting Torchling with all of them (such as Seeds of Strength targeting Torchling three times), you can target that spell with Torchling's third ability. In that case, you change all of those targets to the same new target, as long as it meets each of the spell's targeting conditions."
         }
       ],
       "subtypes": [
@@ -5378,7 +5378,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Mountaincycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Mountaincycling doesn't allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -5529,11 +5529,11 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "After Greater Stone Spirit’s activated ability is activated, the affected creature gains an activated ability that only that creature’s controller can activate."
+          "text": "After Greater Stone Spirit's activated ability is activated, the affected creature gains an activated ability that only that creature's controller can activate."
         },
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don’t actually have Flying."
+          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don't actually have Flying."
         }
       ],
       "subtypes": [
@@ -5908,7 +5908,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The landfall ability checks for an action that has happened in the past. It doesn’t matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
+          "text": "The landfall ability checks for an action that has happened in the past. It doesn't matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
         },
         {
           "date": "2010-03-01",
@@ -5916,11 +5916,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The effect of this spell’s landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
+          "text": "The effect of this spell's landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
         },
         {
           "date": "2010-03-01",
-          "text": "You must choose two targets as you cast Searing Blaze: a player and a creature that player controls. If you can’t (because there are no creatures on the battlefield, perhaps), then you can’t cast the spell."
+          "text": "You must choose two targets as you cast Searing Blaze: a player and a creature that player controls. If you can't (because there are no creatures on the battlefield, perhaps), then you can't cast the spell."
         },
         {
           "date": "2010-03-01",
@@ -6220,7 +6220,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The amount of damage is locked in as you cast Jaws of Stone. It won’t change, even if the number of Mountains you control changes."
+          "text": "The amount of damage is locked in as you cast Jaws of Stone. It won't change, even if the number of Mountains you control changes."
         },
         {
           "date": "2008-05-01",
@@ -6289,7 +6289,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose zero targets. You must choose between 1 and 6 targets."
+          "text": "You can't choose zero targets. You must choose between 1 and 6 targets."
         }
       ],
       "text": "Volley of Boulders deals 6 damage divided as you choose among any number of target creatures and/or players.\nFlashback {R}{R}{R}{R}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",

--- a/json/DDJ.json
+++ b/json/DDJ.json
@@ -143,7 +143,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an instant or sorcery spell, Kiln Fiend’s ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an instant or sorcery spell, Kiln Fiend's ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         }
       ],
       "subtypes": [
@@ -224,11 +224,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Goblin Electromancer can’t reduce colored mana costs or {C} in the cost of instant or sorcery spells."
+          "text": "Goblin Electromancer can't reduce colored mana costs or {C} in the cost of instant or sorcery spells."
         },
         {
           "date": "2017-03-14",
-          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben’s ability), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben's ability), apply those increases before applying cost reductions."
         },
         {
           "date": "2017-03-14",
@@ -442,7 +442,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Wee Dragonauts’s triggered ability will resolve before the spell that caused it to trigger."
+          "text": "Wee Dragonauts's triggered ability will resolve before the spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -583,7 +583,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s both of the listed colors, both abilities will trigger. You’ll remove a total of two -1/-1 counters from the Hatchling."
+          "text": "If you cast a spell that's both of the listed colors, both abilities will trigger. You'll remove a total of two -1/-1 counters from the Hatchling."
         },
         {
           "date": "2008-08-01",
@@ -736,7 +736,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the card you look at isn’t an instant or sorcery card, it remains on top of your library. You don’t reveal it."
+          "text": "If the card you look at isn't an instant or sorcery card, it remains on top of your library. You don't reveal it."
         },
         {
           "date": "2011-06-01",
@@ -894,7 +894,7 @@
         },
         {
           "date": "2006-02-01",
-          "text": "If you cast an instant or sorcery spell that has {X} in its mana cost, the value of X in the spell’s replicate cost will be the same as the value of X you chose for its mana cost."
+          "text": "If you cast an instant or sorcery spell that has {X} in its mana cost, the value of X in the spell's replicate cost will be the same as the value of X you chose for its mana cost."
         }
       ],
       "subtypes": [
@@ -1088,6 +1088,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Theros Block",
           "legality": "Legal"
         },
@@ -1114,7 +1118,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Magma Spray’s replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Magma Spray deals no damage to it (due to a prevention effect) or Magma Spray deals damage to a different creature (due to a redirection effect)."
+          "text": "Magma Spray's replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Magma Spray deals no damage to it (due to a prevention effect) or Magma Spray deals damage to a different creature (due to a redirection effect)."
         }
       ],
       "text": "Magma Spray deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
@@ -1176,7 +1180,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the imprinted card leaves the exile zone while the activated ability is on the stack, the copy can’t be made."
+          "text": "If the imprinted card leaves the exile zone while the activated ability is on the stack, the copy can't be made."
         },
         {
           "date": "2016-06-08",
@@ -1188,7 +1192,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Because you’re already casting the spell using an alternative cost (by casting it without paying its mana cost), you can’t pay any other alternative costs for the card. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
+          "text": "Because you're already casting the spell using an alternative cost (by casting it without paying its mana cost), you can't pay any other alternative costs for the card. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2016-06-08",
@@ -1196,7 +1200,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you don’t want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
+          "text": "If you don't want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
         },
         {
           "date": "2017-04-18",
@@ -1581,7 +1585,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Target player shuffles his or her graveyard into his or her library.",
@@ -1777,7 +1781,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then it does not get exiled."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then it does not get exiled."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
@@ -2018,15 +2022,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an instant or sorcery spell, Sphinx-Bone Wand’s ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an instant or sorcery spell, Sphinx-Bone Wand's ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature or player is an illegal target by the time the ability resolves, the ability is countered. You won’t put a charge counter on Sphinx-Bone Wand and it won’t deal damage."
+          "text": "If the targeted creature or player is an illegal target by the time the ability resolves, the ability is countered. You won't put a charge counter on Sphinx-Bone Wand and it won't deal damage."
         },
         {
           "date": "2010-06-15",
-          "text": "If Sphinx-Bone Wand leaves the battlefield before its ability resolves, you won’t be able to put a charge counter on it. As a result, it won’t deal damage."
+          "text": "If Sphinx-Bone Wand leaves the battlefield before its ability resolves, you won't be able to put a charge counter on it. As a result, it won't deal damage."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell, you may put a charge counter on Sphinx-Bone Wand. If you do, Sphinx-Bone Wand deals damage equal to the number of charge counters on it to target creature or player.",
@@ -2092,23 +2096,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -2116,7 +2120,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Street Spasm deals X damage to target creature without flying you don't control.\nOverload {X}{X}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -2558,15 +2562,15 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "“Until your next turn” means the effect wears off as soon as your next turn starts, even before you untap. It’s basically the same as “until the end of the turn of the player who immediately precedes you.”"
+          "text": "\"Until your next turn\" means the effect wears off as soon as your next turn starts, even before you untap. It's basically the same as \"until the end of the turn of the player who immediately precedes you.\""
         },
         {
           "date": "2006-02-01",
-          "text": "The card is cast using all normal rules and restrictions for casting spells. Casting it means you’ll have to pay its mana cost, and it will go to the graveyard after it resolves or is countered. The only thing that’s different is you’re casting it from the Exile zone."
+          "text": "The card is cast using all normal rules and restrictions for casting spells. Casting it means you'll have to pay its mana cost, and it will go to the graveyard after it resolves or is countered. The only thing that's different is you're casting it from the Exile zone."
         },
         {
           "date": "2006-02-01",
-          "text": "If you don’t cast the card, it stays exiled."
+          "text": "If you don't cast the card, it stays exiled."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{2}{U}{R}, {T}: Exile the top card of your library. Until your next turn, you may cast that card if it's an instant or sorcery card.",
@@ -4852,7 +4856,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Jarad’s first ability applies only when Jarad is on the battlefield."
+          "text": "Jarad's first ability applies only when Jarad is on the battlefield."
         },
         {
           "date": "2012-10-01",
@@ -4860,7 +4864,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "To activate Jarad’s last ability, you must sacrifice two lands. It doesn’t matter what other land types the two lands have, as long as one is a Swamp and one is a Forest. Even if one of the lands you sacrifice is both a Swamp and a Forest, you have to sacrifice another land that is a Swamp or a Forest."
+          "text": "To activate Jarad's last ability, you must sacrifice two lands. It doesn't matter what other land types the two lands have, as long as one is a Swamp and one is a Forest. Even if one of the lands you sacrifice is both a Swamp and a Forest, you have to sacrifice another land that is a Swamp or a Forest."
         },
         {
           "date": "2012-10-01",
@@ -5079,11 +5083,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -5301,7 +5305,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The ability that defines Boneyard Wurm’s power and toughness works in all zones, not just the battlefield. If Boneyard Wurm is in your graveyard, it will count itself."
+          "text": "The ability that defines Boneyard Wurm's power and toughness works in all zones, not just the battlefield. If Boneyard Wurm is in your graveyard, it will count itself."
         }
       ],
       "subtypes": [
@@ -5376,7 +5380,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Use the sacrificed creature’s toughness when it was last on the battlefield to determine the value of X."
+          "text": "Use the sacrificed creature's toughness when it was last on the battlefield to determine the value of X."
         }
       ],
       "subtypes": [
@@ -5523,15 +5527,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         },
         {
           "date": "2013-06-07",
-          "text": "Notably, Stinkweed Imp’s ability isn’t deathtouch. It’s a triggered ability that triggers only on combat damage."
+          "text": "Notably, Stinkweed Imp's ability isn't deathtouch. It's a triggered ability that triggers only on combat damage."
         }
       ],
       "subtypes": [
@@ -5675,7 +5679,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -5813,7 +5817,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -5889,11 +5893,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -5972,11 +5976,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -6112,7 +6116,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -6329,7 +6333,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you have no other creatures to sacrifice, you’ll have to sacrifice Doomgape itself. You’ll gain life equal to its toughness."
+          "text": "If you have no other creatures to sacrifice, you'll have to sacrifice Doomgape itself. You'll gain life equal to its toughness."
         }
       ],
       "subtypes": [
@@ -6585,11 +6589,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "text": "Return up to three target land cards from your graveyard to your hand.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
@@ -6730,7 +6734,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an artifact, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an artifact, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target artifact or creature. It can't be regenerated.",
@@ -6856,11 +6860,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         },
         {
           "date": "2014-02-01",
@@ -7131,7 +7135,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All lands you control become 1/1 creatures until end of turn. They're still lands.",
@@ -7197,7 +7201,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All lands you control become 1/1 creatures until end of turn. They're still lands.",
@@ -7327,11 +7331,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "text": "Dakmor Salvage enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
@@ -7460,15 +7464,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "While animated, Svogthos’s power and toughness changes each time a creature card enters or leaves its controller’s graveyard."
+          "text": "While animated, Svogthos's power and toughness changes each time a creature card enters or leaves its controller's graveyard."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with \"This creature's power and toughness are each equal to the number of creature cards in your graveyard.\" It's still a land.",

--- a/json/DDK.json
+++ b/json/DDK.json
@@ -74,11 +74,11 @@
         },
         {
           "date": "2011-01-22",
-          "text": "You can target a token creature with Sorin, Lord of Innistrad’s third ability, but it won’t return to the battlefield."
+          "text": "You can target a token creature with Sorin, Lord of Innistrad's third ability, but it won't return to the battlefield."
         },
         {
           "date": "2011-01-22",
-          "text": "If a creature with undying is destroyed by Sorin, Lord of Innistrad’s third ability, the undying ability will trigger, but the creature will already have been returned to the battlefield by Sorin. The undying ability won’t do anything when it resolves."
+          "text": "If a creature with undying is destroyed by Sorin, Lord of Innistrad's third ability, the undying ability will trigger, but the creature will already have been returned to the battlefield by Sorin. The undying ability won't do anything when it resolves."
         },
         {
           "date": "2011-01-22",
@@ -619,11 +619,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The first ability only cares that creature tokens leave the battlefield. It doesn’t matter where they went."
+          "text": "The first ability only cares that creature tokens leave the battlefield. It doesn't matter where they went."
         },
         {
           "date": "2005-10-01",
-          "text": "If a player leaves a multiplayer game, all creature tokens that player owns also leave the game. Twilight Drover’s ability will trigger once per token."
+          "text": "If a player leaves a multiplayer game, all creature tokens that player owns also leave the game. Twilight Drover's ability will trigger once per token."
         },
         {
           "date": "2005-10-01",
@@ -631,7 +631,7 @@
         },
         {
           "date": "2005-10-01",
-          "text": "Note that Twilight Drover doesn’t have any way to sacrifice tokens or otherwise cause them to leave the battlefield."
+          "text": "Note that Twilight Drover doesn't have any way to sacrifice tokens or otherwise cause them to leave the battlefield."
         }
       ],
       "subtypes": [
@@ -975,7 +975,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "A creature token that’s a copy of a nontoken creature is still a token. It will get +1/+1, but the original nontoken creature will not."
+          "text": "A creature token that's a copy of a nontoken creature is still a token. It will get +1/+1, but the original nontoken creature will not."
         }
       ],
       "subtypes": [
@@ -1196,15 +1196,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -1284,15 +1284,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners’ graveyards at the same time, Butcher of Malakir’s triggered ability will trigger that many times."
+          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners' graveyards at the same time, Butcher of Malakir's triggered ability will trigger that many times."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers’ abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
+          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers' abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player’s Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player’s Butcher to trigger, and so on."
+          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player's Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player's Butcher to trigger, and so on."
         }
       ],
       "subtypes": [
@@ -1474,7 +1474,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the creature is an illegal target when Sorin’s Thirst tries to resolve, Sorin’s Thirst will be countered and none of its effects will happen. You won’t gain life."
+          "text": "If the creature is an illegal target when Sorin's Thirst tries to resolve, Sorin's Thirst will be countered and none of its effects will happen. You won't gain life."
         }
       ],
       "text": "Sorin's Thirst deals 2 damage to target creature and you gain 2 life.",
@@ -1539,15 +1539,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "You don’t choose which untapped Vampire creatures you control to tap (if any) until Urge to Feed resolves."
+          "text": "You don't choose which untapped Vampire creatures you control to tap (if any) until Urge to Feed resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast Urge to Feed targeting an untapped Vampire creature you control with toughness 3, its toughness will be reduced to 0 by the -3/-3 effect. However, state-based actions aren’t checked until the spell has finished resolving. You may then tap that Vampire and put a +1/+1 counter on it, raising its toughness to 1. It will remain on the battlefield."
+          "text": "If you cast Urge to Feed targeting an untapped Vampire creature you control with toughness 3, its toughness will be reduced to 0 by the -3/-3 effect. However, state-based actions aren't checked until the spell has finished resolving. You may then tap that Vampire and put a +1/+1 counter on it, raising its toughness to 1. It will remain on the battlefield."
         },
         {
           "date": "2010-03-01",
-          "text": "If the targeted creature is an illegal target by the time Urge to Feed resolves, the entire spell is countered. You can’t tap any Vampires."
+          "text": "If the targeted creature is an illegal target by the time Urge to Feed resolves, the entire spell is countered. You can't tap any Vampires."
         }
       ],
       "text": "Target creature gets -3/-3 until end of turn. You may tap any number of untapped Vampire creatures you control. If you do, put a +1/+1 counter on each of those Vampires.",
@@ -1748,7 +1748,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target creature or enchantment.",
@@ -1817,7 +1817,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -1965,7 +1965,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"My ‘condition' is a trial. The weak are consumed by it. The strong transcend it.\"\n—Sorin Markov",
+      "flavor": "\"My 'condition' is a trial. The weak are consumed by it. The strong transcend it.\"\n—Sorin Markov",
       "foreignNames": [
         {
           "language": "Japanese",
@@ -2010,7 +2010,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Multiple instances of lifelink are redundant. If Mark of the Vampire enchants a creature that already has lifelink, damage that creature deals won’t cause you to gain additional life."
+          "text": "multiple instances of lifelink on the same creature are redundant. If Mark of the Vampire enchants a creature that already has lifelink, damage that creature deals won't cause you to gain additional life."
         }
       ],
       "subtypes": [
@@ -2076,7 +2076,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A creature card that you own but don’t control will be put into your graveyard if that creature dies, and Field of Souls’s ability will trigger."
+          "text": "A creature card that you own but don't control will be put into your graveyard if that creature dies, and Field of Souls's ability will trigger."
         }
       ],
       "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, create a 1/1 white Spirit creature token with flying.",
@@ -2143,7 +2143,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -4110,11 +4110,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The number of cards in the target player’s hand is determined when Tibalt’s second ability resolves."
+          "text": "The number of cards in the target player's hand is determined when Tibalt's second ability resolves."
         },
         {
           "date": "2012-05-01",
-          "text": "When Tibalt’s third ability resolves, all creatures will become untapped and gain haste, including ones you controlled before the ability resolved."
+          "text": "When Tibalt's third ability resolves, all creatures will become untapped and gain haste, including ones you controlled before the ability resolved."
         }
       ],
       "subtypes": [
@@ -4384,7 +4384,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Ashmouth Hound’s ability triggers once for each creature it blocks or becomes blocked by."
+          "text": "Ashmouth Hound's ability triggers once for each creature it blocks or becomes blocked by."
         }
       ],
       "subtypes": [
@@ -4522,23 +4522,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -4678,11 +4678,11 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         },
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -4834,7 +4834,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Discarding a card is part of the ability’s activation cost. You can’t activate the ability if you have no cards in hand."
+          "text": "Discarding a card is part of the ability's activation cost. You can't activate the ability if you have no cards in hand."
         }
       ],
       "subtypes": [
@@ -4907,7 +4907,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The damage dealt by Hellrider’s triggered ability isn’t combat damage and may be redirected to a planeswalker controlled by the defending player."
+          "text": "The damage dealt by Hellrider's triggered ability isn't combat damage and may be redirected to a planeswalker controlled by the defending player."
         },
         {
           "date": "2017-03-14",
@@ -5054,23 +5054,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -5143,27 +5143,27 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         },
         {
           "date": "2017-03-14",
-          "text": "Scourge Devil’s triggered ability affects only creatures you control at the time it resolves, including Scourge Devil itself. Creatures you begin to control later in the turn won’t get +1/+0."
+          "text": "Scourge Devil's triggered ability affects only creatures you control at the time it resolves, including Scourge Devil itself. Creatures you begin to control later in the turn won't get +1/+0."
         }
       ],
       "subtypes": [
@@ -5235,7 +5235,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You divide the damage as you put Gang of Devils’s triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
+          "text": "You divide the damage as you put Gang of Devils's triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
         }
       ],
       "subtypes": [
@@ -6059,7 +6059,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The targeted player will discard two cards even if some or all of Blightning’s damage is prevented or redirected."
+          "text": "The targeted player will discard two cards even if some or all of Blightning's damage is prevented or redirected."
         }
       ],
       "text": "Blightning deals 3 damage to target player. That player discards two cards.",
@@ -6128,7 +6128,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -6214,7 +6214,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",

--- a/json/DDL.json
+++ b/json/DDL.json
@@ -82,7 +82,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         }
       ],
       "subtypes": [
@@ -153,7 +153,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Somberwald Vigilante’s ability will trigger for each creature it becomes blocked by."
+          "text": "Somberwald Vigilante's ability will trigger for each creature it becomes blocked by."
         },
         {
           "date": "2012-05-01",
@@ -237,19 +237,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Figure of Destiny’s abilities overwrite its power, toughness, and creature types. Typically, those abilities are activated in the order they appear on the card. However, if Figure of Destiny is an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike, and you activate its first ability, it will become a 2/2 Kithkin Spirit that still has flying and first strike."
+          "text": "Figure of Destiny's abilities overwrite its power, toughness, and creature types. Typically, those abilities are activated in the order they appear on the card. However, if Figure of Destiny is an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike, and you activate its first ability, it will become a 2/2 Kithkin Spirit that still has flying and first strike."
         },
         {
           "date": "2008-08-01",
-          "text": "You can activate Figure of Destiny’s second and third abilities regardless of what creature types it is. Each of those abilities checks Figure of Destiny’s creature types when that ability resolves. If Figure of Destiny isn’t the appropriate creature type at that time, the ability does nothing."
+          "text": "You can activate Figure of Destiny's second and third abilities regardless of what creature types it is. Each of those abilities checks Figure of Destiny's creature types when that ability resolves. If Figure of Destiny isn't the appropriate creature type at that time, the ability does nothing."
         },
         {
           "date": "2008-08-01",
-          "text": "Figure of Destiny’s second ability checks whether it’s a Spirit, and its third ability checks whether it’s a Warrior. It doesn’t matter how it became the appropriate creature type."
+          "text": "Figure of Destiny's second ability checks whether it's a Spirit, and its third ability checks whether it's a Warrior. It doesn't matter how it became the appropriate creature type."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -815,7 +815,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -890,7 +890,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Vigilance only matters when Armory Guard is being declared as an attacking creature. If Armory Guard is already attacking, losing control of your only Gate won’t cause Armory Guard to become tapped or to leave combat."
+          "text": "Vigilance only matters when Armory Guard is being declared as an attacking creature. If Armory Guard is already attacking, losing control of your only Gate won't cause Armory Guard to become tapped or to leave combat."
         }
       ],
       "subtypes": [
@@ -1090,7 +1090,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a static ability. Attacking creatures you control will get +2/+0 from the moment they’re declared as attackers (or enter the battlefield attacking) until the moment the combat phase ends, they’re removed from combat, or Nobilis of War leaves the battlefield, whichever comes first."
+          "text": "This is a static ability. Attacking creatures you control will get +2/+0 from the moment they're declared as attackers (or enter the battlefield attacking) until the moment the combat phase ends, they're removed from combat, or Nobilis of War leaves the battlefield, whichever comes first."
         }
       ],
       "subtypes": [
@@ -1244,7 +1244,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The affected creature’s last known existence on the battlefield is checked to determine its toughness."
+          "text": "The affected creature's last known existence on the battlefield is checked to determine its toughness."
         }
       ],
       "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
@@ -1380,7 +1380,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Pay No Heed doesn’t target anything. You can choose a source with hexproof, for example. You choose the damage source as Pay No Heed resolves."
+          "text": "Pay No Heed doesn't target anything. You can choose a source with hexproof, for example. You choose the damage source as Pay No Heed resolves."
         },
         {
           "date": "2013-07-01",
@@ -1456,7 +1456,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -1597,11 +1597,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Magma Jet deals 2 damage to target creature or player. Scry 2.",
@@ -1670,7 +1670,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won’t sacrifice the Ordeal until the next time the creature attacks."
+          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won't sacrifice the Ordeal until the next time the creature attacks."
         },
         {
           "date": "2013-09-15",
@@ -1744,7 +1744,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Once the enchanted creature has been declared as an attacking or blocking creature, causing it to stop being a Human won’t remove it from combat. It will lose the +2/+2 bonus, however."
+          "text": "Once the enchanted creature has been declared as an attacking or blocking creature, causing it to stop being a Human won't remove it from combat. It will lose the +2/+2 bonus, however."
         }
       ],
       "subtypes": [
@@ -1881,7 +1881,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Undying Rage when it’s cast as a spell is an illegal target when Undying Rage tries to resolve, Undying Rage will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Undying Rage when it's cast as a spell is an illegal target when Undying Rage tries to resolve, Undying Rage will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -1956,7 +1956,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If a creature loses double strike after dealing combat damage in the first combat damage step, it won’t assign combat damage in the second one."
+          "text": "If a creature loses double strike after dealing combat damage in the first combat damage step, it won't assign combat damage in the second one."
         }
       ],
       "subtypes": [
@@ -2026,7 +2026,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide’s ability will trigger."
+          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide's ability will trigger."
         }
       ],
       "subtypes": [
@@ -2224,7 +2224,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "A creature is “enchanted” if it has any Auras attached to it."
+          "text": "A creature is \"enchanted\" if it has any Auras attached to it."
         }
       ],
       "text": "Destroy all creatures that aren't enchanted. They can't be regenerated.",
@@ -4812,31 +4812,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The value of X in Polukranos’s last ability is equal to the value chosen for X when its activated ability was activated."
+          "text": "The value of X in Polukranos's last ability is equal to the value chosen for X when its activated ability was activated."
         },
         {
           "date": "2013-09-15",
-          "text": "The number of targets chosen for the triggered ability must be at least one (if X wasn’t 0) and at most X. You choose the division of damage as you put the ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. In multiplayer games, you may choose creatures controlled by different opponents."
+          "text": "The number of targets chosen for the triggered ability must be at least one (if X wasn't 0) and at most X. You choose the division of damage as you put the ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. In multiplayer games, you may choose creatures controlled by different opponents."
         },
         {
           "date": "2013-09-15",
-          "text": "If some, but not all, of the ability’s targets become illegal, you can’t change the division of damage. Damage that would’ve been dealt to illegal targets simply isn’t dealt."
+          "text": "If some, but not all, of the ability's targets become illegal, you can't change the division of damage. Damage that would've been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2013-09-15",
-          "text": "As Polukranos’s triggered ability resolves, Polukranos deals damage first, then the target creatures do. Although no creature will die until after the ability finishes resolving, the order could matter if Polukranos has wither or infect."
+          "text": "As Polukranos's triggered ability resolves, Polukranos deals damage first, then the target creatures do. Although no creature will die until after the ability finishes resolving, the order could matter if Polukranos has wither or infect."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -5105,7 +5105,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Satyr Hedonist’s ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Satyr Hedonist's ability is a mana ability. It doesn't use the stack and can't be responded to."
         }
       ],
       "subtypes": [
@@ -5179,7 +5179,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Zhur-Taa Druid’s last ability doesn’t trigger if it becomes tapped for any other reason. However, if Zhur-Taa Druid gains another mana ability that requires you tap it, its ability will trigger."
+          "text": "Zhur-Taa Druid's last ability doesn't trigger if it becomes tapped for any other reason. However, if Zhur-Taa Druid gains another mana ability that requires you tap it, its ability will trigger."
         },
         {
           "date": "2013-04-15",
@@ -5187,7 +5187,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Zhur-Taa Druid’s last ability isn’t a mana ability. It uses the stack and can be responded to."
+          "text": "Zhur-Taa Druid's last ability isn't a mana ability. It uses the stack and can be responded to."
         }
       ],
       "subtypes": [
@@ -5589,7 +5589,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "This ability will trigger when Deus of Calamity deals 6 damage to an opponent at one time. It won’t keep track of the accumulated damage that it deals at different times."
+          "text": "This ability will trigger when Deus of Calamity deals 6 damage to an opponent at one time. It won't keep track of the accumulated damage that it deals at different times."
         },
         {
           "date": "2008-05-01",
@@ -5665,7 +5665,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may target a creature that’s already untapped."
+          "text": "You may target a creature that's already untapped."
         },
         {
           "date": "2010-06-15",
@@ -5805,7 +5805,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You can activate Skarrgan Firebird’s last ability if an opponent was dealt damage by any source, even if you didn’t control that source."
+          "text": "You can activate Skarrgan Firebird's last ability if an opponent was dealt damage by any source, even if you didn't control that source."
         }
       ],
       "subtypes": [
@@ -5879,7 +5879,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "Unlike the normal cycling ability, landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a land card of the specified land type, reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-05-01",
@@ -5891,7 +5891,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn’t have to be a basic land."
+          "text": "A landcycling ability lets you search for any card in your library with the stated land type. It doesn't have to be a basic land."
         },
         {
           "date": "2009-05-01",
@@ -5976,7 +5976,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -6391,7 +6391,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Although Terrifying Presence doesn’t affect the target creature, if that creature is an illegal target when Terrifying Presence tries to resolve, it will be countered and none of its effects will happen. No damage will be prevented."
+          "text": "Although Terrifying Presence doesn't affect the target creature, if that creature is an illegal target when Terrifying Presence tries to resolve, it will be countered and none of its effects will happen. No damage will be prevented."
         }
       ],
       "text": "Prevent all combat damage that would be dealt by creatures other than target creature this turn.",
@@ -6459,7 +6459,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You must target an artifact or enchantment to cast Destructive Revelry. If that artifact or enchantment is an illegal target when Destructive Revelry tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt. However, if Destructive Revelry resolves and the artifact or enchantment isn’t destroyed (perhaps because it has indestructible), damage will be dealt."
+          "text": "You must target an artifact or enchantment to cast Destructive Revelry. If that artifact or enchantment is an illegal target when Destructive Revelry tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt. However, if Destructive Revelry resolves and the artifact or enchantment isn't destroyed (perhaps because it has indestructible), damage will be dealt."
         }
       ],
       "text": "Destroy target artifact or enchantment. Destructive Revelry deals 2 damage to that permanent's controller.",
@@ -6583,7 +6583,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the creature or player is an illegal target when Volt Charge tries to resolve, it will be countered and none of its effects will happen. You won’t proliferate."
+          "text": "If the creature or player is an illegal target when Volt Charge tries to resolve, it will be countered and none of its effects will happen. You won't proliferate."
         }
       ],
       "text": "Volt Charge deals 3 damage to target creature or player. Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -6653,7 +6653,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent’s controller won’t get a Beast token."
+          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent's controller won't get a Beast token."
         },
         {
           "date": "2013-07-01",
@@ -6846,7 +6846,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The +1/+1 counter won’t affect Llanowar Reborn in any way unless another effect turns it into a creature."
+          "text": "The +1/+1 counter won't affect Llanowar Reborn in any way unless another effect turns it into a creature."
         }
       ],
       "text": "Llanowar Reborn enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nGraft 1 (This land enters the battlefield with a +1/+1 counter on it. Whenever a creature enters the battlefield, you may move a +1/+1 counter from this land onto it.)",

--- a/json/DDM.json
+++ b/json/DDM.json
@@ -68,11 +68,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Jace’s first ability creates a delayed triggered ability that triggers whenever a creature an opponent controls attacks. It doesn’t matter which player or planeswalker that creature is attacking."
+          "text": "Jace's first ability creates a delayed triggered ability that triggers whenever a creature an opponent controls attacks. It doesn't matter which player or planeswalker that creature is attacking."
         },
         {
           "date": "2012-10-01",
-          "text": "You pick one of your opponents when Jace’s second ability resolves. The ability doesn’t target that opponent. All players may see the revealed cards and offer opinions. You (not your opponent) choose which pile is put into your hand and which pile is put on the bottom of your library."
+          "text": "You pick one of your opponents when Jace's second ability resolves. The ability doesn't target that opponent. All players may see the revealed cards and offer opinions. You (not your opponent) choose which pile is put into your hand and which pile is put on the bottom of your library."
         },
         {
           "date": "2012-10-01",
@@ -80,11 +80,11 @@
         },
         {
           "date": "2012-10-01",
-          "text": "When resolving Jace’s third ability, you search each player’s library (including yours) and exile the nonland cards before casting any of them."
+          "text": "When resolving Jace's third ability, you search each player's library (including yours) and exile the nonland cards before casting any of them."
         },
         {
           "date": "2012-10-01",
-          "text": "For each library, the search is complete only when you explicitly say it is. For example, you can look through one player’s library, set that library down, look at another player’s library, choose a nonland card in the first library, then choose a nonland card in the second library. Don’t reveal any cards from those libraries to any other player until you exile them."
+          "text": "For each library, the search is complete only when you explicitly say it is. For example, you can look through one player's library, set that library down, look at another player's library, choose a nonland card in the first library, then choose a nonland card in the second library. Don't reveal any cards from those libraries to any other player until you exile them."
         },
         {
           "date": "2012-10-01",
@@ -92,15 +92,15 @@
         },
         {
           "date": "2012-10-01",
-          "text": "When casting a card this way, ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "When casting a card this way, ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2012-10-01",
-          "text": "If you can’t cast a card, perhaps because there are no legal targets available, or if you choose not to cast one, it will remain exiled. Jace’s ability won’t allow you to cast it later."
+          "text": "If you can't cast a card, perhaps because there are no legal targets available, or if you choose not to cast one, it will remain exiled. Jace's ability won't allow you to cast it later."
         },
         {
           "date": "2012-10-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-10-01",
@@ -226,11 +226,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The last ability constantly monitors each opponent’s graveyard to see if the bonus applies. If the stated condition becomes no longer true, the bonus immediately stops applying."
+          "text": "The last ability constantly monitors each opponent's graveyard to see if the bonus applies. If the stated condition becomes no longer true, the bonus immediately stops applying."
         },
         {
           "date": "2012-07-01",
-          "text": "In a multiplayer game, a single opponent must have ten or more cards in his or her graveyard for the bonus to apply, although this opponent may change over the course of the game. You don’t have to pick a single opponent; the ability will monitor each opponent’s graveyard."
+          "text": "In a multiplayer game, a single opponent must have ten or more cards in his or her graveyard for the bonus to apply, although this opponent may change over the course of the game. You don't have to pick a single opponent; the ability will monitor each opponent's graveyard."
         }
       ],
       "subtypes": [
@@ -620,7 +620,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are three or fewer cards in your library, you’ll reveal all of them."
+          "text": "If there are three or fewer cards in your library, you'll reveal all of them."
         }
       ],
       "subtypes": [
@@ -694,7 +694,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If there’s only one card in your library as Sea Gate Oracle’s ability resolves, you’ll put it into your hand."
+          "text": "If there's only one card in your library as Sea Gate Oracle's ability resolves, you'll put it into your hand."
         }
       ],
       "subtypes": [
@@ -1033,11 +1033,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Treat Body Double as though it were the chosen card entering the battlefield. Any “As this card enters the battlefield,” “This card enters the battlefield with,” and “When this card enters the battlefield” abilities of the chosen card will work."
+          "text": "Treat Body Double as though it were the chosen card entering the battlefield. Any \"As this card enters the battlefield,\" \"This card enters the battlefield with,\" and \"When this card enters the battlefield\" abilities of the chosen card will work."
         },
         {
           "date": "2007-02-01",
-          "text": "You don’t have to choose a card to copy. If you don’t, Body Double enters the battlefield as a 0/0 creature and is probably put into your graveyard immediately, unless something is increasing its toughness to keep it alive."
+          "text": "You don't have to choose a card to copy. If you don't, Body Double enters the battlefield as a 0/0 creature and is probably put into your graveyard immediately, unless something is increasing its toughness to keep it alive."
         },
         {
           "date": "2007-02-01",
@@ -1181,43 +1181,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1294,39 +1294,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1393,6 +1393,32 @@
         "DDM"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-07-01",
+          "text": "If you cast an instant or sorcery card this way, you do so while the ability of Jace's Mindseeker is resolving. If you choose not to (or can't), you won't get a chance to cast one later."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "\"From among them\" means the five cards put into the graveyard, not all cards in that graveyard."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "When casting an instant or sorcery card this way, ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If a card has {X} in its mana cost, you must choose 0 as its value."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If the five cards are put into a public zone such as exile instead of a graveyard (perhaps due to the ability of Rest in Peace), you can cast one of those instant or sorcery cards from that zone."
+        }
+      ],
       "subtypes": [
         "Fish",
         "Illusion"
@@ -1464,39 +1490,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1570,11 +1596,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If the target player is an illegal target when Thought Scour tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the target player is an illegal target when Thought Scour tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         },
         {
           "date": "2011-01-22",
-          "text": "Follow the instructions in the order listed on the card: if you target yourself, you’ll put the top two cards of your library into your graveyard and then draw a card."
+          "text": "Follow the instructions in the order listed on the card: if you target yourself, you'll put the top two cards of your library into your graveyard and then draw a card."
         }
       ],
       "text": "Target player puts the top two cards of his or her library into his or her graveyard.\nDraw a card.",
@@ -1640,15 +1666,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Only Agoraphobia’s controller can activate its last ability, no matter who controls the creature Agoraphobia’s attached to."
+          "text": "Only Agoraphobia's controller can activate its last ability, no matter who controls the creature Agoraphobia's attached to."
         },
         {
           "date": "2013-01-24",
-          "text": "Agoraphobia’s last ability can be activated only while it’s on the battlefield."
+          "text": "Agoraphobia's last ability can be activated only while it's on the battlefield."
         },
         {
           "date": "2013-01-24",
-          "text": "Players don’t have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Agoraphobia to its owner’s hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get -5/-0)."
+          "text": "Players don't have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Agoraphobia to its owner's hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get -5/-0)."
         }
       ],
       "subtypes": [
@@ -1718,7 +1744,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted permanent is an illegal target by the time Into the Roil resolves, the entire spell is countered. You don’t draw a card."
+          "text": "If the targeted permanent is an illegal target by the time Into the Roil resolves, the entire spell is countered. You don't draw a card."
         }
       ],
       "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If Into the Roil was kicked, draw a card.",
@@ -1786,7 +1812,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell’s destination from its owner’s library to exile."
+          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell's destination from its owner's library to exile."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
@@ -1909,7 +1935,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The countered spell goes to its owner’s hand from the stack. It never hits the graveyard."
+          "text": "The countered spell goes to its owner's hand from the stack. It never hits the graveyard."
         },
         {
           "date": "2007-02-01",
@@ -1985,7 +2011,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The enchanted creature can still be untapped in other ways. Claustrophobia will remain attached, and the creature will continue to not untap during its controller’s untap step."
+          "text": "The enchanted creature can still be untapped in other ways. Claustrophobia will remain attached, and the creature will continue to not untap during its controller's untap step."
         }
       ],
       "subtypes": [
@@ -2128,11 +2154,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The creature returns to the opponent when the “until end of turn” effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
+          "text": "The creature returns to the opponent when the \"until end of turn\" effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command's effect ends, or because a spell or ability causes another player to gain control of it."
         }
       ],
       "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature gains haste until end of turn. When you lose control of the creature, tap it.",
@@ -2202,7 +2228,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -2271,7 +2297,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell is an illegal target by the time Summoner’s Bane resolves, the entire spell is countered. You won’t get a creature token."
+          "text": "If the targeted spell is an illegal target by the time Summoner's Bane resolves, the entire spell is countered. You won't get a creature token."
         },
         {
           "date": "2009-10-01",
@@ -2397,7 +2423,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2016-06-08",
@@ -2409,7 +2435,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability (perhaps because that top card is the card you’re casting) the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability (perhaps because that top card is the card you're casting) the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2016-06-08",
@@ -2475,11 +2501,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Spelltwine has two targets: the instant or sorcery card in your graveyard and the one in an opponent’s graveyard. You can’t cast Spelltwine unless you can choose both legal targets."
+          "text": "Spelltwine has two targets: the instant or sorcery card in your graveyard and the one in an opponent's graveyard. You can't cast Spelltwine unless you can choose both legal targets."
         },
         {
           "date": "2012-07-01",
-          "text": "If one of Spelltwine’s targets is illegal when Spelltwine tries to resolve, you’ll still exile and copy the remaining legal target."
+          "text": "If one of Spelltwine's targets is illegal when Spelltwine tries to resolve, you'll still exile and copy the remaining legal target."
         },
         {
           "date": "2012-07-01",
@@ -2495,7 +2521,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-07-01",
@@ -2558,11 +2584,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}: Dread Statuary becomes a 4/2 Golem artifact creature until end of turn. It's still a land.",
@@ -4088,7 +4114,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Each Assassin token’s triggered ability will trigger whenever it deals combat damage to any player, including you."
+          "text": "Each Assassin token's triggered ability will trigger whenever it deals combat damage to any player, including you."
         }
       ],
       "subtypes": [
@@ -4223,7 +4249,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The black creature that entered the battlefield can be chosen as the target of Shadow Alley Denizen’s ability, but it won’t be able to attack that turn unless it also has haste."
+          "text": "The black creature that entered the battlefield can be chosen as the target of Shadow Alley Denizen's ability, but it won't be able to attack that turn unless it also has haste."
         },
         {
           "date": "2013-01-24",
@@ -4299,11 +4325,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You can’t activate the ability if your life total is less than 3."
+          "text": "You can't activate the ability if your life total is less than 3."
         },
         {
           "date": "2012-10-01",
-          "text": "You can activate the ability if your life total is 3, but it’s probably a bad idea. You’ll lose the game before the ability resolves."
+          "text": "You can activate the ability if your life total is 3, but it's probably a bad idea. You'll lose the game before the ability resolves."
         }
       ],
       "subtypes": [
@@ -4377,7 +4403,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Wight of Precinct Six’s ability applies only if Wight of Precinct Six is on the battlefield."
+          "text": "Wight of Precinct Six's ability applies only if Wight of Precinct Six is on the battlefield."
         }
       ],
       "subtypes": [
@@ -4983,19 +5009,19 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "As the token is created, it checks the printed values of the Spawnwrithe it’s copying — or, if the Spawnwrithe whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the Spawnwrithe, nor will it copy other effects that have changed Spawnwrithe’s power, toughness, types, color, or so on. Normally, this means the token will simply be a Spawnwrithe. But if any copy effects have affected that Spawnwrithe, they’re taken into account."
+          "text": "As the token is created, it checks the printed values of the Spawnwrithe it's copying — or, if the Spawnwrithe whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the Spawnwrithe, nor will it copy other effects that have changed Spawnwrithe's power, toughness, types, color, or so on. Normally, this means the token will simply be a Spawnwrithe. But if any copy effects have affected that Spawnwrithe, they're taken into account."
         },
         {
           "date": "2008-05-01",
-          "text": "If Spawnwrithe’s ability triggers, then Spawnwrithe becomes a copy of another creature before its ability resolves (due to Mirrorweave, perhaps), the token will be a copy of whatever creature the Spawnwrithe is currently a copy of. At the end of the turn, Spawnwrithe will revert back to what it was, but the token will stay as it is."
+          "text": "If Spawnwrithe's ability triggers, then Spawnwrithe becomes a copy of another creature before its ability resolves (due to Mirrorweave, perhaps), the token will be a copy of whatever creature the Spawnwrithe is currently a copy of. At the end of the turn, Spawnwrithe will revert back to what it was, but the token will stay as it is."
         },
         {
           "date": "2008-05-01",
-          "text": "If a copy effect such as Mirrorweave causes some other creature to become a copy of Spawnwrithe, then that creature deals combat damage to a player, the token that’s put onto the battlefield is simply a copy of Spawnwrithe."
+          "text": "If a copy effect such as Mirrorweave causes some other creature to become a copy of Spawnwrithe, then that creature deals combat damage to a player, the token that's put onto the battlefield is simply a copy of Spawnwrithe."
         },
         {
           "date": "2008-05-01",
-          "text": "A token created by a Cemetery Puca that’s copying a Spawnwrithe will be a Spawnwrithe with the Cemetery Puca ability."
+          "text": "A token created by a Cemetery Puca that's copying a Spawnwrithe will be a Spawnwrithe with the Cemetery Puca ability."
         }
       ],
       "subtypes": [
@@ -5067,7 +5093,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Multiple instances of lifelink are redundant. Activating Stonefare Crocodile’s ability more than once during a single turn won’t cause you to gain more life."
+          "text": "multiple instances of lifelink on the same creature are redundant. Activating Stonefare Crocodile's ability more than once during a single turn won't cause you to gain more life."
         }
       ],
       "subtypes": [
@@ -5211,7 +5237,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -5489,7 +5515,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it’s a creature you control."
+          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it's a creature you control."
         }
       ],
       "subtypes": [
@@ -5563,7 +5589,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Reaper of the Wilds’s first ability triggers separately for each creature. For example, if five creatures die at the same time, you’ll scry 1 five times. You won’t scry 5."
+          "text": "Reaper of the Wilds's first ability triggers separately for each creature. For example, if five creatures die at the same time, you'll scry 1 five times. You won't scry 5."
         },
         {
           "date": "2013-09-15",
@@ -5579,11 +5605,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -5675,7 +5701,7 @@
         "Black",
         "Green"
       ],
-      "flavor": "\"The Golgari expand, yes, but I refuse to call their tainted creations ‘growth.'\"\n—Niszka, Selesnya evangel",
+      "flavor": "\"The Golgari expand, yes, but I refuse to call their tainted creations 'growth.'\"\n—Niszka, Selesnya evangel",
       "foreignNames": [
         {
           "language": "Japanese",
@@ -6094,7 +6120,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Last Kiss resolves, the spell is countered. You won’t gain life."
+          "text": "If the targeted creature is an illegal target by the time Last Kiss resolves, the spell is countered. You won't gain life."
         }
       ],
       "text": "Last Kiss deals 2 damage to target creature and you gain 2 life.",
@@ -6346,11 +6372,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Use the creature’s power the last time it was on the battlefield to determine how many cards its controller puts into his or her graveyard."
+          "text": "Use the creature's power the last time it was on the battlefield to determine how many cards its controller puts into his or her graveyard."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature is an illegal target when Grisly Spectacle tries to resolve, it will be countered and none of its effects will happen. The creature’s controller won’t put any cards into his or her graveyard."
+          "text": "If the creature is an illegal target when Grisly Spectacle tries to resolve, it will be countered and none of its effects will happen. The creature's controller won't put any cards into his or her graveyard."
         }
       ],
       "text": "Destroy target nonartifact creature. Its controller puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
@@ -6485,7 +6511,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Activating the second ability of Rogue’s Passage after a creature has become blocked won’t cause it to become unblocked."
+          "text": "Activating the second ability of Rogue's Passage after a creature has become blocked won't cause it to become unblocked."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}, {T}: Target creature can't be blocked this turn.",

--- a/json/DDN.json
+++ b/json/DDN.json
@@ -77,15 +77,15 @@
         },
         {
           "date": "2014-09-20",
-          "text": "If, during your declare attackers step, Zurgo is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having Zurgo attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Zurgo is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having Zurgo attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2014-09-20",
-          "text": "If Zurgo enters the battlefield before the combat phase, it will attack that turn if able. If it enters the battlefield after combat, it won’t attack that turn and will usually be available to block on the following turn."
+          "text": "If Zurgo enters the battlefield before the combat phase, it will attack that turn if able. If it enters the battlefield after combat, it won't attack that turn and will usually be available to block on the following turn."
         },
         {
           "date": "2014-09-20",
-          "text": "Each time a creature dies, check whether Zurgo had dealt any damage to it at any time during that turn. If so, Zurgo’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it went to."
+          "text": "Each time a creature dies, check whether Zurgo had dealt any damage to it at any time during that turn. If so, Zurgo's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it went to."
         }
       ],
       "subtypes": [
@@ -234,7 +234,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         }
       ],
       "subtypes": [
@@ -375,23 +375,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -530,15 +530,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Hellraiser Goblin’s ability also affects itself. If it enters the battlefield before combat, it will have to attack that combat if able."
+          "text": "Hellraiser Goblin's ability also affects itself. If it enters the battlefield before combat, it will have to attack that combat if able."
         },
         {
           "date": "2013-01-24",
-          "text": "If, during your declare attackers step, a creature you control is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having a creature attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, a creature you control is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having a creature attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2013-01-24",
-          "text": "Unlike many other effects that force a creature to attack if able, Hellraiser Goblin’s ability applies during each combat. If a turn has multiple combat phases, creatures you control must attack in each of them if able."
+          "text": "Unlike many other effects that force a creature to attack if able, Hellraiser Goblin's ability applies during each combat. If a turn has multiple combat phases, creatures you control must attack in each of them if able."
         }
       ],
       "subtypes": [
@@ -615,11 +615,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you’ll have to sacrifice Fleshbag Marauder."
+          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you'll have to sacrifice Fleshbag Marauder."
         },
         {
           "date": "2015-06-22",
-          "text": "As Fleshbag Marauder’s ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
+          "text": "As Fleshbag Marauder's ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
         }
       ],
       "subtypes": [
@@ -756,23 +756,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -845,7 +845,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "When Kathari Bomber’s triggered ability resolves, you create two Goblin tokens regardless of how much combat damage Kathari Bomber dealt to the player. You create the tokens even if you can’t sacrifice Kathari Bomber."
+          "text": "When Kathari Bomber's triggered ability resolves, you create two Goblin tokens regardless of how much combat damage Kathari Bomber dealt to the player. You create the tokens even if you can't sacrifice Kathari Bomber."
         }
       ],
       "subtypes": [
@@ -985,11 +985,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -1260,7 +1260,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All creatures under your control when Flame-Kin Zealot’s triggered ability resolves are affected, including Flame-Kin Zealot itself. Ones that come under your control or become creatures later in the turn are not."
+          "text": "All creatures under your control when Flame-Kin Zealot's triggered ability resolves are affected, including Flame-Kin Zealot itself. Ones that come under your control or become creatures later in the turn are not."
         }
       ],
       "subtypes": [
@@ -1333,27 +1333,27 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         },
         {
           "date": "2017-03-14",
-          "text": "Scourge Devil’s triggered ability affects only creatures you control at the time it resolves, including Scourge Devil itself. Creatures you begin to control later in the turn won’t get +1/+0."
+          "text": "Scourge Devil's triggered ability affects only creatures you control at the time it resolves, including Scourge Devil itself. Creatures you begin to control later in the turn won't get +1/+0."
         }
       ],
       "subtypes": [
@@ -1658,11 +1658,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You must sacrifice exactly one creature to cast this spell; you can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast this spell; you can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "Once you begin to cast Bone Splinters, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast Bone Splinters, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         },
         {
           "date": "2017-03-14",
@@ -1920,15 +1920,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Act of Treason can target any creature, even one that’s untapped or one you already control."
+          "text": "Act of Treason can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2013-07-01",
-          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you’ll choose one to remain on the battlefield and put the other into its owner’s graveyard."
+          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you'll choose one to remain on the battlefield and put the other into its owner's graveyard."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
@@ -2123,7 +2123,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -2200,23 +2200,23 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "If it’s somehow not a main phase when Fury of the Horde resolves, all it does is untap all creatures that attacked that turn. No new phases are created."
+          "text": "If it's somehow not a main phase when Fury of the Horde resolves, all it does is untap all creatures that attacked that turn. No new phases are created."
         },
         {
           "date": "2006-07-15",
-          "text": "Paying the alternative cost doesn’t change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
+          "text": "Paying the alternative cost doesn't change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
         },
         {
           "date": "2006-07-15",
-          "text": "You may pay the alternative cost rather than the card’s mana cost. Any additional costs are paid as normal."
+          "text": "You may pay the alternative cost rather than the card's mana cost. Any additional costs are paid as normal."
         },
         {
           "date": "2006-07-15",
-          "text": "If you don’t have two cards of the right color in your hand, you can’t choose to cast the spell using the alternative cost."
+          "text": "If you don't have two cards of the right color in your hand, you can't choose to cast the spell using the alternative cost."
         },
         {
           "date": "2006-07-15",
-          "text": "You can’t exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
+          "text": "You can't exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
         }
       ],
       "text": "You may exile two red cards from your hand rather than pay Fury of the Horde's mana cost.\nUntap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
@@ -2288,11 +2288,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "Banefire can be targeted by spells that try to counter it (such as Countersquall) regardless of what the value of X is. If X is 5 or more, those spells will still resolve, but the part of their effect that would counter Banefire won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Banefire can be targeted by spells that try to counter it (such as Countersquall) regardless of what the value of X is. If X is 5 or more, those spells will still resolve, but the part of their effect that would counter Banefire won't do anything. Any other effects those spells have will work as normal."
         },
         {
           "date": "2009-02-01",
-          "text": "Banefire’s ability won’t prevent it from being countered by the game rules if its target has become an illegal target."
+          "text": "Banefire's ability won't prevent it from being countered by the game rules if its target has become an illegal target."
         }
       ],
       "text": "Banefire deals X damage to target creature or player.\nIf X is 5 or more, Banefire can't be countered by spells or abilities and the damage can't be prevented.",
@@ -2447,11 +2447,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Ghitu Encampment enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\n{1}{R}: Ghitu Encampment becomes a 2/1 red Warrior creature with first strike until end of turn. It's still a land. (It deals combat damage before creatures without first strike.)",
@@ -4513,7 +4513,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Arcanis’s last ability can only be activated while it’s on the battlefield."
+          "text": "Arcanis's last ability can only be activated while it's on the battlefield."
         }
       ],
       "subtypes": [
@@ -4587,7 +4587,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Returning another creature you control to its owner’s hand is optional. You may choose to sacrifice Faerie Impostor, even if you could return a creature."
+          "text": "Returning another creature you control to its owner's hand is optional. You may choose to sacrifice Faerie Impostor, even if you could return a creature."
         }
       ],
       "subtypes": [
@@ -4791,7 +4791,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -4799,7 +4799,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -5229,7 +5229,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Kor Hookmaster’s ability can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Kor Hookmaster's ability can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -5306,11 +5306,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -5380,7 +5380,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The first ability is a replacement effect. The choice is made as Aquamorph Entity is turned face up (or enters the battlefield); it turns face up (or enters the battlefield) as a creature of that size. It doesn’t become a 0/0 and then a creature of the chosen size."
+          "text": "The first ability is a replacement effect. The choice is made as Aquamorph Entity is turned face up (or enters the battlefield); it turns face up (or enters the battlefield) as a creature of that size. It doesn't become a 0/0 and then a creature of the chosen size."
         },
         {
           "date": "2007-02-01",
@@ -5388,7 +5388,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of a face-up Aquamorph Entity, its power and toughness become the power and toughness that were chosen for the Entity."
+          "text": "If a creature that's already on the battlefield becomes a copy of a face-up Aquamorph Entity, its power and toughness become the power and toughness that were chosen for the Entity."
         }
       ],
       "subtypes": [
@@ -5664,7 +5664,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "It doesn’t matter if Thousand Winds is tapped or untapped (or even on the battlefield) when its last ability resolves. Tapped creatures except Thousand Winds will be returned to their owners’ hands."
+          "text": "It doesn't matter if Thousand Winds is tapped or untapped (or even on the battlefield) when its last ability resolves. Tapped creatures except Thousand Winds will be returned to their owners' hands."
         },
         {
           "date": "2014-09-20",
@@ -5676,27 +5676,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -5773,7 +5773,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "A pile can have no cards in it. In this case, you’ll choose whether to put all the revealed cards into your hand or into your graveyard."
+          "text": "A pile can have no cards in it. In this case, you'll choose whether to put all the revealed cards into your hand or into your graveyard."
         },
         {
           "date": "2011-09-22",
@@ -5781,7 +5781,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn’t target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
+          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn't target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
         }
       ],
       "subtypes": [
@@ -5857,11 +5857,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Fleeting Distraction resolves, the spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target by the time Fleeting Distraction resolves, the spell is countered. You won't draw a card."
         },
         {
           "date": "2012-05-01",
-          "text": "If the targeted creature is an illegal target when Fleeting Distraction tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target when Fleeting Distraction tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
@@ -6193,7 +6193,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
@@ -6320,11 +6320,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -6332,11 +6332,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Inferno Trap’s alternative cost condition checks for any damage, not just combat damage."
+          "text": "Inferno Trap's alternative cost condition checks for any damage, not just combat damage."
         },
         {
           "date": "2009-10-01",
-          "text": "The alternative cost condition doesn’t check who controlled the creatures that dealt damage to you. Damage dealt to you by your own creatures counts."
+          "text": "The alternative cost condition doesn't check who controlled the creatures that dealt damage to you. Damage dealt to you by your own creatures counts."
         },
         {
           "date": "2009-10-01",
@@ -6416,7 +6416,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Steam Augury doesn’t target any opponent. In a multiplayer game, you choose the opponent as the spell resolves."
+          "text": "Steam Augury doesn't target any opponent. In a multiplayer game, you choose the opponent as the spell resolves."
         },
         {
           "date": "2013-09-15",
@@ -6487,7 +6487,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -6565,11 +6565,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -6577,7 +6577,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You must target two creatures as you cast Whiplash Trap. If you can’t (because just one creature is on the battlefield, perhaps), you can’t cast the spell."
+          "text": "You must target two creatures as you cast Whiplash Trap. If you can't (because just one creature is on the battlefield, perhaps), you can't cast the spell."
         },
         {
           "date": "2009-10-01",
@@ -6649,11 +6649,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",

--- a/json/DDO.json
+++ b/json/DDO.json
@@ -129,27 +129,27 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Banisher Priest’s ability causes a zone change with a duration, a new style of ability that’s somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Banisher Priest have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Banisher Priest leaves the battlefield."
+          "text": "Banisher Priest's ability causes a zone change with a duration, a new style of ability that's somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Banisher Priest have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Banisher Priest leaves the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "If Banisher Priest leaves the battlefield before its enters-the-battlefield ability resolves, the target creature won’t be exiled."
+          "text": "If Banisher Priest leaves the battlefield before its enters-the-battlefield ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2013-07-01",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "The exiled card returns to the battlefield immediately after Banisher Priest leaves the battlefield. Nothing happens between the two events, including state-based actions. The two creatures aren’t on the battlefield at the same time. For example, if the returning creature is a Clone, it can’t enter the battlefield as a copy of Banisher Priest."
+          "text": "The exiled card returns to the battlefield immediately after Banisher Priest leaves the battlefield. Nothing happens between the two events, including state-based actions. The two creatures aren't on the battlefield at the same time. For example, if the returning creature is a Clone, it can't enter the battlefield as a copy of Banisher Priest."
         },
         {
           "date": "2013-07-01",
-          "text": "In a multiplayer game, if Banisher Priest’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Banisher Priest's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "subtypes": [
@@ -289,7 +289,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the player sacrifices a blocking creature, any attacking creature it was blocking remains blocked. Unless that attacking creature has trample or is being blocked by another creature, it won’t assign or deal combat damage."
+          "text": "If the player sacrifices a blocking creature, any attacking creature it was blocking remains blocked. Unless that attacking creature has trample or is being blocked by another creature, it won't assign or deal combat damage."
         },
         {
           "date": "2013-07-01",
@@ -484,7 +484,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two X’s in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
+          "text": "The two X's in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
         },
         {
           "date": "2004-10-04",
@@ -504,7 +504,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
@@ -635,7 +635,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -1096,7 +1096,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Kor Skyfisher’s triggered ability doesn’t target a permanent. You choose which one to return to its owner’s hand as the ability resolves. No one can respond to the choice."
+          "text": "Kor Skyfisher's triggered ability doesn't target a permanent. You choose which one to return to its owner's hand as the ability resolves. No one can respond to the choice."
         },
         {
           "date": "2017-03-14",
@@ -1252,7 +1252,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
         }
       ],
       "text": "Target creature gets +2/+2 and gains flying until end of turn.",
@@ -3141,7 +3141,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Kiora’s first ability can target any permanent an opponent controls, not just one that can deal or be dealt damage."
+          "text": "Kiora's first ability can target any permanent an opponent controls, not just one that can deal or be dealt damage."
         },
         {
           "date": "2014-02-01",
@@ -3149,7 +3149,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Kiora’s second ability allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you won’t play a land as that ability resolves. The ability will fully resolve (and you’ll draw a card, perhaps a land you’ll play later) first."
+          "text": "Kiora's second ability allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you won't play a land as that ability resolves. The ability will fully resolve (and you'll draw a card, perhaps a land you'll play later) first."
         },
         {
           "date": "2014-02-01",
@@ -3157,7 +3157,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "If Kiora leaves the battlefield after her second ability is activated but before it resolves, you’ll still be able to play an additional land after the ability resolves."
+          "text": "If Kiora leaves the battlefield after her second ability is activated but before it resolves, you'll still be able to play an additional land after the ability resolves."
         }
       ],
       "subtypes": [
@@ -3289,7 +3289,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat. There’s no such thing as an attacking creature outside of the combat phase."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat. There's no such thing as an attacking creature outside of the combat phase."
         }
       ],
       "text": "Return all attacking creatures to their owner's hand.",
@@ -3428,7 +3428,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are no other creatures on the battlefield when Man-o’-War enters the battlefield, its ability must target itself."
+          "text": "If there are no other creatures on the battlefield when Man-o'-War enters the battlefield, its ability must target itself."
         }
       ],
       "subtypes": [
@@ -3508,11 +3508,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -3720,19 +3720,19 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The effect making the land an Island doesn’t have a duration and will last indefinitely. The land retains any land types and abilities it already had. An Island has the ability “{T}: Add {U} to your mana pool.”"
+          "text": "The effect making the land an Island doesn't have a duration and will last indefinitely. The land retains any land types and abilities it already had. An Island has the ability \"{T}: Add {U} to your mana pool.\""
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -3929,15 +3929,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Explore’s effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don’t get to play a land as Explore resolves; Explore fully resolves first and draws a card, perhaps a land you’ll play later."
+          "text": "Explore's effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don't get to play a land as Explore resolves; Explore fully resolves first and draws a card, perhaps a land you'll play later."
         },
         {
           "date": "2017-03-14",
-          "text": "The effects of multiple Explores in the same turn are cumulative. They’re also cumulative with other effects that let you play additional lands, such as the one from Urban Evolution."
+          "text": "The effects of multiple Explores in the same turn are cumulative. They're also cumulative with other effects that let you play additional lands, such as the one from Urban Evolution."
         },
         {
           "date": "2017-03-14",
-          "text": "If you somehow manage to cast Explore when it’s not your turn, you’ll draw a card when it resolves, but you won’t be able to play a land that turn."
+          "text": "If you somehow manage to cast Explore when it's not your turn, you'll draw a card when it resolves, but you won't be able to play a land that turn."
         }
       ],
       "text": "You may play an additional land this turn.\nDraw a card.",
@@ -4075,7 +4075,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -4151,15 +4151,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -4299,7 +4299,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Time to Feed has two targets: a creature an opponent controls and a creature you control. If only one of those creatures is a legal target when Time to Feed tries to resolve, the creatures won’t fight and neither will deal or be dealt damage. If the creature you don’t control is the illegal target, you won’t gain life when it dies."
+          "text": "Time to Feed has two targets: a creature an opponent controls and a creature you control. If only one of those creatures is a legal target when Time to Feed tries to resolve, the creatures won't fight and neither will deal or be dealt damage. If the creature you don't control is the illegal target, you won't gain life when it dies."
         },
         {
           "date": "2013-09-15",
@@ -4307,7 +4307,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If the first target creature dies that turn, you’ll gain 3 life no matter what caused the creature to die or who controls the creature at that time."
+          "text": "If the first target creature dies that turn, you'll gain 3 life no matter what caused the creature to die or who controls the creature at that time."
         }
       ],
       "text": "Choose target creature an opponent controls. When that creature dies this turn, you gain 3 life. Target creature you control fights that creature. (Each deals damage equal to its power to the other.)",
@@ -4520,11 +4520,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "If a spell or ability causes you to draw multiple cards, Lorescale Coatl’s ability triggers that many times."
+          "text": "If a spell or ability causes you to draw multiple cards, Lorescale Coatl's ability triggers that many times."
         },
         {
           "date": "2009-05-01",
-          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word “draw,” Lorescale Coatl’s ability won’t trigger."
+          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word \"draw,\" Lorescale Coatl's ability won't trigger."
         }
       ],
       "subtypes": [
@@ -4663,7 +4663,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If the countered spell had {X} in its mana cost, include the value chosen for that X when determining how much mana to add to your pool. For example, if you counter a spell that costs {X}{R} with X equal to 5, you’ll add six mana to your mana pool."
+          "text": "If the countered spell had {X} in its mana cost, include the value chosen for that X when determining how much mana to add to your pool. For example, if you counter a spell that costs {X}{R} with X equal to 5, you'll add six mana to your mana pool."
         },
         {
           "date": "2013-04-15",
@@ -4805,15 +4805,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Urban Evolution’s effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don’t get to play a land as Urban Evolution resolves; Urban Evolution fully resolves first and draws three cards, perhaps including a land you’ll play later."
+          "text": "Urban Evolution's effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don't get to play a land as Urban Evolution resolves; Urban Evolution fully resolves first and draws three cards, perhaps including a land you'll play later."
         },
         {
           "date": "2017-03-14",
-          "text": "The effects of multiple Urban Evolutions in the same turn are cumulative. They’re also cumulative with other effects that let you play additional lands, such as the one from Explore."
+          "text": "The effects of multiple Urban Evolutions in the same turn are cumulative. They're also cumulative with other effects that let you play additional lands, such as the one from Explore."
         },
         {
           "date": "2017-03-14",
-          "text": "If you somehow manage to cast Urban Evolution when it’s not your turn, you’ll draw three cards when it resolves, but you won’t be able to play a land that turn."
+          "text": "If you somehow manage to cast Urban Evolution when it's not your turn, you'll draw three cards when it resolves, but you won't be able to play a land that turn."
         }
       ],
       "text": "Draw three cards. You may play an additional land this turn.",

--- a/json/DDP.json
+++ b/json/DDP.json
@@ -69,7 +69,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -210,23 +210,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -298,23 +298,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -386,23 +386,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -490,7 +490,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘Invincible' is just a word.\"\n—Gideon Jura",
+      "flavor": "\"'Invincible' is just a word.\"\n—Gideon Jura",
       "foreignNames": [
         {
           "language": "Japanese",
@@ -538,19 +538,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature’s owner has one or more cards in his or her library, that creature is put into that library directly under the top card."
+          "text": "If the targeted creature's owner has one or more cards in his or her library, that creature is put into that library directly under the top card."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature’s owner has no cards left in his or her library, that creature is put into that library as the only card there."
+          "text": "If the targeted creature's owner has no cards left in his or her library, that creature is put into that library as the only card there."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is a token, it will cease to exist after it’s put into its owner’s library."
+          "text": "If the targeted creature is a token, it will cease to exist after it's put into its owner's library."
         },
         {
           "date": "2010-06-15",
-          "text": "Note that the creature’s controller, not its owner, is the one who gains life."
+          "text": "Note that the creature's controller, not its owner, is the one who gains life."
         },
         {
           "date": "2010-06-15",
@@ -620,19 +620,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may target zero, one, or two creatures. The creatures don’t need to be untapped."
+          "text": "You may target zero, one, or two creatures. The creatures don't need to be untapped."
         },
         {
           "date": "2010-06-15",
-          "text": "If you target zero creatures, Repel the Darkness can’t be countered for having no legal targets. When it resolves, all that happens is that you draw a card."
+          "text": "If you target zero creatures, Repel the Darkness can't be countered for having no legal targets. When it resolves, all that happens is that you draw a card."
         },
         {
           "date": "2010-06-15",
-          "text": "If you target one creature and that target is illegal as Repel the Darkness resolves, the spell is countered. You don’t draw a card."
+          "text": "If you target one creature and that target is illegal as Repel the Darkness resolves, the spell is countered. You don't draw a card."
         },
         {
           "date": "2010-06-15",
-          "text": "If you target two creatures and they’re both illegal as Repel the Darkness resolves, the spell is countered; you don’t draw a card. If just one is illegal, the spell does resolve; the remaining legal target becomes tapped (if it’s untapped at that time) and you draw a card."
+          "text": "If you target two creatures and they're both illegal as Repel the Darkness resolves, the spell is countered; you don't draw a card. If just one is illegal, the spell does resolve; the remaining legal target becomes tapped (if it's untapped at that time) and you draw a card."
         }
       ],
       "text": "Tap up to two target creatures.\nDraw a card.",
@@ -701,27 +701,27 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you’ll get both effects."
+          "text": "You can cast a spell with awaken for its mana cost and get only its first effect. If you cast a spell for its awaken cost, you'll get both effects."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can’t cast the spell if you can’t choose a legal target for each instance of the word “target” (though you only need a legal target for the awaken ability if you’re casting the spell for its awaken cost)."
+          "text": "If the non-awaken part of the spell requires a target, you must choose a legal target. You can't cast the spell if you can't choose a legal target for each instance of the word \"target\" (though you only need a legal target for the awaken ability if you're casting the spell for its awaken cost)."
         },
         {
           "date": "2015-08-25",
-          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won’t affect the illegal targets in any way."
+          "text": "If a spell with awaken has multiple targets (including the land you control), and some but not all of those targets become illegal by the time the spell tries to resolve, the spell won't affect the illegal targets in any way."
         },
         {
           "date": "2015-08-25",
-          "text": "If the non-awaken part of the spell doesn’t require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
+          "text": "If the non-awaken part of the spell doesn't require a target and you cast the spell for its awaken cost, then the spell will be countered if the target land you control becomes illegal before the spell resolves (such as due to being destroyed in response to the spell being cast)."
         },
         {
           "date": "2015-08-25",
-          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that’s turned into a creature this way can still be tapped for {G}."
+          "text": "The land will retain any other types, subtypes, or supertypes it previously had. It will also retain any mana abilities it had as a result of those subtypes. For example, a Forest that's turned into a creature this way can still be tapped for {G}."
         },
         {
           "date": "2015-08-25",
-          "text": "Awaken doesn’t give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
+          "text": "Awaken doesn't give the land you control a color. As most lands are colorless, in most cases the resulting land creature will also be colorless."
         }
       ],
       "text": "Destroy target tapped creature.\nAwaken 3—{5}{W} (If you cast this spell for {5}{W}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
@@ -787,23 +787,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -1076,7 +1076,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -1158,7 +1158,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The landfall ability checks for an action that has happened in the past. It doesn’t matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
+          "text": "The landfall ability checks for an action that has happened in the past. It doesn't matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
         },
         {
           "date": "2010-03-01",
@@ -1166,7 +1166,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The effect of this spell’s landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
+          "text": "The effect of this spell's landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn.\nLandfall — If you had a land enter the battlefield under your control this turn, that creature gets +4/+4 until end of turn instead.",
@@ -1247,7 +1247,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can’t pay this cost more than once to get a multiple effect."
+          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can't pay this cost more than once to get a multiple effect."
         },
         {
           "date": "2004-10-04",
@@ -1255,7 +1255,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
@@ -1394,7 +1394,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -1533,11 +1533,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Primal Command’s modes are performed in the order listed. If you put a noncreature permanent on top of its owner’s library and have that player shuffle his or her graveyard into his or her library, that card is shuffled away."
+          "text": "Primal Command's modes are performed in the order listed. If you put a noncreature permanent on top of its owner's library and have that player shuffle his or her graveyard into his or her library, that card is shuffled away."
         },
         {
           "date": "2017-03-14",
-          "text": "Primal Command won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect if you target yourself with its third mode."
+          "text": "Primal Command won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect if you target yourself with its third mode."
         }
       ],
       "text": "Choose two —\n• Target player gains 7 life.\n• Put target noncreature permanent on top of its owner's library.\n• Target player shuffles his or her graveyard into his or her library.\n• Search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
@@ -1615,7 +1615,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "text": "Landfall — Whenever a land enters the battlefield under your control, choose one —\n• Put a +1/+1 counter on target creature.\n• You gain 2 life.",
@@ -1684,7 +1684,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Scute Mob’s ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control five or more lands as your upkeep starts, and (2) the ability will do nothing if you control fewer than five lands by the time it resolves."
+          "text": "Scute Mob's ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control five or more lands as your upkeep starts, and (2) the ability will do nothing if you control fewer than five lands by the time it resolves."
         }
       ],
       "subtypes": [
@@ -1840,7 +1840,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -1856,7 +1856,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -1927,7 +1927,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -1939,19 +1939,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Deciding to have the targeted creature block doesn’t force you to attack with Turntimber Basilisk that turn. If Turntimber Basilisk doesn’t attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "Deciding to have the targeted creature block doesn't force you to attack with Turntimber Basilisk that turn. If Turntimber Basilisk doesn't attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2009-10-01",
-          "text": "If you choose to have the targeted creature block but that creature isn’t able to block Turntimber Basilisk (for example, because the targeted creature can block only creatures with flying), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "If you choose to have the targeted creature block but that creature isn't able to block Turntimber Basilisk (for example, because the targeted creature can block only creatures with flying), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Tapped creatures, creatures that can’t block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren’t controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Turntimber Basilisk’s landfall ability, but the requirement to block does nothing."
+          "text": "Tapped creatures, creatures that can't block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren't controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Turntimber Basilisk's landfall ability, but the requirement to block does nothing."
         },
         {
           "date": "2009-10-01",
-          "text": "If Turntimber Basilisk’s landfall ability triggers multiple times during the same turn, you can have multiple creatures block it that turn if able."
+          "text": "If Turntimber Basilisk's landfall ability triggers multiple times during the same turn, you can have multiple creatures block it that turn if able."
         }
       ],
       "subtypes": [
@@ -2094,11 +2094,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The ability that defines Veteran Warleader’s power and toughness works in all zones, not just the battlefield. If Veteran Warleader is on the battlefield, it will count itself."
+          "text": "The ability that defines Veteran Warleader's power and toughness works in all zones, not just the battlefield. If Veteran Warleader is on the battlefield, it will count itself."
         },
         {
           "date": "2015-08-25",
-          "text": "To activate the last ability, you can tap any other untapped Ally you control, including one that hasn’t been under your control since the beginning of your most recent turn. (Note that ability doesn’t use the tap symbol.)"
+          "text": "To activate the last ability, you can tap any other untapped Ally you control, including one that hasn't been under your control since the beginning of your most recent turn. (Note that ability doesn't use the tap symbol.)"
         },
         {
           "date": "2015-08-25",
@@ -2106,7 +2106,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Vigilance matters only as attackers are declared. Giving a creature vigilance after that point won’t untap it, even if it’s attacking."
+          "text": "Vigilance matters only as attackers are declared. Giving a creature vigilance after that point won't untap it, even if it's attacking."
         }
       ],
       "subtypes": [
@@ -2233,7 +2233,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -2513,11 +2513,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         }
       ],
       "text": "Stirring Wildwood enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.\n{1}{G}{W}: Until end of turn, Stirring Wildwood becomes a 3/4 green and white Elemental creature with reach. It's still a land.",
@@ -4263,11 +4263,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Oblivion Sower’s ability allows you to put any land cards the player owns from exile onto the battlefield, regardless of how those cards were exiled."
+          "text": "Oblivion Sower's ability allows you to put any land cards the player owns from exile onto the battlefield, regardless of how those cards were exiled."
         },
         {
           "date": "2015-08-25",
-          "text": "Cards that are face down in exile have no characteristics. Such cards can’t be put onto the battlefield with Oblivion Sower’s ability."
+          "text": "Cards that are face down in exile have no characteristics. Such cards can't be put onto the battlefield with Oblivion Sower's ability."
         }
       ],
       "subtypes": [
@@ -4336,15 +4336,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -4409,15 +4409,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
@@ -4425,7 +4425,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "It doesn’t matter whose graveyard the permanent is put into, only that it was last controlled by, and sacrificed by, an opponent."
+          "text": "It doesn't matter whose graveyard the permanent is put into, only that it was last controlled by, and sacrificed by, an opponent."
         },
         {
           "date": "2010-06-15",
@@ -4433,15 +4433,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "When the second ability resolves, you must return the card to the battlefield, even if you don’t want to."
+          "text": "When the second ability resolves, you must return the card to the battlefield, even if you don't want to."
         },
         {
           "date": "2010-06-15",
-          "text": "If an opponent sacrifices an Aura, you’ll choose what it enchants as you return it to the battlefield. No player can respond to the choice. Since an Aura doesn’t target anything if it isn’t cast as a spell, you can enchant a permanent with shroud this way."
+          "text": "If an opponent sacrifices an Aura, you'll choose what it enchants as you return it to the battlefield. No player can respond to the choice. Since an Aura doesn't target anything if it isn't cast as a spell, you can enchant a permanent with shroud this way."
         },
         {
           "date": "2010-06-15",
-          "text": "If the sacrificed permanent that caused the second ability to trigger somehow leaves the graveyard before the ability resolves (possibly because it was returned to the battlefield by the ability of another It That Betrays), the ability simply won’t do anything when it resolves."
+          "text": "If the sacrificed permanent that caused the second ability to trigger somehow leaves the graveyard before the ability resolves (possibly because it was returned to the battlefield by the ability of another It That Betrays), the ability simply won't do anything when it resolves."
         }
       ],
       "subtypes": [
@@ -4507,23 +4507,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "If, during your declare attackers step, Ulamog’s Crusher is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then it doesn’t attack. If there’s a cost associated with having Ulamog’s Crusher attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Ulamog's Crusher is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then it doesn't attack. If there's a cost associated with having Ulamog's Crusher attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If there are multiple combat phases in a turn, Ulamog’s Crusher must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Ulamog's Crusher must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -4664,11 +4664,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won’t be on the battlefield to get the bonus."
+          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won't be on the battlefield to get the bonus."
         },
         {
           "date": "2010-06-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -4748,15 +4748,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners’ graveyards at the same time, Butcher of Malakir’s triggered ability will trigger that many times."
+          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners' graveyards at the same time, Butcher of Malakir's triggered ability will trigger that many times."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers’ abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
+          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers' abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player’s Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player’s Butcher to trigger, and so on."
+          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player's Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player's Butcher to trigger, and so on."
         }
       ],
       "subtypes": [
@@ -5015,7 +5015,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Dominator Drone’s last ability checks to see if you control another colorless creature at the moment it enters the battlefield. If you don’t, the ability won’t trigger at all. If you do, the ability will check again as it tries to resolve. If you no longer control another colorless creature, the ability will be removed from the stack and have no effect."
+          "text": "Dominator Drone's last ability checks to see if you control another colorless creature at the moment it enters the battlefield. If you don't, the ability won't trigger at all. If you do, the ability will check again as it tries to resolve. If you no longer control another colorless creature, the ability will be removed from the stack and have no effect."
         },
         {
           "date": "2015-08-25",
@@ -5023,11 +5023,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -5035,7 +5035,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         },
         {
           "date": "2015-08-25",
@@ -5043,7 +5043,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won’t lose the game (until he or she has to draw a card from an empty library)."
+          "text": "If the player has no cards in his or her library when the ingest ability resolves, nothing happens. That player won't lose the game (until he or she has to draw a card from an empty library)."
         }
       ],
       "subtypes": [
@@ -5298,11 +5298,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If multiple nontoken creatures you control (possibly including Pawn of Ulamog itself) are put into their owners’ graveyards at the same time, Pawn of Ulamog’s triggered ability will trigger that many times."
+          "text": "If multiple nontoken creatures you control (possibly including Pawn of Ulamog itself) are put into their owners' graveyards at the same time, Pawn of Ulamog's triggered ability will trigger that many times."
         },
         {
           "date": "2010-06-15",
-          "text": "If you control more than one Pawn of Ulamog and a nontoken creature you control is put into a graveyard, each of those Pawns’ abilities will trigger. You may put up to that many Eldrazi Spawn tokens onto the battlefield."
+          "text": "If you control more than one Pawn of Ulamog and a nontoken creature you control is put into a graveyard, each of those Pawns' abilities will trigger. You may put up to that many Eldrazi Spawn tokens onto the battlefield."
         }
       ],
       "subtypes": [
@@ -5375,7 +5375,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The loss of life is part of the spell’s effect. It’s not an additional cost. If Read the Bones is countered, you won’t lose life."
+          "text": "The loss of life is part of the spell's effect. It's not an additional cost. If Read the Bones is countered, you won't lose life."
         },
         {
           "date": "2013-09-15",
@@ -5387,11 +5387,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -5463,7 +5463,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is copying something else; see below). If its mana cost includes {X}, X is considered to be 0. If it has no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is copying something else; see below). If its mana cost includes {X}, X is considered to be 0. If it has no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
         },
         {
           "date": "2010-03-01",
@@ -5471,7 +5471,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If a creature is copying something else, its converted mana cost is the converted mana cost of whatever it’s copying."
+          "text": "If a creature is copying something else, its converted mana cost is the converted mana cost of whatever it's copying."
         }
       ],
       "text": "Destroy target creature with converted mana cost 3 or less. It can't be regenerated.",
@@ -5947,11 +5947,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "A card with devoid is just colorless. It’s not colorless and the colors of mana in its mana cost."
+          "text": "A card with devoid is just colorless. It's not colorless and the colors of mana in its mana cost."
         },
         {
           "date": "2015-08-25",
-          "text": "Other cards and abilities can give a card with devoid color. If that happens, it’s just the new color, not that color and colorless."
+          "text": "Other cards and abilities can give a card with devoid color. If that happens, it's just the new color, not that color and colorless."
         },
         {
           "date": "2015-08-25",
@@ -5959,7 +5959,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object’s color (like the one created by devoid) are considered before the object loses devoid."
+          "text": "If a card loses devoid, it will still be colorless. This is because effects that change an object's color (like the one created by devoid) are considered before the object loses devoid."
         }
       ],
       "subtypes": [
@@ -6207,7 +6207,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The mana generated by the last ability can’t be spent to activate abilities of Eldrazi sources that aren’t on the battlefield."
+          "text": "The mana generated by the last ability can't be spent to activate abilities of Eldrazi sources that aren't on the battlefield."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}: Add {C}{C} to your mana pool. Spend this mana only to cast colorless Eldrazi spells or activate abilities of colorless Eldrazi.",
@@ -6261,7 +6261,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Rocky Tar Pit enters the battlefield tapped.\n{T}, Sacrifice Rocky Tar Pit: Search your library for a Swamp or Mountain card and put it onto the battlefield. Then shuffle your library.",

--- a/json/DDQ.json
+++ b/json/DDQ.json
@@ -67,7 +67,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Geist of Saint Traft is attacking."
+          "text": "You declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Geist of Saint Traft is attacking."
         },
         {
           "date": "2011-09-22",
@@ -145,7 +145,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Once the enchanted creature has been declared as an attacking or blocking creature, causing it to stop being a Human won’t remove it from combat. It will lose the +2/+2 bonus, however."
+          "text": "Once the enchanted creature has been declared as an attacking or blocking creature, causing it to stop being a Human won't remove it from combat. It will lose the +2/+2 bonus, however."
         }
       ],
       "subtypes": [
@@ -416,7 +416,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "However, you’ll ignore the continuous effects of static abilities that come from other sources. For example, if you control Xenograft with Human as the chosen creature type, a Vampire creature would not enter the battlefield with a +1/+1 counter."
+          "text": "However, you'll ignore the continuous effects of static abilities that come from other sources. For example, if you control Xenograft with Human as the chosen creature type, a Vampire creature would not enter the battlefield with a +1/+1 counter."
         }
       ],
       "subtypes": [
@@ -558,11 +558,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Auras attached to the exiled creatures will be put into their owners’ graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled creatures will cease to exist."
+          "text": "Auras attached to the exiled creatures will be put into their owners' graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled creatures will cease to exist."
         },
         {
           "date": "2016-04-08",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2016-04-08",
@@ -697,7 +697,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The triggered ability doesn’t target a permanent. You choose which one to return to its owner’s hand as the ability resolves. No one can respond to the choice."
+          "text": "The triggered ability doesn't target a permanent. You choose which one to return to its owner's hand as the ability resolves. No one can respond to the choice."
         },
         {
           "date": "2012-05-01",
@@ -1036,11 +1036,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Any “as this enters the battlefield” choices for the affected creature are made by its owner, not its old controller."
+          "text": "Any \"as this enters the battlefield\" choices for the affected creature are made by its owner, not its old controller."
         },
         {
           "date": "2007-02-01",
-          "text": "If Momentary Blink is cast on a token creature, the token will not return to the battlefield, because of the rule that says a token that leaves the battlefield can’t come back."
+          "text": "If Momentary Blink is cast on a token creature, the token will not return to the battlefield, because of the rule that says a token that leaves the battlefield can't come back."
         }
       ],
       "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -1230,7 +1230,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you control the only Vampire, Werewolf, or Zombie, you must target it with Slayer of the Wicked’s ability. You choose whether or not to destroy the target when the ability resolves."
+          "text": "If you control the only Vampire, Werewolf, or Zombie, you must target it with Slayer of the Wicked's ability. You choose whether or not to destroy the target when the ability resolves."
         }
       ],
       "subtypes": [
@@ -1437,19 +1437,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -1519,7 +1519,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         }
       ],
       "subtypes": [
@@ -1785,7 +1785,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Mist Raven’s ability is mandatory. If Mist Raven is the only creature on the battlefield when its ability triggers, you must choose it as the target."
+          "text": "Mist Raven's ability is mandatory. If Mist Raven is the only creature on the battlefield when its ability triggers, you must choose it as the target."
         }
       ],
       "subtypes": [
@@ -1872,7 +1872,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"‘I'm certain that the fate of Markov Manor is connected to these cryptoliths . . .' This Tamiyo was on to something.\"",
+      "flavor": "\"'I'm certain that the fate of Markov Manor is connected to these cryptoliths . . .' This Tamiyo was on to something.\"",
       "foreignNames": [
         {
           "language": "Japanese",
@@ -1989,7 +1989,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Tandem Lookout or the creature it’s paired with is dealt lethal damage at the same time that either deals damage to an opponent, its ability triggers. You’ll draw a card even though that creature no longer has the ability."
+          "text": "If Tandem Lookout or the creature it's paired with is dealt lethal damage at the same time that either deals damage to an opponent, its ability triggers. You'll draw a card even though that creature no longer has the ability."
         }
       ],
       "subtypes": [
@@ -2061,7 +2061,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If there’s only one card in your library when Tower Geist enters the battlefield, you’ll look at that card and put it into your hand."
+          "text": "If there's only one card in your library when Tower Geist enters the battlefield, you'll look at that card and put it into your hand."
         }
       ],
       "subtypes": [
@@ -4020,7 +4020,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Mindwrack Demon’s delirium triggered ability does not include an intervening “if” clause. This ability triggers at the beginning of your upkeep regardless of the number of types in your graveyard, and it checks that number as it resolves to determine whether you lose 4 life or not."
+          "text": "Mindwrack Demon's delirium triggered ability does not include an intervening \"if\" clause. This ability triggers at the beginning of your upkeep regardless of the number of types in your graveyard, and it checks that number as it resolves to determine whether you lose 4 life or not."
         },
         {
           "date": "2016-04-08",
@@ -4028,15 +4028,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -4109,15 +4109,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The card returned to its owner’s hand may be the card he or she discards. If it’s the only card in that player’s hand, it must be discarded."
+          "text": "The card returned to its owner's hand may be the card he or she discards. If it's the only card in that player's hand, it must be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "Compelling Deterrence targets only the nonland permanent. If that permanent becomes an illegal target, Compelling Deterrence is countered and that player doesn’t discard a card."
+          "text": "Compelling Deterrence targets only the nonland permanent. If that permanent becomes an illegal target, Compelling Deterrence is countered and that player doesn't discard a card."
         },
         {
           "date": "2016-04-08",
-          "text": "If you target the only Zombie you control with Compelling Deterrence, you won’t discard a card."
+          "text": "If you target the only Zombie you control with Compelling Deterrence, you won't discard a card."
         }
       ],
       "text": "Return target nonland permanent to its owner's hand. Then that player discards a card if you control a Zombie.",
@@ -4184,7 +4184,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you have fewer than four cards in your library, you’ll look at all the cards there and put one into your hand and the rest into your graveyard."
+          "text": "If you have fewer than four cards in your library, you'll look at all the cards there and put one into your hand and the rest into your graveyard."
         }
       ],
       "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -4250,7 +4250,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Although players may respond to the activated ability, they can’t respond to the paying of its costs. The creature card will already be exiled by the time any player could respond."
+          "text": "Although players may respond to the activated ability, they can't respond to the paying of its costs. The creature card will already be exiled by the time any player could respond."
         },
         {
           "date": "2011-01-22",
@@ -4399,7 +4399,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "When Relentless Skaabs returns to the battlefield because of its undying ability, it’s not being cast. You won’t exile a creature card from your graveyard."
+          "text": "When Relentless Skaabs returns to the battlefield because of its undying ability, it's not being cast. You won't exile a creature card from your graveyard."
         },
         {
           "date": "2013-04-15",
@@ -4684,7 +4684,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You’ll gain life equal to the creature’s last known toughness before it died. For example, if Abattoir Ghoul deals 3 first-strike damage to a 7/7 creature and then you give the creature -5/-5 before the regular combat damage step, you’ll gain 2 life."
+          "text": "You'll gain life equal to the creature's last known toughness before it died. For example, if Abattoir Ghoul deals 3 first-strike damage to a 7/7 creature and then you give the creature -5/-5 before the regular combat damage step, you'll gain 2 life."
         }
       ],
       "subtypes": [
@@ -4753,7 +4753,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "If a card in a player’s hand has {X} in its mana cost, X is 0."
+          "text": "If a card in a player's hand has {X} in its mana cost, X is 0."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose a card from it with converted mana cost 4 or greater and exile that card.",
@@ -4835,7 +4835,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Barter in Blood doesn’t target any creatures and may be cast even if a player controls fewer than two creatures."
+          "text": "Barter in Blood doesn't target any creatures and may be cast even if a player controls fewer than two creatures."
         }
       ],
       "text": "Each player sacrifices two creatures.",
@@ -5163,7 +5163,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Falkenrath Noble and another creature die at the same time, Falkenrath Noble’s triggered ability will trigger for each of them."
+          "text": "If Falkenrath Noble and another creature die at the same time, Falkenrath Noble's triggered ability will trigger for each of them."
         }
       ],
       "subtypes": [
@@ -5298,11 +5298,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Gravecrawler’s ability doesn’t change when you could cast it."
+          "text": "Gravecrawler's ability doesn't change when you could cast it."
         },
         {
           "date": "2011-01-22",
-          "text": "Once you’ve cast Gravecrawler and it’s on the stack, it doesn’t matter if you lose control of the other Zombie."
+          "text": "Once you've cast Gravecrawler and it's on the stack, it doesn't matter if you lose control of the other Zombie."
         }
       ],
       "subtypes": [
@@ -5557,7 +5557,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Only creatures on the battlefield will be exiled. In other zones, they’re “creature cards,” not “creatures.”"
+          "text": "Only creatures on the battlefield will be exiled. In other zones, they're \"creature cards,\" not \"creatures.\""
         },
         {
           "date": "2017-03-14",
@@ -5565,11 +5565,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named “Beast.”"
+          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named \"Beast.\""
         },
         {
           "date": "2017-03-14",
-          "text": "A double-faced creature only has the name of the face that’s up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn’t be exiled."
+          "text": "A double-faced creature only has the name of the face that's up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn't be exiled."
         }
       ],
       "text": "Exile target creature and all other creatures with the same name as that creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -5642,19 +5642,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -5724,7 +5724,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The amount of life you gain is equal to the creature’s toughness as it last existed on the battlefield."
+          "text": "The amount of life you gain is equal to the creature's toughness as it last existed on the battlefield."
         }
       ],
       "text": "Target opponent sacrifices a creature. You gain life equal to that creature's toughness.",

--- a/json/DDR.json
+++ b/json/DDR.json
@@ -135,11 +135,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If no card of the chosen type is found before your library empties, you don’t get a card, but you do get to order all the cards in your library any way you choose."
+          "text": "If no card of the chosen type is found before your library empties, you don't get a card, but you do get to order all the cards in your library any way you choose."
         },
         {
           "date": "2007-07-15",
-          "text": "If your library is empty, Abundance can prevent you from losing the game for being unable to draw a card. If an effect or turn-based action would cause you to draw a card, you can replace that draw with Abundance’s replacement effect. (It doesn’t matter that you’d be unable to actually draw a card.) Since Abundance’s effect has you put a card into your hand instead of drawing a card, you’ll never be forced to draw a card with an empty library."
+          "text": "If your library is empty, Abundance can prevent you from losing the game for being unable to draw a card. If an effect or turn-based action would cause you to draw a card, you can replace that draw with Abundance's replacement effect. (It doesn't matter that you'd be unable to actually draw a card.) Since Abundance's effect has you put a card into your hand instead of drawing a card, you'll never be forced to draw a card with an empty library."
         }
       ],
       "text": "If you would draw a card, you may instead choose land or nonland and reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and put all other cards revealed this way on the bottom of your library in any order.",
@@ -613,7 +613,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Although the targeted player doesn’t need to find a basic land card if he or she doesn’t want to, that player must shuffle his or her library."
+          "text": "Although the targeted player doesn't need to find a basic land card if he or she doesn't want to, that player must shuffle his or her library."
         }
       ],
       "subtypes": [
@@ -688,11 +688,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "When you cast Gaea’s Blessing, you can’t choose it as one of its own targets. This is because you choose the targets when casting this spell, and spells are not put into your graveyard until after they resolve."
+          "text": "When you cast Gaea's Blessing, you can't choose it as one of its own targets. This is because you choose the targets when casting this spell, and spells are not put into your graveyard until after they resolve."
         },
         {
           "date": "2016-06-08",
-          "text": "You must target a player as you cast Gaea’s Blessing. You may target zero, one, two, or three cards in that player’s graveyard."
+          "text": "You must target a player as you cast Gaea's Blessing. You may target zero, one, two, or three cards in that player's graveyard."
         }
       ],
       "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nDraw a card.\nWhen Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
@@ -823,7 +823,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You don’t choose which creatures to tap until the ability resolves. You may tap Jaddi Lifestrider itself this way, assuming it’s still on the battlefield untapped by this time."
+          "text": "You don't choose which creatures to tap until the ability resolves. You may tap Jaddi Lifestrider itself this way, assuming it's still on the battlefield untapped by this time."
         }
       ],
       "subtypes": [
@@ -1101,7 +1101,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -1244,11 +1244,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -1335,7 +1335,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -1469,7 +1469,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “if you do” means “if you choose to reveal cards”. You still shuffle if you have no creature card in your library."
+          "text": "The \"if you do\" means \"if you choose to reveal cards\". You still shuffle if you have no creature card in your library."
         }
       ],
       "subtypes": [
@@ -1678,7 +1678,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -1686,19 +1686,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -1779,7 +1779,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -1908,7 +1908,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "You don’t have to reveal a basic land card from among the five cards you look at, even if one is there. If you don’t, you won’t put a card on top of your library."
+          "text": "You don't have to reveal a basic land card from among the five cards you look at, even if one is there. If you don't, you won't put a card on top of your library."
         }
       ],
       "text": "Fertile Thicket enters the battlefield tapped.\nWhen Fertile Thicket enters the battlefield, you may look at the top five cards of your library. If you do, reveal up to one basic land card from among them, then put that card on top of your library and the rest on the bottom in any order.\n{T}: Add {G} to your mana pool.",
@@ -2087,11 +2087,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
@@ -3581,7 +3581,7 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "The emblem created by Ob Nixilis Reignited’s last ability is both owned and controlled by the target opponent. In a multiplayer game, if you own Ob Nixilis Reignited and use him to give one of your opponents an emblem, the emblem remains even if you leave the game."
+          "text": "The emblem created by Ob Nixilis Reignited's last ability is both owned and controlled by the target opponent. In a multiplayer game, if you own Ob Nixilis Reignited and use him to give one of your opponents an emblem, the emblem remains even if you leave the game."
         }
       ],
       "subtypes": [
@@ -4004,11 +4004,11 @@
         },
         {
           "date": "2015-08-25",
-          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Sacrificing an Eldrazi Scion creature token to add {C} to your mana pool is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-08-25",
-          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won’t get any Eldrazi Scions."
+          "text": "Some instants and sorceries that create Eldrazi Scions require targets. If all targets for such a spell have become illegal by the time that spell tries to resolve, the spell will be countered and none of its effects will happen. You won't get any Eldrazi Scions."
         }
       ],
       "subtypes": [
@@ -4141,7 +4141,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Players won’t know which player or planeswalker Desecration Demon will attack, if any, when deciding whether to sacrifice a creature."
+          "text": "Players won't know which player or planeswalker Desecration Demon will attack, if any, when deciding whether to sacrifice a creature."
         },
         {
           "date": "2017-03-14",
@@ -4719,11 +4719,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The opponent chooses whether he or she sacrifices a creature, pays 3 life, or allows you to draw a card. That player can’t make an impossible choice, such as sacrificing a creature while he or she controls no creatures."
+          "text": "The opponent chooses whether he or she sacrifices a creature, pays 3 life, or allows you to draw a card. That player can't make an impossible choice, such as sacrificing a creature while he or she controls no creatures."
         },
         {
           "date": "2014-07-18",
-          "text": "If there are no legal targets to choose, perhaps because all your opponents have hexproof, the ability is removed from the stack with no effect. You won’t draw a card. This is also true if the target opponent becomes an illegal target in response to the ability."
+          "text": "If there are no legal targets to choose, perhaps because all your opponents have hexproof, the ability is removed from the stack with no effect. You won't draw a card. This is also true if the target opponent becomes an illegal target in response to the ability."
         }
       ],
       "subtypes": [
@@ -4855,7 +4855,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If the number of Swamps you control exceeds the number of cards in the targeted player’s hand, that player reveals all the cards in his or her hand."
+          "text": "If the number of Swamps you control exceeds the number of cards in the targeted player's hand, that player reveals all the cards in his or her hand."
         }
       ],
       "text": "Target player reveals a number of cards from his or her hand equal to the number of Swamps you control. You choose one of them. That player discards that card.",
@@ -5052,7 +5052,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Quest for the Gravelord’s first ability triggers regardless of who controlled the creature and whose graveyard it was put into."
+          "text": "Quest for the Gravelord's first ability triggers regardless of who controlled the creature and whose graveyard it was put into."
         }
       ],
       "text": "Whenever a creature dies, you may put a quest counter on Quest for the Gravelord.\nRemove three quest counters from Quest for the Gravelord and sacrifice it: Create a 5/5 black Zombie Giant creature token.",
@@ -5174,7 +5174,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Once you legally activate the last ability, it doesn’t matter how many creature cards are in your graveyard as it resolves."
+          "text": "Once you legally activate the last ability, it doesn't matter how many creature cards are in your graveyard as it resolves."
         }
       ],
       "text": "Whenever a creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{4}{B}: Each opponent loses 2 life and you gain 2 life. Activate this ability only if there are four or more creature cards in your graveyard.",
@@ -5308,11 +5308,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Squelching Leeches’s power and toughness will change as the number of Swamps you control changes. Its ability counts all lands you control with the subtype Swamp, not just those named Swamp."
+          "text": "Squelching Leeches's power and toughness will change as the number of Swamps you control changes. Its ability counts all lands you control with the subtype Swamp, not just those named Swamp."
         },
         {
           "date": "2014-04-26",
-          "text": "The ability that defines Squelching Leeches’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Squelching Leeches's power and toughness works in all zones, not just the battlefield."
         }
       ],
       "subtypes": [
@@ -5390,7 +5390,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -5456,11 +5456,11 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The card will return to the battlefield under your control only if it’s still in the graveyard when Unhallowed Pact’s ability resolves. If it’s not (perhaps because an ability like undying has already returned it to the battlefield), nothing happens."
+          "text": "The card will return to the battlefield under your control only if it's still in the graveyard when Unhallowed Pact's ability resolves. If it's not (perhaps because an ability like undying has already returned it to the battlefield), nothing happens."
         },
         {
           "date": "2012-05-01",
-          "text": "If Unhallowed Pact is enchanting a token creature, that creature can’t return to the battlefield."
+          "text": "If Unhallowed Pact is enchanting a token creature, that creature can't return to the battlefield."
         }
       ],
       "subtypes": [

--- a/json/DDS.json
+++ b/json/DDS.json
@@ -64,31 +64,31 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -165,7 +165,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Target player takes an extra turn after this one. Shuffle Beacon of Tomorrows into its owner's library.",
@@ -231,39 +231,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -342,15 +342,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -419,7 +419,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If you don’t reveal an instant or sorcery card, put all the revealed cards on the bottom of your library in any order."
+          "text": "If you don't reveal an instant or sorcery card, put all the revealed cards on the bottom of your library in any order."
         }
       ],
       "subtypes": [
@@ -488,11 +488,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You don’t choose a sorcery card when Quicken resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a sorcery card, even if you cast that sorcery at a time you normally could."
+          "text": "You don't choose a sorcery card when Quicken resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a sorcery card, even if you cast that sorcery at a time you normally could."
         },
         {
           "date": "2006-02-01",
-          "text": "If you cast multiple Quickens on the same turn, they’ll all apply to the very next sorcery spell you cast."
+          "text": "If you cast multiple Quickens on the same turn, they'll all apply to the very next sorcery spell you cast."
         },
         {
           "date": "2006-09-25",
@@ -500,7 +500,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Casting a copy of a sorcery card won’t “use up” Quicken’s effect because the copy isn’t a card."
+          "text": "Casting a copy of a sorcery card won't \"use up\" Quicken's effect because the copy isn't a card."
         }
       ],
       "text": "The next sorcery card you cast this turn can be cast as though it had flash. (It can be cast any time you could cast an instant.)\nDraw a card.",
@@ -630,7 +630,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-11-24",
@@ -642,7 +642,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -773,7 +773,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "text": "Return target creature to its owner's hand. Untap up to two lands.",
@@ -836,7 +836,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You’ll put the Drake token onto the battlefield before the spell that caused the ability to trigger resolves. However, that Drake token isn’t on the battlefield when you choose targets for that spell."
+          "text": "You'll put the Drake token onto the battlefield before the spell that caused the ability to trigger resolves. However, that Drake token isn't on the battlefield when you choose targets for that spell."
         },
         {
           "date": "2012-07-01",
@@ -909,15 +909,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -1061,19 +1061,19 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         },
         {
           "date": "2013-06-07",
-          "text": "Desperate Ritual isn’t a mana ability. When cast, it (or the spell it’s spliced onto) goes on the stack like any spell and can be responded to."
+          "text": "Desperate Ritual isn't a mana ability. When cast, it (or the spell it's spliced onto) goes on the stack like any spell and can be responded to."
         }
       ],
       "subtypes": [
@@ -1142,15 +1142,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -1220,15 +1220,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -1302,39 +1302,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1402,39 +1402,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1504,7 +1504,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If the target instant or sorcery card becomes an illegal target before Volcanic Vision resolves, the spell will be countered and none of its effects will happen. No damage will be dealt and Volcanic Vision won’t be exiled."
+          "text": "If the target instant or sorcery card becomes an illegal target before Volcanic Vision resolves, the spell will be countered and none of its effects will happen. No damage will be dealt and Volcanic Vision won't be exiled."
         },
         {
           "date": "2015-02-25",
@@ -1571,7 +1571,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Young Pyromancer’s triggered ability will resolve before the spell that caused it to trigger, but after targets have been chosen for that spell."
+          "text": "Young Pyromancer's triggered ability will resolve before the spell that caused it to trigger, but after targets have been chosen for that spell."
         }
       ],
       "subtypes": [
@@ -1643,7 +1643,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You don’t have to find any instant cards in your library, even if they are there."
+          "text": "You don't have to find any instant cards in your library, even if they are there."
         },
         {
           "date": "2012-10-01",
@@ -1722,11 +1722,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Goblin Electromancer can’t reduce colored mana costs or {C} in the cost of instant or sorcery spells."
+          "text": "Goblin Electromancer can't reduce colored mana costs or {C} in the cost of instant or sorcery spells."
         },
         {
           "date": "2017-03-14",
-          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben’s ability), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben's ability), apply those increases before applying cost reductions."
         },
         {
           "date": "2017-03-14",
@@ -1808,11 +1808,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Jori En’s ability can trigger only once each turn. The ability will resolve before the second spell resolves. It doesn’t matter if the first spell you cast that turn has resolved, was countered, or is still on the stack."
+          "text": "Jori En's ability can trigger only once each turn. The ability will resolve before the second spell resolves. It doesn't matter if the first spell you cast that turn has resolved, was countered, or is still on the stack."
         },
         {
           "date": "2016-01-22",
-          "text": "Jori En must be on the battlefield in order for the ability to function. Notably, the ability won’t trigger if Jori En is the second spell you cast in a turn."
+          "text": "Jori En must be on the battlefield in order for the ability to function. Notably, the ability won't trigger if Jori En is the second spell you cast in a turn."
         }
       ],
       "subtypes": [
@@ -1960,7 +1960,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The ability that defines Spellheart Chimera’s power functions in all zones, not just the battlefield."
+          "text": "The ability that defines Spellheart Chimera's power functions in all zones, not just the battlefield."
         }
       ],
       "subtypes": [
@@ -3835,7 +3835,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Each creature with at least one of those subtypes gets +2/+2 from Lovisa Coldeyes’ ability, regardless of how many of those subtypes it has. For example, a 3/3 Mistform Ultimus would become 5/5, not 9/9."
+          "text": "Each creature with at least one of those subtypes gets +2/+2 from Lovisa Coldeyes' ability, regardless of how many of those subtypes it has. For example, a 3/3 Mistform Ultimus would become 5/5, not 9/9."
         }
       ],
       "subtypes": [
@@ -3908,7 +3908,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Beacon of Destruction deals 5 damage to target creature or player. Shuffle Beacon of Destruction into its owner's library.",
@@ -4800,7 +4800,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -4922,7 +4922,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Skarrgan Pit-Skulk compares each blocker’s power against its own as blockers are being declared."
+          "text": "Skarrgan Pit-Skulk compares each blocker's power against its own as blockers are being declared."
         }
       ],
       "subtypes": [
@@ -5116,7 +5116,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Radha’s triggered ability is not a mana ability (because it doesn’t trigger from another mana ability). It goes on the stack and it can be countered."
+          "text": "Radha's triggered ability is not a mana ability (because it doesn't trigger from another mana ability). It goes on the stack and it can be countered."
         }
       ],
       "subtypes": [
@@ -5264,7 +5264,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Burning-Tree Emissary’s ability isn’t a mana ability. It uses the stack and can be responded to."
+          "text": "Burning-Tree Emissary's ability isn't a mana ability. It uses the stack and can be responded to."
         }
       ],
       "subtypes": [
@@ -5398,7 +5398,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Count the number of attacking creatures you control when Rubblebelt Raiders’s ability resolves, including Rubblebelt Raiders itself, to determine how many +1/+1 counters to put on it."
+          "text": "Count the number of attacking creatures you control when Rubblebelt Raiders's ability resolves, including Rubblebelt Raiders itself, to determine how many +1/+1 counters to put on it."
         }
       ],
       "subtypes": [
@@ -5478,7 +5478,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Coat of Arms counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Coat of Arms counts creatures, not creature types."
         }
       ],
       "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",

--- a/json/DGM.json
+++ b/json/DGM.json
@@ -143,11 +143,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -382,7 +382,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -390,19 +390,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "text": "Detain up to two target creatures your opponents control. (Until your next turn, those creatures can't attack or block and their activated abilities can't be activated.)",
@@ -626,7 +626,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Renounce the Guilds doesn’t target any player and may be cast even if a player doesn’t control a multicolored permanent."
+          "text": "Renounce the Guilds doesn't target any player and may be cast even if a player doesn't control a multicolored permanent."
         }
       ],
       "text": "Each player sacrifices a multicolored permanent.",
@@ -744,7 +744,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Riot Control doesn’t prevent combat damage that would be dealt to planeswalkers you control by creatures attacking them. It also doesn’t prevent damage that would be dealt to creatures you control."
+          "text": "Riot Control doesn't prevent combat damage that would be dealt to planeswalkers you control by creatures attacking them. It also doesn't prevent damage that would be dealt to creatures you control."
         }
       ],
       "text": "You gain 1 life for each creature your opponents control. Prevent all damage that would be dealt to you this turn.",
@@ -854,11 +854,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -866,11 +866,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -878,7 +878,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -1213,11 +1213,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -1225,11 +1225,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -1343,11 +1343,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Aetherling’s first ability will return it to the battlefield only if that ability also exiled it. If Aetherling left the battlefield in response to that ability, it won’t return, even if it was exiled by another spell or ability."
+          "text": "Aetherling's first ability will return it to the battlefield only if that ability also exiled it. If Aetherling left the battlefield in response to that ability, it won't return, even if it was exiled by another spell or ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Aetherling’s last ability can be activated even if its power is 0 or less. If a creature would assign 0 or less damage in combat, it doesn’t assign combat damage at all."
+          "text": "Aetherling's last ability can be activated even if its power is 0 or less. If a creature would assign 0 or less damage in combat, it doesn't assign combat damage at all."
         }
       ],
       "subtypes": [
@@ -1460,15 +1460,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -1484,15 +1484,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -2042,7 +2042,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If the enchanted creature’s power increases to 4 or greater, Runner’s Bane will be put into its owner’s graveyard as a state-based action."
+          "text": "If the enchanted creature's power increases to 4 or greater, Runner's Bane will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2013-04-15",
@@ -2158,15 +2158,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -2182,15 +2182,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -2202,11 +2202,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Trait Doctoring changes the color word or basic land type each time it appears in the permanent’s type line and/or rules text. It doesn’t change the name of the card or any instances of the word being used as part of a card’s name."
+          "text": "Trait Doctoring changes the color word or basic land type each time it appears in the permanent's type line and/or rules text. It doesn't change the name of the card or any instances of the word being used as part of a card's name."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose what word you’re changing and what word you’re changing it to as Trait Doctoring resolves."
+          "text": "You choose what word you're changing and what word you're changing it to as Trait Doctoring resolves."
         },
         {
           "date": "2013-04-15",
@@ -2214,15 +2214,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Trait Doctoring’s effect changes only the text printed on the permanent. It can’t change words found in abilities it’s been granted. For example, if you’ve changed “green” to “blue,” and the permanent gains protection from green (as opposed to having protection from green printed on it), that protection ability is unaffected. The permanent will have protection from green."
+          "text": "Trait Doctoring's effect changes only the text printed on the permanent. It can't change words found in abilities it's been granted. For example, if you've changed \"green\" to \"blue,\" and the permanent gains protection from green (as opposed to having protection from green printed on it), that protection ability is unaffected. The permanent will have protection from green."
         },
         {
           "date": "2013-04-15",
-          "text": "If the basic land type of a land is changed, the associated mana ability of that land will also change, but its name will not. For example, if you’ve changed “Plains” to “Island,” a card named Plains will have the basic land type Island and can be tapped for {U}, and it can no longer be tapped for {W}."
+          "text": "If the basic land type of a land is changed, the associated mana ability of that land will also change, but its name will not. For example, if you've changed \"Plains\" to \"Island,\" a card named Plains will have the basic land type Island and can be tapped for {U}, and it can no longer be tapped for {W}."
         },
         {
           "date": "2013-04-15",
-          "text": "The type-changing effect can change part of a word such as “nonblack” or “swampwalk” if the part of the word is being used to refer to a color or basic land type."
+          "text": "The type-changing effect can change part of a word such as \"nonblack\" or \"swampwalk\" if the part of the word is being used to refer to a color or basic land type."
         }
       ],
       "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another until end of turn.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
@@ -2680,11 +2680,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Any time you are instructed to draw more than one card, you draw them one at a time. For example, if you control Blood Scrivener and have no cards in hand and you’re instructed to “draw two cards,” your first card draw is replaced by drawing two cards and losing 1 life, then you’ll draw the second card from the original instruction. In total, you’ll draw three cards and lose 1 life."
+          "text": "Any time you are instructed to draw more than one card, you draw them one at a time. For example, if you control Blood Scrivener and have no cards in hand and you're instructed to \"draw two cards,\" your first card draw is replaced by drawing two cards and losing 1 life, then you'll draw the second card from the original instruction. In total, you'll draw three cards and lose 1 life."
         },
         {
           "date": "2013-04-15",
-          "text": "Each additional Blood Scrivener you control will effectively add one card and 1 life lost. Say you control two Blood Scriveners and would draw a card while you have no cards in hand. The effect of one Blood Scrivener will replace the event “draw a card” with “draw two cards and lose 1 life.” The effect of the other Blood Scrivener will replace the drawing of the first of those two cards with “draw two cards and lose 1 life.” You’ll draw two cards and lose 1 life, then draw another card and lose another 1 life."
+          "text": "Each additional Blood Scrivener you control will effectively add one card and 1 life lost. Say you control two Blood Scriveners and would draw a card while you have no cards in hand. The effect of one Blood Scrivener will replace the event \"draw a card\" with \"draw two cards and lose 1 life.\" The effect of the other Blood Scrivener will replace the drawing of the first of those two cards with \"draw two cards and lose 1 life.\" You'll draw two cards and lose 1 life, then draw another card and lose another 1 life."
         }
       ],
       "subtypes": [
@@ -3008,15 +3008,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The card stops being revealed after Hired Torturer’s ability resolves."
+          "text": "The card stops being revealed after Hired Torturer's ability resolves."
         },
         {
           "date": "2013-04-15",
-          "text": "You can choose an opponent with no cards in hand as the target of Hired Torturer’s ability. If the target opponent has no cards in hand when the ability resolves, that player will just lose 2 life."
+          "text": "You can choose an opponent with no cards in hand as the target of Hired Torturer's ability. If the target opponent has no cards in hand when the ability resolves, that player will just lose 2 life."
         },
         {
           "date": "2013-04-15",
-          "text": "Each card in the opponent’s hand has an equal chance of being revealed, even if it was previously revealed because of Hired Torturer’s ability."
+          "text": "Each card in the opponent's hand has an equal chance of being revealed, even if it was previously revealed because of Hired Torturer's ability."
         }
       ],
       "subtypes": [
@@ -3244,11 +3244,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -3365,7 +3365,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -3373,11 +3373,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -3709,11 +3709,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "A monocolored creature is exactly one color. (Colorless creatures aren’t monocolored.)"
+          "text": "A monocolored creature is exactly one color. (Colorless creatures aren't monocolored.)"
         },
         {
           "date": "2013-04-15",
-          "text": "No monocolored creature will be able to block that turn, including monocolored creatures that enter the battlefield after Awe for the Guilds resolves. A creature that’s monocolored when Awe for the Guilds resolves but somehow becomes multicolored before blockers are declared will be able to block."
+          "text": "No monocolored creature will be able to block that turn, including monocolored creatures that enter the battlefield after Awe for the Guilds resolves. A creature that's monocolored when Awe for the Guilds resolves but somehow becomes multicolored before blockers are declared will be able to block."
         }
       ],
       "text": "Monocolored creatures can't block this turn.",
@@ -4040,15 +4040,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The original spell is part of the group of exiled cards put on the bottom of the library in a random order. If the exiled card that shared a card type with that card wasn’t cast, it’s also part of this group."
+          "text": "The original spell is part of the group of exiled cards put on the bottom of the library in a random order. If the exiled card that shared a card type with that card wasn't cast, it's also part of this group."
         },
         {
           "date": "2013-04-15",
-          "text": "If Possibility Storm’s ability doesn’t exile the original spell (perhaps because another Possibility Storm already exiled it), you’ll still exile cards from the top of your library until you exile a card that shares a card type with it and have the opportunity to cast that spell."
+          "text": "If Possibility Storm's ability doesn't exile the original spell (perhaps because another Possibility Storm already exiled it), you'll still exile cards from the top of your library until you exile a card that shares a card type with it and have the opportunity to cast that spell."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a spell without paying its mana cost, you can’t pay any alternative costs, such as overload costs. You can pay additional costs, such as kicker costs. If the spell has any mandatory additional costs, you must pay those."
+          "text": "If you cast a spell without paying its mana cost, you can't pay any alternative costs, such as overload costs. You can pay additional costs, such as kicker costs. If the spell has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2013-04-15",
@@ -4056,7 +4056,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Instant and sorcery cards with miracle allow a player to cast a card immediately upon drawing it. If a player casts a spell this way, the spell is cast from that player’s hand. Possibility Storm will trigger."
+          "text": "Instant and sorcery cards with miracle allow a player to cast a card immediately upon drawing it. If a player casts a spell this way, the spell is cast from that player's hand. Possibility Storm will trigger."
         }
       ],
       "text": "Whenever a player casts a spell from his or her hand, that player exiles it, then exiles cards from the top of his or her library until he or she exiles a card that shares a card type with it. That player may cast that card without paying its mana cost. Then he or she puts all cards exiled with Possibility Storm on the bottom of his or her library in a random order.",
@@ -4170,7 +4170,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If one of Punish the Enemy’s targets is illegal when it tries to resolve, it will still deal damage to the remaining legal target."
+          "text": "If one of Punish the Enemy's targets is illegal when it tries to resolve, it will still deal damage to the remaining legal target."
         }
       ],
       "text": "Punish the Enemy deals 3 damage to target player and 3 damage to target creature.",
@@ -4281,19 +4281,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Pyrewild Shaman’s last ability triggers only once for each time combat damage is dealt, no matter how many creatures are dealing damage at that time."
+          "text": "Pyrewild Shaman's last ability triggers only once for each time combat damage is dealt, no matter how many creatures are dealing damage at that time."
         },
         {
           "date": "2017-03-14",
-          "text": "Pyrewild Shaman’s ability can trigger during each combat damage step. For example, if a creature with first strike deals combat damage, you can return Pyrewild Shaman to your hand and discard it using its bloodrush ability to pump up an attacking creature without first strike. Then, when that creature deals combat damage, you can return Pyrewild Shaman to your hand again."
+          "text": "Pyrewild Shaman's ability can trigger during each combat damage step. For example, if a creature with first strike deals combat damage, you can return Pyrewild Shaman to your hand and discard it using its bloodrush ability to pump up an attacking creature without first strike. Then, when that creature deals combat damage, you can return Pyrewild Shaman to your hand again."
         },
         {
           "date": "2017-03-14",
-          "text": "Pyrewild Shaman’s last ability triggers only if it’s in your graveyard when the creatures deal combat damage to a player. It returns to your hand only if it’s still in your graveyard when the ability resolves. Notably, if Pyrewild Shaman is dealt lethal damage at the same time that a creature you control deals combat damage to a player, Pyrewild Shaman’s ability won’t trigger."
+          "text": "Pyrewild Shaman's last ability triggers only if it's in your graveyard when the creatures deal combat damage to a player. It returns to your hand only if it's still in your graveyard when the ability resolves. Notably, if Pyrewild Shaman is dealt lethal damage at the same time that a creature you control deals combat damage to a player, Pyrewild Shaman's ability won't trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "If creatures you control deal combat damage to more than one player at the same time (perhaps because it’s a multiplayer game), Pyrewild Shaman’s ability will trigger once for each of those players. However, only the first such ability that you pay for will return Pyrewild Shaman to your hand. Even if it’s put back into your graveyard before the other abilities resolve, it’s considered a different Pyrewild Shaman than the one whose ability triggered."
+          "text": "If creatures you control deal combat damage to more than one player at the same time (perhaps because it's a multiplayer game), Pyrewild Shaman's ability will trigger once for each of those players. However, only the first such ability that you pay for will return Pyrewild Shaman to your hand. Even if it's put back into your graveyard before the other abilities resolve, it's considered a different Pyrewild Shaman than the one whose ability triggered."
         }
       ],
       "subtypes": [
@@ -4738,23 +4738,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -4762,7 +4762,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Target creature you control gets +1/+0 and gains first strike until end of turn.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -4877,7 +4877,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -4893,7 +4893,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -5332,11 +5332,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Only a creature with a +1/+1 counter on it can be chosen as the first target of Mutant’s Prey."
+          "text": "Only a creature with a +1/+1 counter on it can be chosen as the first target of Mutant's Prey."
         },
         {
           "date": "2013-04-15",
-          "text": "If one of the targets is illegal when Mutant’s Prey tries to resolve (for example, if the first target creature no longer has a +1/+1 counter on it), neither creature will deal or be dealt damage."
+          "text": "If one of the targets is illegal when Mutant's Prey tries to resolve (for example, if the first target creature no longer has a +1/+1 counter on it), neither creature will deal or be dealt damage."
         }
       ],
       "text": "Target creature you control with a +1/+1 counter on it fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
@@ -5554,7 +5554,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -5570,15 +5570,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         },
         {
           "date": "2013-04-15",
-          "text": "Renegade Krasis “evolves” when its evolve ability resolves and a +1/+1 counter is put on it. If a replacement effect such as Doubling Season’s causes the evolve ability to put more than one +1/+1 counter on Renegade Krasis, its last ability triggers only once. If no +1/+1 counter is put on it (perhaps because it left the battlefield in response to its evolve ability triggering), then its last ability doesn’t trigger."
+          "text": "Renegade Krasis \"evolves\" when its evolve ability resolves and a +1/+1 counter is put on it. If a replacement effect such as Doubling Season's causes the evolve ability to put more than one +1/+1 counter on Renegade Krasis, its last ability triggers only once. If no +1/+1 counter is put on it (perhaps because it left the battlefield in response to its evolve ability triggering), then its last ability doesn't trigger."
         },
         {
           "date": "2013-04-15",
-          "text": "Renegade Krasis’s last ability won’t trigger if a +1/+1 counter is put on it for any reason other than its evolve ability resolving."
+          "text": "Renegade Krasis's last ability won't trigger if a +1/+1 counter is put on it for any reason other than its evolve ability resolving."
         }
       ],
       "subtypes": [
@@ -5913,7 +5913,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -6365,11 +6365,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If Beetleform Mage’s ability is activated by one player, then another player gains control of it during the same turn, the second player can’t activate its ability that turn."
+          "text": "If Beetleform Mage's ability is activated by one player, then another player gains control of it during the same turn, the second player can't activate its ability that turn."
         },
         {
           "date": "2013-04-15",
-          "text": "Activating Beetleform Mage’s ability after it’s been blocked by a creature without flying or reach won’t cause it to become unblocked."
+          "text": "Activating Beetleform Mage's ability after it's been blocked by a creature without flying or reach won't cause it to become unblocked."
         }
       ],
       "subtypes": [
@@ -6488,7 +6488,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You choose the target creature or player as part of casting the spell. If that creature or player is an illegal target when Blast of Genius tries to resolve, it will be countered and none of its effects will happen. You won’t draw or discard any cards."
+          "text": "You choose the target creature or player as part of casting the spell. If that creature or player is an illegal target when Blast of Genius tries to resolve, it will be countered and none of its effects will happen. You won't draw or discard any cards."
         },
         {
           "date": "2013-04-15",
@@ -6610,11 +6610,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Blaze Commando’s ability triggers each time an instant or sorcery spell you control deals damage (or, put another way, the number of times the word “deals” appears in its instructions), no matter how much damage is dealt or how many players or permanents are dealt damage. For example, if you cast Punish the Enemy and it “deals 3 damage to target player and 3 damage to target creature,” Blaze Commando’s ability will trigger once and you’ll get two Soldier tokens."
+          "text": "Blaze Commando's ability triggers each time an instant or sorcery spell you control deals damage (or, put another way, the number of times the word \"deals\" appears in its instructions), no matter how much damage is dealt or how many players or permanents are dealt damage. For example, if you cast Punish the Enemy and it \"deals 3 damage to target player and 3 damage to target creature,\" Blaze Commando's ability will trigger once and you'll get two Soldier tokens."
         },
         {
           "date": "2013-04-15",
-          "text": "Some instant or sorcery spells cause other objects to deal damage, rather than deal damage themselves. Such spells don’t cause Blaze Commando to trigger."
+          "text": "Some instant or sorcery spells cause other objects to deal damage, rather than deal damage themselves. Such spells don't cause Blaze Commando to trigger."
         }
       ],
       "subtypes": [
@@ -6850,11 +6850,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You may choose zero targets for either or both instances of “up to one target creature.”"
+          "text": "You may choose zero targets for either or both instances of \"up to one target creature.\""
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose two targets for Boros Battleshaper’s ability, and only one of those targets is legal when the ability tries to resolve, only the legal target will be affected. If all targets are illegal when the ability tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If you choose two targets for Boros Battleshaper's ability, and only one of those targets is legal when the ability tries to resolve, only the legal target will be affected. If all targets are illegal when the ability tries to resolve, it will be countered and none of its effects will happen."
         },
         {
           "date": "2013-04-15",
@@ -6862,15 +6862,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature forced to attack does so only if it’s able to do so as attackers are declared. If, at that time, the creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having the creature attack, the creature’s controller isn’t forced to pay that cost, so it doesn’t attack in that case either."
+          "text": "A creature forced to attack does so only if it's able to do so as attackers are declared. If, at that time, the creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having the creature attack, the creature's controller isn't forced to pay that cost, so it doesn't attack in that case either."
         },
         {
           "date": "2013-04-15",
-          "text": "A creature forced to block does so only if it’s able to do so as blockers are declared. If, at that time, the creature is tapped, is affected by a spell or ability that says it can’t block, or no creatures are attacking its controller or a planeswalker controlled by that player, then it doesn’t block. If there’s a cost associated with having the creature block, its controller isn’t forced to pay that cost, so it doesn’t block in that case either."
+          "text": "A creature forced to block does so only if it's able to do so as blockers are declared. If, at that time, the creature is tapped, is affected by a spell or ability that says it can't block, or no creatures are attacking its controller or a planeswalker controlled by that player, then it doesn't block. If there's a cost associated with having the creature block, its controller isn't forced to pay that cost, so it doesn't block in that case either."
         },
         {
           "date": "2013-04-15",
-          "text": "If another player gains control of the creature chosen to attack or block if able after it attacks, that creature isn’t forced to then block during that same combat."
+          "text": "If another player gains control of the creature chosen to attack or block if able after it attacks, that creature isn't forced to then block during that same combat."
         }
       ],
       "subtypes": [
@@ -6989,7 +6989,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "A creature that deals combat damage to a player must have a +1/+1 counter on it at the time damage is dealt in order for Bred for the Hunt’s ability to trigger."
+          "text": "A creature that deals combat damage to a player must have a +1/+1 counter on it at the time damage is dealt in order for Bred for the Hunt's ability to trigger."
         }
       ],
       "text": "Whenever a creature you control with a +1/+1 counter on it deals combat damage to a player, you may draw a card.",
@@ -7218,11 +7218,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Carnage Gladiator’s ability triggers whenever any creature blocks, regardless of who controls that creature or which creature it blocked."
+          "text": "Carnage Gladiator's ability triggers whenever any creature blocks, regardless of who controls that creature or which creature it blocked."
         },
         {
           "date": "2017-03-14",
-          "text": "If a creature can block multiple creatures and does so, Carnage Gladiator’s ability triggers only once."
+          "text": "If a creature can block multiple creatures and does so, Carnage Gladiator's ability triggers only once."
         }
       ],
       "subtypes": [
@@ -7340,7 +7340,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The last ability can’t reduce the colored mana requirement of a spell."
+          "text": "The last ability can't reduce the colored mana requirement of a spell."
         },
         {
           "date": "2013-04-15",
@@ -7356,7 +7356,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You can name either half of a split card, but not both. If you name half of a split card, your opponents can cast the other half. If that split card has fuse, your opponents can’t cast that card as a fused split card."
+          "text": "You can name either half of a split card, but not both. If you name half of a split card, your opponents can cast the other half. If that split card has fuse, your opponents can't cast that card as a fused split card."
         },
         {
           "date": "2013-04-15",
@@ -7477,11 +7477,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The card is chosen at random as the ability resolves. If any player responds to the ability, that player won’t yet know what card will be chosen."
+          "text": "The card is chosen at random as the ability resolves. If any player responds to the ability, that player won't yet know what card will be chosen."
         },
         {
           "date": "2013-04-15",
-          "text": "Because the last ability doesn’t target any card in your graveyard, any card put into your graveyard in response to the ability may be chosen."
+          "text": "Because the last ability doesn't target any card in your graveyard, any card put into your graveyard in response to the ability may be chosen."
         },
         {
           "date": "2013-04-15",
@@ -7818,23 +7818,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -7842,7 +7842,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -7854,7 +7854,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Each affected creature will lose any abilities it may have gained prior to Dragonshift resolving. Notably, this includes the ability to cast the copies of a card with cipher that’s encoded on the creature, although that ability will return after the turn ends."
+          "text": "Each affected creature will lose any abilities it may have gained prior to Dragonshift resolving. Notably, this includes the ability to cast the copies of a card with cipher that's encoded on the creature, although that ability will return after the turn ends."
         },
         {
           "date": "2013-04-15",
@@ -7862,11 +7862,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Dragonshift overwrites all previous effects that set a creature’s power or toughness to specific values. However, effects that set a creature’s power or toughness to specific values that start to apply after Dragonshift resolves will overwrite this effect."
+          "text": "Dragonshift overwrites all previous effects that set a creature's power or toughness to specific values. However, effects that set a creature's power or toughness to specific values that start to apply after Dragonshift resolves will overwrite this effect."
         },
         {
           "date": "2013-04-15",
-          "text": "Effects that modify the power or toughness of an affected creature, such as the effects of Phytoburst or Legion’s Initiative, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify the power or toughness of an affected creature, such as the effects of Phytoburst or Legion's Initiative, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         }
       ],
       "text": "Until end of turn, target creature you control becomes a blue and red Dragon with base power and toughness 4/4, loses all abilities, and gains flying.\nOverload {3}{U}{U}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -7979,7 +7979,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You choose the target of Drown in Filth as you cast the spell. You won’t necessarily know what will happen to that creature’s power and toughness at that time."
+          "text": "You choose the target of Drown in Filth as you cast the spell. You won't necessarily know what will happen to that creature's power and toughness at that time."
         }
       ],
       "text": "Choose target creature. Put the top four cards of your library into your graveyard, then that creature gets -1/-1 until end of turn for each land card in your graveyard.",
@@ -8093,7 +8093,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Emmara Tandris’s ability prevents all damage that would be dealt to creature tokens you control, not just combat damage."
+          "text": "Emmara Tandris's ability prevents all damage that would be dealt to creature tokens you control, not just combat damage."
         },
         {
           "date": "2013-04-15",
@@ -8218,7 +8218,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -8226,11 +8226,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -8357,11 +8357,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You don’t choose the value of X. The bonus Feral Animist gets is based on its power when the ability resolves. For example, if you activate the ability twice, the first ability will give it +2/+0 and the second one will give it +4/+0."
+          "text": "You don't choose the value of X. The bonus Feral Animist gets is based on its power when the ability resolves. For example, if you activate the ability twice, the first ability will give it +2/+0 and the second one will give it +4/+0."
         },
         {
-          "date": "2013-04-15",
-          "text": "If Feral Animist’s power is negative when its ability resolves, it will lose power. For example, if it’s somehow -3/1 when the ability resolves, it will become -6/1."
+          "date": "2017-06-27",
+          "text": "If this creature's power is negative as its ability resolves, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -8484,7 +8484,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -8606,7 +8606,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The converted mana cost of a creature token is 0 unless that token is a copy of another creature, in which case it copies that creature’s mana cost."
+          "text": "The converted mana cost of a creature token is 0 unless that token is a copy of another creature, in which case it copies that creature's mana cost."
         }
       ],
       "text": "Destroy each nonland permanent with converted mana cost X or less.",
@@ -8723,7 +8723,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature enters the battlefield attacking, it won’t cause Gleam of Battle to trigger."
+          "text": "If a creature enters the battlefield attacking, it won't cause Gleam of Battle to trigger."
         }
       ],
       "text": "Whenever a creature you control attacks, put a +1/+1 counter on it.",
@@ -9408,11 +9408,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Returning Krasis Incubation to its owner’s hand is part of the cost to activate its last ability. Once that ability is announced, players can’t respond to it until after you’ve paid its activation cost and returned Krasis Incubation to hand."
+          "text": "Returning Krasis Incubation to its owner's hand is part of the cost to activate its last ability. Once that ability is announced, players can't respond to it until after you've paid its activation cost and returned Krasis Incubation to hand."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -9528,7 +9528,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -9536,27 +9536,27 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         },
         {
           "date": "2013-04-15",
-          "text": "The converted mana cost of a creature token is 0 unless that token is a copy of another creature, in which case it copies that creature’s mana cost."
+          "text": "The converted mana cost of a creature token is 0 unless that token is a copy of another creature, in which case it copies that creature's mana cost."
         },
         {
           "date": "2013-04-15",
-          "text": "Lavinia’s ability doesn’t affect permanents an opponent gains control of after its enters-the-battlefield ability has resolved. Similarly, if you gain control of a detained permanent after that ability resolves, it will continue to be detained until your next turn."
+          "text": "Lavinia's ability doesn't affect permanents an opponent gains control of after its enters-the-battlefield ability has resolved. Similarly, if you gain control of a detained permanent after that ability resolves, it will continue to be detained until your next turn."
         }
       ],
       "subtypes": [
@@ -9676,11 +9676,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The beginning of the next combat will happen even if the player whose turn it is doesn’t intend to attack with any creatures."
+          "text": "The beginning of the next combat will happen even if the player whose turn it is doesn't intend to attack with any creatures."
         },
         {
           "date": "2013-04-15",
-          "text": "A creature that’s both red and white will get +1/+1 from Legion’s Initiative."
+          "text": "A creature that's both red and white will get +1/+1 from Legion's Initiative."
         }
       ],
       "text": "Red creatures you control get +1/+0.\nWhite creatures you control get +0/+1.\n{R}{W}, Exile Legion's Initiative: Exile all creatures you control. At the beginning of the next combat, return those cards to the battlefield under their owner's control and those creatures gain haste until end of turn.",
@@ -9793,27 +9793,27 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         },
         {
           "date": "2013-04-15",
-          "text": "Master of Cruelties isn’t forced to attack, but if it does, it must do so alone. If you control another creature with an ability that says it must attack if able, that creature must attack and Master of Cruelties won’t be able to."
+          "text": "Master of Cruelties isn't forced to attack, but if it does, it must do so alone. If you control another creature with an ability that says it must attack if able, that creature must attack and Master of Cruelties won't be able to."
         },
         {
           "date": "2013-04-15",
-          "text": "If Master of Cruelties attacks alone, another creature entering the battlefield attacking will have no effect on it. Master of Cruelties continues to be an attacking creature. The other attacking creature will assign combat damage normally, regardless of whether Master of Cruelties’s last ability triggers."
+          "text": "If Master of Cruelties attacks alone, another creature entering the battlefield attacking will have no effect on it. Master of Cruelties continues to be an attacking creature. The other attacking creature will assign combat damage normally, regardless of whether Master of Cruelties's last ability triggers."
         },
         {
           "date": "2013-04-15",
-          "text": "Master of Cruelties’s last ability won’t trigger if it attacks a planeswalker."
+          "text": "Master of Cruelties's last ability won't trigger if it attacks a planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "For a player’s life total to become 1, what actually happens is that the player loses (or in some rare cases, gains) the appropriate amount of life. For example, if the player’s life total is 4 when the last ability resolves, it will cause that player to lose 3 life. Other effects that interact with life loss (or gain) will interact with this effect accordingly."
+          "text": "For a player's life total to become 1, what actually happens is that the player loses (or in some rare cases, gains) the appropriate amount of life. For example, if the player's life total is 4 when the last ability resolves, it will cause that player to lose 3 life. Other effects that interact with life loss (or gain) will interact with this effect accordingly."
         },
         {
           "date": "2013-04-15",
-          "text": "Assigning no combat damage isn’t the same as preventing that damage. Effects that make damage unpreventable will have no effect if no combat damage can be assigned."
+          "text": "Assigning no combat damage isn't the same as preventing that damage. Effects that make damage unpreventable will have no effect if no combat damage can be assigned."
         }
       ],
       "subtypes": [
@@ -10044,27 +10044,27 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Melek doesn’t affect the timing rules associated with when you can cast the card. If it’s a sorcery card, you can cast it only during your main phase when the stack is empty."
+          "text": "Melek doesn't affect the timing rules associated with when you can cast the card. If it's a sorcery card, you can cast it only during your main phase when the stack is empty."
         },
         {
           "date": "2013-04-15",
-          "text": "You still pay all costs for that spell, including additional costs. You may also pay alternative costs, such as overload costs. Although you can’t pay additional costs for the copy that’s created, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
+          "text": "You still pay all costs for that spell, including additional costs. You may also pay alternative costs, such as overload costs. Although you can't pay additional costs for the copy that's created, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2013-04-15",
-          "text": "Melek’s last ability will copy any instant or sorcery spell you cast from your library, not just one with targets."
+          "text": "Melek's last ability will copy any instant or sorcery spell you cast from your library, not just one with targets."
         },
         {
           "date": "2013-04-15",
-          "text": "When the last ability resolves, it creates a copy of the spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When the last ability resolves, it creates a copy of the spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell being copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell being copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2013-04-15",
@@ -10072,15 +10072,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Instant and sorcery cards with miracle allow a player to cast a card immediately upon drawing it. If you cast a spell this way, you’re casting it from your hand, not your library. Melek’s ability won’t trigger."
+          "text": "Instant and sorcery cards with miracle allow a player to cast a card immediately upon drawing it. If you cast a spell this way, you're casting it from your hand, not your library. Melek's ability won't trigger."
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -10205,7 +10205,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If the player has fewer than four land cards in his or her library, all cards from that library will be revealed and put into that player’s graveyard."
+          "text": "If the player has fewer than four land cards in his or her library, all cards from that library will be revealed and put into that player's graveyard."
         }
       ],
       "subtypes": [
@@ -10329,7 +10329,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If the creature card is an illegal target when Morgue Burst tried to resolve (most likely because it was exiled in response), it won’t be returned to your hand and no damage will be dealt to the target creature or player."
+          "text": "If the creature card is an illegal target when Morgue Burst tried to resolve (most likely because it was exiled in response), it won't be returned to your hand and no damage will be dealt to the target creature or player."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand. Morgue Burst deals damage to target creature or player equal to the power of the card returned this way.",
@@ -10560,7 +10560,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you and an opponent each control a Notion Thief, the replacement effects generated by their abilities will essentially cancel each other out. If the opponent would draw a card other than the first of his or her draw step, that draw will be skipped and you’ll draw a card. The opponent’s Notion Thief will then cause that draw to be skipped and the opponent will draw a card instead. Neither replacement effect can apply to this event again, so your opponent draws a card."
+          "text": "If you and an opponent each control a Notion Thief, the replacement effects generated by their abilities will essentially cancel each other out. If the opponent would draw a card other than the first of his or her draw step, that draw will be skipped and you'll draw a card. The opponent's Notion Thief will then cause that draw to be skipped and the opponent will draw a card instead. Neither replacement effect can apply to this event again, so your opponent draws a card."
         }
       ],
       "subtypes": [
@@ -10682,7 +10682,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If the target is an Aura card, you choose what it will enchant as Obzedat’s Aid resolves. If there’s nothing legal for it to enchant, it stays in the graveyard."
+          "text": "If the target is an Aura card, you choose what it will enchant as Obzedat's Aid resolves. If there's nothing legal for it to enchant, it stays in the graveyard."
         }
       ],
       "text": "Return target permanent card from your graveyard to the battlefield.",
@@ -10796,7 +10796,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you target yourself, you’ll put the top two cards of your library into your graveyard before drawing cards."
+          "text": "If you target yourself, you'll put the top two cards of your library into your graveyard before drawing cards."
         }
       ],
       "text": "Target player puts the top two cards of his or her library into his or her graveyard. Draw two cards.",
@@ -10910,7 +10910,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If the countered spell had {X} in its mana cost, include the value chosen for that X when determining how much mana to add to your pool. For example, if you counter a spell that costs {X}{R} with X equal to 5, you’ll add six mana to your mana pool."
+          "text": "If the countered spell had {X} in its mana cost, include the value chosen for that X when determining how much mana to add to your pool. For example, if you counter a spell that costs {X}{R} with X equal to 5, you'll add six mana to your mana pool."
         },
         {
           "date": "2013-04-15",
@@ -11028,7 +11028,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Progenitor Mimic copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Progenitor Mimic copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2013-04-15",
@@ -11036,15 +11036,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to have Progenitor Mimic enter the battlefield as a copy of a creature, the triggered ability it gains will become part of its copiable values. For example, suppose Progenitor Mimic enters the battlefield as a copy of Runeclaw Bear, a 2/2 green Bear creature with mana cost {1}{G}. The resulting object is a 2/2 green Bear creature named Runeclaw Bear with mana cost {1}{G} and with “At the beginning of your upkeep, if this creature isn’t a token, put a token onto the battlefield that’s a copy of this creature.” If another Progenitor Mimic enters the battlefield as a copy of that creature, it will be a Runeclaw Bear with two instances of the triggered ability."
+          "text": "If you choose to have Progenitor Mimic enter the battlefield as a copy of a creature, the triggered ability it gains will become part of its copiable values. For example, suppose Progenitor Mimic enters the battlefield as a copy of Runeclaw Bear, a 2/2 green Bear creature with mana cost {1}{G}. The resulting object is a 2/2 green Bear creature named Runeclaw Bear with mana cost {1}{G} and with \"At the beginning of your upkeep, if this creature isn't a token, put a token onto the battlefield that's a copy of this creature.\" If another Progenitor Mimic enters the battlefield as a copy of that creature, it will be a Runeclaw Bear with two instances of the triggered ability."
         },
         {
           "date": "2013-04-15",
-          "text": "If the chosen creature is a token, Progenitor Mimic copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Copying a token doesn’t make Progenitor Mimic become a token."
+          "text": "If the chosen creature is a token, Progenitor Mimic copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Copying a token doesn't make Progenitor Mimic become a token."
         },
         {
           "date": "2013-04-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Progenitor Mimic enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Progenitor Mimic enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2013-04-15",
@@ -11052,7 +11052,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If Progenitor Mimic somehow enters the battlefield at the same time as another creature, it can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Progenitor Mimic somehow enters the battlefield at the same time as another creature, it can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2013-04-15",
@@ -11184,7 +11184,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an artifact, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an artifact, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target artifact or creature. It can't be regenerated.",
@@ -11405,15 +11405,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Once Reap Intellect begins to resolve, no player can cast spells or activate abilities until it has completely resolved. For example, the opponent can’t cast any cards that would be exiled after his or her hand is revealed."
+          "text": "Once Reap Intellect begins to resolve, no player can cast spells or activate abilities until it has completely resolved. For example, the opponent can't cast any cards that would be exiled after his or her hand is revealed."
         },
         {
           "date": "2013-04-15",
-          "text": "You can choose to leave cards with those names in the zone they are in. You don’t have to exile them."
+          "text": "You can choose to leave cards with those names in the zone they are in. You don't have to exile them."
         },
         {
           "date": "2013-04-15",
-          "text": "If you don’t exile any cards from the player’s hand, you don’t search that player’s library."
+          "text": "If you don't exile any cards from the player's hand, you don't search that player's library."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose up to X nonland cards from it and exile them. For each card exiled this way, search that player's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles his or her library.",
@@ -11531,7 +11531,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Render Silent doesn’t stop any player from casting spells in response to Render Silent before it resolves."
+          "text": "Render Silent doesn't stop any player from casting spells in response to Render Silent before it resolves."
         },
         {
           "date": "2013-04-15",
@@ -11539,11 +11539,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell is an illegal target when Render Silent tries to resolve (because it’s been countered by another spell, for example), Render Silent will be countered and none of its effects will happen."
+          "text": "If the spell is an illegal target when Render Silent tries to resolve (because it's been countered by another spell, for example), Render Silent will be countered and none of its effects will happen."
         },
         {
           "date": "2013-04-15",
-          "text": "A spell that “can’t be countered” is a legal target for Render Silent. The spell won’t be countered when Render Silent resolves, but that spell’s controller won’t be able to cast spells for the rest of the turn."
+          "text": "A spell that \"can't be countered\" is a legal target for Render Silent. The spell won't be countered when Render Silent resolves, but that spell's controller won't be able to cast spells for the rest of the turn."
         }
       ],
       "text": "Counter target spell. Its controller can't cast spells this turn.",
@@ -11660,7 +11660,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Only creatures on the battlefield will be returned. If a creature dealt damage and then died, the creature card won’t be returned from the graveyard to its owner’s hand."
+          "text": "Only creatures on the battlefield will be returned. If a creature dealt damage and then died, the creature card won't be returned from the graveyard to its owner's hand."
         }
       ],
       "text": "Return each creature that dealt damage this turn to its owner's hand.",
@@ -11777,11 +11777,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Putting four cards from your library into your graveyard is part of the activation cost of Rot Farm Skeleton’s ability. The four cards will be in the graveyard before any player can respond."
+          "text": "Putting four cards from your library into your graveyard is part of the activation cost of Rot Farm Skeleton's ability. The four cards will be in the graveyard before any player can respond."
         },
         {
           "date": "2013-04-15",
-          "text": "If you have three or fewer cards in your library, you can’t activate Rot Farm Skeleton’s last ability."
+          "text": "If you have three or fewer cards in your library, you can't activate Rot Farm Skeleton's last ability."
         }
       ],
       "subtypes": [
@@ -11899,7 +11899,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Ruric Thar’s ability triggers whenever any player casts a noncreature spell, including you."
+          "text": "Ruric Thar's ability triggers whenever any player casts a noncreature spell, including you."
         },
         {
           "date": "2013-04-15",
@@ -12148,7 +12148,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "In a multiplayer game, you don’t choose a single opponent at random. Any creature controlled by any of your opponents may be chosen at random."
+          "text": "In a multiplayer game, you don't choose a single opponent at random. Any creature controlled by any of your opponents may be chosen at random."
         }
       ],
       "subtypes": [
@@ -12266,11 +12266,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Creatures that come under your control after Showstopper resolves won’t have the ability."
+          "text": "Creatures that come under your control after Showstopper resolves won't have the ability."
         },
         {
           "date": "2013-04-15",
-          "text": "If another player gains control of a creature you control after Showstopper resolves, and then later that turn that creature dies, the creature’s controller when it died controls the triggered ability. That player chooses a creature that one of his or her opponents controls as a target."
+          "text": "If another player gains control of a creature you control after Showstopper resolves, and then later that turn that creature dies, the creature's controller when it died controls the triggered ability. That player chooses a creature that one of his or her opponents controls as a target."
         }
       ],
       "text": "Until end of turn, creatures you control gain \"When this creature dies, it deals 2 damage to target creature an opponent controls.\"",
@@ -12386,7 +12386,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "No player can do anything between you choosing a card and that card being exiled. Notably, your opponent can’t cast the card once Sin Collector’s ability has started to resolve."
+          "text": "No player can do anything between you choosing a card and that card being exiled. Notably, your opponent can't cast the card once Sin Collector's ability has started to resolve."
         }
       ],
       "subtypes": [
@@ -12844,11 +12844,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -12974,19 +12974,19 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Protection from creatures means that Teysa, Envoy of Ghosts can’t be the target of abilities of creatures or abilities of creature cards in other zones, such as bloodrush abilities. Teysa also can’t be blocked by creatures, and all damage that would be dealt to Teysa by creatures is prevented."
+          "text": "Protection from creatures means that Teysa, Envoy of Ghosts can't be the target of abilities of creatures or abilities of creature cards in other zones, such as bloodrush abilities. Teysa also can't be blocked by creatures, and all damage that would be dealt to Teysa by creatures is prevented."
         },
         {
           "date": "2013-04-15",
-          "text": "Teysa’s last ability doesn’t target the creature. It will destroy a creature with hexproof or protection from white, for example."
+          "text": "Teysa's last ability doesn't target the creature. It will destroy a creature with hexproof or protection from white, for example."
         },
         {
           "date": "2013-04-15",
-          "text": "Teysa’s controller gets the Spirit creature token, not the controller of the creature that dealt combat damage."
+          "text": "Teysa's controller gets the Spirit creature token, not the controller of the creature that dealt combat damage."
         },
         {
           "date": "2013-07-01",
-          "text": "You get a Spirit creature token even if Teysa’s triggered ability doesn’t destroy the creature (perhaps because it regenerated or has indestructible)."
+          "text": "You get a Spirit creature token even if Teysa's triggered ability doesn't destroy the creature (perhaps because it regenerated or has indestructible)."
         }
       ],
       "subtypes": [
@@ -13111,11 +13111,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -13462,7 +13462,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         },
         {
           "date": "2013-04-15",
@@ -13470,11 +13470,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Abilities that reduce the cost to cast a creature spell or alternative costs you can pay rather than a card’s mana cost don’t apply to activating a card’s scavenge ability."
+          "text": "Abilities that reduce the cost to cast a creature spell or alternative costs you can pay rather than a card's mana cost don't apply to activating a card's scavenge ability."
         },
         {
           "date": "2013-04-15",
-          "text": "The number of counters that a card’s scavenge ability puts on a creature is based on the card’s power as it last existed in the graveyard."
+          "text": "The number of counters that a card's scavenge ability puts on a creature is based on the card's power as it last existed in the graveyard."
         },
         {
           "date": "2013-04-15",
@@ -13482,7 +13482,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature card has multiple instances of scavenge, you can activate either ability (but not both, as the card will be exiled when you activate one of them). Varolz’s ability doesn’t affect the scavenge cost of a creature’s other scavenge ability."
+          "text": "If a creature card has multiple instances of scavenge, you can activate either ability (but not both, as the card will be exiled when you activate one of them). Varolz's ability doesn't affect the scavenge cost of a creature's other scavenge ability."
         }
       ],
       "subtypes": [
@@ -13717,11 +13717,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Voice of Resurgence’s ability triggers because an opponent cast a spell during your turn, the token will be created before that spell resolves."
+          "text": "If Voice of Resurgence's ability triggers because an opponent cast a spell during your turn, the token will be created before that spell resolves."
         },
         {
           "date": "2017-03-14",
-          "text": "The power and toughness of the token change as the number of creatures you control changes. The token’s ability counts itself, so it’ll be at least 1/1."
+          "text": "The power and toughness of the token change as the number of creatures you control changes. The token's ability counts itself, so it'll be at least 1/1."
         },
         {
           "date": "2017-03-14",
@@ -13844,7 +13844,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The effect of Vorel’s ability will essentially double the counters on the target artifact, creature, or land. For example, if a creature has three +1/+1 counters and a divinity counter on it before the ability resolves, it will have six +1/+1 counters and two divinity counters on it after the ability resolves."
+          "text": "The effect of Vorel's ability will essentially double the counters on the target artifact, creature, or land. For example, if a creature has three +1/+1 counters and a divinity counter on it before the ability resolves, it will have six +1/+1 counters and two divinity counters on it after the ability resolves."
         }
       ],
       "subtypes": [
@@ -13966,7 +13966,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If the target creature or player is an illegal target when Warleader’s Helix tries to resolve, it will be countered and none of its effects will happen. You won’t gain 4 life."
+          "text": "If the target creature or player is an illegal target when Warleader's Helix tries to resolve, it will be countered and none of its effects will happen. You won't gain 4 life."
         }
       ],
       "text": "Warleader's Helix deals 4 damage to target creature or player and you gain 4 life.",
@@ -14079,11 +14079,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Use the number of cards in your hand as Warped Physique resolves to determine the value of X. Warped Physique won’t be in your hand at that time."
+          "text": "Use the number of cards in your hand as Warped Physique resolves to determine the value of X. Warped Physique won't be in your hand at that time."
         },
         {
           "date": "2013-04-15",
-          "text": "Once Warped Physique resolves, the effect won’t change if the number of cards in your hand changes."
+          "text": "Once Warped Physique resolves, the effect won't change if the number of cards in your hand changes."
         }
       ],
       "text": "Target creature gets +X/-X until end of turn, where X is the number of cards in your hand.",
@@ -14423,7 +14423,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Zhur-Taa Druid’s last ability doesn’t trigger if it becomes tapped for any other reason. However, if Zhur-Taa Druid gains another mana ability that requires you tap it, its ability will trigger."
+          "text": "Zhur-Taa Druid's last ability doesn't trigger if it becomes tapped for any other reason. However, if Zhur-Taa Druid gains another mana ability that requires you tap it, its ability will trigger."
         },
         {
           "date": "2013-04-15",
@@ -14431,7 +14431,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Zhur-Taa Druid’s last ability isn’t a mana ability. It uses the stack and can be responded to."
+          "text": "Zhur-Taa Druid's last ability isn't a mana ability. It uses the stack and can be responded to."
         }
       ],
       "subtypes": [
@@ -14445,159 +14445,6 @@
         "Creature"
       ],
       "watermark": "Gruul"
-    },
-    {
-      "artist": "Nils Hamm",
-      "cmc": 4,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "活跃",
-          "multiverseid": 368781
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "活躍",
-          "multiverseid": 368882
-        },
-        {
-          "language": "French",
-          "name": "Vivant",
-          "multiverseid": 369194
-        },
-        {
-          "language": "German",
-          "name": "Am Leben",
-          "multiverseid": 369377
-        },
-        {
-          "language": "Italian",
-          "name": "Vivo",
-          "multiverseid": 369522
-        },
-        {
-          "language": "Japanese",
-          "name": "生存",
-          "multiverseid": 369721
-        },
-        {
-          "language": "Korean",
-          "name": "만수",
-          "multiverseid": 369838
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Vivo",
-          "multiverseid": 370003
-        },
-        {
-          "language": "Russian",
-          "name": "Жив",
-          "multiverseid": 370064
-        },
-        {
-          "language": "Spanish",
-          "name": "Sano",
-          "multiverseid": 370258
-        }
-      ],
-      "id": "06871a821d91f7c3b20b84a2f7615db64eead45d",
-      "imageName": "alivewell2",
-      "layout": "split",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{3}{G}",
-      "mciNumber": "121a",
-      "multiverseid": 369041,
-      "name": "Alive",
-      "names": [
-        "Alive",
-        "Well"
-      ],
-      "number": "121a",
-      "originalText": "Put a 3/3 green Centaur creature token onto the battlefield.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "originalType": "Sorcery",
-      "printings": [
-        "DGM"
-      ],
-      "rarity": "Uncommon",
-      "rulings": [
-        {
-          "date": "2013-04-15",
-          "text": "If you cast Alive // Well as a fused split spell, the Centaur creature token will count toward the amount of life you gain."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "To cast a fused split spell, pay both of its mana costs. While the spell is on the stack, its converted mana cost is the total amount of mana in both costs."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "You can choose the same object as the target of each half of a fused split spell, if appropriate."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "When a fused split spell resolves, follow the instructions of the left half first, then the instructions on the right half."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "Some split cards with fuse have two monocolor halves of different colors. If such a card is cast as a fused split spell, the resulting spell is multicolored. If only one half is cast, the spell is the color of that half. While not on the stack, such a card is multicolored."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If a player names a card, the player may name either half of a split card, but not both. A split card has the chosen name if one of its two names matches the chosen name."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
-        }
-      ],
-      "text": "Create a 3/3 green Centaur creature token.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "type": "Sorcery",
-      "types": [
-        "Sorcery"
-      ]
     },
     {
       "artist": "Nils Hamm",
@@ -14707,7 +14554,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -14719,7 +14566,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -14727,7 +14574,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -14735,7 +14582,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -14753,68 +14600,68 @@
       ]
     },
     {
-      "artist": "David Palumbo",
-      "cmc": 2,
+      "artist": "Nils Hamm",
+      "cmc": 4,
       "colorIdentity": [
-        "R"
+        "G"
       ],
       "colors": [
-        "Red"
+        "Green"
       ],
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "武装",
-          "multiverseid": 368758
+          "name": "活跃",
+          "multiverseid": 368781
         },
         {
           "language": "Chinese Traditional",
-          "name": "武裝",
-          "multiverseid": 368942
+          "name": "活躍",
+          "multiverseid": 368882
         },
         {
           "language": "French",
-          "name": "Armé",
-          "multiverseid": 369187
+          "name": "Vivant",
+          "multiverseid": 369194
         },
         {
           "language": "German",
-          "name": "Bewaffnet",
-          "multiverseid": 369307
+          "name": "Am Leben",
+          "multiverseid": 369377
         },
         {
           "language": "Italian",
-          "name": "Armato",
-          "multiverseid": 369519
+          "name": "Vivo",
+          "multiverseid": 369522
         },
         {
           "language": "Japanese",
-          "name": "武装",
-          "multiverseid": 369648
+          "name": "生存",
+          "multiverseid": 369721
         },
         {
           "language": "Korean",
-          "name": "무쌍",
-          "multiverseid": 369875
+          "name": "만수",
+          "multiverseid": 369838
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Armado",
-          "multiverseid": 369933
+          "name": "Vivo",
+          "multiverseid": 370003
         },
         {
           "language": "Russian",
-          "name": "Вооружен",
-          "multiverseid": 370090
+          "name": "Жив",
+          "multiverseid": 370064
         },
         {
           "language": "Spanish",
-          "name": "Armado",
-          "multiverseid": 370317
+          "name": "Sano",
+          "multiverseid": 370258
         }
       ],
-      "id": "60b8d6181ec8501c3e18fa197558fddfd5f79509",
-      "imageName": "armeddangerous2",
+      "id": "06871a821d91f7c3b20b84a2f7615db64eead45d",
+      "imageName": "alivewell2",
       "layout": "split",
       "legalities": [
         {
@@ -14838,16 +14685,16 @@
           "legality": "Legal"
         }
       ],
-      "manaCost": "{1}{R}",
-      "mciNumber": "122a",
-      "multiverseid": 368989,
-      "name": "Armed",
+      "manaCost": "{3}{G}",
+      "mciNumber": "121a",
+      "multiverseid": 369041,
+      "name": "Alive",
       "names": [
-        "Armed",
-        "Dangerous"
+        "Alive",
+        "Well"
       ],
-      "number": "122a",
-      "originalText": "Target creature gets +1/+1 and gains double strike until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "number": "121a",
+      "originalText": "Put a 3/3 green Centaur creature token onto the battlefield.\nFuse (You may cast one or both halves of this card from your hand.)",
       "originalType": "Sorcery",
       "printings": [
         "DGM"
@@ -14856,7 +14703,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you cast Alive // Well as a fused split spell, the Centaur creature token will count toward the amount of life you gain."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -14868,7 +14719,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -14876,7 +14727,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -14884,7 +14735,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -14895,7 +14746,7 @@
           "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
         }
       ],
-      "text": "Target creature gets +1/+1 and gains double strike until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "text": "Create a 3/3 green Centaur creature token.\nFuse (You may cast one or both halves of this card from your hand.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -15005,7 +14856,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -15017,7 +14868,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -15025,7 +14876,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -15033,7 +14884,156 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If a player names a card, the player may name either half of a split card, but not both. A split card has the chosen name if one of its two names matches the chosen name."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
+        }
+      ],
+      "text": "Target creature gets +1/+1 and gains double strike until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "David Palumbo",
+      "cmc": 2,
+      "colorIdentity": [
+        "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "武装",
+          "multiverseid": 368758
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "武裝",
+          "multiverseid": 368942
+        },
+        {
+          "language": "French",
+          "name": "Armé",
+          "multiverseid": 369187
+        },
+        {
+          "language": "German",
+          "name": "Bewaffnet",
+          "multiverseid": 369307
+        },
+        {
+          "language": "Italian",
+          "name": "Armato",
+          "multiverseid": 369519
+        },
+        {
+          "language": "Japanese",
+          "name": "武装",
+          "multiverseid": 369648
+        },
+        {
+          "language": "Korean",
+          "name": "무쌍",
+          "multiverseid": 369875
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Armado",
+          "multiverseid": 369933
+        },
+        {
+          "language": "Russian",
+          "name": "Вооружен",
+          "multiverseid": 370090
+        },
+        {
+          "language": "Spanish",
+          "name": "Armado",
+          "multiverseid": 370317
+        }
+      ],
+      "id": "60b8d6181ec8501c3e18fa197558fddfd5f79509",
+      "imageName": "armeddangerous2",
+      "layout": "split",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{R}",
+      "mciNumber": "122a",
+      "multiverseid": 368989,
+      "name": "Armed",
+      "names": [
+        "Armed",
+        "Dangerous"
+      ],
+      "number": "122a",
+      "originalText": "Target creature gets +1/+1 and gains double strike until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "originalType": "Sorcery",
+      "printings": [
+        "DGM"
+      ],
+      "rarity": "Uncommon",
+      "rulings": [
+        {
+          "date": "2013-04-15",
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "To cast a fused split spell, pay both of its mana costs. While the spell is on the stack, its converted mana cost is the total amount of mana in both costs."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "You can choose the same object as the target of each half of a fused split spell, if appropriate."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "When a fused split spell resolves, follow the instructions of the left half first, then the instructions on the right half."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "Some split cards with fuse have two monocolor halves of different colors. If such a card is cast as a fused split spell, the resulting spell is multicolored. If only one half is cast, the spell is the color of that half. While not on the stack, such a card is multicolored."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -15160,11 +15160,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast Beck // Call as a fused split spell, the triggered ability it creates will be in effect when the Bird creature tokens enter the battlefield. You’ll draw up to four cards."
+          "text": "If you cast Beck // Call as a fused split spell, the triggered ability it creates will be in effect when the Bird creature tokens enter the battlefield. You'll draw up to four cards."
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -15176,7 +15176,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -15184,7 +15184,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -15192,7 +15192,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -15319,11 +15319,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast Beck // Call as a fused split spell, the triggered ability it creates will be in effect when the Bird creature tokens enter the battlefield. You’ll draw up to four cards."
+          "text": "If you cast Beck // Call as a fused split spell, the triggered ability it creates will be in effect when the Bird creature tokens enter the battlefield. You'll draw up to four cards."
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -15335,7 +15335,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -15343,7 +15343,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -15351,7 +15351,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -15475,7 +15475,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -15487,7 +15487,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -15495,7 +15495,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -15503,7 +15503,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -15627,7 +15627,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -15639,7 +15639,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -15647,7 +15647,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -15655,7 +15655,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -15667,165 +15667,6 @@
         }
       ],
       "text": "Target player puts the top eight cards of his or her library into his or her graveyard.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "type": "Sorcery",
-      "types": [
-        "Sorcery"
-      ]
-    },
-    {
-      "artist": "Kev Walker",
-      "cmc": 3,
-      "colorIdentity": [
-        "U",
-        "R"
-      ],
-      "colors": [
-        "Blue",
-        "Red"
-      ],
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "擒获",
-          "multiverseid": 368658
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "擒獲",
-          "multiverseid": 368808
-        },
-        {
-          "language": "French",
-          "name": "Prise",
-          "multiverseid": 369101
-        },
-        {
-          "language": "German",
-          "name": "Fangen",
-          "multiverseid": 369396
-        },
-        {
-          "language": "Italian",
-          "name": "Prendere",
-          "multiverseid": 369422
-        },
-        {
-          "language": "Japanese",
-          "name": "捕獲",
-          "multiverseid": 369629
-        },
-        {
-          "language": "Korean",
-          "name": "영입",
-          "multiverseid": 369837
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Pegar",
-          "multiverseid": 369978
-        },
-        {
-          "language": "Russian",
-          "name": "Поймать",
-          "multiverseid": 370080
-        },
-        {
-          "language": "Spanish",
-          "name": "Atrapar",
-          "multiverseid": 370231
-        }
-      ],
-      "id": "e7e9199b8533be7c8a83407d3ff82c24e8ecbb83",
-      "imageName": "catchrelease1",
-      "layout": "split",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{U}{R}",
-      "mciNumber": "125a",
-      "multiverseid": 368982,
-      "name": "Catch",
-      "names": [
-        "Catch",
-        "Release"
-      ],
-      "number": "125a",
-      "originalText": "Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "originalType": "Sorcery",
-      "printings": [
-        "DGM"
-      ],
-      "rarity": "Rare",
-      "rulings": [
-        {
-          "date": "2013-04-15",
-          "text": "Catch can target any permanent, including one that’s untapped or one you already control."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If you cast Catch/Release as a fused split spell, you can sacrifice the permanent you just gained control of."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "To cast a fused split spell, pay both of its mana costs. While the spell is on the stack, its converted mana cost is the total amount of mana in both costs."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "You can choose the same object as the target of each half of a fused split spell, if appropriate."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "When a fused split spell resolves, follow the instructions of the left half first, then the instructions on the right half."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "Some split cards with fuse have two monocolor halves of different colors. If such a card is cast as a fused split spell, the resulting spell is multicolored. If only one half is cast, the spell is the color of that half. While not on the stack, such a card is multicolored."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If a player names a card, the player may name either half of a split card, but not both. A split card has the chosen name if one of its two names matches the chosen name."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
-        }
-      ],
-      "text": "Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -15937,7 +15778,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Catch can target any permanent, including one that’s untapped or one you already control."
+          "text": "Catch can target any permanent, including one that's untapped or one you already control."
         },
         {
           "date": "2013-04-15",
@@ -15945,7 +15786,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -15957,7 +15798,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -15965,7 +15806,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -15973,7 +15814,166 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If a player names a card, the player may name either half of a split card, but not both. A split card has the chosen name if one of its two names matches the chosen name."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
+        }
+      ],
+      "text": "Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "Kev Walker",
+      "cmc": 3,
+      "colorIdentity": [
+        "U",
+        "R"
+      ],
+      "colors": [
+        "Blue",
+        "Red"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "擒获",
+          "multiverseid": 368658
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "擒獲",
+          "multiverseid": 368808
+        },
+        {
+          "language": "French",
+          "name": "Prise",
+          "multiverseid": 369101
+        },
+        {
+          "language": "German",
+          "name": "Fangen",
+          "multiverseid": 369396
+        },
+        {
+          "language": "Italian",
+          "name": "Prendere",
+          "multiverseid": 369422
+        },
+        {
+          "language": "Japanese",
+          "name": "捕獲",
+          "multiverseid": 369629
+        },
+        {
+          "language": "Korean",
+          "name": "영입",
+          "multiverseid": 369837
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pegar",
+          "multiverseid": 369978
+        },
+        {
+          "language": "Russian",
+          "name": "Поймать",
+          "multiverseid": 370080
+        },
+        {
+          "language": "Spanish",
+          "name": "Atrapar",
+          "multiverseid": 370231
+        }
+      ],
+      "id": "e7e9199b8533be7c8a83407d3ff82c24e8ecbb83",
+      "imageName": "catchrelease1",
+      "layout": "split",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{U}{R}",
+      "mciNumber": "125a",
+      "multiverseid": 368982,
+      "name": "Catch",
+      "names": [
+        "Catch",
+        "Release"
+      ],
+      "number": "125a",
+      "originalText": "Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "originalType": "Sorcery",
+      "printings": [
+        "DGM"
+      ],
+      "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-04-15",
+          "text": "Catch can target any permanent, including one that's untapped or one you already control."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If you cast Catch/Release as a fused split spell, you can sacrifice the permanent you just gained control of."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "To cast a fused split spell, pay both of its mana costs. While the spell is on the stack, its converted mana cost is the total amount of mana in both costs."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "You can choose the same object as the target of each half of a fused split spell, if appropriate."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "When a fused split spell resolves, follow the instructions of the left half first, then the instructions on the right half."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "Some split cards with fuse have two monocolor halves of different colors. If such a card is cast as a fused split spell, the resulting spell is multicolored. If only one half is cast, the spell is the color of that half. While not on the stack, such a card is multicolored."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -16094,7 +16094,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -16106,7 +16106,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -16114,7 +16114,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -16122,7 +16122,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -16243,7 +16243,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -16255,7 +16255,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -16263,7 +16263,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -16271,7 +16271,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -16286,155 +16286,6 @@
       "type": "Sorcery",
       "types": [
         "Sorcery"
-      ]
-    },
-    {
-      "artist": "Greg Staples",
-      "cmc": 2,
-      "colorIdentity": [
-        "U"
-      ],
-      "colors": [
-        "Blue"
-      ],
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "遥远",
-          "multiverseid": 368666
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "遙遠",
-          "multiverseid": 368813
-        },
-        {
-          "language": "French",
-          "name": "Lointain",
-          "multiverseid": 369148
-        },
-        {
-          "language": "German",
-          "name": "Weit",
-          "multiverseid": 369400
-        },
-        {
-          "language": "Italian",
-          "name": "Lontano",
-          "multiverseid": 369566
-        },
-        {
-          "language": "Japanese",
-          "name": "遠隔",
-          "multiverseid": 369637
-        },
-        {
-          "language": "Korean",
-          "name": "오리",
-          "multiverseid": 369770
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Longe",
-          "multiverseid": 370030
-        },
-        {
-          "language": "Russian",
-          "name": "Там",
-          "multiverseid": 370089
-        },
-        {
-          "language": "Spanish",
-          "name": "Lejos",
-          "multiverseid": 370300
-        }
-      ],
-      "id": "5f2d8f23453f8d092a8d723c97076c17614b4320",
-      "imageName": "faraway2",
-      "layout": "split",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{U}",
-      "mciNumber": "127a",
-      "multiverseid": 369042,
-      "name": "Far",
-      "names": [
-        "Far",
-        "Away"
-      ],
-      "number": "127a",
-      "originalText": "Return target creature to its owner's hand.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "originalType": "Instant",
-      "printings": [
-        "DGM"
-      ],
-      "rarity": "Uncommon",
-      "rulings": [
-        {
-          "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "To cast a fused split spell, pay both of its mana costs. While the spell is on the stack, its converted mana cost is the total amount of mana in both costs."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "You can choose the same object as the target of each half of a fused split spell, if appropriate."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "When a fused split spell resolves, follow the instructions of the left half first, then the instructions on the right half."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "Some split cards with fuse have two monocolor halves of different colors. If such a card is cast as a fused split spell, the resulting spell is multicolored. If only one half is cast, the spell is the color of that half. While not on the stack, such a card is multicolored."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If a player names a card, the player may name either half of a split card, but not both. A split card has the chosen name if one of its two names matches the chosen name."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
-        }
-      ],
-      "text": "Return target creature to its owner's hand.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "type": "Instant",
-      "types": [
-        "Instant"
       ]
     },
     {
@@ -16541,7 +16392,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -16553,7 +16404,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -16561,7 +16412,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -16569,7 +16420,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -16587,70 +16438,68 @@
       ]
     },
     {
-      "artist": "Lucas Graciano",
-      "cmc": 5,
+      "artist": "Greg Staples",
+      "cmc": 2,
       "colorIdentity": [
-        "B",
-        "G"
+        "U"
       ],
       "colors": [
-        "Black",
-        "Green"
+        "Blue"
       ],
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "肉身",
-          "multiverseid": 368645
+          "name": "遥远",
+          "multiverseid": 368666
         },
         {
           "language": "Chinese Traditional",
-          "name": "肉身",
-          "multiverseid": 368936
+          "name": "遙遠",
+          "multiverseid": 368813
         },
         {
           "language": "French",
-          "name": "Chair",
-          "multiverseid": 369227
+          "name": "Lointain",
+          "multiverseid": 369148
         },
         {
           "language": "German",
-          "name": "Fleisch",
-          "multiverseid": 369375
+          "name": "Weit",
+          "multiverseid": 369400
         },
         {
           "language": "Italian",
-          "name": "Carne",
-          "multiverseid": 369531
+          "name": "Lontano",
+          "multiverseid": 369566
         },
         {
           "language": "Japanese",
-          "name": "肉体",
-          "multiverseid": 369700
+          "name": "遠隔",
+          "multiverseid": 369637
         },
         {
           "language": "Korean",
-          "name": "골육",
-          "multiverseid": 369808
+          "name": "오리",
+          "multiverseid": 369770
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Carne",
-          "multiverseid": 369992
+          "name": "Longe",
+          "multiverseid": 370030
         },
         {
           "language": "Russian",
-          "name": "Плоть",
-          "multiverseid": 370084
+          "name": "Там",
+          "multiverseid": 370089
         },
         {
           "language": "Spanish",
-          "name": "Carne",
-          "multiverseid": 370198
+          "name": "Lejos",
+          "multiverseid": 370300
         }
       ],
-      "id": "b3102a80fdef34597bffe1fcf57c2faf20f9e530",
-      "imageName": "fleshblood2",
+      "id": "5f2d8f23453f8d092a8d723c97076c17614b4320",
+      "imageName": "faraway2",
       "layout": "split",
       "legalities": [
         {
@@ -16674,37 +16523,25 @@
           "legality": "Legal"
         }
       ],
-      "manaCost": "{3}{B}{G}",
-      "mciNumber": "128a",
-      "multiverseid": 368991,
-      "name": "Flesh",
+      "manaCost": "{1}{U}",
+      "mciNumber": "127a",
+      "multiverseid": 369042,
+      "name": "Far",
       "names": [
-        "Flesh",
-        "Blood"
+        "Far",
+        "Away"
       ],
-      "number": "128a",
-      "originalText": "Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "originalType": "Sorcery",
+      "number": "127a",
+      "originalText": "Return target creature to its owner's hand.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "originalType": "Instant",
       "printings": [
         "DGM"
       ],
-      "rarity": "Rare",
+      "rarity": "Uncommon",
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "As Flesh is resolving, if the creature is an illegal target but the creature card is still a legal target, the creature card will be exiled but no counters will be put onto the creature. If the creature is the only legal target, Flesh will still resolve but will have no effect as you didn’t exile a card."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "The number of +1/+1 counters is based on the power of the creature card as it last existed in the graveyard."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If you cast Flesh // Blood as a fused split card, the +1/+1 counters will have been placed before the amount of damage is determined."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -16716,7 +16553,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -16724,7 +16561,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -16732,7 +16569,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -16743,10 +16580,10 @@
           "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
         }
       ],
-      "text": "Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "type": "Sorcery",
+      "text": "Return target creature to its owner's hand.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "type": "Instant",
       "types": [
-        "Sorcery"
+        "Instant"
       ]
     },
     {
@@ -16855,7 +16692,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "As Flesh is resolving, if the creature is an illegal target but the creature card is still a legal target, the creature card will be exiled but no counters will be put onto the creature. If the creature is the only legal target, Flesh will still resolve but will have no effect as you didn’t exile a card."
+          "text": "As Flesh is resolving, if the creature is an illegal target but the creature card is still a legal target, the creature card will be exiled but no counters will be put onto the creature. If the creature is the only legal target, Flesh will still resolve but will have no effect as you didn't exile a card."
         },
         {
           "date": "2013-04-15",
@@ -16867,7 +16704,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -16879,7 +16716,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -16887,7 +16724,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -16895,7 +16732,170 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If a player names a card, the player may name either half of a split card, but not both. A split card has the chosen name if one of its two names matches the chosen name."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
+        }
+      ],
+      "text": "Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "Lucas Graciano",
+      "cmc": 5,
+      "colorIdentity": [
+        "B",
+        "G"
+      ],
+      "colors": [
+        "Black",
+        "Green"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "肉身",
+          "multiverseid": 368645
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "肉身",
+          "multiverseid": 368936
+        },
+        {
+          "language": "French",
+          "name": "Chair",
+          "multiverseid": 369227
+        },
+        {
+          "language": "German",
+          "name": "Fleisch",
+          "multiverseid": 369375
+        },
+        {
+          "language": "Italian",
+          "name": "Carne",
+          "multiverseid": 369531
+        },
+        {
+          "language": "Japanese",
+          "name": "肉体",
+          "multiverseid": 369700
+        },
+        {
+          "language": "Korean",
+          "name": "골육",
+          "multiverseid": 369808
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Carne",
+          "multiverseid": 369992
+        },
+        {
+          "language": "Russian",
+          "name": "Плоть",
+          "multiverseid": 370084
+        },
+        {
+          "language": "Spanish",
+          "name": "Carne",
+          "multiverseid": 370198
+        }
+      ],
+      "id": "b3102a80fdef34597bffe1fcf57c2faf20f9e530",
+      "imageName": "fleshblood2",
+      "layout": "split",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{3}{B}{G}",
+      "mciNumber": "128a",
+      "multiverseid": 368991,
+      "name": "Flesh",
+      "names": [
+        "Flesh",
+        "Blood"
+      ],
+      "number": "128a",
+      "originalText": "Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "originalType": "Sorcery",
+      "printings": [
+        "DGM"
+      ],
+      "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-04-15",
+          "text": "As Flesh is resolving, if the creature is an illegal target but the creature card is still a legal target, the creature card will be exiled but no counters will be put onto the creature. If the creature is the only legal target, Flesh will still resolve but will have no effect as you didn't exile a card."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "The number of +1/+1 counters is based on the power of the creature card as it last existed in the graveyard."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If you cast Flesh // Blood as a fused split card, the +1/+1 counters will have been placed before the amount of damage is determined."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "To cast a fused split spell, pay both of its mana costs. While the spell is on the stack, its converted mana cost is the total amount of mana in both costs."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "You can choose the same object as the target of each half of a fused split spell, if appropriate."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "When a fused split spell resolves, follow the instructions of the left half first, then the instructions on the right half."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "Some split cards with fuse have two monocolor halves of different colors. If such a card is cast as a fused split spell, the resulting spell is multicolored. If only one half is cast, the spell is the color of that half. While not on the stack, such a card is multicolored."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -17020,7 +17020,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -17032,7 +17032,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -17040,7 +17040,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -17048,7 +17048,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -17173,7 +17173,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -17185,7 +17185,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -17193,7 +17193,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -17201,7 +17201,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -17322,7 +17322,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -17334,7 +17334,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -17342,7 +17342,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -17350,7 +17350,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -17471,7 +17471,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -17483,7 +17483,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -17491,7 +17491,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -17499,7 +17499,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -17620,7 +17620,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -17632,7 +17632,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -17640,7 +17640,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -17648,7 +17648,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -17769,7 +17769,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -17781,7 +17781,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -17789,7 +17789,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -17797,7 +17797,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -17809,161 +17809,6 @@
         }
       ],
       "text": "Target creature gets +2/+4 until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "type": "Instant",
-      "types": [
-        "Instant"
-      ]
-    },
-    {
-      "artist": "Zoltan Boros",
-      "cmc": 3,
-      "colorIdentity": [
-        "W",
-        "G"
-      ],
-      "colors": [
-        "White",
-        "Green"
-      ],
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "就绪",
-          "multiverseid": 368696
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "就緒",
-          "multiverseid": 368858
-        },
-        {
-          "language": "French",
-          "name": "Prêt",
-          "multiverseid": 369206
-        },
-        {
-          "language": "German",
-          "name": "Bereit",
-          "multiverseid": 369380
-        },
-        {
-          "language": "Italian",
-          "name": "Pronto",
-          "multiverseid": 369419
-        },
-        {
-          "language": "Japanese",
-          "name": "覚悟",
-          "multiverseid": 369681
-        },
-        {
-          "language": "Korean",
-          "name": "원기",
-          "multiverseid": 369816
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Pronto",
-          "multiverseid": 369975
-        },
-        {
-          "language": "Russian",
-          "name": "Готовность",
-          "multiverseid": 370066
-        },
-        {
-          "language": "Spanish",
-          "name": "Listo",
-          "multiverseid": 370274
-        }
-      ],
-      "id": "91544b05aa9c63724a21ae86f2c14981b69b83ce",
-      "imageName": "readywilling2",
-      "layout": "split",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{G}{W}",
-      "mciNumber": "132a",
-      "multiverseid": 368967,
-      "name": "Ready",
-      "names": [
-        "Ready",
-        "Willing"
-      ],
-      "number": "132a",
-      "originalText": "Creatures you control are indestructible this turn. Untap each creature you control.\nFuse (You may cast one or both halves of this card from your hand.)",
-      "originalType": "Instant",
-      "printings": [
-        "DGM"
-      ],
-      "rarity": "Rare",
-      "rulings": [
-        {
-          "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "To cast a fused split spell, pay both of its mana costs. While the spell is on the stack, its converted mana cost is the total amount of mana in both costs."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "You can choose the same object as the target of each half of a fused split spell, if appropriate."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "When a fused split spell resolves, follow the instructions of the left half first, then the instructions on the right half."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "Some split cards with fuse have two monocolor halves of different colors. If such a card is cast as a fused split spell, the resulting spell is multicolored. If only one half is cast, the spell is the color of that half. While not on the stack, such a card is multicolored."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If a player names a card, the player may name either half of a split card, but not both. A split card has the chosen name if one of its two names matches the chosen name."
-        },
-        {
-          "date": "2013-04-15",
-          "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "A creature that comes under your control after Ready resolves will not be granted by this effect."
-        }
-      ],
-      "text": "Creatures you control gain indestructible until end of turn. Untap each creature you control.\nFuse (You may cast one or both halves of this card from your hand.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -18075,7 +17920,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -18087,7 +17932,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -18095,7 +17940,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -18103,7 +17948,162 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If a player names a card, the player may name either half of a split card, but not both. A split card has the chosen name if one of its two names matches the chosen name."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "If you cast a split card with fuse from your hand without paying its mana cost, you can choose to use its fuse ability and cast both halves without paying their mana costs."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "A creature that comes under your control after Ready resolves will not be granted by this effect."
+        }
+      ],
+      "text": "Creatures you control gain indestructible until end of turn. Untap each creature you control.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "type": "Instant",
+      "types": [
+        "Instant"
+      ]
+    },
+    {
+      "artist": "Zoltan Boros",
+      "cmc": 3,
+      "colorIdentity": [
+        "W",
+        "G"
+      ],
+      "colors": [
+        "White",
+        "Green"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "就绪",
+          "multiverseid": 368696
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "就緒",
+          "multiverseid": 368858
+        },
+        {
+          "language": "French",
+          "name": "Prêt",
+          "multiverseid": 369206
+        },
+        {
+          "language": "German",
+          "name": "Bereit",
+          "multiverseid": 369380
+        },
+        {
+          "language": "Italian",
+          "name": "Pronto",
+          "multiverseid": 369419
+        },
+        {
+          "language": "Japanese",
+          "name": "覚悟",
+          "multiverseid": 369681
+        },
+        {
+          "language": "Korean",
+          "name": "원기",
+          "multiverseid": 369816
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pronto",
+          "multiverseid": 369975
+        },
+        {
+          "language": "Russian",
+          "name": "Готовность",
+          "multiverseid": 370066
+        },
+        {
+          "language": "Spanish",
+          "name": "Listo",
+          "multiverseid": 370274
+        }
+      ],
+      "id": "91544b05aa9c63724a21ae86f2c14981b69b83ce",
+      "imageName": "readywilling2",
+      "layout": "split",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{G}{W}",
+      "mciNumber": "132a",
+      "multiverseid": 368967,
+      "name": "Ready",
+      "names": [
+        "Ready",
+        "Willing"
+      ],
+      "number": "132a",
+      "originalText": "Creatures you control are indestructible this turn. Untap each creature you control.\nFuse (You may cast one or both halves of this card from your hand.)",
+      "originalType": "Instant",
+      "printings": [
+        "DGM"
+      ],
+      "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-04-15",
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "To cast a fused split spell, pay both of its mana costs. While the spell is on the stack, its converted mana cost is the total amount of mana in both costs."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "You can choose the same object as the target of each half of a fused split spell, if appropriate."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "When a fused split spell resolves, follow the instructions of the left half first, then the instructions on the right half."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "Some split cards with fuse have two monocolor halves of different colors. If such a card is cast as a fused split spell, the resulting spell is multicolored. If only one half is cast, the spell is the color of that half. While not on the stack, such a card is multicolored."
+        },
+        {
+          "date": "2013-04-15",
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -18228,11 +18228,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast Toil // Trouble as a fused split card and choose to target the same player twice, the two drawn cards are counted when determining how much damage is dealt. The player can’t do anything between the effects of Toil and Trouble to have fewer cards in his or her hand."
+          "text": "If you cast Toil // Trouble as a fused split card and choose to target the same player twice, the two drawn cards are counted when determining how much damage is dealt. The player can't do anything between the effects of Toil and Trouble to have fewer cards in his or her hand."
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -18244,7 +18244,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -18252,7 +18252,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -18260,7 +18260,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -18381,11 +18381,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast Toil // Trouble as a fused split card and choose to target the same player twice, the two drawn cards are counted when determining how much damage is dealt. The player can’t do anything between the effects of Toil and Trouble to have fewer cards in his or her hand."
+          "text": "If you cast Toil // Trouble as a fused split card and choose to target the same player twice, the two drawn cards are counted when determining how much damage is dealt. The player can't do anything between the effects of Toil and Trouble to have fewer cards in his or her hand."
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -18397,7 +18397,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -18405,7 +18405,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -18413,7 +18413,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -18538,11 +18538,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Turn overwrites all previous effects that set the targeted creature’s power or toughness to specific values. Effects that set its power or toughness to specific values that start to apply after Turn resolves will overwrite this effect."
+          "text": "Turn overwrites all previous effects that set the targeted creature's power or toughness to specific values. Effects that set its power or toughness to specific values that start to apply after Turn resolves will overwrite this effect."
         },
         {
           "date": "2013-04-15",
-          "text": "Turn doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering."
+          "text": "Turn doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering."
         },
         {
           "date": "2013-04-15",
@@ -18550,11 +18550,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Effects that modify the targeted creature’s power or toughness, such as the effects of Phytoburst or Legion’s Initiative, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify the targeted creature's power or toughness, such as the effects of Phytoburst or Legion's Initiative, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -18566,7 +18566,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -18574,7 +18574,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -18582,7 +18582,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -18707,11 +18707,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Turn overwrites all previous effects that set the targeted creature’s power or toughness to specific values. Effects that set its power or toughness to specific values that start to apply after Turn resolves will overwrite this effect."
+          "text": "Turn overwrites all previous effects that set the targeted creature's power or toughness to specific values. Effects that set its power or toughness to specific values that start to apply after Turn resolves will overwrite this effect."
         },
         {
           "date": "2013-04-15",
-          "text": "Turn doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering."
+          "text": "Turn doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering."
         },
         {
           "date": "2013-04-15",
@@ -18719,11 +18719,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Effects that modify the targeted creature’s power or toughness, such as the effects of Phytoburst or Legion’s Initiative, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify the targeted creature's power or toughness, such as the effects of Phytoburst or Legion's Initiative, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -18735,7 +18735,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -18743,7 +18743,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -18751,7 +18751,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -18872,7 +18872,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -18884,7 +18884,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -18892,7 +18892,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -18900,7 +18900,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -19021,7 +19021,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you’re casting a split card with fuse from any zone other than your hand, you can’t cast both halves. You’ll only be able to cast one half or the other."
+          "text": "If you're casting a split card with fuse from any zone other than your hand, you can't cast both halves. You'll only be able to cast one half or the other."
         },
         {
           "date": "2013-04-15",
@@ -19033,7 +19033,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can’t perform any actions or have any actions performed on it."
+          "text": "When resolving a fused split spell with multiple targets, treat it as you would any spell with multiple targets. If all targets are illegal when the spell tries to resolve, the spell is countered and none of its effects happen. If at least one target is still legal at that time, the spell resolves, but an illegal target can't perform any actions or have any actions performed on it."
         },
         {
           "date": "2013-04-15",
@@ -19041,7 +19041,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "On the stack, a split spell that hasn’t been fused has only that half’s characteristics and converted mana cost. The other half is treated as though it didn’t exist."
+          "text": "On the stack, a split spell that hasn't been fused has only that half's characteristics and converted mana cost. The other half is treated as though it didn't exist."
         },
         {
           "date": "2013-04-15",
@@ -19049,7 +19049,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It’s also multicolored while not on the stack."
+          "text": "Some split cards with fuse have two halves that are both multicolored. That card is multicolored no matter which half is cast, or if both halves are cast. It's also multicolored while not on the stack."
         },
         {
           "date": "2013-04-15",
@@ -20900,19 +20900,19 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Returning Maze’s End to its owner’s hand is part of the cost to activate its last ability. Once that ability is announced, players can’t respond to it until after you’ve paid its activation cost and returned Maze’s End to hand."
+          "text": "Returning Maze's End to its owner's hand is part of the cost to activate its last ability. Once that ability is announced, players can't respond to it until after you've paid its activation cost and returned Maze's End to hand."
         },
         {
           "date": "2013-04-15",
-          "text": "When the last ability of Maze’s End resolves, you’ll search for a Gate and put it onto the battlefield before checking to see if you win the game. This check will happen even if you don’t put a Gate onto the battlefield this way. This check will happen only as the ability resolves, not at other times."
+          "text": "When the last ability of Maze's End resolves, you'll search for a Gate and put it onto the battlefield before checking to see if you win the game. This check will happen even if you don't put a Gate onto the battlefield this way. This check will happen only as the ability resolves, not at other times."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a Gate onto the battlefield with Maze’s End doesn’t count as the one land you can play during your turn. If it’s your turn, you can play Maze’s End or a different land card from your hand after its ability has resolved."
+          "text": "Putting a Gate onto the battlefield with Maze's End doesn't count as the one land you can play during your turn. If it's your turn, you can play Maze's End or a different land card from your hand after its ability has resolved."
         },
         {
           "date": "2013-04-15",
-          "text": "Controlling multiple Gates with the same name has no effect on your ability to win the game with Maze’s End. The excess Gates are simply ignored."
+          "text": "Controlling multiple Gates with the same name has no effect on your ability to win the game with Maze's End. The excess Gates are simply ignored."
         }
       ],
       "text": "Maze's End enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{3}, {T}, Return Maze's End to its owner's hand: Search your library for a Gate card, put it onto the battlefield, then shuffle your library. If you control ten or more Gates with different names, you win the game.",

--- a/json/DIS.json
+++ b/json/DIS.json
@@ -228,7 +228,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -622,11 +622,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If either target has left the battlefield before the damage would be dealt, that damage isn’t redirected."
+          "text": "If either target has left the battlefield before the damage would be dealt, that damage isn't redirected."
         },
         {
           "date": "2006-05-01",
-          "text": "Carom’s controller draws a card when Carom resolves, not when the damage is redirected."
+          "text": "Carom's controller draws a card when Carom resolves, not when the damage is redirected."
         }
       ],
       "text": "The next 1 damage that would be dealt to target creature this turn is dealt to another target creature instead.\nDraw a card.",
@@ -833,7 +833,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The affected creature’s last known existence on the battlefield is checked to determine its toughness."
+          "text": "The affected creature's last known existence on the battlefield is checked to determine its toughness."
         }
       ],
       "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
@@ -1934,7 +1934,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"As my father taught, ‘Training will raise your shield to the blow, but courage fills the gaps the shield leaves open.'\"",
+      "flavor": "\"As my father taught, 'Training will raise your shield to the blow, but courage fills the gaps the shield leaves open.'\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -2113,11 +2113,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "Wakestone Gargoyle’s ability allows itself to attack."
+          "text": "Wakestone Gargoyle's ability allows itself to attack."
         },
         {
           "date": "2006-05-01",
-          "text": "Wakestone Gargoyle’s ability will affect creatures with defender that come under your control after the ability resolves but before you declare attackers (though those creatures still can’t attack unless they have haste)."
+          "text": "Wakestone Gargoyle's ability will affect creatures with defender that come under your control after the ability resolves but before you declare attackers (though those creatures still can't attack unless they have haste)."
         }
       ],
       "subtypes": [
@@ -2223,7 +2223,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -2329,11 +2329,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The control change lasts as long as Cytoplast Manipulator is on the battlefield. It doesn’t end if the creature loses all its +1/+1 counters, it stops being a creature, or if Cytoplast Manipulator becomes untapped."
+          "text": "The control change lasts as long as Cytoplast Manipulator is on the battlefield. It doesn't end if the creature loses all its +1/+1 counters, it stops being a creature, or if Cytoplast Manipulator becomes untapped."
         },
         {
           "date": "2006-05-01",
-          "text": "If the ability is activated and Cytoplast Manipulator leaves the battlefield before it resolves, the ability does nothing. The target creature will remain under its current controller’s control."
+          "text": "If the ability is activated and Cytoplast Manipulator leaves the battlefield before it resolves, the ability does nothing. The target creature will remain under its current controller's control."
         }
       ],
       "subtypes": [
@@ -2942,7 +2942,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -3047,23 +3047,23 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "Enchanting an opponent works very much like enchanting a permanent. The Aura spell targets the opponent. When it resolves, it enters the battlefield “attached” to that player. Once it’s on the battlefield, it no longer targets that player."
+          "text": "Enchanting an opponent works very much like enchanting a permanent. The Aura spell targets the opponent. When it resolves, it enters the battlefield \"attached\" to that player. Once it's on the battlefield, it no longer targets that player."
         },
         {
           "date": "2006-05-01",
-          "text": "Psychic Possession’s controller, not the enchanted player, skips his or her draw step."
+          "text": "Psychic Possession's controller, not the enchanted player, skips his or her draw step."
         },
         {
           "date": "2006-05-01",
-          "text": "If Psychic Possession’s controller ever happens to be the player it’s enchanting, Psychic Possession will be put into its owner’s graveyard as a state-based action."
+          "text": "If Psychic Possession's controller ever happens to be the player it's enchanting, Psychic Possession will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2006-05-01",
-          "text": "An Aura with enchant opponent can’t be attached to a permanent."
+          "text": "An Aura with enchant opponent can't be attached to a permanent."
         },
         {
           "date": "2006-05-01",
-          "text": "In a multiplayer game, if the enchanted opponent leaves the game, Psychic Possession will be put into its owner’s graveyard as a state-based action. If Psychic Possession’s owner leaves the game, Psychic Possession immediately leaves the game; this is not a state-based action."
+          "text": "In a multiplayer game, if the enchanted opponent leaves the game, Psychic Possession will be put into its owner's graveyard as a state-based action. If Psychic Possession's owner leaves the game, Psychic Possession immediately leaves the game; this is not a state-based action."
         }
       ],
       "subtypes": [
@@ -3853,11 +3853,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "You can’t choose an X that’s greater than your life total."
+          "text": "You can't choose an X that's greater than your life total."
         },
         {
           "date": "2006-05-01",
-          "text": "You can choose an X that’s equal to your life total. If you do, you’ll pay that much life when the spell is cast and will lose the game before it resolves."
+          "text": "You can choose an X that's equal to your life total. If you do, you'll pay that much life when the spell is cast and will lose the game before it resolves."
         },
         {
           "date": "2013-04-15",
@@ -3961,7 +3961,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "You name the card during Brain Pry’s resolution, then the player reveals his or her hand and discards if appropriate. There is no way for the player to do anything between you naming the card and the player discarding."
+          "text": "You name the card during Brain Pry's resolution, then the player reveals his or her hand and discards if appropriate. There is no way for the player to do anything between you naming the card and the player discarding."
         },
         {
           "date": "2014-02-01",
@@ -4066,11 +4066,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The first triggered ability isn’t targeted, so the creature cards aren’t chosen until the ability resolves. Each player chooses which creature card from his or her own graveyard to return. If a player doesn’t have an applicable creature card, that player does nothing. If a player does have any applicable cards, that player must return one to the battlefield."
+          "text": "The first triggered ability isn't targeted, so the creature cards aren't chosen until the ability resolves. Each player chooses which creature card from his or her own graveyard to return. If a player doesn't have an applicable creature card, that player does nothing. If a player does have any applicable cards, that player must return one to the battlefield."
         },
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -4778,11 +4778,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If you have no other cards in hand, you’ll have to discard one of the creature cards you return to your hand."
+          "text": "If you have no other cards in hand, you'll have to discard one of the creature cards you return to your hand."
         },
         {
           "date": "2016-04-08",
-          "text": "You may cast Macabre Waltz targeting one or zero creature cards. You’ll still discard a card, even if you target no creature cards."
+          "text": "You may cast Macabre Waltz targeting one or zero creature cards. You'll still discard a card, even if you target no creature cards."
         }
       ],
       "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
@@ -4801,7 +4801,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"I call them ‘Poke' and ‘Prod.'\"\n—Chagrach, Rakdos cursemage",
+      "flavor": "\"I call them 'Poke' and 'Prod.'\"\n—Chagrach, Rakdos cursemage",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -4981,19 +4981,19 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "This effect overwrites all creatures’ colors. Creatures will be black instead of any other color or colors."
+          "text": "This effect overwrites all creatures' colors. Creatures will be black instead of any other color or colors."
         },
         {
           "date": "2006-05-01",
-          "text": "This effect overwrites all lands’ land types. Lands will be Swamps instead of any other land types. This won’t affect a land’s supertypes (such as basic or legendary). Lands will lose their normal abilities and have the ability “{T}: Add {B} to your mana pool” instead."
+          "text": "This effect overwrites all lands' land types. Lands will be Swamps instead of any other land types. This won't affect a land's supertypes (such as basic or legendary). Lands will lose their normal abilities and have the ability \"{T}: Add {B} to your mana pool\" instead."
         },
         {
           "date": "2006-05-01",
-          "text": "If a permanent is both a creature and a land, Nightcreep replaces all of its land types with Swamp, but it doesn’t affect its creature types. The creature land loses all abilities generated by its rules text and its previous land types but retains any abilities granted to it by other effects. For example, an animated Blinkmoth Nexus becomes a black creature land with the land subtype Swamp whose only abilities are flying and “{T}: Add {B} to your mana pool.”"
+          "text": "If a permanent is both a creature and a land, Nightcreep replaces all of its land types with Swamp, but it doesn't affect its creature types. The creature land loses all abilities generated by its rules text and its previous land types but retains any abilities granted to it by other effects. For example, an animated Blinkmoth Nexus becomes a black creature land with the land subtype Swamp whose only abilities are flying and \"{T}: Add {B} to your mana pool.\""
         },
         {
           "date": "2006-05-01",
-          "text": "A land or creature that enters the battlefield after Nightcreep resolves won’t be affected by it."
+          "text": "A land or creature that enters the battlefield after Nightcreep resolves won't be affected by it."
         }
       ],
       "text": "Until end of turn, all creatures become black and all lands become Swamps.",
@@ -5591,7 +5591,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If you declare Slithering Shade as an attacker, then a card is put into your hand, the Shade won’t be removed from combat. It continues to attack."
+          "text": "If you declare Slithering Shade as an attacker, then a card is put into your hand, the Shade won't be removed from combat. It continues to attack."
         }
       ],
       "subtypes": [
@@ -5614,7 +5614,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"The victim bears the marks of the ‘Ktozok Impaler'. . . but he was executed years ago!\"\n—Gorev Hadszak, Wojek investigator",
+      "flavor": "\"The victim bears the marks of the 'Ktozok Impaler'. . . but he was executed years ago!\"\n—Gorev Hadszak, Wojek investigator",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -6189,7 +6189,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If multiple creatures enter the battlefield at the same time, Flame-Kin War Scout’s ability will trigger multiple times. When the first of these triggers resolves, if Flame Kin War Scout can be sacrificed by the ability’s controller, it will be sacrificed and deal 4 damage. When the other triggers resolve, it won’t be on the battlefield, so it can’t be sacrificed and the other creatures won’t be dealt any damage."
+          "text": "If multiple creatures enter the battlefield at the same time, Flame-Kin War Scout's ability will trigger multiple times. When the first of these triggers resolves, if Flame Kin War Scout can be sacrificed by the ability's controller, it will be sacrificed and deal 4 damage. When the other triggers resolve, it won't be on the battlefield, so it can't be sacrificed and the other creatures won't be dealt any damage."
         }
       ],
       "subtypes": [
@@ -6396,7 +6396,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don’t actually have Flying."
+          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don't actually have Flying."
         }
       ],
       "subtypes": [
@@ -6501,11 +6501,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "No player may look at the cards while they’re face down."
+          "text": "No player may look at the cards while they're face down."
         },
         {
           "date": "2006-05-01",
-          "text": "If you cast this during the End step, you won’t return the cards to your hand or draw a card until the next turn’s End step."
+          "text": "If you cast this during the End step, you won't return the cards to your hand or draw a card until the next turn's End step."
         },
         {
           "date": "2006-05-01",
@@ -6611,7 +6611,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "This ability causes a creature to be destroyed instead of being dealt damage. Damage replaced this way isn’t dealt, and effects that would happen based on this damage (such as Demonfire’s “exile it” effect) don’t happen."
+          "text": "This ability causes a creature to be destroyed instead of being dealt damage. Damage replaced this way isn't dealt, and effects that would happen based on this damage (such as Demonfire's \"exile it\" effect) don't happen."
         }
       ],
       "subtypes": [
@@ -6721,15 +6721,15 @@
         },
         {
           "date": "2006-05-01",
-          "text": "Any damage prevention or regeneration abilities must be activated before Kindle the Carnage starts resolving in order to have any effect. You can’t wait to see which (if any) cards are discarded."
+          "text": "Any damage prevention or regeneration abilities must be activated before Kindle the Carnage starts resolving in order to have any effect. You can't wait to see which (if any) cards are discarded."
         },
         {
           "date": "2006-05-01",
-          "text": "A creature that’s been dealt lethal damage by an iteration of this effect will remain on the battlefield and be dealt more damage by any further iterations. After you stop, all creatures that have been dealt lethal damage are put into their owners’ graveyards at the same time."
+          "text": "A creature that's been dealt lethal damage by an iteration of this effect will remain on the battlefield and be dealt more damage by any further iterations. After you stop, all creatures that have been dealt lethal damage are put into their owners' graveyards at the same time."
         },
         {
           "date": "2006-05-01",
-          "text": "All the damage has the same source. However, each iteration of this process is a separate instance of damage. An effect that prevents damage the “next time” this card would deal it will prevent damage from only one iteration."
+          "text": "All the damage has the same source. However, each iteration of this process is a separate instance of damage. An effect that prevents damage the \"next time\" this card would deal it will prevent damage from only one iteration."
         },
         {
           "date": "2006-05-01",
@@ -7029,7 +7029,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If Rakdos Pit Dragon loses double strike after first strike combat damage has been dealt, it won’t deal damage during the normal combat damage step."
+          "text": "If Rakdos Pit Dragon loses double strike after first strike combat damage has been dealt, it won't deal damage during the normal combat damage step."
         }
       ],
       "subtypes": [
@@ -7334,15 +7334,15 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "For this creature to not be sacrificed, {B} must have been spent on the {1}{R} mana cost. It doesn’t matter if {B} is spent on {X}."
+          "text": "For this creature to not be sacrificed, {B} must have been spent on the {1}{R} mana cost. It doesn't matter if {B} is spent on {X}."
         },
         {
           "date": "2006-05-01",
-          "text": "You choose the value of X as Squealing Devil’s ability resolves. X can be 0."
+          "text": "You choose the value of X as Squealing Devil's ability resolves. X can be 0."
         },
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -7548,7 +7548,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "You can’t discard a card at random, see what it is, and then decide whether or not to pay the mana. Mana abilities must be activated before costs are paid. At the time you pay the cost of discarding a card, you either have enough mana in your mana pool to pay the {2}{R}, in which case you must continue no matter what you discarded, or you don’t have enough mana in your mana pool to pay the {2}{R}, in which case you must back up no matter what you discarded."
+          "text": "You can't discard a card at random, see what it is, and then decide whether or not to pay the mana. Mana abilities must be activated before costs are paid. At the time you pay the cost of discarding a card, you either have enough mana in your mana pool to pay the {2}{R}, in which case you must continue no matter what you discarded, or you don't have enough mana in your mana pool to pay the {2}{R}, in which case you must back up no matter what you discarded."
         }
       ],
       "subtypes": [
@@ -7851,7 +7851,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "Your opponent can tap lands for mana in response to the triggered ability. The effect won’t prevent your opponent from casting spells or activating abilities, but it will make it difficult for that player to cast other spells or activate abilities later in the turn because players’ mana pools empty at the end of each step."
+          "text": "Your opponent can tap lands for mana in response to the triggered ability. The effect won't prevent your opponent from casting spells or activating abilities, but it will make it difficult for that player to cast other spells or activate abilities later in the turn because players' mana pools empty at the end of each step."
         }
       ],
       "text": "Whenever an opponent taps a land for mana, tap all lands that player controls.\nIf a creature an opponent controls attacks, all creatures that opponent controls attack if able.",
@@ -8446,19 +8446,19 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If the enchanted permanent’s mana cost is {2}{W}{U}, this Aura’s controller adds {C}{C}{W}{U} to his or her mana pool. If its mana cost is {X}{G}, this Aura’s controller adds {G} to his or her mana pool. If its mana cost is (W/U)(W/U), this Aura’s controller chooses whether to add {W}{W}, {W}{U}, or {U}{U} to his or her mana pool. The choice may be different each time the ability resolves."
+          "text": "If the enchanted permanent's mana cost is {2}{W}{U}, this Aura's controller adds {C}{C}{W}{U} to his or her mana pool. If its mana cost is {X}{G}, this Aura's controller adds {G} to his or her mana pool. If its mana cost is (W/U)(W/U), this Aura's controller chooses whether to add {W}{W}, {W}{U}, or {U}{U} to his or her mana pool. The choice may be different each time the ability resolves."
         },
         {
           "date": "2006-05-01",
-          "text": "This ability isn’t a mana ability. It uses the stack."
+          "text": "This ability isn't a mana ability. It uses the stack."
         },
         {
           "date": "2006-05-01",
-          "text": "Only the first main phase in a turn is the “precombat main phase,” even if additional main phases are generated by some effect."
+          "text": "Only the first main phase in a turn is the \"precombat main phase,\" even if additional main phases are generated by some effect."
         },
         {
           "date": "2009-10-01",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -8654,15 +8654,15 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The Saproling token is blocking the attacking creature, even if the block couldn’t legally be declared (for example, if the attacking creature has flying, or is Vindictive Mob)."
+          "text": "The Saproling token is blocking the attacking creature, even if the block couldn't legally be declared (for example, if the attacking creature has flying, or is Vindictive Mob)."
         },
         {
           "date": "2006-05-01",
-          "text": "Putting a blocking creature onto the battlefield doesn’t trigger “When this creature blocks” abilities. It also won’t check blocking restrictions, costs, or requirements."
+          "text": "Putting a blocking creature onto the battlefield doesn't trigger \"When this creature blocks\" abilities. It also won't check blocking restrictions, costs, or requirements."
         },
         {
           "date": "2006-05-01",
-          "text": "Putting a blocking creature onto the battlefield will trigger “When this creature becomes blocked by a creature” abilities. It may trigger “When this creature becomes blocked” abilities, but only if the creature the Saproling is blocking had not yet been blocked that combat."
+          "text": "Putting a blocking creature onto the battlefield will trigger \"When this creature becomes blocked by a creature\" abilities. It may trigger \"When this creature becomes blocked\" abilities, but only if the creature the Saproling is blocking had not yet been blocked that combat."
         },
         {
           "date": "2006-05-01",
@@ -8670,7 +8670,7 @@
         },
         {
           "date": "2006-05-01",
-          "text": "Flash Foliage can be cast only during an opponent’s combat phase, after attackers have been declared. If it’s cast after combat damage is dealt, the Saproling will enter the battlefield blocking the attacking creature, but will neither deal combat damage to it nor be dealt combat damage by it."
+          "text": "Flash Foliage can be cast only during an opponent's combat phase, after attackers have been declared. If it's cast after combat damage is dealt, the Saproling will enter the battlefield blocking the attacking creature, but will neither deal combat damage to it nor be dealt combat damage by it."
         },
         {
           "date": "2006-07-01",
@@ -8678,7 +8678,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s after the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's after the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Flash Foliage only during combat after blockers are declared.\nCreate a 1/1 green Saproling creature token that's blocking target creature attacking you.\nDraw a card.",
@@ -8883,7 +8883,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "Loaming Shaman’s controller chooses all the targets when the ability is put on the stack."
+          "text": "Loaming Shaman's controller chooses all the targets when the ability is put on the stack."
         }
       ],
       "subtypes": [
@@ -9084,7 +9084,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can’t have been paid, and you’ll have to sacrifice it."
+          "text": "If this enters the battlefield in a way other than announcing it as a spell, then the appropriate mana can't have been paid, and you'll have to sacrifice it."
         }
       ],
       "subtypes": [
@@ -9805,7 +9805,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "This spell can’t be cast unless there are both an artifact and an enchantment on the battlefield to target. If a permanent is both an artifact and an enchantment, it can be both targets."
+          "text": "This spell can't be cast unless there are both an artifact and an enchantment on the battlefield to target. If a permanent is both an artifact and an enchantment, it can be both targets."
         }
       ],
       "text": "Destroy target artifact and target enchantment.",
@@ -9905,7 +9905,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "“Landwalk abilities” are abilities such as “forestwalk” or “legendary landwalk” that have “walk” in the name."
+          "text": "\"Landwalk abilities\" are abilities such as \"forestwalk\" or \"legendary landwalk\" that have \"walk\" in the name."
         }
       ],
       "subtypes": [
@@ -10014,7 +10014,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It means X different creatures. You can’t give more than one +1/+1 counter to a creature with this spell."
+          "text": "It means X different creatures. You can't give more than one +1/+1 counter to a creature with this spell."
         }
       ],
       "text": "Put a +1/+1 counter on each of X target creatures.",
@@ -10311,19 +10311,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If you don’t reveal any creature cards, or if you choose not to put a revealed creature card onto the battlefield, all the revealed cards go on the bottom of your library."
+          "text": "If you don't reveal any creature cards, or if you choose not to put a revealed creature card onto the battlefield, all the revealed cards go on the bottom of your library."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature that you put onto the battlefield leaves the battlefield before your next end step, it won’t be returned to your hand at the beginning of your next end step."
+          "text": "If the creature that you put onto the battlefield leaves the battlefield before your next end step, it won't be returned to your hand at the beginning of your next end step."
         },
         {
           "date": "2017-03-14",
-          "text": "If you put a creature onto the battlefield this way during your end step, it won’t be returned to your hand until your next end step."
+          "text": "If you put a creature onto the battlefield this way during your end step, it won't be returned to your hand until your next end step."
         },
         {
           "date": "2017-03-14",
-          "text": "The triggered ability that the creature gains won’t be copied if an effect creates a token that’s a copy of that creature or causes another object to become a copy of that creature."
+          "text": "The triggered ability that the creature gains won't be copied if an effect creates a token that's a copy of that creature or causes another object to become a copy of that creature."
         }
       ],
       "text": "Reveal the top four cards of your library. You may put a creature card from among them onto the battlefield. It gains \"At the beginning of your end step, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
@@ -10425,7 +10425,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The first ability triggers once for each creature you attack with. If you attack with three creatures, for example, they’ll each get +2/+0 and you’ll be dealt 3 damage."
+          "text": "The first ability triggers once for each creature you attack with. If you attack with three creatures, for example, they'll each get +2/+0 and you'll be dealt 3 damage."
         },
         {
           "date": "2006-05-01",
@@ -10433,7 +10433,7 @@
         },
         {
           "date": "2006-05-01",
-          "text": "If damage that would be dealt to a player or creature is affected by both Anthem of Rakdos and a damage prevention effect, that player or that creature’s controller chooses the order to apply the effects. In most cases that player will want to prevent damage, then double what’s left."
+          "text": "If damage that would be dealt to a player or creature is affected by both Anthem of Rakdos and a damage prevention effect, that player or that creature's controller chooses the order to apply the effects. In most cases that player will want to prevent damage, then double what's left."
         },
         {
           "date": "2006-05-01",
@@ -10642,7 +10642,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "This ability will trigger whenever any permanent, including a token creature or Azorius Aethermage itself, is returned to your hand. It doesn’t matter who controlled the permanent or if it had ever actually been in your hand before."
+          "text": "This ability will trigger whenever any permanent, including a token creature or Azorius Aethermage itself, is returned to your hand. It doesn't matter who controlled the permanent or if it had ever actually been in your hand before."
         }
       ],
       "subtypes": [
@@ -10751,7 +10751,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "“Protection from enchantments” means that Azorius First-Wing can’t be enchanted, it can’t be targeted by Aura spells or by abilities of enchantments, all damage that would be dealt to it by enchantments is prevented, and it can’t be blocked by creatures that are also enchantments."
+          "text": "\"Protection from enchantments\" means that Azorius First-Wing can't be enchanted, it can't be targeted by Aura spells or by abilities of enchantments, all damage that would be dealt to it by enchantments is prevented, and it can't be blocked by creatures that are also enchantments."
         },
         {
           "date": "2006-05-01",
@@ -10759,7 +10759,7 @@
         },
         {
           "date": "2006-05-01",
-          "text": "Azorius First-Wing doesn’t have protection from creatures that are enchanted."
+          "text": "Azorius First-Wing doesn't have protection from creatures that are enchanted."
         }
       ],
       "subtypes": [
@@ -11079,19 +11079,19 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "Only the creature that’s becoming a copy is targeted. The creature that it will copy isn’t chosen until Cytoshape resolves."
+          "text": "Only the creature that's becoming a copy is targeted. The creature that it will copy isn't chosen until Cytoshape resolves."
         },
         {
           "date": "2006-05-01",
-          "text": "The creature copies the printed values of the chosen creature, plus any copy effects that have been applied to it. It won’t copy counters on that creature. It won’t copy effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "The creature copies the printed values of the chosen creature, plus any copy effects that have been applied to it. It won't copy counters on that creature. It won't copy effects that have changed the creature's power, toughness, types, color, or so on."
         },
         {
           "date": "2006-05-01",
-          "text": "If the creature copies a creature that’s copying a creature, it will become whatever the chosen creature is copying."
+          "text": "If the creature copies a creature that's copying a creature, it will become whatever the chosen creature is copying."
         },
         {
           "date": "2006-05-01",
-          "text": "If the creature becomes a copy of a face-down creature, it will become a 2/2 creature with no name, creature type, abilities, mana cost, or color. It will not become face-down and thus can’t be turned face up."
+          "text": "If the creature becomes a copy of a face-down creature, it will become a 2/2 creature with no name, creature type, abilities, mana cost, or color. It will not become face-down and thus can't be turned face up."
         },
         {
           "date": "2006-05-01",
@@ -11103,11 +11103,11 @@
         },
         {
           "date": "2006-05-01",
-          "text": "A creature may become a copy of itself this way. This generally won’t have any visible effect."
+          "text": "A creature may become a copy of itself this way. This generally won't have any visible effect."
         },
         {
           "date": "2006-05-01",
-          "text": "At the end of the turn, the creature reverts to what it was before. If two Cytoshapes affect the same creature on the same turn, they’ll both wear off at the same time."
+          "text": "At the end of the turn, the creature reverts to what it was before. If two Cytoshapes affect the same creature on the same turn, they'll both wear off at the same time."
         }
       ],
       "text": "Choose a nonlegendary creature on the battlefield. Target creature becomes a copy of that creature until end of turn.",
@@ -11317,7 +11317,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -11749,7 +11749,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The card is named when the ability resolves. The named card can’t be played after it’s named but before the player’s hand is revealed."
+          "text": "The card is named when the ability resolves. The named card can't be played after it's named but before the player's hand is revealed."
         }
       ],
       "subtypes": [
@@ -12069,7 +12069,7 @@
         },
         {
           "date": "2006-05-01",
-          "text": "You must choose a target for the ability, even if the creature you sacrifice isn’t red. If the target becomes illegal before the ability resolves, the ability will be countered; you won’t draw a card, even if the creature you sacrificed was black."
+          "text": "You must choose a target for the ability, even if the creature you sacrifice isn't red. If the target becomes illegal before the ability resolves, the ability will be countered; you won't draw a card, even if the creature you sacrificed was black."
         }
       ],
       "subtypes": [
@@ -12297,7 +12297,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the target creature is affected by any effects that modify its power or toughness without setting them to specific values (such as from Giant Growth), Omnibian’s effect will be applied before those effects. In the example given, the creature will be 6/6."
+          "text": "If the target creature is affected by any effects that modify its power or toughness without setting them to specific values (such as from Giant Growth), Omnibian's effect will be applied before those effects. In the example given, the creature will be 6/6."
         },
         {
           "date": "2013-04-15",
@@ -12409,7 +12409,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "You gain the life whether or not the spell’s controller pays {X} and whether or not the spell is countered."
+          "text": "You gain the life whether or not the spell's controller pays {X} and whether or not the spell is countered."
         }
       ],
       "text": "Counter target spell unless its controller pays {X}. You gain X life.",
@@ -12512,7 +12512,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "This triggers only if all 3 or more damage is dealt at the same time. It doesn’t trigger if damage that adds up to 3 or more is dealt at different times by the same source."
+          "text": "This triggers only if all 3 or more damage is dealt at the same time. It doesn't trigger if damage that adds up to 3 or more is dealt at different times by the same source."
         },
         {
           "date": "2006-05-01",
@@ -13327,11 +13327,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "To calculate the number of permanents that must be sacrificed, count the number of permanents the affected player controls that don’t have the subtype Demon, then divide that number in half and round up. For example, a player who controls eleven non-Demon permanents will need to sacrifice six of them."
+          "text": "To calculate the number of permanents that must be sacrificed, count the number of permanents the affected player controls that don't have the subtype Demon, then divide that number in half and round up. For example, a player who controls eleven non-Demon permanents will need to sacrifice six of them."
         },
         {
           "date": "2006-05-01",
-          "text": "A permanent with the subtype Demon, including Rakdos the Defiler itself, can’t be sacrificed this way."
+          "text": "A permanent with the subtype Demon, including Rakdos the Defiler itself, can't be sacrificed this way."
         }
       ],
       "subtypes": [
@@ -13948,7 +13948,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "Even though this creature can’t attack, it doesn’t have defender."
+          "text": "Even though this creature can't attack, it doesn't have defender."
         }
       ],
       "subtypes": [
@@ -14153,7 +14153,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Counter target spell, activated ability, or triggered ability. (Mana abilities can't be targeted.)",
@@ -14261,7 +14261,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -14574,7 +14574,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -14785,7 +14785,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The Bird tokens are created even if the spell isn’t countered by Dovescape’s ability. This may happen because the spell can’t be countered, because it’s already been countered, or because it’s otherwise been removed from the stack by the time Dovescape’s ability resolves."
+          "text": "The Bird tokens are created even if the spell isn't countered by Dovescape's ability. This may happen because the spell can't be countered, because it's already been countered, or because it's otherwise been removed from the stack by the time Dovescape's ability resolves."
         },
         {
           "date": "2006-05-01",
@@ -14997,7 +14997,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If the second ability is activated during the End step, the token won’t be exiled until the following turn’s End step."
+          "text": "If the second ability is activated during the End step, the token won't be exiled until the following turn's End step."
         }
       ],
       "subtypes": [
@@ -15204,7 +15204,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "This is not the same as hexproof. If, for example, you target one of your opponent’s creatures, your opponents won’t be able to target their own creature with spells or abilities."
+          "text": "This is not the same as hexproof. If, for example, you target one of your opponent's creatures, your opponents won't be able to target their own creature with spells or abilities."
         }
       ],
       "subtypes": [
@@ -15310,15 +15310,15 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "For the first ability, the first target creature doesn’t need to have a +1/+1 counter on it. If it doesn’t, the ability does nothing."
+          "text": "For the first ability, the first target creature doesn't need to have a +1/+1 counter on it. If it doesn't, the ability does nothing."
         },
         {
           "date": "2006-05-01",
-          "text": "For the first ability, if the two target creatures aren’t controlled by the same player when the ability resolves, the ability does nothing. The player who controls the two creatures doesn’t have to be the same player who controlled them when the ability was activated, and that player doesn’t have to be Simic Guildmage’s controller."
+          "text": "For the first ability, if the two target creatures aren't controlled by the same player when the ability resolves, the ability does nothing. The player who controls the two creatures doesn't have to be the same player who controlled them when the ability was activated, and that player doesn't have to be Simic Guildmage's controller."
         },
         {
           "date": "2006-05-01",
-          "text": "For the second ability, only the Aura is targeted. When the ability resolves, you choose a permanent to move the Aura onto. It can’t be the permanent the Aura is already attached to, it must be controlled by the player who controls the permanent the Aura is attached to, and it must be able to be enchanted by the Aura. (It doesn’t matter who controls the Aura or who controls Simic Guildmage.) If no such permanent exists, the Aura doesn’t move."
+          "text": "For the second ability, only the Aura is targeted. When the ability resolves, you choose a permanent to move the Aura onto. It can't be the permanent the Aura is already attached to, it must be controlled by the player who controls the permanent the Aura is attached to, and it must be able to be enchanted by the Aura. (It doesn't matter who controls the Aura or who controls Simic Guildmage.) If no such permanent exists, the Aura doesn't move."
         }
       ],
       "subtypes": [
@@ -15429,11 +15429,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The creature is sacrificed when Bound resolves. It’s not an additional cost. It’s not optional. If you can’t sacrifice a creature or a colorless creature is sacrificed, no cards are returned."
+          "text": "The creature is sacrificed when Bound resolves. It's not an additional cost. It's not optional. If you can't sacrifice a creature or a colorless creature is sacrificed, no cards are returned."
         },
         {
           "date": "2006-05-01",
-          "text": "The cards in the graveyard that you return as part of Bound’s effect aren’t targeted. They’re chosen when the spell resolves. The creature you sacrificed may be one of them."
+          "text": "The cards in the graveyard that you return as part of Bound's effect aren't targeted. They're chosen when the spell resolves. The creature you sacrificed may be one of them."
         }
       ],
       "text": "Sacrifice a creature. Return up to X cards from your graveyard to your hand, where X is the number of colors that creature was. Exile this card.",
@@ -15539,11 +15539,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The creature is sacrificed when Bound resolves. It’s not an additional cost. It’s not optional. If you can’t sacrifice a creature or a colorless creature is sacrificed, no cards are returned."
+          "text": "The creature is sacrificed when Bound resolves. It's not an additional cost. It's not optional. If you can't sacrifice a creature or a colorless creature is sacrificed, no cards are returned."
         },
         {
           "date": "2006-05-01",
-          "text": "The cards in the graveyard that you return as part of Bound’s effect aren’t targeted. They’re chosen when the spell resolves. The creature you sacrificed may be one of them."
+          "text": "The cards in the graveyard that you return as part of Bound's effect aren't targeted. They're chosen when the spell resolves. The creature you sacrificed may be one of them."
         }
       ],
       "text": "Sacrifice a creature. Return up to X cards from your graveyard to your hand, where X is the number of colors that creature was. Exile this card.",
@@ -16249,7 +16249,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The Odds coin flip has no winner or loser, and no player calls “heads” or “tails.”"
+          "text": "The Odds coin flip has no winner or loser, and no player calls \"heads\" or \"tails.\""
         }
       ],
       "text": "Flip a coin. If it comes up heads, counter target instant or sorcery spell. If it comes up tails, copy that spell and you may choose new targets for the copy.",
@@ -16355,7 +16355,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "The Odds coin flip has no winner or loser, and no player calls “heads” or “tails.”"
+          "text": "The Odds coin flip has no winner or loser, and no player calls \"heads\" or \"tails.\""
         }
       ],
       "text": "Flip a coin. If it comes up heads, counter target instant or sorcery spell. If it comes up tails, copy that spell and you may choose new targets for the copy.",
@@ -16661,11 +16661,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A card “from outside the game” may be a card from your collection or a card from your sideboard. In tournament play, you can’t choose a card from your collection. The cards you choose don’t all have to come from the same place."
+          "text": "A card \"from outside the game\" may be a card from your collection or a card from your sideboard. In tournament play, you can't choose a card from your collection. The cards you choose don't all have to come from the same place."
         },
         {
           "date": "2009-10-01",
-          "text": "The exile zone is a part of the game, so you can’t get exiled cards."
+          "text": "The exile zone is a part of the game, so you can't get exiled cards."
         }
       ],
       "text": "Choose up to four cards you own from outside the game and shuffle them into your library.",
@@ -16771,11 +16771,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A card “from outside the game” may be a card from your collection or a card from your sideboard. In tournament play, you can’t choose a card from your collection. The cards you choose don’t all have to come from the same place."
+          "text": "A card \"from outside the game\" may be a card from your collection or a card from your sideboard. In tournament play, you can't choose a card from your collection. The cards you choose don't all have to come from the same place."
         },
         {
           "date": "2009-10-01",
-          "text": "The exile zone is a part of the game, so you can’t get exiled cards."
+          "text": "The exile zone is a part of the game, so you can't get exiled cards."
         }
       ],
       "text": "Choose up to four cards you own from outside the game and shuffle them into your library.",
@@ -17570,11 +17570,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "This ability is a state trigger. Once it triggers, it won’t trigger again while the ability is on the stack. If the triggered ability leaves the stack and the creature is still on the battlefield under the control of a player other than its owner, the ability will immediately trigger again."
+          "text": "This ability is a state trigger. Once it triggers, it won't trigger again while the ability is on the stack. If the triggered ability leaves the stack and the creature is still on the battlefield under the control of a player other than its owner, the ability will immediately trigger again."
         },
         {
           "date": "2006-05-01",
-          "text": "Bronze Bombshell deals 7 damage only if it was sacrificed as a result of its ability. If it leaves the battlefield or changes controllers before the ability resolves, it can’t be sacrificed and won’t deal damage."
+          "text": "Bronze Bombshell deals 7 damage only if it was sacrificed as a result of its ability. If it leaves the battlefield or changes controllers before the ability resolves, it can't be sacrificed and won't deal damage."
         }
       ],
       "subtypes": [
@@ -17766,11 +17766,11 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If an activated ability with {T} in its cost is granted to a creature by an effect (such as Hypervolt Grasp’s effect, for instance), Magewright’s Stone can untap that creature."
+          "text": "If an activated ability with {T} in its cost is granted to a creature by an effect (such as Hypervolt Grasp's effect, for instance), Magewright's Stone can untap that creature."
         },
         {
           "date": "2006-05-01",
-          "text": "This looks for the {T} symbol. The phrase “tap an untapped creature you control” isn’t the same and doesn’t count."
+          "text": "This looks for the {T} symbol. The phrase \"tap an untapped creature you control\" isn't the same and doesn't count."
         }
       ],
       "text": "{1}, {T}: Untap target creature that has an activated ability with {T} in its cost.",
@@ -18352,7 +18352,7 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "Transguild Courier appears in a multicolored card frame, but it’s still an artifact."
+          "text": "Transguild Courier appears in a multicolored card frame, but it's still an artifact."
         },
         {
           "date": "2011-09-22",
@@ -18360,7 +18360,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -18665,15 +18665,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -18779,15 +18779,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -18893,15 +18893,15 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won’t get to search for a land card."
+          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won't get to search for a land card."
         },
         {
           "date": "2011-09-22",
-          "text": "If the targeted land is an illegal target by the time Ghost Quarter’s ability resolves, it will be countered and none of its effects will happen. The land’s controller won’t get to search for a basic land card."
+          "text": "If the targeted land is an illegal target by the time Ghost Quarter's ability resolves, it will be countered and none of its effects will happen. The land's controller won't get to search for a basic land card."
         },
         {
           "date": "2013-07-01",
-          "text": "The target land’s controller gets to search for a basic land card even if that land wasn’t destroyed by Ghost Quarter’s ability. This may happen because the land has indestructible or because it was regenerated."
+          "text": "The target land's controller gets to search for a basic land card even if that land wasn't destroyed by Ghost Quarter's ability. This may happen because the land has indestructible or because it was regenerated."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it onto the battlefield, then shuffle his or her library.",
@@ -19002,15 +19002,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [

--- a/json/DKA.json
+++ b/json/DKA.json
@@ -25,7 +25,10 @@
     "common",
     "common",
     "land",
-    "marketing"
+    [
+      "marketing",
+      "checklist"
+    ]
   ],
   "translations": {
     "de": "Dunkles Erwachen",
@@ -143,11 +146,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Archangel’s Light isn’t put into the graveyard until after its instructions are followed. You won’t gain 2 life for it, and it won’t be shuffled into your library."
+          "text": "Archangel's Light isn't put into the graveyard until after its instructions are followed. You won't gain 2 life for it, and it won't be shuffled into your library."
         },
         {
           "date": "2011-01-22",
-          "text": "If you have no cards in your graveyard, you won’t gain any life, but you’ll still shuffle your library."
+          "text": "If you have no cards in your graveyard, you won't gain any life, but you'll still shuffle your library."
         }
       ],
       "text": "You gain 2 life for each card in your graveyard, then shuffle your graveyard into your library.",
@@ -360,7 +363,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Because Break of Day affects only creatures you control when it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Because Break of Day affects only creatures you control when it resolves. It won't affect creatures that come under your control later in the turn."
         },
         {
           "date": "2013-07-01",
@@ -474,7 +477,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Only Burden of Guilt’s controller can activate its ability."
+          "text": "Only Burden of Guilt's controller can activate its ability."
         }
       ],
       "subtypes": [
@@ -587,7 +590,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Curse of Exhaustion will look at the entire turn to see if the enchanted player has cast a spell yet that turn, even if Curse of Exhaustion wasn’t on the battlefield when that spell was cast."
+          "text": "Curse of Exhaustion will look at the entire turn to see if the enchanted player has cast a spell yet that turn, even if Curse of Exhaustion wasn't on the battlefield when that spell was cast."
         }
       ],
       "subtypes": [
@@ -810,15 +813,15 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Faith’s Shield targets a permanent regardless of how much life you have. If that permanent is an illegal target when Faith’s Shield tries to resolve, Faith’s Shield will be countered and none of its effects will happen. Neither you nor any of your permanents will gain protection from a color."
+          "text": "Faith's Shield targets a permanent regardless of how much life you have. If that permanent is an illegal target when Faith's Shield tries to resolve, Faith's Shield will be countered and none of its effects will happen. Neither you nor any of your permanents will gain protection from a color."
         },
         {
           "date": "2011-01-22",
-          "text": "You choose only one color (not one color per player and permanent). You choose the color as Faith’s Shield resolves."
+          "text": "You choose only one color (not one color per player and permanent). You choose the color as Faith's Shield resolves."
         },
         {
           "date": "2011-01-22",
-          "text": "A player with protection from a color can’t be damaged, enchanted (including by Curses), or targeted by anything of that color."
+          "text": "A player with protection from a color can't be damaged, enchanted (including by Curses), or targeted by anything of that color."
         }
       ],
       "text": "Target permanent you control gains protection from the color of your choice until end of turn.\nFateful hour — If you have 5 or less life, instead you and each permanent you control gain protection from the color of your choice until end of turn.",
@@ -1146,15 +1149,15 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Removing an attacking creature from combat doesn’t untap that creature."
+          "text": "Removing an attacking creature from combat doesn't untap that creature."
         },
         {
           "date": "2011-01-22",
-          "text": "Removing a blocking creature from combat doesn’t cause the creature it was blocking to become unblocked. If no other creatures are blocking that attacking creature, it won’t assign combat damage (unless it has trample)."
+          "text": "Removing a blocking creature from combat doesn't cause the creature it was blocking to become unblocked. If no other creatures are blocking that attacking creature, it won't assign combat damage (unless it has trample)."
         },
         {
           "date": "2011-01-22",
-          "text": "If there are multiple combat phases in a turn, a creature that’s been removed from combat can still attack or block in future combat phases that turn."
+          "text": "If there are multiple combat phases in a turn, a creature that's been removed from combat can still attack or block in future combat phases that turn."
         }
       ],
       "subtypes": [
@@ -1487,7 +1490,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "When Loyal Cathar dies, it will return to the battlefield with its back face (Unhallowed Cathar) up. It doesn’t return to the battlefield and then transform."
+          "text": "When Loyal Cathar dies, it will return to the battlefield with its back face (Unhallowed Cathar) up. It doesn't return to the battlefield and then transform."
         },
         {
           "date": "2011-01-22",
@@ -1495,11 +1498,11 @@
         },
         {
           "date": "2011-01-22",
-          "text": "If you gain control of a Loyal Cathar owned by another player and it dies, it will be put into to its owner’s graveyard and then return to the battlefield under your control."
+          "text": "If you gain control of a Loyal Cathar owned by another player and it dies, it will be put into to its owner's graveyard and then return to the battlefield under your control."
         },
         {
           "date": "2016-04-08",
-          "text": "If a card that isn’t a double-faced card becomes a copy of Loyal Cathar (due to Cytoshape, for example) and then dies, that card won’t return to the battlefield. It will remain in its owner’s graveyard."
+          "text": "If a card that isn't a double-faced card becomes a copy of Loyal Cathar (due to Cytoshape, for example) and then dies, that card won't return to the battlefield. It will remain in its owner's graveyard."
         },
         {
           "date": "2016-07-13",
@@ -2388,11 +2391,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The token doesn’t have haste (unless the card it’s copying has haste) and usually won’t be able to attack."
+          "text": "The token doesn't have haste (unless the card it's copying has haste) and usually won't be able to attack."
         },
         {
           "date": "2017-03-14",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-03-14",
@@ -2400,7 +2403,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The delayed triggered ability that exiles the token isn’t a characteristic of the token. If an effect such as populate copies the token, the new copy won’t be exiled."
+          "text": "The delayed triggered ability that exiles the token isn't a characteristic of the token. If an effect such as populate copies the token, the new copy won't be exiled."
         },
         {
           "date": "2017-03-14",
@@ -2408,7 +2411,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         }
       ],
       "text": "At the beginning of each upkeep, you may exile target creature card from your graveyard. If you do, create a token that's a copy of that card, except it's a Spirit in addition to its other types. Exile it at the beginning of the next end step.",
@@ -2730,7 +2733,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If Sudden Disappearance’s delayed triggered ability is countered or otherwise removed from the stack after triggering, the exiled cards will remain in exile indefinitely. The delayed triggered ability will only trigger once."
+          "text": "If Sudden Disappearance's delayed triggered ability is countered or otherwise removed from the stack after triggering, the exiled cards will remain in exile indefinitely. The delayed triggered ability will only trigger once."
         }
       ],
       "text": "Exile all nonland permanents target player controls. Return the exiled cards to the battlefield under their owner's control at the beginning of the next end step.",
@@ -2835,21 +2838,22 @@
       "originalType": "Legendary Creature — Human Soldier",
       "power": "2",
       "printings": [
-        "DKA"
+        "DKA",
+        "pWCQ"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The ability affects each spell that’s not a creature spell, including your own."
+          "text": "The ability affects each spell that's not a creature spell, including your own."
         },
         {
           "date": "2011-01-22",
-          "text": "The ability affects the total cost of each noncreature spell, but it doesn’t change that spell’s mana cost or converted mana cost."
+          "text": "The ability affects the total cost of each noncreature spell, but it doesn't change that spell's mana cost or converted mana cost."
         },
         {
           "date": "2011-01-22",
-          "text": "When determining a spell’s total cost, effects that increase the cost are applied before effects that reduce the cost."
+          "text": "When determining a spell's total cost, effects that increase the cost are applied before effects that reduce the cost."
         }
       ],
       "subtypes": [
@@ -2968,11 +2972,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "A creature whose toughness is being increased by Thraben Doomsayer’s fateful hour ability loses that bonus as soon as its controller has 6 or more life (or as soon as Thraben Doomsayer leaves the battlefield). If damage marked on that creature is greater than or equal to its toughness after the fateful hour ability stops applying, the creature is destroyed and put into its owner’s graveyard."
+          "text": "A creature whose toughness is being increased by Thraben Doomsayer's fateful hour ability loses that bonus as soon as its controller has 6 or more life (or as soon as Thraben Doomsayer leaves the battlefield). If damage marked on that creature is greater than or equal to its toughness after the fateful hour ability stops applying, the creature is destroyed and put into its owner's graveyard."
         },
         {
           "date": "2011-01-22",
-          "text": "If Thraben Doomsayer’s activated ability resolves while you have 5 or less life, the creature token will be 3/3 as it enters the battlefield."
+          "text": "If Thraben Doomsayer's activated ability resolves while you have 5 or less life, the creature token will be 3/3 as it enters the battlefield."
         }
       ],
       "subtypes": [
@@ -3423,11 +3427,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If the creature spell is an illegal target (because it’s left the stack, for example) when Bone to Ash tries to resolve, Bone to Ash will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the creature spell is an illegal target (because it's left the stack, for example) when Bone to Ash tries to resolve, Bone to Ash will be countered and none of its effects will happen. You won't draw a card."
         },
         {
           "date": "2011-01-22",
-          "text": "A creature spell that can’t be countered by spells and abilities is a legal target for Bone to Ash. The creature spell won’t be countered when Bone to Ash resolves, but you’ll still draw a card."
+          "text": "A creature spell that can't be countered by spells and abilities is a legal target for Bone to Ash. The creature spell won't be countered when Bone to Ash resolves, but you'll still draw a card."
         }
       ],
       "text": "Counter target creature spell.\nDraw a card.",
@@ -3649,7 +3653,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "A creature with power 0 or less assigns no combat damage. (It doesn’t assign a negative amount of combat damage.)"
+          "text": "A creature with power 0 or less assigns no combat damage. (It doesn't assign a negative amount of combat damage.)"
         }
       ],
       "subtypes": [
@@ -3866,11 +3870,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "You cast the card in your hand as part of the resolution of Counterlash. Timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other restrictions are not (such as “Cast [this card] only during combat”)."
+          "text": "You cast the card in your hand as part of the resolution of Counterlash. Timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other restrictions are not (such as \"Cast [this card] only during combat\")."
         },
         {
           "date": "2011-01-22",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs, such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs, such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2011-01-22",
@@ -3983,19 +3987,19 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "When the triggered ability resolves, it creates a copy of that spell for each other player. The active player creates his or her copy and may choose new targets first (if that player isn’t the enchanted player), then each other player (except the enchanted player) creates his or her copy and may choose new targets in turn order. The last player who creates his or her copy controls the copy that will resolve first."
+          "text": "When the triggered ability resolves, it creates a copy of that spell for each other player. The active player creates his or her copy and may choose new targets first (if that player isn't the enchanted player), then each other player (except the enchanted player) creates his or her copy and may choose new targets in turn order. The last player who creates his or her copy controls the copy that will resolve first."
         },
         {
           "date": "2011-01-22",
-          "text": "All the copies are created on the stack, so none of them are cast. Abilities that trigger when a player casts a spell won’t trigger. The copies will then resolve as normal, after players get a chance to cast spells and activate abilities."
+          "text": "All the copies are created on the stack, so none of them are cast. Abilities that trigger when a player casts a spell won't trigger. The copies will then resolve as normal, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2011-01-22",
-          "text": "Each copy will have the same targets as the spell it’s copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. If, for one of the targets, that player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "Each copy will have the same targets as the spell it's copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. If, for one of the targets, that player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2011-01-22",
-          "text": "If the original spell is modal (that is, it says “Choose one —” or the like), each copy will have the same mode(s). You can’t choose different ones."
+          "text": "If the original spell is modal (that is, it says \"Choose one —\" or the like), each copy will have the same mode(s). You can't choose different ones."
         },
         {
           "date": "2011-01-22",
@@ -4003,7 +4007,7 @@
         },
         {
           "date": "2011-01-22",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if the enchanted player sacrifices a 3/3 creature to cast Fling, each copy of Fling will also deal 3 damage."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if the enchanted player sacrifices a 3/3 creature to cast Fling, each copy of Fling will also deal 3 damage."
         }
       ],
       "subtypes": [
@@ -4238,11 +4242,11 @@
         },
         {
           "date": "2011-01-22",
-          "text": "If you gain control of the creature that’s being prevented from untapping, that creature won’t untap during your untap step for as long as you control Dungeon Geists."
+          "text": "If you gain control of the creature that's being prevented from untapping, that creature won't untap during your untap step for as long as you control Dungeon Geists."
         },
         {
           "date": "2013-04-15",
-          "text": "The ability can target a tapped creature. If the targeted creature is already tapped when it resolves, that creature just remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "The ability can target a tapped creature. If the targeted creature is already tapped when it resolves, that creature just remains tapped and doesn't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -4577,7 +4581,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Although players may respond to the activated ability, they can’t respond to the paying of its costs. The creature card will already be exiled by the time any player could respond."
+          "text": "Although players may respond to the activated ability, they can't respond to the paying of its costs. The creature card will already be exiled by the time any player could respond."
         },
         {
           "date": "2011-01-22",
@@ -4815,7 +4819,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Regardless of which zone Increasing Confusion is cast from, it puts cards from the top of target player’s library into that player’s graveyard."
+          "text": "Regardless of which zone Increasing Confusion is cast from, it puts cards from the top of target player's library into that player's graveyard."
         }
       ],
       "text": "Target player puts the top X cards of his or her library into his or her graveyard. If Increasing Confusion was cast from a graveyard, that player puts twice that many cards into his or her graveyard instead.\nFlashback {X}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -4926,7 +4930,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Mystic Retrieval can’t target itself. It’s on the stack when you choose its target."
+          "text": "Mystic Retrieval can't target itself. It's on the stack when you choose its target."
         }
       ],
       "text": "Return target instant or sorcery card from your graveyard to your hand.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -5256,7 +5260,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "When Relentless Skaabs returns to the battlefield because of its undying ability, it’s not being cast. You won’t exile a creature card from your graveyard."
+          "text": "When Relentless Skaabs returns to the battlefield because of its undying ability, it's not being cast. You won't exile a creature card from your graveyard."
         },
         {
           "date": "2013-04-15",
@@ -5601,7 +5605,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Secrets of the Dead’s triggered ability resolves before the spell you cast from your graveyard does."
+          "text": "Secrets of the Dead's triggered ability resolves before the spell you cast from your graveyard does."
         }
       ],
       "text": "Whenever you cast a spell from your graveyard, draw a card.",
@@ -5824,15 +5828,15 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "You choose the target for Soul Seizer’s triggered ability when that ability triggers and goes on the stack. You choose whether or not to transform it when that ability resolves. If the creature is an illegal target by that time, the ability is countered and none of its effects happen. You can’t have Soul Seizer transform."
+          "text": "You choose the target for Soul Seizer's triggered ability when that ability triggers and goes on the stack. You choose whether or not to transform it when that ability resolves. If the creature is an illegal target by that time, the ability is countered and none of its effects happen. You can't have Soul Seizer transform."
         },
         {
           "date": "2011-01-22",
-          "text": "If Soul Seizer leaves the battlefield in response to its triggered ability, you won’t be able to transform it and it won’t return to the battlefield or become attached to the target."
+          "text": "If Soul Seizer leaves the battlefield in response to its triggered ability, you won't be able to transform it and it won't return to the battlefield or become attached to the target."
         },
         {
           "date": "2011-01-22",
-          "text": "If Soul Seizer has any +1/+1 counters on it when it transforms, they remain on Ghastly Haunting. They won’t affect the power or toughness of the enchanted creature, however."
+          "text": "If Soul Seizer has any +1/+1 counters on it when it transforms, they remain on Ghastly Haunting. They won't affect the power or toughness of the enchanted creature, however."
         },
         {
           "date": "2016-07-13",
@@ -6169,11 +6173,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If the target player is an illegal target when Thought Scour tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the target player is an illegal target when Thought Scour tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         },
         {
           "date": "2011-01-22",
-          "text": "Follow the instructions in the order listed on the card: if you target yourself, you’ll put the top two cards of your library into your graveyard and then draw a card."
+          "text": "Follow the instructions in the order listed on the card: if you target yourself, you'll put the top two cards of your library into your graveyard and then draw a card."
         }
       ],
       "text": "Target player puts the top two cards of his or her library into his or her graveyard.\nDraw a card.",
@@ -6286,7 +6290,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If there’s only one card in your library when Tower Geist enters the battlefield, you’ll look at that card and put it into your hand."
+          "text": "If there's only one card in your library when Tower Geist enters the battlefield, you'll look at that card and put it into your hand."
         }
       ],
       "subtypes": [
@@ -6516,7 +6520,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "You can tap any untapped Vampire you control, including one you haven’t controlled continuously since the beginning of your most recent turn, to pay the cost of Chosen of Markov’s activated ability. You must have controlled Chosen of Markov continuously since the beginning of your most recent turn, however."
+          "text": "You can tap any untapped Vampire you control, including one you haven't controlled continuously since the beginning of your most recent turn, to pay the cost of Chosen of Markov's activated ability. You must have controlled Chosen of Markov continuously since the beginning of your most recent turn, however."
         },
         {
           "date": "2016-07-13",
@@ -7087,11 +7091,11 @@
         },
         {
           "date": "2011-01-22",
-          "text": "If the target creature isn’t on the battlefield or is otherwise an illegal target when Death’s Caress tries to resolve, Death’s Caress is countered and none of its effects will happen. You won’t gain any life."
+          "text": "If the target creature isn't on the battlefield or is otherwise an illegal target when Death's Caress tries to resolve, Death's Caress is countered and none of its effects will happen. You won't gain any life."
         },
         {
           "date": "2013-07-01",
-          "text": "If Death’s Caress resolves but the target creature isn’t destroyed, perhaps because it has indestructible or it regenerated, you still check if it’s a Human. If so, you’ll gain life equal to its toughness."
+          "text": "If Death's Caress resolves but the target creature isn't destroyed, perhaps because it has indestructible or it regenerated, you still check if it's a Human. If so, you'll gain life equal to its toughness."
         }
       ],
       "text": "Destroy target creature. If that creature was a Human, you gain life equal to its toughness.",
@@ -7202,7 +7206,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The ability checks whether the sacrificed creature as it last existed on the battlefield was a Human. (It doesn’t matter what its creature types are in the graveyard.)"
+          "text": "The ability checks whether the sacrificed creature as it last existed on the battlefield was a Human. (It doesn't matter what its creature types are in the graveyard.)"
         },
         {
           "date": "2011-01-22",
@@ -7322,7 +7326,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Farbog Boneflinger’s ability is mandatory. If it’s the only creature on the battlefield, you must choose it as the target and give it -2/-2 until end of turn."
+          "text": "Farbog Boneflinger's ability is mandatory. If it's the only creature on the battlefield, you must choose it as the target and give it -2/-2 until end of turn."
         }
       ],
       "subtypes": [
@@ -7440,7 +7444,7 @@
         },
         {
           "date": "2011-01-22",
-          "text": "You may only play the card, meaning play it as a land or cast it as a spell. It’s not in your hand. You can’t discard it, activate its cycling abilities, and so on."
+          "text": "You may only play the card, meaning play it as a land or cast it as a spell. It's not in your hand. You can't discard it, activate its cycling abilities, and so on."
         },
         {
           "date": "2011-01-22",
@@ -7674,11 +7678,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Gravecrawler’s ability doesn’t change when you could cast it."
+          "text": "Gravecrawler's ability doesn't change when you could cast it."
         },
         {
           "date": "2011-01-22",
-          "text": "Once you’ve cast Gravecrawler and it’s on the stack, it doesn’t matter if you lose control of the other Zombie."
+          "text": "Once you've cast Gravecrawler and it's on the stack, it doesn't matter if you lose control of the other Zombie."
         }
       ],
       "subtypes": [
@@ -7801,15 +7805,15 @@
         },
         {
           "date": "2011-01-22",
-          "text": "You can cast Gravepurge with zero targets. If you do, you’ll draw a card as the spell resolves."
+          "text": "You can cast Gravepurge with zero targets. If you do, you'll draw a card as the spell resolves."
         },
         {
           "date": "2011-01-22",
-          "text": "If you cast Gravepurge with at least one target and all of those targets become illegal, the spell will be countered and you won’t get to draw a card."
+          "text": "If you cast Gravepurge with at least one target and all of those targets become illegal, the spell will be countered and you won't get to draw a card."
         },
         {
           "date": "2015-02-25",
-          "text": "You can cast Gravepurge with no targets. If you do, you’ll just draw a card. However, if you cast it with at least one target and all of those targets become illegal, the spell will be countered and you won’t draw a card."
+          "text": "You can cast Gravepurge with no targets. If you do, you'll just draw a card. However, if you cast it with at least one target and all of those targets become illegal, the spell will be countered and you won't draw a card."
         }
       ],
       "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
@@ -8338,15 +8342,15 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Noncombat damage dealt to you by a Human and damage dealt to you by a Human you control will also cause Mikaeus’s triggered ability to trigger."
+          "text": "Noncombat damage dealt to you by a Human and damage dealt to you by a Human you control will also cause Mikaeus's triggered ability to trigger."
         },
         {
           "date": "2011-01-22",
-          "text": "The +1/+1 bonus that Mikaeus gives to other non-Human creatures is not a counter and won’t prevent the undying ability from working."
+          "text": "The +1/+1 bonus that Mikaeus gives to other non-Human creatures is not a counter and won't prevent the undying ability from working."
         },
         {
           "date": "2011-01-22",
-          "text": "Mikaeus, the Unhallowed and the Innistrad set’s Mikaeus, the Lunarch can be on the battlefield at the same time. The “legend rule” applies only to legendary permanents that have exactly the same name."
+          "text": "Mikaeus, the Unhallowed and the Innistrad set's Mikaeus, the Lunarch can be on the battlefield at the same time. The \"legend rule\" applies only to legendary permanents that have exactly the same name."
         }
       ],
       "subtypes": [
@@ -8917,7 +8921,7 @@
         },
         {
           "date": "2011-01-22",
-          "text": "Because targets are chosen before costs are paid, you can activate Skirsdag Flayer’s ability targeting itself and then sacrifice Skirsdag Flayer to pay the cost."
+          "text": "Because targets are chosen before costs are paid, you can activate Skirsdag Flayer's ability targeting itself and then sacrifice Skirsdag Flayer to pay the cost."
         }
       ],
       "subtypes": [
@@ -9698,19 +9702,19 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "You choose the target artifact when Werewolf Ransacker’s first triggered ability goes on the stack. You choose whether or not to destroy the artifact when that ability resolves."
+          "text": "You choose the target artifact when Werewolf Ransacker's first triggered ability goes on the stack. You choose whether or not to destroy the artifact when that ability resolves."
         },
         {
           "date": "2011-01-22",
-          "text": "An artifact token that’s destroyed is put into its owner’s graveyard before it ceases to exist. If a token is destroyed by Werewolf Ransacker ability, Werewolf Ransacker deals damage to that token’s controller."
+          "text": "An artifact token that's destroyed is put into its owner's graveyard before it ceases to exist. If a token is destroyed by Werewolf Ransacker ability, Werewolf Ransacker deals damage to that token's controller."
         },
         {
           "date": "2011-01-22",
-          "text": "If something becomes a copy of Werewolf Ransacker, that doesn’t count as “transforming into Werewolf Ransacker.” The first triggered ability of the new Werewolf Ransacker doesn’t trigger."
+          "text": "If something becomes a copy of Werewolf Ransacker, that doesn't count as \"transforming into Werewolf Ransacker.\" The first triggered ability of the new Werewolf Ransacker doesn't trigger."
         },
         {
           "date": "2013-07-01",
-          "text": "If the targeted artifact has indestructible or regenerates (or you choose not to destroy it), Werewolf Ransacker doesn’t deal damage to that artifact’s controller. Similarly, if the targeted artifact is destroyed but a replacement effect moves it to a different zone instead of its owner’s graveyard, Werewolf Ransacker doesn’t deal damage to that artifact’s controller."
+          "text": "If the targeted artifact has indestructible or regenerates (or you choose not to destroy it), Werewolf Ransacker doesn't deal damage to that artifact's controller. Similarly, if the targeted artifact is destroyed but a replacement effect moves it to a different zone instead of its owner's graveyard, Werewolf Ransacker doesn't deal damage to that artifact's controller."
         },
         {
           "date": "2016-07-13",
@@ -9940,7 +9944,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The two parts of Alpha Brawl’s effect happen sequentially: first the targeted creature deals damage, then the other creatures deal damage. State-based actions aren’t checked in the middle, so creatures that are dealt lethal damage by the targeted creature will still deal damage."
+          "text": "The two parts of Alpha Brawl's effect happen sequentially: first the targeted creature deals damage, then the other creatures deal damage. State-based actions aren't checked in the middle, so creatures that are dealt lethal damage by the targeted creature will still deal damage."
         },
         {
           "date": "2011-01-22",
@@ -9948,7 +9952,7 @@
         },
         {
           "date": "2011-01-22",
-          "text": "Combat abilities like first strike, double strike, and trample don’t apply and will have no impact on Alpha Brawl’s effect."
+          "text": "Combat abilities like first strike, double strike, and trample don't apply and will have no impact on Alpha Brawl's effect."
         },
         {
           "date": "2011-01-22",
@@ -10285,11 +10289,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Curse of Bloodletting works with any damage, not just combat damage. It also doesn’t matter who controls the source of the damage that’s being dealt."
+          "text": "Curse of Bloodletting works with any damage, not just combat damage. It also doesn't matter who controls the source of the damage that's being dealt."
         },
         {
           "date": "2011-01-22",
-          "text": "The source of the damage doesn’t change. A spell that deals damage will specify the source of the damage, often the spell itself. An ability that deals damage will also specify the source of the damage, although the ability itself will never be that source. Often the source of the ability is also the source of the damage."
+          "text": "The source of the damage doesn't change. A spell that deals damage will specify the source of the damage, often the spell itself. An ability that deals damage will also specify the source of the damage, although the ability itself will never be that source. Often the source of the ability is also the source of the damage."
         },
         {
           "date": "2011-01-22",
@@ -10297,11 +10301,11 @@
         },
         {
           "date": "2011-01-22",
-          "text": "If multiple effects modify how damage will be dealt to the enchanted player, that player chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn.” Suppose a spell would deal 5 damage to enchanted player and that player has cast Mending Hands targeting him or herself. The enchanted player can either (a) prevent 4 damage first and then let Curse of Bloodletting’s effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt to the enchanted player, that player chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn.\" Suppose a spell would deal 5 damage to enchanted player and that player has cast Mending Hands targeting him or herself. The enchanted player can either (a) prevent 4 damage first and then let Curse of Bloodletting's effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         },
         {
           "date": "2011-01-22",
-          "text": "If the enchanted player controls a planeswalker and noncombat damage is being dealt to the player from a source controlled by an opponent, the enchanted player will choose whether to apply Curse of Bloodletting or the planeswalker redirection effect first. If the player chooses to apply the planeswalker redirection effect first, and the opponent chooses to redirect the damage to the planeswalker, then Curse of Bloodletting won’t double the damage."
+          "text": "If the enchanted player controls a planeswalker and noncombat damage is being dealt to the player from a source controlled by an opponent, the enchanted player will choose whether to apply Curse of Bloodletting or the planeswalker redirection effect first. If the player chooses to apply the planeswalker redirection effect first, and the opponent chooses to redirect the damage to the planeswalker, then Curse of Bloodletting won't double the damage."
         }
       ],
       "subtypes": [
@@ -10416,7 +10420,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The +1/+1 counter isn’t put on the creature in time to increase the amount of combat damage dealt during that combat step."
+          "text": "The +1/+1 counter isn't put on the creature in time to increase the amount of combat damage dealt during that combat step."
         },
         {
           "date": "2011-01-22",
@@ -10754,15 +10758,15 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Flayer of the Hatebound’s last ability will trigger even if a creature enters the battlefield from your graveyard under another player’s control."
+          "text": "Flayer of the Hatebound's last ability will trigger even if a creature enters the battlefield from your graveyard under another player's control."
         },
         {
           "date": "2011-01-22",
-          "text": "The creature that entered the battlefield from your graveyard deals damage equal to its current power (including any +1/+1 counters it entered the battlefield with) to the target creature or player. If it’s no longer on the battlefield when the ability resolves, its last known existence on the battlefield is checked to determine its power."
+          "text": "The creature that entered the battlefield from your graveyard deals damage equal to its current power (including any +1/+1 counters it entered the battlefield with) to the target creature or player. If it's no longer on the battlefield when the ability resolves, its last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2011-01-22",
-          "text": "Flayer of the Hatebound is the source of the ability, but it may be another creature that is the source of the damage. If a black creature enters the battlefield from your graveyard, the ability could target a creature with protection from black, although the damage will be prevented. It couldn’t target a creature with protection from red."
+          "text": "Flayer of the Hatebound is the source of the ability, but it may be another creature that is the source of the damage. If a black creature enters the battlefield from your graveyard, the ability could target a creature with protection from black, although the damage will be prevented. It couldn't target a creature with protection from red."
         },
         {
           "date": "2011-01-22",
@@ -10770,7 +10774,7 @@
         },
         {
           "date": "2011-01-22",
-          "text": "If you cast a creature card from your graveyard, that card will be put on the stack before entering the battlefield. Flayer of the Hatebound won’t trigger."
+          "text": "If you cast a creature card from your graveyard, that card will be put on the stack before entering the battlefield. Flayer of the Hatebound won't trigger."
         }
       ],
       "subtypes": [
@@ -10870,6 +10874,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -10900,11 +10908,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its power."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         },
         {
           "date": "2013-04-15",
@@ -11024,7 +11032,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Forge Devil’s ability is mandatory. If it’s the only creature on the battlefield, you’ll have to choose it as the target and have it deal 1 damage to itself and 1 damage to you."
+          "text": "Forge Devil's ability is mandatory. If it's the only creature on the battlefield, you'll have to choose it as the target and have it deal 1 damage to itself and 1 damage to you."
         }
       ],
       "subtypes": [
@@ -11140,11 +11148,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The creature’s controller still decides which player or planeswalker the creature attacks."
+          "text": "The creature's controller still decides which player or planeswalker the creature attacks."
         },
         {
           "date": "2011-01-22",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -11261,7 +11269,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The damage dealt by Hellrider’s triggered ability isn’t combat damage and may be redirected to a planeswalker controlled by the defending player."
+          "text": "The damage dealt by Hellrider's triggered ability isn't combat damage and may be redirected to a planeswalker controlled by the defending player."
         },
         {
           "date": "2017-03-14",
@@ -11622,15 +11630,15 @@
         },
         {
           "date": "2011-01-22",
-          "text": "When Increasing Vengeance resolves, it creates one or two copies of a spell. You control each of the copies. Those copies are created on the stack, so they’re not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copies will then resolve like normal spells, after players get a chance to cast spells and activate abilities."
+          "text": "When Increasing Vengeance resolves, it creates one or two copies of a spell. You control each of the copies. Those copies are created on the stack, so they're not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copies will then resolve like normal spells, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2011-01-22",
-          "text": "Each of the copies will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal). If there are two copies, you may change the targets of each of them to different legal targets."
+          "text": "Each of the copies will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal). If there are two copies, you may change the targets of each of them to different legal targets."
         },
         {
           "date": "2011-01-22",
-          "text": "If the spell Increasing Vengeance copies is modal (that is, it says “Choose one —” or the like), the copies will have the same mode(s). You can’t choose different ones."
+          "text": "If the spell Increasing Vengeance copies is modal (that is, it says \"Choose one —\" or the like), the copies will have the same mode(s). You can't choose different ones."
         },
         {
           "date": "2011-01-22",
@@ -11638,7 +11646,7 @@
         },
         {
           "date": "2011-01-22",
-          "text": "You can’t choose to pay any additional costs for the copies. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copies too. For example, if you sacrifice a 3/3 creature to cast Fling and then copy it with Increasing Vengeance, the copies of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copies. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copies too. For example, if you sacrifice a 3/3 creature to cast Fling and then copy it with Increasing Vengeance, the copies of Fling will also deal 3 damage to its target."
         }
       ],
       "text": "Copy target instant or sorcery spell you control. If Increasing Vengeance was cast from a graveyard, copy that spell twice instead. You may choose new targets for the copies.\nFlashback {3}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -11749,7 +11757,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The +1/+1 counter isn’t put on Markov Blademaster in time to increase the amount of combat damage dealt during that combat step. However, the +1/+1 counter put on Markov Blademaster when first-strike damage is dealt will increase the amount of damage dealt during the regular combat damage step."
+          "text": "The +1/+1 counter isn't put on Markov Blademaster in time to increase the amount of combat damage dealt during that combat step. However, the +1/+1 counter put on Markov Blademaster when first-strike damage is dealt will increase the amount of damage dealt during the regular combat damage step."
         },
         {
           "date": "2011-01-22",
@@ -11869,11 +11877,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "You may target zero, one, or two creatures with Markov Warlord’s enters-the-battlefield triggered ability."
+          "text": "You may target zero, one, or two creatures with Markov Warlord's enters-the-battlefield triggered ability."
         },
         {
           "date": "2011-01-22",
-          "text": "The creatures can’t block any creatures that turn, not just Markov Warlord."
+          "text": "The creatures can't block any creatures that turn, not just Markov Warlord."
         }
       ],
       "subtypes": [
@@ -11994,7 +12002,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Tovolar’s Magehunter’s first triggered ability will resolve before the spell that caused it to trigger. If this causes the player who cast that spell to lose the game, that spell won’t resolve."
+          "text": "Tovolar's Magehunter's first triggered ability will resolve before the spell that caused it to trigger. If this causes the player who cast that spell to lose the game, that spell won't resolve."
         },
         {
           "date": "2016-07-13",
@@ -12665,7 +12673,7 @@
         },
         {
           "date": "2011-01-22",
-          "text": "Scorch the Fields doesn’t target any Humans. You can cast Scorch the Fields even if there aren’t any Humans on the battlefield."
+          "text": "Scorch the Fields doesn't target any Humans. You can cast Scorch the Fields even if there aren't any Humans on the battlefield."
         }
       ],
       "text": "Destroy target land. Scorch the Fields deals 1 damage to each Human creature.",
@@ -13316,11 +13324,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "In most cases, attacking creatures will already be tapped. They still won’t untap during their controller’s next untap step."
+          "text": "In most cases, attacking creatures will already be tapped. They still won't untap during their controller's next untap step."
         },
         {
           "date": "2011-01-22",
-          "text": "Clinging Mists doesn’t track the controller of the attacking creatures. If one of them changes controller before its previous controller’s next untap step, it won’t untap during its new controller’s next untap step."
+          "text": "Clinging Mists doesn't track the controller of the attacking creatures. If one of them changes controller before its previous controller's next untap step, it won't untap during its new controller's next untap step."
         }
       ],
       "text": "Prevent all combat damage that would be dealt this turn.\nFateful hour — If you have 5 or less life, tap all attacking creatures. Those creatures don't untap during their controller's next untap step.",
@@ -13648,7 +13656,7 @@
         },
         {
           "date": "2011-01-22",
-          "text": "Because targets are chosen before costs are paid, you can activate Deranged Outcast’s ability targeting itself and then sacrifice Deranged Outcast to pay the cost."
+          "text": "Because targets are chosen before costs are paid, you can activate Deranged Outcast's ability targeting itself and then sacrifice Deranged Outcast to pay the cost."
         }
       ],
       "subtypes": [
@@ -13875,11 +13883,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "You choose whether to sacrifice a nontoken creature and which creature to sacrifice when Feed the Pack’s ability resolves."
+          "text": "You choose whether to sacrifice a nontoken creature and which creature to sacrifice when Feed the Pack's ability resolves."
         },
         {
           "date": "2011-01-22",
-          "text": "Check the sacrificed creature’s toughness as it last existed on the battlefield to determine how many Wolves you put onto the battlefield."
+          "text": "Check the sacrificed creature's toughness as it last existed on the battlefield to determine how many Wolves you put onto the battlefield."
         }
       ],
       "text": "At the beginning of your end step, you may sacrifice a nontoken creature. If you do, create X 2/2 green Wolf creature tokens, where X is the sacrificed creature's toughness.",
@@ -13990,11 +13998,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Ghoultree’s ability can’t reduce the total cost to cast the spell below {G}."
+          "text": "Ghoultree's ability can't reduce the total cost to cast the spell below {G}."
         },
         {
           "date": "2011-01-22",
-          "text": "Although players may respond to Ghoultree once it’s been cast, once it’s announced, they can’t respond before the cost is calculated and paid."
+          "text": "Although players may respond to Ghoultree once it's been cast, once it's announced, they can't respond before the cost is calculated and paid."
         }
       ],
       "subtypes": [
@@ -14986,11 +14994,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Removing an attacking creature from combat doesn’t untap that creature."
+          "text": "Removing an attacking creature from combat doesn't untap that creature."
         },
         {
           "date": "2011-01-22",
-          "text": "Because Lost in the Woods will trigger once for each creature that attacks you or a planeswalker you control, it’s important to specify which trigger is associated with which attacking creature before revealing any cards."
+          "text": "Because Lost in the Woods will trigger once for each creature that attacks you or a planeswalker you control, it's important to specify which trigger is associated with which attacking creature before revealing any cards."
         }
       ],
       "text": "Whenever a creature attacks you or a planeswalker you control, reveal the top card of your library. If it's a Forest card, remove that creature from combat. Then put the revealed card on the bottom of your library.",
@@ -15100,7 +15108,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Each time a creature dies, check whether Predator Ooze had dealt any damage to it at any time during that turn. If so, Predator Ooze’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature dies, check whether Predator Ooze had dealt any damage to it at any time during that turn. If so, Predator Ooze's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         }
       ],
       "subtypes": [
@@ -15665,7 +15673,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "You must put a creature card from among the revealed cards into your hand if one is there, even if you’d rather put all the revealed cards into your graveyard."
+          "text": "You must put a creature card from among the revealed cards into your hand if one is there, even if you'd rather put all the revealed cards into your graveyard."
         }
       ],
       "text": "Reveal the top four cards of your library. Put a creature card from among them into your hand and the rest into your graveyard.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -16217,11 +16225,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "You can activate Wolfbitten Captive’s ability, let it transform into Krallenhorde Killer, then activate Krallenhorde Killer’s ability, all on the same turn, and vice versa."
+          "text": "You can activate Wolfbitten Captive's ability, let it transform into Krallenhorde Killer, then activate Krallenhorde Killer's ability, all on the same turn, and vice versa."
         },
         {
           "date": "2011-01-22",
-          "text": "If you activate one face’s ability, and some effect causes the card to transform twice that turn, you won’t be able to activate that face’s ability again that turn."
+          "text": "If you activate one face's ability, and some effect causes the card to transform twice that turn, you won't be able to activate that face's ability again that turn."
         },
         {
           "date": "2016-07-13",
@@ -16788,7 +16796,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If Drogskol Reaver deals enough first-strike damage to destroy each creature it’s blocking or was blocked by, it won’t deal any damage during the regular combat damage step (unless it’s attacking and somehow gains trample). Its ability won’t trigger a second time that combat."
+          "text": "If Drogskol Reaver deals enough first-strike damage to destroy each creature it's blocking or was blocked by, it won't deal any damage during the regular combat damage step (unless it's attacking and somehow gains trample). Its ability won't trigger a second time that combat."
         },
         {
           "date": "2011-01-22",
@@ -16796,7 +16804,7 @@
         },
         {
           "date": "2011-01-22",
-          "text": "If multiple creatures with lifelink you control deal combat damage at the same time, the damage dealt by each of those creatures is a separate life-gaining event and Drogskol Reaver’s ability will trigger that many times."
+          "text": "If multiple creatures with lifelink you control deal combat damage at the same time, the damage dealt by each of those creatures is a separate life-gaining event and Drogskol Reaver's ability will trigger that many times."
         },
         {
           "date": "2011-01-22",
@@ -16918,7 +16926,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Falkenrath Aristocrat’s activated ability checks whether the sacrificed creature as it last existed on the battlefield was a Human. It doesn’t matter what its creature types are in the graveyard."
+          "text": "Falkenrath Aristocrat's activated ability checks whether the sacrificed creature as it last existed on the battlefield was a Human. It doesn't matter what its creature types are in the graveyard."
         },
         {
           "date": "2017-03-14",
@@ -17043,11 +17051,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Havengul Lich’s activated ability creates a delayed triggered ability that triggers when you cast the creature card. This triggered ability will go on the stack on top of the creature spell and will resolve before the creature spell will."
+          "text": "Havengul Lich's activated ability creates a delayed triggered ability that triggers when you cast the creature card. This triggered ability will go on the stack on top of the creature spell and will resolve before the creature spell will."
         },
         {
           "date": "2011-01-22",
-          "text": "If you don’t cast the creature card that turn, Havengul Lich won’t gain any of its abilities."
+          "text": "If you don't cast the creature card that turn, Havengul Lich won't gain any of its abilities."
         },
         {
           "date": "2011-01-22",
@@ -17055,11 +17063,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Havengul Lich’s ability changes the zone you are permitted to cast the card from, not the times you are permitted to cast it. You can cast a creature card that has been targeted by Havengul Lich from the graveyard, but unless it has flash, you can only do so if it’s your main phase, the stack is empty, and you have priority."
+          "text": "Havengul Lich's ability changes the zone you are permitted to cast the card from, not the times you are permitted to cast it. You can cast a creature card that has been targeted by Havengul Lich from the graveyard, but unless it has flash, you can only do so if it's your main phase, the stack is empty, and you have priority."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -17410,15 +17418,15 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "A creature that’s both a Wolf and a Werewolf gets the bonus only once."
+          "text": "A creature that's both a Wolf and a Werewolf gets the bonus only once."
         },
         {
           "date": "2011-01-22",
-          "text": "Immerwolf’s bonus never applies to itself, even if it somehow becomes a Werewolf creature."
+          "text": "Immerwolf's bonus never applies to itself, even if it somehow becomes a Werewolf creature."
         },
         {
           "date": "2011-01-22",
-          "text": "A “non-Human Werewolf” is a creature that is a Werewolf but is not a Human."
+          "text": "A \"non-Human Werewolf\" is a creature that is a Werewolf but is not a Human."
         }
       ],
       "subtypes": [
@@ -17539,11 +17547,11 @@
         },
         {
           "date": "2011-01-22",
-          "text": "You can target a token creature with Sorin, Lord of Innistrad’s third ability, but it won’t return to the battlefield."
+          "text": "You can target a token creature with Sorin, Lord of Innistrad's third ability, but it won't return to the battlefield."
         },
         {
           "date": "2011-01-22",
-          "text": "If a creature with undying is destroyed by Sorin, Lord of Innistrad’s third ability, the undying ability will trigger, but the creature will already have been returned to the battlefield by Sorin. The undying ability won’t do anything when it resolves."
+          "text": "If a creature with undying is destroyed by Sorin, Lord of Innistrad's third ability, the undying ability will trigger, but the creature will already have been returned to the battlefield by Sorin. The undying ability won't do anything when it resolves."
         },
         {
           "date": "2011-01-22",
@@ -17663,7 +17671,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If a creature with first strike deals damage in the first combat damage step, but then loses first strike before regular combat damage, it won’t deal combat damage a second time (unless it also has double strike)."
+          "text": "If a creature with first strike deals damage in the first combat damage step, but then loses first strike before regular combat damage, it won't deal combat damage a second time (unless it also has double strike)."
         }
       ],
       "subtypes": [
@@ -17771,11 +17779,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Altar of the Lost doesn’t allow you to cast spells from any other player’s graveyard, although you can spend the mana it produces on such spells if something else allows you to."
+          "text": "Altar of the Lost doesn't allow you to cast spells from any other player's graveyard, although you can spend the mana it produces on such spells if something else allows you to."
         },
         {
           "date": "2011-01-22",
-          "text": "You can spend mana produced by Altar of the Lost to cast any spell with flashback that you cast from a graveyard. You don’t have to be using flashback to cast that spell, however, as long as something else is allowing you to cast that spell."
+          "text": "You can spend mana produced by Altar of the Lost to cast any spell with flashback that you cast from a graveyard. You don't have to be using flashback to cast that spell, however, as long as something else is allowing you to cast that spell."
         }
       ],
       "text": "Altar of the Lost enters the battlefield tapped.\n{T}: Add two mana in any combination of colors to your mana pool. Spend this mana only to cast spells with flashback from a graveyard.",
@@ -17878,7 +17886,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The triggered ability checks whether the equipped creature as it last existed on the battlefield was a Human. (It doesn’t matter what its creature types are in the graveyard.)"
+          "text": "The triggered ability checks whether the equipped creature as it last existed on the battlefield was a Human. (It doesn't matter what its creature types are in the graveyard.)"
         }
       ],
       "subtypes": [
@@ -17989,7 +17997,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Your starting life total is the life total you began the game with. For most two-player formats, this is 20. For Two-Headed Giant, it’s the life total your team started with, usually 30. In Commander games, the starting life total is 40."
+          "text": "Your starting life total is the life total you began the game with. For most two-player formats, this is 20. For Two-Headed Giant, it's the life total your team started with, usually 30. In Commander games, the starting life total is 40."
         },
         {
           "date": "2011-01-22",
@@ -18209,7 +18217,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The “legend rule” checks only for permanents with exactly the same name. Elbrus, the Binding Blade and Withengar Unbound can be on the battlefield at the same time without either going to its owner’s graveyard."
+          "text": "The \"legend rule\" checks only for permanents with exactly the same name. Elbrus, the Binding Blade and Withengar Unbound can be on the battlefield at the same time without either going to its owner's graveyard."
         },
         {
           "date": "2011-01-22",
@@ -18217,11 +18225,11 @@
         },
         {
           "date": "2011-01-22",
-          "text": "Withengar’s triggered ability will trigger no matter how a player loses the game: due to a state-based action (as a result of having a life total of 0 or less, trying to draw a card from an empty library, or having ten poison counters), a spell or ability that says that player loses the game, a concession, or a game loss awarded by a judge."
+          "text": "Withengar's triggered ability will trigger no matter how a player loses the game: due to a state-based action (as a result of having a life total of 0 or less, trying to draw a card from an empty library, or having ten poison counters), a spell or ability that says that player loses the game, a concession, or a game loss awarded by a judge."
         },
         {
           "date": "2011-01-22",
-          "text": "In a multiplayer game using the limited range of influence option (such as a Grand Melee game), if a spell or ability says that you win the game, it instead causes all of your opponents within your range of influence to lose the game. This is another way by which Withengar’s ability can trigger."
+          "text": "In a multiplayer game using the limited range of influence option (such as a Grand Melee game), if a spell or ability says that you win the game, it instead causes all of your opponents within your range of influence to lose the game. This is another way by which Withengar's ability can trigger."
         },
         {
           "date": "2016-07-13",
@@ -18555,19 +18563,19 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The second ability doesn’t stop players from playing land cards from graveyards or libraries since lands aren’t cast."
+          "text": "The second ability doesn't stop players from playing land cards from graveyards or libraries since lands aren't cast."
         },
         {
           "date": "2017-04-18",
-          "text": "A noncreature card can enter the battlefield from a graveyard or library if another card’s effect (such as that of March of the Machines) will make it a creature after it has entered the battlefield."
+          "text": "A noncreature card can enter the battlefield from a graveyard or library if another card's effect (such as that of March of the Machines) will make it a creature after it has entered the battlefield."
         },
         {
           "date": "2017-04-18",
-          "text": "If an object has a static ability that could cause it to become a creature or stop being a creature, that ability is considered when applying Grafdigger’s Cage. For example, Rusted Relic can enter the battlefield from a graveyard or library only if you control fewer than three artifacts before it enters. Thassa, God of the Sea can enter only if your devotion to blue is less than five before it enters."
+          "text": "If an object has a static ability that could cause it to become a creature or stop being a creature, that ability is considered when applying Grafdigger's Cage. For example, Rusted Relic can enter the battlefield from a graveyard or library only if you control fewer than three artifacts before it enters. Thassa, God of the Sea can enter only if your devotion to blue is less than five before it enters."
         },
         {
           "date": "2017-04-18",
-          "text": "Applying a replacement effect may cause Grafdigger’s Cage to stop an object from entering the battlefield. For example, Sculpting Steel can enter the battlefield from a graveyard or library only if it’s not entering as a copy of an artifact creature. However, a replacement effect can’t be applied to cause Grafdigger’s Cage to not apply. Phyrexian Metamorph can’t enter the battlefield even if you wish to copy a noncreature artifact."
+          "text": "Applying a replacement effect may cause Grafdigger's Cage to stop an object from entering the battlefield. For example, Sculpting Steel can enter the battlefield from a graveyard or library only if it's not entering as a copy of an artifact creature. However, a replacement effect can't be applied to cause Grafdigger's Cage to not apply. Phyrexian Metamorph can't enter the battlefield even if you wish to copy a noncreature artifact."
         }
       ],
       "text": "Creature cards can't enter the battlefield from graveyards or libraries.\nPlayers can't cast spells from graveyards or libraries.",
@@ -18771,7 +18779,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Helvault’s first and third abilities are linked. Similarly, Helvault’s second and third abilities are linked. Only cards exiled as a result of Helvault’s first or second abilities will be returned to the battlefield by its third ability."
+          "text": "Helvault's first and third abilities are linked. Similarly, Helvault's second and third abilities are linked. Only cards exiled as a result of Helvault's first or second abilities will be returned to the battlefield by its third ability."
         }
       ],
       "supertypes": [
@@ -18975,7 +18983,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Warden of the Wall still has the ability to tap for mana when it’s not your turn."
+          "text": "Warden of the Wall still has the ability to tap for mana when it's not your turn."
         }
       ],
       "text": "Warden of the Wall enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\nAs long as it's not your turn, Warden of the Wall is a 2/3 Gargoyle artifact creature with flying.",
@@ -19079,7 +19087,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Only the equipped creature’s controller can activate the abilities it gains from Wolfhunter’s Quiver."
+          "text": "Only the equipped creature's controller can activate the abilities it gains from Wolfhunter's Quiver."
         },
         {
           "date": "2011-01-22",
@@ -19435,11 +19443,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "The creature card returned to your hand is chosen at random as the ability resolves. If any player responds to the ability, that player won’t yet know what card will be returned."
+          "text": "The creature card returned to your hand is chosen at random as the ability resolves. If any player responds to the ability, that player won't yet know what card will be returned."
         },
         {
           "date": "2011-01-22",
-          "text": "Because the ability doesn’t target any creature card, any creature card put into the graveyard in response to that ability may be returned to your hand."
+          "text": "Because the ability doesn't target any creature card, any creature card put into the graveyard in response to that ability may be returned to your hand."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{3}, {T}, Sacrifice Haunted Fengraf: Return a creature card at random from your graveyard to your hand.",
@@ -19546,7 +19554,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Vault of the Archangel’s last ability affects only creatures you control when that ability resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Vault of the Archangel's last ability affects only creatures you control when that ability resolves. It won't affect creatures that come under your control later in the turn."
         },
         {
           "date": "2011-01-22",

--- a/json/DRB.json
+++ b/json/DRB.json
@@ -184,7 +184,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -261,11 +261,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -334,15 +334,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -460,11 +460,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It sets your life total at the beginning of the end step of every player’s turn, not just your own."
+          "text": "It sets your life total at the beginning of the end step of every player's turn, not just your own."
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "At the beginning of your upkeep, Form of the Dragon deals 5 damage to target creature or player.\nAt the beginning of each end step, your life total becomes 5.\nCreatures without flying can't attack you.",
@@ -656,7 +656,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Nicol Bolas’s third ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Nicol Bolas's third ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [

--- a/json/DRK.json
+++ b/json/DRK.json
@@ -219,7 +219,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If both of the targeted creatures are illegal targets by the time Ashes to Ashes resolves, it’s countered. It doesn’t deal 5 damage to you."
+          "text": "If both of the targeted creatures are illegal targets by the time Ashes to Ashes resolves, it's countered. It doesn't deal 5 damage to you."
         }
       ],
       "text": "Exile two target nonartifact creatures. Ashes to Ashes deals 5 damage to you.",
@@ -335,7 +335,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Banshee’s ability resolves, the ability is countered. You won’t be dealt damage."
+          "text": "If the targeted creature or player is an illegal target by the time Banshee's ability resolves, the ability is countered. You won't be dealt damage."
         }
       ],
       "subtypes": [
@@ -385,19 +385,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Does not prevent a creature from untapping at other times. It just stops the “normal” untap during the untap step."
+          "text": "Does not prevent a creature from untapping at other times. It just stops the \"normal\" untap during the untap step."
         },
         {
           "date": "2009-10-01",
-          "text": "You may target any creature with this ability. It doesn’t have to be tapped."
+          "text": "You may target any creature with this ability. It doesn't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when the targeted creature is tapped."
+          "text": "If the targeted creature is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when the targeted creature is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Barl’s Cage doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Barl's Cage doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "text": "{3}: Target creature doesn't untap during its controller's next untap step.",
@@ -449,25 +449,26 @@
         "8ED",
         "9ED",
         "MMA",
-        "MM3"
+        "MM3",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability “{T}: Add {R} to your mana pool.”"
+          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability \"{T}: Add {R} to your mana pool.\""
         },
         {
           "date": "2017-03-14",
-          "text": "Blood Moon’s effect doesn’t affect names or supertypes. It won’t turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won’t be named “Mountain.”"
+          "text": "Blood Moon's effect doesn't affect names or supertypes. It won't turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won't be named \"Mountain.\""
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply “as” a land enters the battlefield, such as the first ability of Cavern of Souls."
+          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply \"as\" a land enters the battlefield, such as the first ability of Cavern of Souls."
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that triggers “when” it enters the battlefield, it will lose that ability before it triggers."
+          "text": "If a nonbasic land has an ability that triggers \"when\" it enters the battlefield, it will lose that ability before it triggers."
         }
       ],
       "text": "Nonbasic lands are Mountains.",
@@ -669,7 +670,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The ability affects only creatures on the battlefield at the time it resolves. A creature that enters the battlefield later in the turn won’t get -1/-0."
+          "text": "The ability affects only creatures on the battlefield at the time it resolves. A creature that enters the battlefield later in the turn won't get -1/-0."
         }
       ],
       "text": "{2}, {T}: All creatures get -1/-0 until end of turn.",
@@ -713,7 +714,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t spend yourself to below zero life. You can’t spend life you don’t have."
+          "text": "You can't spend yourself to below zero life. You can't spend life you don't have."
         }
       ],
       "text": "{2}, Pay 2 life: Draw a card.",
@@ -969,11 +970,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The storage counters aren’t removed when you activate the mana ability."
+          "text": "The storage counters aren't removed when you activate the mana ability."
         },
         {
           "date": "2009-10-01",
-          "text": "You can activate City of Shadows’s second ability while it has no storage counters on it, though it won’t add any mana to your mana pool in this case. You did not tap it for mana, though, in case any abilities (such as the ability of a Fertile Ground enchanting it) care about that."
+          "text": "You can activate City of Shadows's second ability while it has no storage counters on it, though it won't add any mana to your mana pool in this case. You did not tap it for mana, though, in case any abilities (such as the ability of a Fertile Ground enchanting it) care about that."
         }
       ],
       "text": "{T}, Exile a creature you control: Put a storage counter on City of Shadows.\n{T}: Add {C} to your mana pool for each storage counter on City of Shadows.",
@@ -1180,7 +1181,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Dance of Many leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and put a token onto the battlefield. That token won’t have any connection to a Dance of Many permanent, so it won’t be exiled when a Dance of Many leaves the battlefield."
+          "text": "If Dance of Many leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and put a token onto the battlefield. That token won't have any connection to a Dance of Many permanent, so it won't be exiled when a Dance of Many leaves the battlefield."
         }
       ],
       "text": "When Dance of Many enters the battlefield, create a token that's a copy of target nontoken creature.\nWhen Dance of Many leaves the battlefield, exile the token.\nWhen the token leaves the battlefield, sacrifice Dance of Many.\nAt the beginning of your upkeep, sacrifice Dance of Many unless you pay {U}{U}.",
@@ -1532,11 +1533,11 @@
         },
         {
           "date": "2007-09-16",
-          "text": "You can activate the ability whether or not Eater of the Dead is tapped. However, if Eater of the Dead is untapped when the ability resolves, the ability won’t do anything."
+          "text": "You can activate the ability whether or not Eater of the Dead is tapped. However, if Eater of the Dead is untapped when the ability resolves, the ability won't do anything."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -1900,7 +1901,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This works even if the opponent’s lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
+          "text": "This works even if the opponent's lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
         },
         {
           "date": "2004-10-04",
@@ -1908,19 +1909,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, take into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, take into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Fellwar Stone doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -2245,7 +2246,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -2298,7 +2299,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The land enters the battlefield directly from your hand, but it is not “played”. This means it does not count towards the number of lands played this turn and doesn’t trigger abilities that would trigger if the Forest had been played."
+          "text": "The land enters the battlefield directly from your hand, but it is not \"played\". This means it does not count towards the number of lands played this turn and doesn't trigger abilities that would trigger if the Forest had been played."
         }
       ],
       "text": "{0}: You may put a basic Forest card from your hand onto the battlefield. Activate this ability only any time you could cast a sorcery and only once each turn.\nSacrifice Gaea's Touch: Add {G}{G} to your mana pool.",
@@ -2471,7 +2472,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Works even if placed on one of your opponent’s Mountains."
+          "text": "Works even if placed on one of your opponent's Mountains."
         },
         {
           "date": "2004-10-04",
@@ -2681,7 +2682,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Works even if placed on one of your opponent’s Mountains."
+          "text": "Works even if placed on one of your opponent's Mountains."
         }
       ],
       "subtypes": [
@@ -3091,7 +3092,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -3218,7 +3219,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
+          "text": "You don't have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
         }
       ],
       "subtypes": [
@@ -3374,7 +3375,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This card’s coin flip has no winner or loser."
+          "text": "This card's coin flip has no winner or loser."
         }
       ],
       "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
@@ -3428,7 +3429,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Mana Vortex’s third ability is a “state trigger.” Once a state trigger triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "Mana Vortex's third ability is a \"state trigger.\" Once a state trigger triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         }
       ],
       "text": "When you cast Mana Vortex, counter it unless you sacrifice a land.\nAt the beginning of each player's upkeep, that player sacrifices a land.\nWhen there are no lands on the battlefield, sacrifice Mana Vortex.",
@@ -3671,11 +3672,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The creature isn’t removed from combat; it just has its damage prevented. It’s still an attacking creature until the combat phase is complete."
+          "text": "The creature isn't removed from combat; it just has its damage prevented. It's still an attacking creature until the combat phase is complete."
         },
         {
           "date": "2016-06-08",
-          "text": "You can activate Maze of Ith’s ability targeting an attacking creature you control during the combat damage step or the end of combat step. It’ll be untapped and the damage it had already dealt won’t be undone."
+          "text": "You can activate Maze of Ith's ability targeting an attacking creature you control during the combat damage step or the end of combat step. It'll be untapped and the damage it had already dealt won't be undone."
         }
       ],
       "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
@@ -3929,7 +3930,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -3991,7 +3992,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "This currently has no creature type. It’s Nameless."
+          "text": "This currently has no creature type. It's Nameless."
         }
       ],
       "text": "Trample\nAs Nameless Race enters the battlefield, pay any amount of life. The amount you pay can't be more than the total number of white nontoken permanents your opponents control plus the total number of white cards in their graveyards.\nNameless Race's power and toughness are each equal to the life paid as it entered the battlefield.",
@@ -4035,7 +4036,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -4205,7 +4206,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"As the cavalry bore down, we faced them with swords drawn and pikes hidden in the grass at our feet. ‘Don't lift your pikes 'til I give the word,' I said.\" —Maeveen O'Donagh, Memoirs of a Soldier",
+      "flavor": "\"As the cavalry bore down, we faced them with swords drawn and pikes hidden in the grass at our feet. 'Don't lift your pikes 'til I give the word,' I said.\" —Maeveen O'Donagh, Memoirs of a Soldier",
       "id": "3aae00072a81589de279963e7c7def30ed1e0085",
       "imageName": "pikemen",
       "layout": "normal",
@@ -4239,7 +4240,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -4307,11 +4308,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The target of the ability is a creature the chosen opponent controls. As the ability resolves, if the target isn’t a creature controlled by the chosen opponent, the ability will be countered. If the ability’s target is changed somehow, the new target must be a creature controlled by the chosen opponent."
+          "text": "The target of the ability is a creature the chosen opponent controls. As the ability resolves, if the target isn't a creature controlled by the chosen opponent, the ability will be countered. If the ability's target is changed somehow, the new target must be a creature controlled by the chosen opponent."
         },
         {
           "date": "2007-09-16",
-          "text": "Whether Preacher is tapped is checked continually, starting when the ability is activated. If, before the ability resolves, there’s any point at which Preacher is untapped, the ability has no effect — even if Preacher is tapped again by the time the ability resolves."
+          "text": "Whether Preacher is tapped is checked continually, starting when the ability is activated. If, before the ability resolves, there's any point at which Preacher is untapped, the ability has no effect — even if Preacher is tapped again by the time the ability resolves."
         },
         {
           "date": "2007-09-16",
@@ -4458,7 +4459,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t be used on abilities of permanents. Those are abilities and not spells."
+          "text": "Can't be used on abilities of permanents. Those are abilities and not spells."
         },
         {
           "date": "2004-10-04",
@@ -4466,7 +4467,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This can’t be used on spells which affect “you” and which do not say they target you."
+          "text": "This can't be used on spells which affect \"you\" and which do not say they target you."
         }
       ],
       "text": "{X}, {T}: Change the target of target spell with a single target if that target is you. The new target must be a player. X is twice the converted mana cost of that spell.",
@@ -4603,11 +4604,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If changed to another land type, the creature cards are not lost but can’t be released until the land reverts to normal."
+          "text": "If changed to another land type, the creature cards are not lost but can't be released until the land reverts to normal."
         },
         {
           "date": "2004-10-04",
-          "text": "When the creature leaves the battlefield any damage or “will be destroyed at some future time” effects are removed from the creature."
+          "text": "When the creature leaves the battlefield any damage or \"will be destroyed at some future time\" effects are removed from the creature."
         },
         {
           "date": "2004-10-04",
@@ -4969,11 +4970,11 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "At the beginning of every end step, regardless of whose turn it is, the second ability triggers. When it resolves every creature that could have been declared as an attacker during that turn’s Declare Attackers Step but wasn’t will be destroyed."
+          "text": "At the beginning of every end step, regardless of whose turn it is, the second ability triggers. When it resolves every creature that could have been declared as an attacker during that turn's Declare Attackers Step but wasn't will be destroyed."
         },
         {
           "date": "2013-09-20",
-          "text": "A creature won’t be destroyed if it was unable to attack that turn, even if you had a way to enable it to attack. For example, a creature that had summoning sickness wouldn’t be destroyed even if you had a way to give it haste."
+          "text": "A creature won't be destroyed if it was unable to attack that turn, even if you had a way to enable it to attack. For example, a creature that had summoning sickness wouldn't be destroyed even if you had a way to give it haste."
         }
       ],
       "text": "At the beginning of your upkeep, sacrifice Season of the Witch unless you pay 2 life.\nAt the beginning of the end step, destroy all untapped creatures that didn't attack this turn, except for creatures that couldn't attack.",
@@ -5117,15 +5118,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two blocking creatures a single opponent controls. Whether those creatures could block all creatures the other is blocking isn’t determined until the ability resolves."
+          "text": "The first ability can target any two blocking creatures a single opponent controls. Whether those creatures could block all creatures the other is blocking isn't determined until the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
         },
         {
           "date": "2009-10-01",
-          "text": "When Sorrow’s Path’s first ability is activated, its second ability triggers and goes on the stack on top of the first ability. The second ability resolves first, and may cause some of the attacking creatures to be dealt lethal damage."
+          "text": "When Sorrow's Path's first ability is activated, its second ability triggers and goes on the stack on top of the first ability. The second ability resolves first, and may cause some of the attacking creatures to be dealt lethal damage."
         },
         {
           "date": "2009-10-01",
@@ -5133,11 +5134,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "When the first ability resolves, if all the creatures that one of the targeted creatures was blocking have left combat, then the other targeted creature is considered to be able to block all creatures the first creature is blocking. If the ability has its full effect, the second creature will be removed from combat but not returned to combat; it doesn’t block anything."
+          "text": "When the first ability resolves, if all the creatures that one of the targeted creatures was blocking have left combat, then the other targeted creature is considered to be able to block all creatures the first creature is blocking. If the ability has its full effect, the second creature will be removed from combat but not returned to combat; it doesn't block anything."
         },
         {
           "date": "2009-10-01",
-          "text": "Abilities that trigger whenever one of the targeted creatures blocks will trigger when the first ability resolves, because those creatures will change from not blocking (since they’re removed from combat) to blocking. It doesn’t matter if those abilities triggered when those creatures blocked the first time. Abilities that trigger whenever one of the attacking creatures becomes blocked will not trigger again, because they never stopped being blocked creatures. Abilities that trigger whenever a creature blocks one of the attacking creatures will trigger again, though; those kinds of abilities trigger once for each creature that blocks."
+          "text": "Abilities that trigger whenever one of the targeted creatures blocks will trigger when the first ability resolves, because those creatures will change from not blocking (since they're removed from combat) to blocking. It doesn't matter if those abilities triggered when those creatures blocked the first time. Abilities that trigger whenever one of the attacking creatures becomes blocked will not trigger again, because they never stopped being blocked creatures. Abilities that trigger whenever a creature blocks one of the attacking creatures will trigger again, though; those kinds of abilities trigger once for each creature that blocks."
         }
       ],
       "text": "{T}: Choose two target blocking creatures an opponent controls. If each of those creatures could block all creatures that the other is blocking, remove both of them from combat. Each one then blocks all creatures the other was blocking.\nWhenever Sorrow's Path becomes tapped, it deals 2 damage to you and each creature you control.",
@@ -5334,7 +5335,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You may choose not to apply Stone Calendar’s cost reduction effect."
+          "text": "You may choose not to apply Stone Calendar's cost reduction effect."
         }
       ],
       "text": "Spells you cast cost up to {1} less to cast.",
@@ -5483,11 +5484,11 @@
         },
         {
           "date": "2007-09-16",
-          "text": "The Fallen’s ability causes it to deal damage only to opponents of its current controller. If The Fallen has dealt damage to you, and then you gain control of it, you won’t be damaged during your upkeep."
+          "text": "The Fallen's ability causes it to deal damage only to opponents of its current controller. If The Fallen has dealt damage to you, and then you gain control of it, you won't be damaged during your upkeep."
         },
         {
           "date": "2007-09-16",
-          "text": "The effect isn’t cumulative. When it resolves, The Fallen deals 1 damage to each opponent previously dealt damage by it, regardless of how many times The Fallen dealt damage to that opponent before."
+          "text": "The effect isn't cumulative. When it resolves, The Fallen deals 1 damage to each opponent previously dealt damage by it, regardless of how many times The Fallen dealt damage to that opponent before."
         }
       ],
       "subtypes": [
@@ -6142,11 +6143,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land can’t enter the battlefield, so an effect that “puts a land onto the battlefield” won’t do anything, and the land will stay where it is."
+          "text": "Land can't enter the battlefield, so an effect that \"puts a land onto the battlefield\" won't do anything, and the land will stay where it is."
         },
         {
           "date": "2004-10-04",
-          "text": "If you cast a spell or activate an ability that lets you put a land onto the battlefield, the effect fails. You’ll still do everything else the spell or ability tells you to do, such as shuffle the library."
+          "text": "If you cast a spell or activate an ability that lets you put a land onto the battlefield, the effect fails. You'll still do everything else the spell or ability tells you to do, such as shuffle the library."
         },
         {
           "date": "2006-05-01",
@@ -6154,7 +6155,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If a permanent spell tries to enter the battlefield as a land during its resolution (for instance, a Clone entering the battlefield as a copy of a Dryad Arbor or an animated Mutavault), it is put into its owner’s graveyard instead of entering the battlefield. It never enters the battlefield, so abilities that would have triggered on it entering the battlefield won’t trigger."
+          "text": "If a permanent spell tries to enter the battlefield as a land during its resolution (for instance, a Clone entering the battlefield as a copy of a Dryad Arbor or an animated Mutavault), it is put into its owner's graveyard instead of entering the battlefield. It never enters the battlefield, so abilities that would have triggered on it entering the battlefield won't trigger."
         }
       ],
       "text": "Players can't play lands.\nLands can't enter the battlefield.\nAt the beginning of each upkeep, any player may sacrifice two lands or have Worms of the Earth deal 5 damage to him or her. If a player does either, destroy Worms of the Earth.",
@@ -6206,7 +6207,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Causing Wormwood Treefolk to gain forestwalk or swampwalk is useful only during the declare attackers step or earlier. Once it becomes blocked, giving it a landwalk ability won’t change that."
+          "text": "Causing Wormwood Treefolk to gain forestwalk or swampwalk is useful only during the declare attackers step or earlier. Once it becomes blocked, giving it a landwalk ability won't change that."
         }
       ],
       "subtypes": [

--- a/json/DST.json
+++ b/json/DST.json
@@ -583,11 +583,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "An equip ability uses the keyword ability “equip.” Normally, equip abilities can be activated only any time you could cast a sorcery."
+          "text": "An equip ability uses the keyword ability \"equip.\" Normally, equip abilities can be activated only any time you could cast a sorcery."
         },
         {
           "date": "2004-12-01",
-          "text": "Leonin Shikari allows you to move your Equipment around during the combat phase or in response to a spell or ability. You’re still subject to any other restrictions on activating equip abilities."
+          "text": "Leonin Shikari allows you to move your Equipment around during the combat phase or in response to a spell or ability. You're still subject to any other restrictions on activating equip abilities."
         }
       ],
       "subtypes": [
@@ -1515,7 +1515,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Notably, the ability granted by the second mode isn’t lifelink. It’s a triggered ability that triggers whenever the creature with that ability deals damage. If that creature also has lifelink, you’ll gain life as a result of that damage and also when the triggered ability resolves. Multiple instances of this ability trigger separately."
+          "text": "Notably, the ability granted by the second mode isn't lifelink. It's a triggered ability that triggers whenever the creature with that ability deals damage. If that creature also has lifelink, you'll gain life as a result of that damage and also when the triggered ability resolves. Multiple instances of this ability trigger separately."
         }
       ],
       "text": "Choose one —\n• Creatures you control get +2/+2 until end of turn.\n• Until end of turn, creatures you control gain \"Whenever this creature deals damage, you gain that much life.\"\nEntwine {1}{W} (Choose both if you pay the entwine cost.)",
@@ -1707,7 +1707,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If the targeted creature isn’t on the battlefield when the combat damage would be dealt, the damage isn’t redirected."
+          "text": "If the targeted creature isn't on the battlefield when the combat damage would be dealt, the damage isn't redirected."
         },
         {
           "date": "2004-12-01",
@@ -1806,7 +1806,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Normally, gaining control of an Equipment doesn’t change what it’s attached to. However, Carry Away has a triggered ability that unattaches the Equipment from whatever it’s attached to. The Equipment’s new controller can activate its equip ability to move it onto a creature he or she controls."
+          "text": "Normally, gaining control of an Equipment doesn't change what it's attached to. However, Carry Away has a triggered ability that unattaches the Equipment from whatever it's attached to. The Equipment's new controller can activate its equip ability to move it onto a creature he or she controls."
         }
       ],
       "subtypes": [
@@ -2545,15 +2545,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Neurok Transmuter’s second ability removes the type “artifact” — and any artifact subtypes — from the artifact creature it targets. It doesn’t remove any other types or any subtypes of other types, and it doesn’t remove supertypes. If the artifact was legendary, it’s still legendary, and the “Legend rule” applies normally."
+          "text": "Neurok Transmuter's second ability removes the type \"artifact\" — and any artifact subtypes — from the artifact creature it targets. It doesn't remove any other types or any subtypes of other types, and it doesn't remove supertypes. If the artifact was legendary, it's still legendary, and the \"Legend rule\" applies normally."
         },
         {
           "date": "2004-12-01",
-          "text": "Equipment that stops being an artifact loses the subtype “Equipment.” Permanents without the subtype Equipment can’t equip creatures. Of course, artifact creatures can’t equip anything either."
+          "text": "Equipment that stops being an artifact loses the subtype \"Equipment.\" Permanents without the subtype Equipment can't equip creatures. Of course, artifact creatures can't equip anything either."
         },
         {
           "date": "2004-12-01",
-          "text": "Neurok Transmuter’s second ability interacts strangely with March of the Machines from the Mirrodin set. If an artifact is an artifact creature only because March of the Machines is on the battlefield and you then activate Neurok Transmuter’s second ability on that artifact creature, the result is a permanent with no types whatsoever. Neurok Transmuter’s ability removes the type “artifact.” March of the Machines depends on knowing what is and isn’t an artifact. The permanent won’t be an artifact when March of the Machine’s effect is applied and therefore it won’t be turned into a creature."
+          "text": "Neurok Transmuter's second ability interacts strangely with March of the Machines from the Mirrodin set. If an artifact is an artifact creature only because March of the Machines is on the battlefield and you then activate Neurok Transmuter's second ability on that artifact creature, the result is a permanent with no types whatsoever. Neurok Transmuter's ability removes the type \"artifact.\" March of the Machines depends on knowing what is and isn't an artifact. The permanent won't be an artifact when March of the Machine's effect is applied and therefore it won't be turned into a creature."
         }
       ],
       "subtypes": [
@@ -3477,7 +3477,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Counters on objects that aren’t permanents, such as time counters on a suspended card or poison counters on a player, are unaffected by Aether Snap."
+          "text": "Counters on objects that aren't permanents, such as time counters on a suspended card or poison counters on a player, are unaffected by Aether Snap."
         }
       ],
       "text": "Remove all counters from all permanents and exile all tokens.",
@@ -3756,7 +3756,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If you control a permanent that’s a creature and a land, and you choose to sacrifice it as you sacrifice creatures, it won’t be on the battlefield when you sacrifice lands. You can’t sacrifice it again."
+          "text": "If you control a permanent that's a creature and a land, and you choose to sacrifice it as you sacrifice creatures, it won't be on the battlefield when you sacrifice lands. You can't sacrifice it again."
         }
       ],
       "text": "Each player loses X life, discards X cards, sacrifices X creatures, then sacrifices X lands.",
@@ -4036,7 +4036,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If the target creature or player is an illegal target when Essence Drain tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "If the target creature or player is an illegal target when Essence Drain tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "text": "Essence Drain deals 3 damage to target creature or player and you gain 3 life.",
@@ -4867,11 +4867,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If another player has gained control of Screams from Within, its triggered ability does nothing when it’s put into a graveyard. Cards are always put into their owner’s graveyard, but Screams from Within’s ability looks for the card only in its controller’s graveyard."
+          "text": "If another player has gained control of Screams from Within, its triggered ability does nothing when it's put into a graveyard. Cards are always put into their owner's graveyard, but Screams from Within's ability looks for the card only in its controller's graveyard."
         },
         {
           "date": "2005-08-01",
-          "text": "If Screams from Within returns to the battlefield from your graveyard, you choose the creature that Screams from Within enchants (just as you would for any Aura that you’re putting onto the battlefield without casting it). If your opponent doesn’t control any creatures, you must choose one of your creatures. If there’s nothing at all that Screams from Within can enchant, it remains in your graveyard."
+          "text": "If Screams from Within returns to the battlefield from your graveyard, you choose the creature that Screams from Within enchants (just as you would for any Aura that you're putting onto the battlefield without casting it). If your opponent doesn't control any creatures, you must choose one of your creatures. If there's nothing at all that Screams from Within can enchant, it remains in your graveyard."
         }
       ],
       "subtypes": [
@@ -5334,15 +5334,15 @@
         },
         {
           "date": "2004-12-01",
-          "text": "It doesn’t matter what kind of counters the destroyed artifact had on it, only how many. If an artifact had five bomb counters and two trap counters on it, that converts to seven +1/+1 counters or seven charge counters."
+          "text": "It doesn't matter what kind of counters the destroyed artifact had on it, only how many. If an artifact had five bomb counters and two trap counters on it, that converts to seven +1/+1 counters or seven charge counters."
         },
         {
           "date": "2004-12-01",
-          "text": "You can put +1/+1 counters on a noncreature artifact. They won’t do anything unless the artifact becomes a creature, at which time they’ll add to the creature’s power and toughness."
+          "text": "You can put +1/+1 counters on a noncreature artifact. They won't do anything unless the artifact becomes a creature, at which time they'll add to the creature's power and toughness."
         },
         {
           "date": "2013-07-01",
-          "text": "If the artifact regenerates or has indestructible, it won’t be destroyed, but you still put the appropriate number of counters onto an artifact you control."
+          "text": "If the artifact regenerates or has indestructible, it won't be destroyed, but you still put the appropriate number of counters onto an artifact you control."
         }
       ],
       "text": "Destroy target artifact. If that artifact had counters on it, put that many +1/+1 counters or charge counters on an artifact you control.",
@@ -5644,7 +5644,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -5656,7 +5656,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -5844,7 +5844,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -6315,7 +6315,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional combat phase is directly after the combat phase in which Savage Beating is cast. There isn’t a main phase between the two combat phases."
+          "text": "The additional combat phase is directly after the combat phase in which Savage Beating is cast. There isn't a main phase between the two combat phases."
         }
       ],
       "text": "Cast Savage Beating only during your turn and only during combat.\nChoose one —\n• Creatures you control gain double strike until end of turn.\n• Untap all creatures you control. After this phase, there is an additional combat phase.\nEntwine {1}{R} (Choose both if you pay the entwine cost.)",
@@ -6423,7 +6423,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -6443,11 +6443,11 @@
         },
         {
           "date": "2007-07-15",
-          "text": "If a spell targets multiple things, you can’t target it with Shunt, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Shunt, even if all but one of those targets has become illegal."
         },
         {
           "date": "2007-07-15",
-          "text": "If a spell targets the same player or object multiple times, you can’t target it with Shunt."
+          "text": "If a spell targets the same player or object multiple times, you can't target it with Shunt."
         }
       ],
       "text": "Change the target of target spell with a single target.",
@@ -6735,7 +6735,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Unforge deals damage only to the creature that the Equipment was attached to when the Equipment was destroyed. It doesn’t deal damage to creatures that the Equipment had previously equipped."
+          "text": "Unforge deals damage only to the creature that the Equipment was attached to when the Equipment was destroyed. It doesn't deal damage to creatures that the Equipment had previously equipped."
         }
       ],
       "text": "Destroy target Equipment. If that Equipment was attached to a creature, Unforge deals 2 damage to that creature.",
@@ -8684,7 +8684,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a white spell, Angel’s Feather’s ability triggers and is put on the stack on top of that spell. Angel’s Feather’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a white spell, Angel's Feather's ability triggers and is put on the stack on top of that spell. Angel's Feather's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a white spell, you may gain 1 life.",
@@ -9046,7 +9046,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The creature that’s targeted by Arcbound Fiend’s middle ability doesn’t have to have any +1/+1 counters on it. If it doesn’t have a counter on it when the ability resolves, nothing happens."
+          "text": "The creature that's targeted by Arcbound Fiend's middle ability doesn't have to have any +1/+1 counters on it. If it doesn't have a counter on it when the ability resolves, nothing happens."
         },
         {
           "date": "2006-09-25",
@@ -9904,7 +9904,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Remember that an effect that says you “can’t” do something overrides an effect that says you can or must do something. If you activate both of Auriok Siege Sled’s abilities on the same creature, that creature can’t block Auriok Siege Sled this turn."
+          "text": "Remember that an effect that says you \"can't\" do something overrides an effect that says you can or must do something. If you activate both of Auriok Siege Sled's abilities on the same creature, that creature can't block Auriok Siege Sled this turn."
         }
       ],
       "subtypes": [
@@ -9997,7 +9997,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Whenever an opponent casts a nonartifact spell, put a charge counter on Chimeric Egg.\nRemove three charge counters from Chimeric Egg: Chimeric Egg becomes a 6/6 Construct artifact creature with trample until end of turn.",
@@ -10174,7 +10174,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Indestructible (Damage and effects that say \"destroy\" don't destroy this artifact.)\n{3}: Darksteel Brute becomes a 2/2 Beast artifact creature until end of turn.",
@@ -10264,7 +10264,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Lethal damage, damage from a source with deathtouch, and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed or if its toughness is 0 or less. (In these cases, of course, Darksteel Colossus would be shuffled into its owner’s library instead of being put into its owner’s graveyard.)"
+          "text": "Lethal damage, damage from a source with deathtouch, and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed or if its toughness is 0 or less. (In these cases, of course, Darksteel Colossus would be shuffled into its owner's library instead of being put into its owner's graveyard.)"
         }
       ],
       "subtypes": [
@@ -10895,7 +10895,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a black spell, Demon’s Horn’s ability triggers and is put on the stack on top of that spell. Demon’s Horn’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a black spell, Demon's Horn's ability triggers and is put on the stack on top of that spell. Demon's Horn's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a black spell, you may gain 1 life.",
@@ -10995,7 +10995,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a red spell, Dragon’s Claw’s ability triggers and is put on the stack on top of that spell. Dragon’s Claw’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a red spell, Dragon's Claw's ability triggers and is put on the stack on top of that spell. Dragon's Claw's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a red spell, you may gain 1 life.",
@@ -11351,19 +11351,19 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The Twin token enters the battlefield as an untapped attacking creature. It’s not subject to any costs to attack or restrictions on attacking."
+          "text": "The Twin token enters the battlefield as an untapped attacking creature. It's not subject to any costs to attack or restrictions on attacking."
         },
         {
           "date": "2004-12-01",
-          "text": "The Twin token won’t trigger any abilities that trigger “when [a creature] attacks.”"
+          "text": "The Twin token won't trigger any abilities that trigger \"when [a creature] attacks.\""
         },
         {
           "date": "2004-12-01",
-          "text": "The token’s power and toughness are set equal to Gemini Engine’s power and toughness. If there’s a Glorious Anthem on the battlefield (which gives your creatures +1/+1), Gemini Engine is 4/5. The Twin token starts as a 4/5, and then the Anthem gives it +1/+1, making the Twin a 5/6 creature."
+          "text": "The token's power and toughness are set equal to Gemini Engine's power and toughness. If there's a Glorious Anthem on the battlefield (which gives your creatures +1/+1), Gemini Engine is 4/5. The Twin token starts as a 4/5, and then the Anthem gives it +1/+1, making the Twin a 5/6 creature."
         },
         {
           "date": "2004-12-01",
-          "text": "Once the token has been created, its power and toughness aren’t dependent on Gemini Engine’s power and toughness, and they won’t change if Gemini Engine’s power and toughness change."
+          "text": "Once the token has been created, its power and toughness aren't dependent on Gemini Engine's power and toughness, and they won't change if Gemini Engine's power and toughness change."
         }
       ],
       "subtypes": [
@@ -11626,11 +11626,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The equipped creature’s controller chooses whether or not to activate the activated ability. It doesn’t matter who controls Heartseeker."
+          "text": "The equipped creature's controller chooses whether or not to activate the activated ability. It doesn't matter who controls Heartseeker."
         },
         {
           "date": "2004-12-01",
-          "text": "“Unattach Heartseeker” means just that — Heartseeker moves off the creature it was equipping and remains on the battlefield."
+          "text": "\"Unattach Heartseeker\" means just that — Heartseeker moves off the creature it was equipping and remains on the battlefield."
         }
       ],
       "subtypes": [
@@ -11737,11 +11737,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -11845,7 +11845,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a blue spell, Kraken’s Eye’s ability triggers and is put on the stack on top of that spell. Kraken’s Eye’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a blue spell, Kraken's Eye's ability triggers and is put on the stack on top of that spell. Kraken's Eye's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a blue spell, you may gain 1 life.",
@@ -11937,11 +11937,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The equipped creature’s controller chooses whether or not to activate the activated ability. It doesn’t matter who controls Leonin Bola."
+          "text": "The equipped creature's controller chooses whether or not to activate the activated ability. It doesn't matter who controls Leonin Bola."
         },
         {
           "date": "2004-12-01",
-          "text": "“Unattach Leonin Bola” means just that — Leonin Bola moves off the creature it was equipping and remains on the battlefield."
+          "text": "\"Unattach Leonin Bola\" means just that — Leonin Bola moves off the creature it was equipping and remains on the battlefield."
         }
       ],
       "subtypes": [
@@ -12121,7 +12121,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The effects of Memnarch’s abilities don’t end at end of turn, and they don’t end when Memnarch leaves the battlefield. Both effects last until the affected permanent leaves the battlefield."
+          "text": "The effects of Memnarch's abilities don't end at end of turn, and they don't end when Memnarch leaves the battlefield. Both effects last until the affected permanent leaves the battlefield."
         },
         {
           "date": "2004-12-01",
@@ -12221,19 +12221,19 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Mycosynth Lattice turns all permanents on the battlefield into artifacts. Spells on the stack and cards in other zones aren’t permanents, so those spells and cards don’t become artifacts."
+          "text": "Mycosynth Lattice turns all permanents on the battlefield into artifacts. Spells on the stack and cards in other zones aren't permanents, so those spells and cards don't become artifacts."
         },
         {
           "date": "2004-12-01",
-          "text": "Mycosynth Lattice’s second ability makes everything, in every zone of the game, colorless."
+          "text": "Mycosynth Lattice's second ability makes everything, in every zone of the game, colorless."
         },
         {
           "date": "2004-12-01",
-          "text": "The Lattice’s third ability lets players spend even colorless mana as though it had a color. However, it doesn’t remove restrictions on the mana. For example, Mycosynth Lattice doesn’t allow mana from Vedalken Engineer to be used to cast a nonartifact spell."
+          "text": "The Lattice's third ability lets players spend even colorless mana as though it had a color. However, it doesn't remove restrictions on the mana. For example, Mycosynth Lattice doesn't allow mana from Vedalken Engineer to be used to cast a nonartifact spell."
         },
         {
           "date": "2009-10-01",
-          "text": "The Lattice’s first ability causes Auras to become artifacts. Combined with March of the Machines from the Mirrodin set, this can then make those Auras become creatures. An Aura that’s also a creature can’t enchant anything. It’s unattached the next time state-based actions are checked, and then immediately put into its owner’s graveyard as a second state-based action."
+          "text": "The Lattice's first ability causes Auras to become artifacts. Combined with March of the Machines from the Mirrodin set, this can then make those Auras become creatures. An Aura that's also a creature can't enchant anything. It's unattached the next time state-based actions are checked, and then immediately put into its owner's graveyard as a second state-based action."
         }
       ],
       "text": "All permanents are artifacts in addition to their other types.\nAll cards that aren't on the battlefield, spells, and permanents are colorless.\nPlayers may spend mana as though it were mana of any color.",
@@ -12323,7 +12323,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The land keeps all its other types, subtypes, and supertypes: If it was a basic land, it’s still basic. If it was a Forest, it’s still a Forest."
+          "text": "The land keeps all its other types, subtypes, and supertypes: If it was a basic land, it's still basic. If it was a Forest, it's still a Forest."
         }
       ],
       "subtypes": [
@@ -12500,7 +12500,7 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -12769,11 +12769,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "As Panoptic Mirror’s triggered ability resolves, it allows you to create a copy of one of the instant or sorcery cards imprinted on Panoptic Mirror in the Exile zone (that’s where the imprinted card is) and then cast it without paying its mana cost."
+          "text": "As Panoptic Mirror's triggered ability resolves, it allows you to create a copy of one of the instant or sorcery cards imprinted on Panoptic Mirror in the Exile zone (that's where the imprinted card is) and then cast it without paying its mana cost."
         },
         {
           "date": "2004-12-01",
-          "text": "You don’t pay the spell’s mana cost. If the spell has X in its mana cost, X is 0. You do pay any additional costs for that spell. You can’t use any alternative costs."
+          "text": "You don't pay the spell's mana cost. If the spell has X in its mana cost, X is 0. You do pay any additional costs for that spell. You can't use any alternative costs."
         },
         {
           "date": "2004-12-01",
@@ -12793,7 +12793,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "To imprint a split card, you pay X equal to card’s converted mana cost, determined by the combined mana cost of its two halves. If the copied card is a split card, you choose which one side of it to cast, but you can’t cast both sides."
+          "text": "To imprint a split card, you pay X equal to card's converted mana cost, determined by the combined mana cost of its two halves. If the copied card is a split card, you choose which one side of it to cast, but you can't cast both sides."
         }
       ],
       "text": "Imprint — {X}, {T}: You may exile an instant or sorcery card with converted mana cost X from your hand.\nAt the beginning of your upkeep, you may copy a card exiled with Panoptic Mirror. If you do, you may cast the copy without paying its mana cost.",
@@ -12970,7 +12970,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You can use Serum Powder’s second ability only while it’s in your hand. If this card is in your hand, you can choose either to mulligan or to use Serum Powder’s ability. Using the ability doesn’t prevent you from taking further mulligans, and taking a mulligan doesn’t prevent you from using a Serum Powder’s ability if you happen to draw one."
+          "text": "You can use Serum Powder's second ability only while it's in your hand. If this card is in your hand, you can choose either to mulligan or to use Serum Powder's ability. Using the ability doesn't prevent you from taking further mulligans, and taking a mulligan doesn't prevent you from using a Serum Powder's ability if you happen to draw one."
         },
         {
           "date": "2004-12-01",
@@ -12978,7 +12978,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The cards in your hand are exiled for the rest of the game; they aren’t shuffled back into your library if you take another mulligan. Cards exiled are always face up unless the effect that exiled them says they aren’t. Be sure to return those cards to your deck for your next game."
+          "text": "The cards in your hand are exiled for the rest of the game; they aren't shuffled back into your library if you take another mulligan. Cards exiled are always face up unless the effect that exiled them says they aren't. Be sure to return those cards to your deck for your next game."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\nAny time you could mulligan and Serum Powder is in your hand, you may exile all the cards from your hand, then draw that many cards. (You can do this in addition to taking mulligans.)",
@@ -13414,19 +13414,19 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Spellbinder’s second ability allows you to create a copy of the imprinted instant card in the Exile zone (that’s where the imprinted instant card is) and then cast it without paying its mana cost."
+          "text": "Spellbinder's second ability allows you to create a copy of the imprinted instant card in the Exile zone (that's where the imprinted instant card is) and then cast it without paying its mana cost."
         },
         {
           "date": "2004-12-01",
-          "text": "You don’t pay the spell’s mana cost. If the spell has X in its mana cost, X is 0. You do pay any additional costs for that spell. You can’t use any alternative costs."
+          "text": "You don't pay the spell's mana cost. If the spell has X in its mana cost, X is 0. You do pay any additional costs for that spell. You can't use any alternative costs."
         },
         {
           "date": "2004-12-01",
-          "text": "If the copied card is a split card, you choose which one side of it to cast, but you can’t cast both sides. You can choose the other side later in the game, though."
+          "text": "If the copied card is a split card, you choose which one side of it to cast, but you can't cast both sides. You can choose the other side later in the game, though."
         },
         {
           "date": "2004-12-01",
-          "text": "Spellbinder imprints a card only once, when it enters the battlefield. Attaching Spellbinder to a creature doesn’t trigger its enters-the-battlefield ability."
+          "text": "Spellbinder imprints a card only once, when it enters the battlefield. Attaching Spellbinder to a creature doesn't trigger its enters-the-battlefield ability."
         },
         {
           "date": "2005-03-01",
@@ -13705,11 +13705,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Sundering Titan’s two abilities aren’t targeted. When one of the abilities resolves, the Titan’s controller must choose one land for each basic land type (Plains, Island, Swamp, Mountain, and Forest)."
+          "text": "Sundering Titan's two abilities aren't targeted. When one of the abilities resolves, the Titan's controller must choose one land for each basic land type (Plains, Island, Swamp, Mountain, and Forest)."
         },
         {
           "date": "2004-12-01",
-          "text": "If one of the basic land types isn’t present, it isn’t chosen. If the only land of a certain type is one you control, you must choose it."
+          "text": "If one of the basic land types isn't present, it isn't chosen. If the only land of a certain type is one you control, you must choose it."
         },
         {
           "date": "2004-12-01",
@@ -13814,11 +13814,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The equipped creature’s controller chooses whether or not to activate the activated ability. It doesn’t matter who controls Surestrike Trident."
+          "text": "The equipped creature's controller chooses whether or not to activate the activated ability. It doesn't matter who controls Surestrike Trident."
         },
         {
           "date": "2004-12-01",
-          "text": "“Unattach Surestrike Trident” means just that — Surestrike Trident moves off the creature it was equipping and remains on the battlefield."
+          "text": "\"Unattach Surestrike Trident\" means just that — Surestrike Trident moves off the creature it was equipping and remains on the battlefield."
         }
       ],
       "subtypes": [
@@ -13912,7 +13912,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The triggered ability has one target: the creature or player to be dealt 2 damage. If that creature or player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "The triggered ability has one target: the creature or player to be dealt 2 damage. If that creature or player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "subtypes": [
@@ -14006,7 +14006,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You may put the triggered ability with no targets. However, If you choose a target creature in your graveyard, and that card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "You may put the triggered ability with no targets. However, If you choose a target creature in your graveyard, and that card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "subtypes": [
@@ -14268,7 +14268,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You put the artifact card onto the battlefield even if Thought Dissector has already left the battlefield and you can’t sacrifice it."
+          "text": "You put the artifact card onto the battlefield even if Thought Dissector has already left the battlefield and you can't sacrifice it."
         }
       ],
       "text": "{X}, {T}: Target opponent reveals cards from the top of his or her library until an artifact card or X cards are revealed, whichever comes first. If an artifact card is revealed this way, put it onto the battlefield under your control and sacrifice Thought Dissector. Put the rest of the revealed cards into that player's graveyard.",
@@ -14359,7 +14359,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If Thunderstaff is untapped, it prevents 1 damage from each creature, each time it would deal combat damage to you. So if three creatures with double strike attack you and aren’t blocked, Thunderstaff will prevent a total of 6 damage."
+          "text": "If Thunderstaff is untapped, it prevents 1 damage from each creature, each time it would deal combat damage to you. So if three creatures with double strike attack you and aren't blocked, Thunderstaff will prevent a total of 6 damage."
         }
       ],
       "text": "As long as Thunderstaff is untapped, if a creature would deal combat damage to you, prevent 1 of that damage.\n{2}, {T}: Attacking creatures get +1/+0 until end of turn.",
@@ -14449,15 +14449,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Trinisphere’s ability affects the total cost of the spell. It is applied *after* any other cost increasers or cost reducers are applied: First apply any cost increases. Next apply any cost reducers. Finally look at the amount of mana you have to pay. If it’s less than three mana, you’ll pay three mana."
+          "text": "Trinisphere's ability affects the total cost of the spell. It is applied *after* any other cost increasers or cost reducers are applied: First apply any cost increases. Next apply any cost reducers. Finally look at the amount of mana you have to pay. If it's less than three mana, you'll pay three mana."
         },
         {
           "date": "2004-12-01",
-          "text": "Even with a cost reducer on the battlefield, spells can’t cost less than three mana to cast."
+          "text": "Even with a cost reducer on the battlefield, spells can't cost less than three mana to cast."
         },
         {
           "date": "2004-12-01",
-          "text": "If a spell costs at least three mana due to additional costs, such as kicker costs, that’s fine."
+          "text": "If a spell costs at least three mana due to additional costs, such as kicker costs, that's fine."
         },
         {
           "date": "2004-12-01",
@@ -14465,7 +14465,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Casting a creature with morph face down already costs three mana, even though the converted mana cost of the face-down spell is zero, so Trinisphere normally doesn’t modify the total cost of a face-down creature spell. However, if Dream Chisel is reducing that cost while Trinisphere is on the battlefield, you’ll still have to pay three mana for the spell."
+          "text": "Casting a creature with morph face down already costs three mana, even though the converted mana cost of the face-down spell is zero, so Trinisphere normally doesn't modify the total cost of a face-down creature spell. However, if Dream Chisel is reducing that cost while Trinisphere is on the battlefield, you'll still have to pay three mana for the spell."
         }
       ],
       "text": "As long as Trinisphere is untapped, each spell that would cost less than three mana to cast costs three mana to cast. (Additional mana in the cost may be paid with any color of mana or colorless mana. For example, a spell that would cost {1}{B} to cast costs {2}{B} to cast instead.)",
@@ -14998,7 +14998,7 @@
     {
       "artist": "Nottsuo",
       "cmc": 3,
-      "flavor": "\"The lifespan of a wirefly can be precisely described as ‘short.'\"\n—Bruenna, Neurok leader",
+      "flavor": "\"The lifespan of a wirefly can be precisely described as 'short.'\"\n—Bruenna, Neurok leader",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -15168,7 +15168,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a green spell, Wurm’s Tooth’s ability triggers and is put on the stack on top of that spell. Wurm’s Tooth’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a green spell, Wurm's Tooth's ability triggers and is put on the stack on top of that spell. Wurm's Tooth's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a green spell, you may gain 1 life.",
@@ -15256,19 +15256,19 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Blinkmoth Nexus gains the creature type “Blinkmoth” when it becomes a creature. This means that it ends up with three types (land, artifact, and creature), plus one creature subtype (Blinkmoth)."
+          "text": "Blinkmoth Nexus gains the creature type \"Blinkmoth\" when it becomes a creature. This means that it ends up with three types (land, artifact, and creature), plus one creature subtype (Blinkmoth)."
         },
         {
           "date": "2004-12-01",
-          "text": "The “target Blinkmoth gets +1/+1” ability can target any creature with the creature type Blinkmoth."
+          "text": "The \"target Blinkmoth gets +1/+1\" ability can target any creature with the creature type Blinkmoth."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.",
@@ -15360,7 +15360,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Although Darksteel Citadel is an artifact, it can’t be cast as a spell. Playing it follows the normal rules for playing a land."
+          "text": "Although Darksteel Citadel is an artifact, it can't be cast as a spell. Playing it follows the normal rules for playing a land."
         }
       ],
       "text": "Indestructible\n{T}: Add {C} to your mana pool.",

--- a/json/DTK.json
+++ b/json/DTK.json
@@ -139,7 +139,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Scion of Ugin is colorless. It isn’t monocolored, nor is it an artifact."
+          "text": "Scion of Ugin is colorless. It isn't monocolored, nor is it an artifact."
         }
       ],
       "subtypes": [
@@ -256,11 +256,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "subtypes": [
@@ -490,15 +490,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -506,7 +506,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -514,11 +514,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -629,11 +629,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -754,11 +754,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "subtypes": [
@@ -881,7 +881,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If a creature loses double strike after dealing combat damage in the first combat damage step, it won’t assign combat damage in the second one."
+          "text": "If a creature loses double strike after dealing combat damage in the first combat damage step, it won't assign combat damage in the second one."
         }
       ],
       "subtypes": [
@@ -993,15 +993,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -1009,7 +1009,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -1017,11 +1017,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Target creature you control gains protection from the color of your choice until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -1466,11 +1466,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "subtypes": [
@@ -1806,11 +1806,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "text": "{2}{W}: Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
@@ -1921,11 +1921,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "text": "Destroy target attacking or blocking creature. Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
@@ -2139,7 +2139,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If you cast Glaring Aegis, and the creature being targeted by the enchant creature ability becomes an illegal target before Glaring Aegis resolves, Glaring Aegis will be countered. It won’t enter the battlefield, and its triggered ability won’t trigger."
+          "text": "If you cast Glaring Aegis, and the creature being targeted by the enchant creature ability becomes an illegal target before Glaring Aegis resolves, Glaring Aegis will be countered. It won't enter the battlefield, and its triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
@@ -2255,11 +2255,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "subtypes": [
@@ -2483,15 +2483,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -2499,7 +2499,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -2507,11 +2507,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Creatures you control get +2/+1 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -2740,11 +2740,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -2976,11 +2976,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -3098,11 +3098,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Myth Realized can’t attack the turn it enters the battlefield."
+          "text": "Myth Realized can't attack the turn it enters the battlefield."
         },
         {
           "date": "2015-02-25",
-          "text": "Activating the ability that turns Myth Realized into a creature while it’s already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
+          "text": "Activating the ability that turns Myth Realized into a creature while it's already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
         }
       ],
       "text": "Whenever you cast a noncreature spell, put a lore counter on Myth Realized.\n{2}{W}: Put a lore counter on Myth Realized.\n{W}: Until end of turn, Myth Realized becomes a Monk Avatar creature in addition to its other types and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\"",
@@ -3213,11 +3213,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If Ojutai Exemplars leaves the battlefield in response to its ability with the third mode chosen, that ability won’t return Ojutai Exemplars to the battlefield. It will stay wherever it is."
+          "text": "If Ojutai Exemplars leaves the battlefield in response to its ability with the third mode chosen, that ability won't return Ojutai Exemplars to the battlefield. It will stay wherever it is."
         },
         {
           "date": "2015-02-25",
-          "text": "After the ability returns Ojutai Exemplars to the battlefield, it will be a new object with no connection to the Ojutai Exemplars that left the battlefield. It won’t be in combat or have any additional abilities it may have had when it left the battlefield. Any +1/+1 counters on it or Auras attached to it are removed."
+          "text": "After the ability returns Ojutai Exemplars to the battlefield, it will be a new object with no connection to the Ojutai Exemplars that left the battlefield. It won't be in combat or have any additional abilities it may have had when it left the battlefield. Any +1/+1 counters on it or Auras attached to it are removed."
         }
       ],
       "subtypes": [
@@ -3334,15 +3334,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If one of these spells is copied, the controller of the copy will get the “Dragon bonus” only if a Dragon card was revealed as an additional cost. The copy wasn’t cast, so whether you controlled a Dragon won’t matter."
+          "text": "If one of these spells is copied, the controller of the copy will get the \"Dragon bonus\" only if a Dragon card was revealed as an additional cost. The copy wasn't cast, so whether you controlled a Dragon won't matter."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
+          "text": "You can't reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
         },
         {
           "date": "2015-02-25",
-          "text": "If you don’t reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won’t get the bonus."
+          "text": "If you don't reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won't get the bonus."
         }
       ],
       "subtypes": [
@@ -3600,15 +3600,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -3616,7 +3616,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -3624,11 +3624,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Return target permanent card from your graveyard to the battlefield.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -3948,11 +3948,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "subtypes": [
@@ -4069,11 +4069,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -4192,11 +4192,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "text": "Bolster 1, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it. (To bolster 1, choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
@@ -4411,11 +4411,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -4538,19 +4538,19 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Silkwrap’s ability causes a zone change with a duration, a style of ability that’s somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Silkwrap have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Silkwrap leaves the battlefield."
+          "text": "Silkwrap's ability causes a zone change with a duration, a style of ability that's somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Silkwrap have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Silkwrap leaves the battlefield."
         },
         {
           "date": "2015-02-25",
-          "text": "If Silkwrap leaves the battlefield before its triggered ability resolves, the target creature won’t be exiled."
+          "text": "If Silkwrap leaves the battlefield before its triggered ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2015-02-25",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2015-02-25",
@@ -4558,7 +4558,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "In a multiplayer game, if Silkwrap’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Silkwrap's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "When Silkwrap enters the battlefield, exile target creature with converted mana cost 3 or less an opponent controls until Silkwrap leaves the battlefield. (That creature returns under its owner's control.)",
@@ -5001,11 +5001,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If Surge of Righteousness resolves but the creature isn’t destroyed (perhaps because it regenerated or it has indestructible), you’ll still gain 2 life."
+          "text": "If Surge of Righteousness resolves but the creature isn't destroyed (perhaps because it regenerated or it has indestructible), you'll still gain 2 life."
         },
         {
           "date": "2015-02-25",
-          "text": "However, if the creature becomes an illegal target before Surge of Righteousness resolves, it will be countered and none of its effects will happen. You won’t gain life."
+          "text": "However, if the creature becomes an illegal target before Surge of Righteousness resolves, it will be countered and none of its effects will happen. You won't gain life."
         }
       ],
       "text": "Destroy target black or red creature that's attacking or blocking. You gain 2 life.",
@@ -5445,11 +5445,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -5572,15 +5572,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -5588,7 +5588,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -5596,11 +5596,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Exile target creature an opponent controls. That player reveals cards from the top of his or her library until a creature card is revealed. The player puts that card onto the battlefield, then shuffles the rest into his or her library.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -5719,7 +5719,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Each token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Each token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-02-25",
@@ -5735,11 +5735,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-02-25",
-          "text": "Remember that if you control more than one legendary permanent with the same name, you’ll choose one to remain on the battlefield and put the rest into their owners’ graveyards."
+          "text": "Remember that if you control more than one legendary permanent with the same name, you'll choose one to remain on the battlefield and put the rest into their owners' graveyards."
         }
       ],
       "text": "For each creature target player controls, create a token that's a copy of that creature.",
@@ -5849,11 +5849,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If the spell becomes an illegal target (because it’s left the stack, for example) when Contradict tries to resolve, Contradict will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the spell becomes an illegal target (because it's left the stack, for example) when Contradict tries to resolve, Contradict will be countered and none of its effects will happen. You won't draw a card."
         },
         {
           "date": "2015-02-25",
-          "text": "A spell that can’t be countered by spells and abilities is a legal target for Contradict. The spell won’t be countered when Contradict resolves, but you’ll draw a card."
+          "text": "A spell that can't be countered by spells and abilities is a legal target for Contradict. The spell won't be countered when Contradict resolves, but you'll draw a card."
         }
       ],
       "text": "Counter target spell.\nDraw a card.",
@@ -5967,7 +5967,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "The target creature will lose any abilities it may have gained prior to Dance of the Skywise resolving. Notably, if the creature is a face-down creature with morph or megamorph, you can’t turn it face up, as it wouldn’t have a morph or megamorph cost when face up (because it’s lost all abilities other than flying)."
+          "text": "The target creature will lose any abilities it may have gained prior to Dance of the Skywise resolving. Notably, if the creature is a face-down creature with morph or megamorph, you can't turn it face up, as it wouldn't have a morph or megamorph cost when face up (because it's lost all abilities other than flying)."
         },
         {
           "date": "2015-02-25",
@@ -5975,11 +5975,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Dance of the Skywise overrides all previous effects that set the creature’s power or toughness to specific values. However, effects that set its power or toughness to specific values that start to apply after Dance of the Skywise resolves will override this effect."
+          "text": "Dance of the Skywise overrides all previous effects that set the creature's power or toughness to specific values. However, effects that set its power or toughness to specific values that start to apply after Dance of the Skywise resolves will override this effect."
         },
         {
           "date": "2015-02-25",
-          "text": "Effects that modify the power or toughness of the creature, such as the effects of Giant Growth or Hall of Triumph, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify the power or toughness of the creature, such as the effects of Giant Growth or Hall of Triumph, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         }
       ],
       "text": "Until end of turn, target creature you control becomes a blue Dragon Illusion with base power and toughness 4/4, loses all abilities, and gains flying.",
@@ -6093,11 +6093,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -6214,15 +6214,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If one of these spells is copied, the controller of the copy will get the “Dragon bonus” only if a Dragon card was revealed as an additional cost. The copy wasn’t cast, so whether you controlled a Dragon won’t matter."
+          "text": "If one of these spells is copied, the controller of the copy will get the \"Dragon bonus\" only if a Dragon card was revealed as an additional cost. The copy wasn't cast, so whether you controlled a Dragon won't matter."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
+          "text": "You can't reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
         },
         {
           "date": "2015-02-25",
-          "text": "If you don’t reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won’t get the bonus."
+          "text": "If you don't reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won't get the bonus."
         }
       ],
       "text": "As an additional cost to cast Dragonlord's Prerogative, you may reveal a Dragon card from your hand.\nIf you revealed a Dragon card or controlled a Dragon as you cast Dragonlord's Prerogative, Dragonlord's Prerogative can't be countered.\nDraw four cards.",
@@ -6333,7 +6333,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Once Elusive Spellfist has been blocked, causing its ability to trigger won’t change or undo that block."
+          "text": "Once Elusive Spellfist has been blocked, causing its ability to trigger won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -6448,7 +6448,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If the enchanted creature stops being red or green, or if it stops being a creature, Encase in Ice will be put into its owner’s graveyard."
+          "text": "If the enchanted creature stops being red or green, or if it stops being a creature, Encase in Ice will be put into its owner's graveyard."
         },
         {
           "date": "2015-02-25",
@@ -6670,15 +6670,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If a face-down Gudul Lurker attacks and is blocked, turning it face up won’t cause it to become unblocked."
+          "text": "If a face-down Gudul Lurker attacks and is blocked, turning it face up won't cause it to become unblocked."
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -6796,7 +6796,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -6804,15 +6804,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -6930,7 +6930,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Icefall Regent’s triggered ability can target any creature controlled by an opponent, including one that is already tapped. In that case, the creature stays tapped and won’t untap during its controller’s untap step."
+          "text": "Icefall Regent's triggered ability can target any creature controlled by an opponent, including one that is already tapped. In that case, the creature stays tapped and won't untap during its controller's untap step."
         },
         {
           "date": "2015-02-25",
@@ -6942,13 +6942,13 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Icefall Regent’s last ability affects all spells cast by your opponents that target it, including Aura spells and spells with multiple targets. It doesn’t affect abilities."
+          "text": "Icefall Regent's last ability affects all spells cast by your opponents that target it, including Aura spells and spells with multiple targets. It doesn't affect abilities."
         }
       ],
       "subtypes": [
         "Dragon"
       ],
-      "text": "Flying\nWhen Icefall Regent enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Icefall Regent. \nSpells your opponents cast that target Icefall Regent cost {2} more to cast.",
+      "text": "Flying\nWhen Icefall Regent enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Icefall Regent.\nSpells your opponents cast that target Icefall Regent cost {2} more to cast.",
       "toughness": "3",
       "type": "Creature — Dragon",
       "types": [
@@ -7056,19 +7056,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Illusory Gains’s last ability is mandatory. You can’t choose to have Illusory Gains not move."
+          "text": "Illusory Gains's last ability is mandatory. You can't choose to have Illusory Gains not move."
         },
         {
           "date": "2015-02-25",
-          "text": "If Illusory Gains can’t legally enchant the creature that enters the battlefield (perhaps because it has protection from blue), it remains where it is. You retain control of the creature it’s currently enchanting."
+          "text": "If Illusory Gains can't legally enchant the creature that enters the battlefield (perhaps because it has protection from blue), it remains where it is. You retain control of the creature it's currently enchanting."
         },
         {
           "date": "2015-02-25",
-          "text": "The last ability of Illusory Gains doesn’t target the new creature. It will become attached to that creature even if that creature has hexproof or shroud."
+          "text": "The last ability of Illusory Gains doesn't target the new creature. It will become attached to that creature even if that creature has hexproof or shroud."
         },
         {
           "date": "2015-02-25",
-          "text": "If multiple creatures enter the battlefield under an opponent’s control at the same time, Illusory Gains will trigger for each of them. You may put these abilities on the stack in any order. As each resolves, you’ll briefly gain control of the associated creature. The last one to resolve determines which one you’ll ultimately control."
+          "text": "If multiple creatures enter the battlefield under an opponent's control at the same time, Illusory Gains will trigger for each of them. You may put these abilities on the stack in any order. As each resolves, you'll briefly gain control of the associated creature. The last one to resolve determines which one you'll ultimately control."
         }
       ],
       "subtypes": [
@@ -7181,7 +7181,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If the player’s graveyard is empty, the player will shuffle his or her library, then you’ll draw a card."
+          "text": "If the player's graveyard is empty, the player will shuffle his or her library, then you'll draw a card."
         }
       ],
       "text": "Target player shuffles his or her graveyard into his or her library.\nDraw a card.",
@@ -7292,7 +7292,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If there are no instant or sorcery cards in your graveyard as Living Lore enters the battlefield, it will enter the battlefield as a 0/0 creature and be put into its owner’s graveyard due to having 0 toughness."
+          "text": "If there are no instant or sorcery cards in your graveyard as Living Lore enters the battlefield, it will enter the battlefield as a 0/0 creature and be put into its owner's graveyard due to having 0 toughness."
         },
         {
           "date": "2015-02-25",
@@ -7300,19 +7300,19 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Similarly, if the exiled card somehow leaves exile while Living Lore is on the battlefield, it will become a 0/0 creature and be put into its owner’s graveyard (unless something else is raising its toughness)."
+          "text": "Similarly, if the exiled card somehow leaves exile while Living Lore is on the battlefield, it will become a 0/0 creature and be put into its owner's graveyard (unless something else is raising its toughness)."
         },
         {
           "date": "2015-02-25",
-          "text": "Living Lore’s last ability will trigger whenever it deals combat damage, no matter if that damage is dealt to an opponent, an opposing planeswalker, or a creature it’s blocking or being blocked by. You choose whether to sacrifice Living Lore as that ability resolves."
+          "text": "Living Lore's last ability will trigger whenever it deals combat damage, no matter if that damage is dealt to an opponent, an opposing planeswalker, or a creature it's blocking or being blocked by. You choose whether to sacrifice Living Lore as that ability resolves."
         },
         {
           "date": "2015-02-25",
-          "text": "When casting a card with Living Lore’s last ability, ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "When casting a card with Living Lore's last ability, ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay alternative costs. You can pay additional costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs. You can pay additional costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2015-02-25",
@@ -7431,11 +7431,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Notably, the token won’t be attacking."
+          "text": "Notably, the token won't be attacking."
         },
         {
           "date": "2015-02-25",
-          "text": "If Mirror Mockery enchants a creature you don’t control, and you are the defending player, you can block with the token."
+          "text": "If Mirror Mockery enchants a creature you don't control, and you are the defending player, you can block with the token."
         },
         {
           "date": "2015-02-25",
@@ -7447,7 +7447,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If Mirror Mockery’s ability creates multiple tokens (due to an effect such as the one Doubling Season creates), all such tokens will be exiled by the delayed triggered ability."
+          "text": "If Mirror Mockery's ability creates multiple tokens (due to an effect such as the one Doubling Season creates), all such tokens will be exiled by the delayed triggered ability."
         },
         {
           "date": "2015-02-25",
@@ -7455,7 +7455,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-02-25",
@@ -7471,7 +7471,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         }
       ],
       "subtypes": [
@@ -7584,11 +7584,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -7847,7 +7847,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -7958,11 +7958,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -8081,23 +8081,23 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Ojutai’s Breath can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Ojutai's Breath can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         },
         {
           "date": "2015-02-25",
-          "text": "Ojutai’s Breath tracks the creature, but not its controller. If the creature changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "Ojutai's Breath tracks the creature, but not its controller. If the creature changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -8105,7 +8105,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -8113,11 +8113,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -8227,15 +8227,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -8243,7 +8243,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -8251,11 +8251,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Create a 2/2 blue Djinn Monk creature token with flying.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -8477,11 +8477,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Use the toughness of the exploited creature as it last existed on the battlefield to determine which creatures to return to their owners’ hands."
+          "text": "Use the toughness of the exploited creature as it last existed on the battlefield to determine which creatures to return to their owners' hands."
         },
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -8489,15 +8489,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -8613,15 +8613,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "The mana produced by Qarsi Deceiver can’t be used to cast a spell that instructs you to manifest cards."
+          "text": "The mana produced by Qarsi Deceiver can't be used to cast a spell that instructs you to manifest cards."
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -8741,11 +8741,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Reduce in Stature overrides all previous effects that set the creature’s power or toughness to specific values. However, effects that set its power or toughness to specific values that start to apply after Reduce in Stature becomes attached to the creature will override this effect."
+          "text": "Reduce in Stature overrides all previous effects that set the creature's power or toughness to specific values. However, effects that set its power or toughness to specific values that start to apply after Reduce in Stature becomes attached to the creature will override this effect."
         },
         {
           "date": "2015-02-25",
-          "text": "Effects that modify the power or toughness of the creature, such as the effects of Giant Growth or Honor of the Pure, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify the power or toughness of the creature, such as the effects of Giant Growth or Honor of the Pure, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         }
       ],
       "subtypes": [
@@ -8858,7 +8858,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "After Shorecrasher Elemental’s first ability returns it to the battlefield, it will be a new object with no connection to the Shorecrasher Elemental that left the battlefield. It won’t be in combat or have any additional abilities it may have had when it left the battlefield. Any +1/+1 counters on it or Auras attached to it are removed."
+          "text": "After Shorecrasher Elemental's first ability returns it to the battlefield, it will be a new object with no connection to the Shorecrasher Elemental that left the battlefield. It won't be in combat or have any additional abilities it may have had when it left the battlefield. Any +1/+1 counters on it or Auras attached to it are removed."
         },
         {
           "date": "2015-02-25",
@@ -8866,11 +8866,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -8880,7 +8880,7 @@
       "subtypes": [
         "Elemental"
       ],
-      "text": "{U}: Exile Shorecrasher Elemental, then return it to the battlefield face down under its owner's control.\n{1}: Shorecrasher Elemental gets +1/-1 or -1/+1 until end of turn. \nMegamorph {4}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
+      "text": "{U}: Exile Shorecrasher Elemental, then return it to the battlefield face down under its owner's control.\n{1}: Shorecrasher Elemental gets +1/-1 or -1/+1 until end of turn.\nMegamorph {4}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
       "toughness": "3",
       "type": "Creature — Elemental",
       "types": [
@@ -8989,7 +8989,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -8997,15 +8997,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -9120,15 +9120,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -9136,7 +9136,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -9144,11 +9144,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -9259,7 +9259,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -9267,15 +9267,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -9391,11 +9391,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -9514,15 +9514,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If one of these spells is copied, the controller of the copy will get the “Dragon bonus” only if a Dragon card was revealed as an additional cost. The copy wasn’t cast, so whether you controlled a Dragon won’t matter."
+          "text": "If one of these spells is copied, the controller of the copy will get the \"Dragon bonus\" only if a Dragon card was revealed as an additional cost. The copy wasn't cast, so whether you controlled a Dragon won't matter."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
+          "text": "You can't reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
         },
         {
           "date": "2015-02-25",
-          "text": "If you don’t reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won’t get the bonus."
+          "text": "If you don't reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won't get the bonus."
         }
       ],
       "text": "As an additional cost to cast Silumgar's Scorn, you may reveal a Dragon card from your hand.\nCounter target spell unless its controller pays {1}. If you revealed a Dragon card or controlled a Dragon as you cast Silumgar's Scorn, counter that spell instead.",
@@ -9745,11 +9745,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -9868,15 +9868,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -9884,7 +9884,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -9892,11 +9892,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Target creature gets +2/+0 until end of turn and can't be blocked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -10116,15 +10116,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can’t (perhaps because there are no legal targets available), the card will stay exiled. You won’t get another chance to cast it on a future turn."
+          "text": "Casting the card again due to the delayed triggered ability is optional. If you choose not to cast the card, or if you can't (perhaps because there are no legal targets available), the card will stay exiled. You won't get another chance to cast it on a future turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won’t resolve and none of its effects will happen, including rebound. The spell will be put into its owner’s graveyard and you won’t get to cast it again on your next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (either because of another spell or ability or because all its targets are illegal as it tries to resolve), that spell won't resolve and none of its effects will happen, including rebound. The spell will be put into its owner's graveyard and you won't get to cast it again on your next turn."
         },
         {
           "date": "2015-02-25",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” must be followed."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
         },
         {
           "date": "2015-02-25",
@@ -10132,7 +10132,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent’s hand), rebound will have no effect."
+          "text": "If you cast a spell with rebound from any zone other than your hand (including your opponent's hand), rebound will have no effect."
         },
         {
           "date": "2015-02-25",
@@ -10140,11 +10140,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast a card from exile this way, it will go to its owner’s graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to its owner's graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Return target nonland permanent to its owner's hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -10477,11 +10477,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -10604,19 +10604,19 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -10734,7 +10734,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Use the creature’s power as it last existed on the battlefield, including any +1/+1 counters it had, when determining the value of X."
+          "text": "Use the creature's power as it last existed on the battlefield, including any +1/+1 counters it had, when determining the value of X."
         }
       ],
       "subtypes": [
@@ -11173,7 +11173,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "“Exiled this way” refers to that activation of the ability, not any creature cards that have been previously exiled."
+          "text": "\"Exiled this way\" refers to that activation of the ability, not any creature cards that have been previously exiled."
         }
       ],
       "text": "{1}{B}, Exile one or more creature cards from your graveyard: Create a tapped X/X black Zombie Horror creature token, where X is twice the number of cards exiled this way.",
@@ -11605,11 +11605,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If you cast a creature spell that enters the battlefield as a copy of Deathbringer Regent, the enters-the-battlefield ability will trigger (assuming the “five or more other creatures” requirement is also met)."
+          "text": "If you cast a creature spell that enters the battlefield as a copy of Deathbringer Regent, the enters-the-battlefield ability will trigger (assuming the \"five or more other creatures\" requirement is also met)."
         },
         {
           "date": "2015-02-25",
-          "text": "Deathbringer Regent’s last ability destroys all creatures except Deathbringer Regent, including the five other creatures required for the ability to have an effect."
+          "text": "Deathbringer Regent's last ability destroys all creatures except Deathbringer Regent, including the five other creatures required for the ability to have an effect."
         }
       ],
       "subtypes": [
@@ -12165,7 +12165,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You must target a creature card in your graveyard and a creature on the battlefield to cast Foul Renewal. If the creature becomes an illegal target before Foul Renewal resolves, you’ll still return the creature card to your hand. If the creature card in your graveyard becomes an illegal target, the creature on the battlefield will be unaffected as there is no “card returned this way.”"
+          "text": "You must target a creature card in your graveyard and a creature on the battlefield to cast Foul Renewal. If the creature becomes an illegal target before Foul Renewal resolves, you'll still return the creature card to your hand. If the creature card in your graveyard becomes an illegal target, the creature on the battlefield will be unaffected as there is no \"card returned this way.\""
         }
       ],
       "text": "Return target creature card from your graveyard to your hand. Target creature gets -X/-X until end of turn, where X is the toughness of the card returned this way.",
@@ -12274,19 +12274,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You may cast Foul-Tongue Invocation targeting a player who controls no creatures. If you qualify for the “Dragon bonus,” you’ll just gain 4 life."
+          "text": "You may cast Foul-Tongue Invocation targeting a player who controls no creatures. If you qualify for the \"Dragon bonus,\" you'll just gain 4 life."
         },
         {
           "date": "2015-02-25",
-          "text": "If one of these spells is copied, the controller of the copy will get the “Dragon bonus” only if a Dragon card was revealed as an additional cost. The copy wasn’t cast, so whether you controlled a Dragon won’t matter."
+          "text": "If one of these spells is copied, the controller of the copy will get the \"Dragon bonus\" only if a Dragon card was revealed as an additional cost. The copy wasn't cast, so whether you controlled a Dragon won't matter."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
+          "text": "You can't reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
         },
         {
           "date": "2015-02-25",
-          "text": "If you don’t reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won’t get the bonus."
+          "text": "If you don't reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won't get the bonus."
         }
       ],
       "text": "As an additional cost to cast Foul-Tongue Invocation, you may reveal a Dragon card from your hand.\nTarget player sacrifices a creature. If you revealed a Dragon card or controlled a Dragon as you cast Foul-Tongue Invocation, you gain 4 life.",
@@ -12510,15 +12510,15 @@
         },
         {
           "date": "2011-01-22",
-          "text": "You can cast Gravepurge with zero targets. If you do, you’ll draw a card as the spell resolves."
+          "text": "You can cast Gravepurge with zero targets. If you do, you'll draw a card as the spell resolves."
         },
         {
           "date": "2011-01-22",
-          "text": "If you cast Gravepurge with at least one target and all of those targets become illegal, the spell will be countered and you won’t get to draw a card."
+          "text": "If you cast Gravepurge with at least one target and all of those targets become illegal, the spell will be countered and you won't get to draw a card."
         },
         {
           "date": "2015-02-25",
-          "text": "You can cast Gravepurge with no targets. If you do, you’ll just draw a card. However, if you cast it with at least one target and all of those targets become illegal, the spell will be countered and you won’t draw a card."
+          "text": "You can cast Gravepurge with no targets. If you do, you'll just draw a card. However, if you cast it with at least one target and all of those targets become illegal, the spell will be countered and you won't draw a card."
         }
       ],
       "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
@@ -12742,7 +12742,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "The once-a-turn restriction of the last ability applies only to nonland cards. You can play a land card exiled with Hedonist’s Trove on the same turn you cast a nonland card exiled that way."
+          "text": "The once-a-turn restriction of the last ability applies only to nonland cards. You can play a land card exiled with Hedonist's Trove on the same turn you cast a nonland card exiled that way."
         },
         {
           "date": "2015-02-25",
@@ -12750,11 +12750,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Under normal circumstances, you can play a land card exiled with Hedonist’s Trove only if you haven’t played a land yet that turn."
+          "text": "Under normal circumstances, you can play a land card exiled with Hedonist's Trove only if you haven't played a land yet that turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If Hedonist’s Trove leaves the battlefield, any cards it exiled remain exiled. Those cards can no longer be played. Any future instance of Hedonist’s Trove (even one represented by the same card) will be a new object and won’t allow you to play those cards."
+          "text": "If Hedonist's Trove leaves the battlefield, any cards it exiled remain exiled. Those cards can no longer be played. Any future instance of Hedonist's Trove (even one represented by the same card) will be a new object and won't allow you to play those cards."
         }
       ],
       "text": "When Hedonist's Trove enters the battlefield, exile all cards from target opponent's graveyard.\nYou may play land cards exiled with Hedonist's Trove.\nYou may cast nonland cards exiled with Hedonist's Trove. You can't cast more than one spell this way each turn.",
@@ -12865,19 +12865,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -12994,11 +12994,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -13118,11 +13118,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -13376,7 +13376,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -13384,15 +13384,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -13509,19 +13509,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -13638,7 +13638,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -13646,15 +13646,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -13771,7 +13771,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -13779,15 +13779,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -13903,19 +13903,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -14030,11 +14030,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Risen Executioner’s last ability doesn’t change when you can cast it."
+          "text": "Risen Executioner's last ability doesn't change when you can cast it."
         },
         {
           "date": "2015-02-25",
-          "text": "Once you start to cast Risen Executioner from your graveyard, you’ll finish casting it, including paying its cost, before any player receives priority. No one can respond in time to affect the cost you’ll pay (perhaps by destroying one of your other creatures)."
+          "text": "Once you start to cast Risen Executioner from your graveyard, you'll finish casting it, including paying its cost, before any player receives priority. No one can respond in time to affect the cost you'll pay (perhaps by destroying one of your other creatures)."
         }
       ],
       "subtypes": [
@@ -14477,7 +14477,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -14485,15 +14485,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -14613,15 +14613,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "The powers of Silumgar Assassin and the creature trying to block it are checked only as blockers are declared. Changing the powers of either of those creatures after Silumgar Assassin is legally blocked won’t change or undo the block."
+          "text": "The powers of Silumgar Assassin and the creature trying to block it are checked only as blockers are declared. Changing the powers of either of those creatures after Silumgar Assassin is legally blocked won't change or undo the block."
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -14742,7 +14742,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -14750,15 +14750,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -15103,7 +15103,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If an effect creates a creature token that normally has toughness 2 or less, it will enter the battlefield with toughness 0 or less, be put into its owner’s graveyard, and then cease to exist. Any abilities that trigger when a creature enters the battlefield or dies will trigger."
+          "text": "If an effect creates a creature token that normally has toughness 2 or less, it will enter the battlefield with toughness 0 or less, be put into its owner's graveyard, and then cease to exist. Any abilities that trigger when a creature enters the battlefield or dies will trigger."
         }
       ],
       "text": "Creature tokens get -2/-2.",
@@ -15213,7 +15213,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature with exploit “exploits a creature” when the controller of the exploit ability sacrifices a creature as that ability resolves."
+          "text": "A creature with exploit \"exploits a creature\" when the controller of the exploit ability sacrifices a creature as that ability resolves."
         },
         {
           "date": "2015-02-25",
@@ -15221,15 +15221,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "You can sacrifice the creature with exploit if it’s still on the battlefield. This will cause its other ability to trigger."
+          "text": "You can sacrifice the creature with exploit if it's still on the battlefield. This will cause its other ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If the creature with exploit isn’t on the battlefield as the exploit ability resolves, you won’t get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn’t on the battlefield, its other triggered ability won’t trigger."
+          "text": "If the creature with exploit isn't on the battlefield as the exploit ability resolves, you won't get any bonus from the creature with exploit, even if you sacrifice a creature. Because the creature with exploit isn't on the battlefield, its other triggered ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t sacrifice more than one creature to any one exploit ability."
+          "text": "You can't sacrifice more than one creature to any one exploit ability."
         }
       ],
       "subtypes": [
@@ -15454,11 +15454,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -15578,7 +15578,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Activating Atarka Pummeler’s ability more than once conveys no additional benefit to creatures you control."
+          "text": "Activating Atarka Pummeler's ability more than once conveys no additional benefit to creatures you control."
         },
         {
           "date": "2015-02-25",
@@ -15586,11 +15586,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -15818,11 +15818,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Under normal circumstances, you can play a land card exiled with Commune with Lava only if you haven’t played a land yet that turn."
+          "text": "Under normal circumstances, you can play a land card exiled with Commune with Lava only if you haven't played a land yet that turn."
         },
         {
           "date": "2015-02-25",
-          "text": "Any cards you don’t play will remain exiled."
+          "text": "Any cards you don't play will remain exiled."
         }
       ],
       "text": "Exile the top X cards of your library. Until the end of your next turn, you may play those cards.",
@@ -15933,11 +15933,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Crater Elemental’s last ability overrides all previous effects that set its power to a specific value. Other effects that set its power to a specific value that start to apply after the ability resolves will override this effect."
+          "text": "Crater Elemental's last ability overrides all previous effects that set its power to a specific value. Other effects that set its power to a specific value that start to apply after the ability resolves will override this effect."
         },
         {
           "date": "2015-02-25",
-          "text": "Effects that modify Crater Elemental’s power, such as the effects of Giant Growth or Hall of Triumph, will apply to it no matter when they started to take effect. The same is true for counters that change its power (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify Crater Elemental's power, such as the effects of Giant Growth or Hall of Triumph, will apply to it no matter when they started to take effect. The same is true for counters that change its power (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2015-02-25",
@@ -15945,11 +15945,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -16064,7 +16064,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If a creature is targeted but not destroyed (for example, if it regenerates or has indestructible), it won’t count toward the number of Dragon tokens put onto the battlefield."
+          "text": "If a creature is targeted but not destroyed (for example, if it regenerates or has indestructible), it won't count toward the number of Dragon tokens put onto the battlefield."
         }
       ],
       "text": "Destroy any number of target creatures. For each creature destroyed this way, its controller creates a 4/4 red Dragon creature token with flying.",
@@ -16177,15 +16177,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If one of these spells is copied, the controller of the copy will get the “Dragon bonus” only if a Dragon card was revealed as an additional cost. The copy wasn’t cast, so whether you controlled a Dragon won’t matter."
+          "text": "If one of these spells is copied, the controller of the copy will get the \"Dragon bonus\" only if a Dragon card was revealed as an additional cost. The copy wasn't cast, so whether you controlled a Dragon won't matter."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
+          "text": "You can't reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
         },
         {
           "date": "2015-02-25",
-          "text": "If you don’t reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won’t get the bonus."
+          "text": "If you don't reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won't get the bonus."
         }
       ],
       "text": "As an additional cost to cast Draconic Roar, you may reveal a Dragon card from your hand.\nDraconic Roar deals 3 damage to target creature. If you revealed a Dragon card or controlled a Dragon as you cast Draconic Roar, Draconic Roar deals 3 damage to that creature's controller.",
@@ -16413,7 +16413,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "The two abilities aren’t mutually exclusive. If a Dragon with flying (which is most of them) enters the battlefield under your control, both abilities will trigger."
+          "text": "The two abilities aren't mutually exclusive. If a Dragon with flying (which is most of them) enters the battlefield under your control, both abilities will trigger."
         }
       ],
       "text": "Whenever a creature with flying enters the battlefield under your control, it gains haste until end of turn.\nWhenever a Dragon enters the battlefield under your control, it deals X damage to target creature or player, where X is the number of Dragons you control.",
@@ -16527,11 +16527,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -16646,6 +16646,20 @@
         "DTK"
       ],
       "rarity": "Uncommon",
+      "rulings": [
+        {
+          "date": "2015-02-25",
+          "text": "Dragonlord's Servant can't reduce the colored mana requirement of a Dragon spell you cast."
+        },
+        {
+          "date": "2015-02-25",
+          "text": "If there are any additional costs to cast a Dragon spell, apply those before applying Dragonlord's Servant and any other cost reductions."
+        },
+        {
+          "date": "2015-02-25",
+          "text": "The ability can apply to alternative costs to cast a Dragon spell."
+        }
+      ],
       "subtypes": [
         "Goblin",
         "Shaman"
@@ -16760,7 +16774,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Hardened Berserker can’t reduce the colored mana requirement of a spell you cast."
+          "text": "Hardened Berserker can't reduce the colored mana requirement of a spell you cast."
         },
         {
           "date": "2015-02-25",
@@ -16995,31 +17009,31 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If a face-down Ire Shaman attacks and is blocked by one creature, turning it face up won’t cause it to become unblocked."
+          "text": "If a face-down Ire Shaman attacks and is blocked by one creature, turning it face up won't cause it to become unblocked."
         },
         {
           "date": "2015-02-25",
-          "text": "The card exiled with Ire Shaman’s last ability is exiled face up."
+          "text": "The card exiled with Ire Shaman's last ability is exiled face up."
         },
         {
           "date": "2015-02-25",
-          "text": "Playing the card exiled with Ire Shaman’s last ability follows the normal rules for playing the card. You must pay its costs, and you must follow all applicable timing rules. For example, if the card is a creature card, you can cast that card only during your main phase while the stack is empty."
+          "text": "Playing the card exiled with Ire Shaman's last ability follows the normal rules for playing the card. You must pay its costs, and you must follow all applicable timing rules. For example, if the card is a creature card, you can cast that card only during your main phase while the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "Under normal circumstances, you can play a land card exiled with Ire Shaman only if you haven’t played a land yet that turn."
+          "text": "Under normal circumstances, you can play a land card exiled with Ire Shaman only if you haven't played a land yet that turn."
         },
         {
           "date": "2015-02-25",
-          "text": "If you don’t play the card, it will remain exiled."
+          "text": "If you don't play the card, it will remain exiled."
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -17105,6 +17119,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -17151,7 +17169,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn’t prevent that creature from dealing combat damage."
+          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn't prevent that creature from dealing combat damage."
         }
       ],
       "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
@@ -17266,7 +17284,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "The damage Kolaghan Aspirant deals because of its triggered ability isn’t combat damage. If that damage causes each creature blocking it to leave combat, Kolaghan Aspirant will remain blocked. It won’t be dealt combat damage in this case."
+          "text": "The damage Kolaghan Aspirant deals because of its triggered ability isn't combat damage. If that damage causes each creature blocking it to leave combat, Kolaghan Aspirant will remain blocked. It won't be dealt combat damage in this case."
         }
       ],
       "subtypes": [
@@ -17382,23 +17400,23 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "The ability that defines Kolaghan Forerunners’s power functions in all zones, not just the battlefield. If Kolaghan Forerunners is on the battlefield, its ability will count itself."
+          "text": "The ability that defines Kolaghan Forerunners's power functions in all zones, not just the battlefield. If Kolaghan Forerunners is on the battlefield, its ability will count itself."
         },
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -17514,11 +17532,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -17638,19 +17656,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -17766,11 +17784,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Lose Calm can target any creature, including one that’s untapped or one you already control."
+          "text": "Lose Calm can target any creature, including one that's untapped or one you already control."
         },
         {
           "date": "2015-02-25",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste and menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
@@ -17889,7 +17907,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Because Magmatic Chasm’s effect doesn’t change the characteristics of any permanents, the set of creatures affected by Magmatic Chasm is constantly updated. Creatures without flying that enter the battlefield later in the turn won’t be able to block."
+          "text": "Because Magmatic Chasm's effect doesn't change the characteristics of any permanents, the set of creatures affected by Magmatic Chasm is constantly updated. Creatures without flying that enter the battlefield later in the turn won't be able to block."
         }
       ],
       "text": "Creatures without flying can't block this turn.",
@@ -18329,11 +18347,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -18449,7 +18467,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Sarkhan’s Rage checks whether you control a Dragon as it resolves."
+          "text": "Sarkhan's Rage checks whether you control a Dragon as it resolves."
         }
       ],
       "text": "Sarkhan's Rage deals 5 damage to target creature or player. If you control no Dragons, Sarkhan's Rage deals 2 damage to you.",
@@ -18664,19 +18682,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -18900,23 +18918,23 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If, during your declare attackers step, Sprinting Warbrute is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under your control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, you’re not forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Sprinting Warbrute is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under your control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, you're not forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -19033,11 +19051,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -19155,11 +19173,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -19386,7 +19404,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If either creature is an illegal target as Tail Slash tries to resolve, the creature you control won’t deal damage."
+          "text": "If either creature is an illegal target as Tail Slash tries to resolve, the creature you control won't deal damage."
         }
       ],
       "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
@@ -19499,7 +19517,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Thunderbreak Regent’s ability will resolve before the spell or ability that caused it to trigger."
+          "text": "Thunderbreak Regent's ability will resolve before the spell or ability that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -19630,7 +19648,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Because discarding a card is an additional cost, you can’t cast Tormenting Voice if you have no other cards in hand."
+          "text": "Because discarding a card is an additional cost, you can't cast Tormenting Voice if you have no other cards in hand."
         }
       ],
       "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
@@ -19745,7 +19763,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you cast Twin Bolt with two targets and one of those targets becomes illegal before Twin Bolt resolves, the remaining legal target will be dealt 1 damage. You can’t change the original division of damage."
+          "text": "If you cast Twin Bolt with two targets and one of those targets becomes illegal before Twin Bolt resolves, the remaining legal target will be dealt 1 damage. You can't change the original division of damage."
         }
       ],
       "text": "Twin Bolt deals 2 damage divided as you choose among one or two target creatures and/or players.",
@@ -19959,7 +19977,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "An “attacking creature” is one that has been declared as an attacker that combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left the battlefield."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker that combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left the battlefield."
         },
         {
           "date": "2015-02-25",
@@ -19967,7 +19985,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Only creatures that are attacking as Volcanic Rush resolves will receive the bonus. In other words, casting it before you declare attackers usually won’t do anything."
+          "text": "Only creatures that are attacking as Volcanic Rush resolves will receive the bonus. In other words, casting it before you declare attackers usually won't do anything."
         }
       ],
       "text": "Attacking creatures get +2/+0 and gain trample until end of turn.",
@@ -20079,7 +20097,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If the target instant or sorcery card becomes an illegal target before Volcanic Vision resolves, the spell will be countered and none of its effects will happen. No damage will be dealt and Volcanic Vision won’t be exiled."
+          "text": "If the target instant or sorcery card becomes an illegal target before Volcanic Vision resolves, the spell will be countered and none of its effects will happen. No damage will be dealt and Volcanic Vision won't be exiled."
         },
         {
           "date": "2015-02-25",
@@ -20193,27 +20211,27 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Warbringer’s first ability doesn’t affect Warbringer itself."
+          "text": "Warbringer's first ability doesn't affect Warbringer itself."
         },
         {
           "date": "2015-02-25",
-          "text": "Warbringer’s first ability can’t affect the colored mana requirement of a dash cost. If a card’s dash cost includes one generic mana, that cost will be reduced by {1}."
+          "text": "Warbringer's first ability can't affect the colored mana requirement of a dash cost. If a card's dash cost includes one generic mana, that cost will be reduced by {1}."
         },
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -20330,27 +20348,27 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Once Zurgo Bellstriker has legally blocked a creature, raising that creature’s power to 2 or greater won’t undo the block."
+          "text": "Once Zurgo Bellstriker has legally blocked a creature, raising that creature's power to 2 or greater won't undo the block."
         },
         {
           "date": "2015-02-25",
-          "text": "Even though both cards portray the same character, Zurgo Bellstriker and Zurgo Helmsmasher have different names. Controlling both of them won’t invoke the “legend rule.”"
+          "text": "Even though both cards portray the same character, Zurgo Bellstriker and Zurgo Helmsmasher have different names. Controlling both of them won't invoke the \"legend rule.\""
         },
         {
           "date": "2015-02-25",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2015-02-25",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2015-02-25",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -20469,11 +20487,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -20704,11 +20722,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -20831,7 +20849,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "The first ability doesn’t actually change any creature’s power. It changes only the value of the combat damage it assigns. All other rules and effects that check power or toughness use the real values."
+          "text": "The first ability doesn't actually change any creature's power. It changes only the value of the combat damage it assigns. All other rules and effects that check power or toughness use the real values."
         }
       ],
       "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\n{G}: Target creature with defender can attack this turn as though it didn't have defender.\n{2}{G}: Creatures you control get +0/+1 until end of turn.",
@@ -20946,11 +20964,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -21068,7 +21086,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "When determining how many +1/+1 counters Avatar of the Resolute enters the battlefield with, don’t count any creatures entering the battlefield at the same time, even if those creatures enter the battlefield with +1/+1 counters on them."
+          "text": "When determining how many +1/+1 counters Avatar of the Resolute enters the battlefield with, don't count any creatures entering the battlefield at the same time, even if those creatures enter the battlefield with +1/+1 counters on them."
         }
       ],
       "subtypes": [
@@ -21188,11 +21206,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -21308,7 +21326,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Each of the creature cards can have converted mana cost 3 or less. It’s not the total converted mana cost of the two cards."
+          "text": "Each of the creature cards can have converted mana cost 3 or less. It's not the total converted mana cost of the two cards."
         }
       ],
       "text": "Look at the top six cards of your library. Put up to two creature cards with converted mana cost 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in any order.",
@@ -21634,7 +21652,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Deathmist Raptor’s second ability triggers only if Deathmist Raptor is in the graveyard when a permanent you control is turned face up."
+          "text": "Deathmist Raptor's second ability triggers only if Deathmist Raptor is in the graveyard when a permanent you control is turned face up."
         },
         {
           "date": "2015-02-25",
@@ -21642,11 +21660,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -21767,15 +21785,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You compare Den Protector’s power to the power of any creature trying to block it only as blockers are assigned. Once Den Protector has been legally blocked by a creature, changing the power of either creature won’t change or undo the block."
+          "text": "You compare Den Protector's power to the power of any creature trying to block it only as blockers are assigned. Once Den Protector has been legally blocked by a creature, changing the power of either creature won't change or undo the block."
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -21894,7 +21912,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If you choose the second mode, and if a permanent you control is being targeted by a spell when Display of Dominance resolves, nothing happens right away. When that spell would resolve, its color is checked. If it’s blue or black, that permanent will be an illegal target for that spell and won’t be affected by it. If all that spell’s targets have become illegal by the time it would resolve, it’s countered."
+          "text": "If you choose the second mode, and if a permanent you control is being targeted by a spell when Display of Dominance resolves, nothing happens right away. When that spell would resolve, its color is checked. If it's blue or black, that permanent will be an illegal target for that spell and won't be affected by it. If all that spell's targets have become illegal by the time it would resolve, it's countered."
         },
         {
           "date": "2015-02-25",
@@ -21902,11 +21920,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If you choose the second mode, Display of Dominance will affect any permanent you happen to control at any point during the rest of the turn, not just permanents you control as it resolves. That’s because it doesn’t grant an ability to those permanents; rather, it affects the game rules and states something that’s now true about those permanents."
+          "text": "If you choose the second mode, Display of Dominance will affect any permanent you happen to control at any point during the rest of the turn, not just permanents you control as it resolves. That's because it doesn't grant an ability to those permanents; rather, it affects the game rules and states something that's now true about those permanents."
         },
         {
           "date": "2015-02-25",
-          "text": "Keep in mind that an Aura spell targets the permanent it will enchant (but an Aura on the battlefield doesn’t target the permanent it’s attached to)."
+          "text": "Keep in mind that an Aura spell targets the permanent it will enchant (but an Aura on the battlefield doesn't target the permanent it's attached to)."
         },
         {
           "date": "2015-02-25",
@@ -22025,11 +22043,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -22144,11 +22162,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "text": "Bolster 4. (Choose a creature with the least toughness among creatures you control and put four +1/+1 counters on it.)",
@@ -22259,7 +22277,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If the creature you control is an illegal target as Epic Confrontation tries to resolve, the creature you control won’t get +1/+2. If that creature is a legal target but the creature you don’t control isn’t, your creature will still get +1/+2. In both cases, neither creature will deal or be dealt damage."
+          "text": "If the creature you control is an illegal target as Epic Confrontation tries to resolve, the creature you control won't get +1/+2. If that creature is a legal target but the creature you don't control isn't, your creature will still get +1/+2. In both cases, neither creature will deal or be dealt damage."
         }
       ],
       "text": "Target creature you control gets +1/+2 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
@@ -22488,11 +22506,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If the target creature you don’t control becomes an illegal target of the first triggered ability before it resolves, Foe-Razer Regent won’t fight and its last ability won’t trigger."
+          "text": "If the target creature you don't control becomes an illegal target of the first triggered ability before it resolves, Foe-Razer Regent won't fight and its last ability won't trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature you control fights during an end step, the delayed triggered ability that puts +1/+1 counters on that creature won’t trigger until the beginning of the following turn’s end step."
+          "text": "If a creature you control fights during an end step, the delayed triggered ability that puts +1/+1 counters on that creature won't trigger until the beginning of the following turn's end step."
         }
       ],
       "subtypes": [
@@ -22611,11 +22629,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -22730,11 +22748,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -22854,11 +22872,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -22981,7 +22999,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Creatures you control that have +1/+1 counters put on them after Inspiring Call resolves won’t gain indestructible."
+          "text": "Creatures you control that have +1/+1 counters put on them after Inspiring Call resolves won't gain indestructible."
         }
       ],
       "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn.",
@@ -23093,19 +23111,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You may activate Lurking Arynx’s ability multiple times in a turn to force multiple creatures to block it if able."
+          "text": "You may activate Lurking Arynx's ability multiple times in a turn to force multiple creatures to block it if able."
         },
         {
           "date": "2015-02-25",
-          "text": "Activating Lurking Arynx’s ability doesn’t force you to attack with it that turn. If it doesn’t attack, the creatures affected by its ability can block other attacking creatures or not block at all."
+          "text": "Activating Lurking Arynx's ability doesn't force you to attack with it that turn. If it doesn't attack, the creatures affected by its ability can block other attacking creatures or not block at all."
         },
         {
           "date": "2015-02-25",
-          "text": "If a creature affected by Lurking Arynx’s ability can’t legally block it (perhaps because Lurking Arynx has gained flying), that creature can block other attacking creatures or not block at all."
+          "text": "If a creature affected by Lurking Arynx's ability can't legally block it (perhaps because Lurking Arynx has gained flying), that creature can block other attacking creatures or not block at all."
         },
         {
           "date": "2015-02-25",
-          "text": "If, during the declare blockers step, a creature is tapped or is affected by a spell or ability that says it can’t block, it doesn’t block. If there’s a cost associated with having a creature block, its controller isn’t forced to pay that cost, so it doesn’t have to block in that case either."
+          "text": "If, during the declare blockers step, a creature is tapped or is affected by a spell or ability that says it can't block, it doesn't block. If there's a cost associated with having a creature block, its controller isn't forced to pay that cost, so it doesn't have to block in that case either."
         },
         {
           "date": "2015-02-25",
@@ -23113,11 +23131,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -23375,7 +23393,7 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Note that Obscuring Aether doesn’t have a morph cost. Once it’s turned face down, it doesn’t have a way to turn itself face up."
+          "text": "Note that Obscuring Aether doesn't have a morph cost. Once it's turned face down, it doesn't have a way to turn itself face up."
         }
       ],
       "text": "Face-down creature spells you cast cost {1} less to cast.\n{1}{G}: Turn Obscuring Aether face down. (It becomes a 2/2 creature.)",
@@ -23485,15 +23503,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You must choose a creature with flying in order to cast Pinion Feast. You can’t cast it without a legal target just to bolster."
+          "text": "You must choose a creature with flying in order to cast Pinion Feast. You can't cast it without a legal target just to bolster."
         },
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "text": "Destroy target creature with flying. Bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
@@ -23825,15 +23843,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "The face-down permanent must be a creature both before it’s turned face up and when the triggered ability resolves to have +1/+1 counters placed on it."
+          "text": "The face-down permanent must be a creature both before it's turned face up and when the triggered ability resolves to have +1/+1 counters placed on it."
         },
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -24064,11 +24082,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "subtypes": [
@@ -24185,15 +24203,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If one of these spells is copied, the controller of the copy will get the “Dragon bonus” only if a Dragon card was revealed as an additional cost. The copy wasn’t cast, so whether you controlled a Dragon won’t matter."
+          "text": "If one of these spells is copied, the controller of the copy will get the \"Dragon bonus\" only if a Dragon card was revealed as an additional cost. The copy wasn't cast, so whether you controlled a Dragon won't matter."
         },
         {
           "date": "2015-02-25",
-          "text": "You can’t reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
+          "text": "You can't reveal more than one Dragon card to multiply the bonus. There is also no additional benefit for both revealing a Dragon card as an additional cost and controlling a Dragon as you cast the spell."
         },
         {
           "date": "2015-02-25",
-          "text": "If you don’t reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won’t get the bonus."
+          "text": "If you don't reveal a Dragon card from your hand, you must control a Dragon as you are finished casting the spell to get the bonus. For example, if you lose control of your only Dragon while casting the spell (because, for example, you sacrificed it to activate a mana ability), you won't get the bonus."
         }
       ],
       "subtypes": [
@@ -24310,11 +24328,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Turning a face-down creature with megamorph face up and putting a +1/+1 counter on it is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
-          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won’t put a +1/+1 counter on it."
+          "text": "If a face-down creature with megamorph is turned face up some other way (for example, if you manifest a card with megamorph and then pay its mana cost to turn it face up), you won't put a +1/+1 counter on it."
         },
         {
           "date": "2015-02-25",
@@ -24542,7 +24560,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "The first ability of Shaman of Forgotten Ways is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The first ability of Shaman of Forgotten Ways is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-02-25",
@@ -24550,15 +24568,15 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Count the number of creatures each player controls when the last ability resolves to determine what number each player’s life total will become."
+          "text": "Count the number of creatures each player controls when the last ability resolves to determine what number each player's life total will become."
         },
         {
           "date": "2015-02-25",
-          "text": "For a player’s life total to become a specific number, the player gains or loses the appropriate amount of life. For example, if a player’s life total is 12 and that player controls three creatures as the ability resolves, he or she will lose 9 life. Other effects that interact with life gain or loss will interact with this effect accordingly."
+          "text": "For a player's life total to become a specific number, the player gains or loses the appropriate amount of life. For example, if a player's life total is 12 and that player controls three creatures as the ability resolves, he or she will lose 9 life. Other effects that interact with life gain or loss will interact with this effect accordingly."
         },
         {
           "date": "2015-02-25",
-          "text": "If a player controls no creatures as the last ability resolves, his or her life total will become 0, causing that player to lose the game. If all players’ life totals become 0 this way, the game will be a draw."
+          "text": "If a player controls no creatures as the last ability resolves, his or her life total will become 0, causing that player to lose the game. If all players' life totals become 0 this way, the game will be a draw."
         },
         {
           "date": "2015-02-25",
@@ -24566,11 +24584,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -25006,11 +25024,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -25124,15 +25142,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Count the number of cards in your hand as Sunbringer’s Touch resolves to determine the value of X."
+          "text": "Count the number of cards in your hand as Sunbringer's Touch resolves to determine the value of X."
         },
         {
           "date": "2015-02-25",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Aven Tactician's bolster ability."
         },
         {
           "date": "2015-02-25",
-          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it’s still under your control and has the least toughness."
+          "text": "You determine which creature to put counters on as the spell or ability that instructs you to bolster resolves. That could be the creature with the bolster ability, if it's still under your control and has the least toughness."
         }
       ],
       "text": "Bolster X, where X is the number of cards in your hand. Each creature you control with a +1/+1 counter on it gains trample until end of turn. (To bolster X, choose a creature with the least toughness among creatures you control and put X +1/+1 counters on it.)",
@@ -25249,11 +25267,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn’t matter what happens to the total power of creatures you control."
+          "text": "Some formidable abilities are activated abilities that require creatures you control to have total power 8 or greater. Once you activate these abilities, it doesn't matter what happens to the total power of creatures you control."
         },
         {
           "date": "2015-02-25",
-          "text": "Other formidable abilities are triggered abilities with an “intervening ‘if’” clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
+          "text": "Other formidable abilities are triggered abilities with an \"intervening 'if'\" clause. Such abilities check the total power of creatures you control twice: once at the appropriate time to see if the ability will trigger, and again as the ability tries to resolve. If, at that time, the total power of creatures you control is no longer 8 or greater, the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -25481,11 +25499,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "The player who controlled Arashin Sovereign when it died chooses whether to put it on the top or bottom of its owner’s library. The player may also choose to leave Arashin Sovereign in the graveyard. This choice is made as the ability resolves."
+          "text": "The player who controlled Arashin Sovereign when it died chooses whether to put it on the top or bottom of its owner's library. The player may also choose to leave Arashin Sovereign in the graveyard. This choice is made as the ability resolves."
         },
         {
           "date": "2015-02-25",
-          "text": "Arashin Sovereign will be put on the top or bottom of that library only if it’s still in the graveyard when its ability resolves. If it leaves the graveyard before that point, it will stay in whatever zone it’s in, even if it’s returned to the graveyard before the ability resolves."
+          "text": "Arashin Sovereign will be put on the top or bottom of that library only if it's still in the graveyard when its ability resolves. If it leaves the graveyard before that point, it will stay in whatever zone it's in, even if it's returned to the graveyard before the ability resolves."
         }
       ],
       "subtypes": [
@@ -25602,19 +25620,27 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can’t be changed."
+          "text": "The first mode won't affect life that was gained earlier in the turn."
         },
         {
           "date": "2015-02-25",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren’t chosen. For example, you can cast Ojutai’s Command without targeting a creature spell provided you don’t choose the third mode."
+          "text": "If you choose the third mode and put a land card onto the battlefield, that doesn't count as playing a land. For example, you can both play a land and put a land onto the battlefield this way during your turn."
         },
         {
           "date": "2015-02-25",
-          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai’s Command, you would gain 4 life and then draw a card. (The order won’t matter in most cases.)"
+          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-02-25",
-          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can’t choose new modes."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren't chosen. For example, you can cast Ojutai's Command without targeting a creature spell provided you don't choose the third mode."
+        },
+        {
+          "date": "2015-02-25",
+          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai's Command, you would gain 4 life and then draw a card. (The order won't matter in most cases.)"
+        },
+        {
+          "date": "2015-02-25",
+          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can't choose new modes."
         },
         {
           "date": "2015-02-25",
@@ -25734,7 +25760,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Any creature on the battlefield can be the target of Boltwing Marauder’s triggered ability, including the one that entered the battlefield and caused the ability to trigger."
+          "text": "Any creature on the battlefield can be the target of Boltwing Marauder's triggered ability, including the one that entered the battlefield and caused the ability to trigger."
         }
       ],
       "subtypes": [
@@ -26207,11 +26233,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Casting a spell face down won’t cause Dragonlord Kolaghan’s last ability to trigger. A spell with no name can’t have the same name as any other card."
+          "text": "Casting a spell face down won't cause Dragonlord Kolaghan's last ability to trigger. A spell with no name can't have the same name as any other card."
         },
         {
           "date": "2015-02-25",
-          "text": "If an opponent casts a creature spell with delve and exiles all cards from his or her graveyard with the same name to help pay its cost, Dragonlord Kolaghan’s ability won’t trigger."
+          "text": "If an opponent casts a creature spell with delve and exiles all cards from his or her graveyard with the same name to help pay its cost, Dragonlord Kolaghan's ability won't trigger."
         }
       ],
       "subtypes": [
@@ -26454,11 +26480,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If Dragonlord Silumgar ceases to be under your control before its ability resolves, you won’t gain control of the creature or planeswalker at all."
+          "text": "If Dragonlord Silumgar ceases to be under your control before its ability resolves, you won't gain control of the creature or planeswalker at all."
         },
         {
           "date": "2015-02-25",
-          "text": "If another player gains control of Dragonlord Silumgar, its control-change effect ends. Regaining control of Dragonlord Silumgar won’t cause you to regain control of the creature or planeswalker."
+          "text": "If another player gains control of Dragonlord Silumgar, its control-change effect ends. Regaining control of Dragonlord Silumgar won't cause you to regain control of the creature or planeswalker."
         }
       ],
       "subtypes": [
@@ -26579,19 +26605,27 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can’t be changed."
+          "text": "Although most instants and sorceries that cause damage to be dealt are the sources of that damage, a few cause other objects to deal damage (for example, spells that cause creatures to fight). The first ability of Dromoka's Command won't prevent damage caused by those other sources."
         },
         {
           "date": "2015-02-25",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren’t chosen. For example, you can cast Ojutai’s Command without targeting a creature spell provided you don’t choose the third mode."
+          "text": "You can target any player with the second ability, including one that doesn't control an enchantment."
         },
         {
           "date": "2015-02-25",
-          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai’s Command, you would gain 4 life and then draw a card. (The order won’t matter in most cases.)"
+          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-02-25",
-          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can’t choose new modes."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren't chosen. For example, you can cast Ojutai's Command without targeting a creature spell provided you don't choose the third mode."
+        },
+        {
+          "date": "2015-02-25",
+          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai's Command, you would gain 4 life and then draw a card. (The order won't matter in most cases.)"
+        },
+        {
+          "date": "2015-02-25",
+          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can't choose new modes."
         },
         {
           "date": "2015-02-25",
@@ -26710,15 +26744,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A creature entering the battlefield with one or more +1/+1 counters on it will cause Enduring Scalelord’s ability to trigger."
+          "text": "A creature entering the battlefield with one or more +1/+1 counters on it will cause Enduring Scalelord's ability to trigger."
         },
         {
           "date": "2015-02-25",
-          "text": "If +1/+1 counters are put on multiple creatures you control (other than Enduring Scalelord) at the same time, Enduring Scalelord’s ability will trigger once for each of those creatures."
+          "text": "If +1/+1 counters are put on multiple creatures you control (other than Enduring Scalelord) at the same time, Enduring Scalelord's ability will trigger once for each of those creatures."
         },
         {
           "date": "2015-02-25",
-          "text": "If you control two Enduring Scalelords, putting a +1/+1 counter on one of them will cause the ability of the other one to trigger. When this ability resolves, you’ll put a +1/+1 counter on the other Scalelord. This will cause the ability of the first one to trigger. This loop will repeat until you choose not to put a +1/+1 counter on one of the Enduring Scalelords."
+          "text": "If you control two Enduring Scalelords, putting a +1/+1 counter on one of them will cause the ability of the other one to trigger. When this ability resolves, you'll put a +1/+1 counter on the other Scalelord. This will cause the ability of the first one to trigger. This loop will repeat until you choose not to put a +1/+1 counter on one of the Enduring Scalelords."
         }
       ],
       "subtypes": [
@@ -26955,19 +26989,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can’t be changed."
+          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-02-25",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren’t chosen. For example, you can cast Ojutai’s Command without targeting a creature spell provided you don’t choose the third mode."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren't chosen. For example, you can cast Ojutai's Command without targeting a creature spell provided you don't choose the third mode."
         },
         {
           "date": "2015-02-25",
-          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai’s Command, you would gain 4 life and then draw a card. (The order won’t matter in most cases.)"
+          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai's Command, you would gain 4 life and then draw a card. (The order won't matter in most cases.)"
         },
         {
           "date": "2015-02-25",
-          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can’t choose new modes."
+          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can't choose new modes."
         },
         {
           "date": "2015-02-25",
@@ -27084,11 +27118,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "When resolving Narset’s first ability, if the top card of your library is a creature or a land card, or if you don’t wish to put it into your hand, it isn’t revealed."
+          "text": "When resolving Narset's first ability, if the top card of your library is a creature or a land card, or if you don't wish to put it into your hand, it isn't revealed."
         },
         {
           "date": "2015-02-25",
-          "text": "If a spell that exiles itself as part of its own resolution, such as Volcanic Vision, gains rebound, the ability that lets you cast the spell again won’t be created. The spell will simply be exiled."
+          "text": "If a spell that exiles itself as part of its own resolution, such as Volcanic Vision, gains rebound, the ability that lets you cast the spell again won't be created. The spell will simply be exiled."
         }
       ],
       "subtypes": [
@@ -27205,7 +27239,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Necromaster Dragon’s last ability will trigger once for each player it deals combat damage to. For each of these abilities, you may pay {2} only once."
+          "text": "Necromaster Dragon's last ability will trigger once for each player it deals combat damage to. For each of these abilities, you may pay {2} only once."
         }
       ],
       "subtypes": [
@@ -27323,19 +27357,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can’t be changed."
+          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-02-25",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren’t chosen. For example, you can cast Ojutai’s Command without targeting a creature spell provided you don’t choose the third mode."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren't chosen. For example, you can cast Ojutai's Command without targeting a creature spell provided you don't choose the third mode."
         },
         {
           "date": "2015-02-25",
-          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai’s Command, you would gain 4 life and then draw a card. (The order won’t matter in most cases.)"
+          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai's Command, you would gain 4 life and then draw a card. (The order won't matter in most cases.)"
         },
         {
           "date": "2015-02-25",
-          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can’t choose new modes."
+          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can't choose new modes."
         },
         {
           "date": "2015-02-25",
@@ -27567,11 +27601,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Ruthless Deathfang’s triggered ability will trigger whenever you sacrifice any creature, including Ruthless Deathfang itself. It will trigger whenever you sacrifice a creature for any reason, including to pay a cost or as the result of a spell or ability (such as an opposing Ruthless Deathfang’s ability)."
+          "text": "Ruthless Deathfang's triggered ability will trigger whenever you sacrifice any creature, including Ruthless Deathfang itself. It will trigger whenever you sacrifice a creature for any reason, including to pay a cost or as the result of a spell or ability (such as an opposing Ruthless Deathfang's ability)."
         },
         {
           "date": "2015-02-25",
-          "text": "Notably, the “legend rule” does not cause any permanents to be sacrificed. They are simply put into their owners’ graveyards."
+          "text": "Notably, the \"legend rule\" does not cause any permanents to be sacrificed. They are simply put into their owners' graveyards."
         }
       ],
       "subtypes": [
@@ -27799,7 +27833,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "This mana won’t empty from your mana pool as steps and phases end for the remainder of the turn even if Savage Ventmaw leaves the battlefield during the turn."
+          "text": "This mana won't empty from your mana pool as steps and phases end for the remainder of the turn even if Savage Ventmaw leaves the battlefield during the turn."
         }
       ],
       "subtypes": [
@@ -27916,19 +27950,19 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can’t be changed."
+          "text": "You choose the two modes as you cast the spell. You must choose two different modes. Once modes are chosen, they can't be changed."
         },
         {
           "date": "2015-02-25",
-          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren’t chosen. For example, you can cast Ojutai’s Command without targeting a creature spell provided you don’t choose the third mode."
+          "text": "You can choose a mode only if you can choose legal targets for that mode. Ignore the targeting requirements for modes that aren't chosen. For example, you can cast Ojutai's Command without targeting a creature spell provided you don't choose the third mode."
         },
         {
           "date": "2015-02-25",
-          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai’s Command, you would gain 4 life and then draw a card. (The order won’t matter in most cases.)"
+          "text": "As the spell resolves, follow the instructions of the modes you chose in the order they are printed on the card. For example, if you chose the second and fourth modes of Ojutai's Command, you would gain 4 life and then draw a card. (The order won't matter in most cases.)"
         },
         {
           "date": "2015-02-25",
-          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can’t choose new modes."
+          "text": "If a Command is copied, the effect that creates the copy will usually allow you to choose new targets for the copy, but you can't choose new modes."
         },
         {
           "date": "2015-02-25",
@@ -28045,11 +28079,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "You can’t put creatures onto the battlefield face down this way."
+          "text": "You can't put creatures onto the battlefield face down this way."
         },
         {
           "date": "2015-02-25",
-          "text": "The creature you put onto the battlefield will be returned to your hand only if it’s still on the battlefield as the delayed triggered ability resolves during the next end step. If it leaves the battlefield before then, it will remain wherever it is."
+          "text": "The creature you put onto the battlefield will be returned to your hand only if it's still on the battlefield as the delayed triggered ability resolves during the next end step. If it leaves the battlefield before then, it will remain wherever it is."
         },
         {
           "date": "2015-02-25",
@@ -28163,11 +28197,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Ancestral Statue’s ability is mandatory. If Ancestral Statue is the only nonland permanent you control when its ability resolves, you must return it to its owner’s hand."
+          "text": "Ancestral Statue's ability is mandatory. If Ancestral Statue is the only nonland permanent you control when its ability resolves, you must return it to its owner's hand."
         },
         {
           "date": "2015-02-25",
-          "text": "The triggered ability doesn’t target any permanent. You choose which one to return as the ability resolves. No player can respond to this choice once the ability starts resolving."
+          "text": "The triggered ability doesn't target any permanent. You choose which one to return as the ability resolves. No player can respond to this choice once the ability starts resolving."
         }
       ],
       "subtypes": [
@@ -28280,7 +28314,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A Monument can’t attack on the turn it enters the battlefield."
+          "text": "A Monument can't attack on the turn it enters the battlefield."
         },
         {
           "date": "2015-02-25",
@@ -28288,11 +28322,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn’t a creature, but they will apply again if the Monument later becomes a creature."
+          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn't a creature, but they will apply again if the Monument later becomes a creature."
         },
         {
           "date": "2015-02-25",
-          "text": "Activating the last ability of a Monument while it’s already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
+          "text": "Activating the last ability of a Monument while it's already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
         }
       ],
       "text": "{T}: Add {R} or {G} to your mana pool.\n{4}{R}{G}: Atarka Monument becomes a 4/4 red and green Dragon artifact creature with flying until end of turn.",
@@ -28609,7 +28643,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A Monument can’t attack on the turn it enters the battlefield."
+          "text": "A Monument can't attack on the turn it enters the battlefield."
         },
         {
           "date": "2015-02-25",
@@ -28617,11 +28651,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn’t a creature, but they will apply again if the Monument later becomes a creature."
+          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn't a creature, but they will apply again if the Monument later becomes a creature."
         },
         {
           "date": "2015-02-25",
-          "text": "Activating the last ability of a Monument while it’s already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
+          "text": "Activating the last ability of a Monument while it's already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
         }
       ],
       "text": "{T}: Add {G} or {W} to your mana pool.\n{4}{G}{W}: Dromoka Monument becomes a 4/4 green and white Dragon artifact creature with flying until end of turn.",
@@ -28725,7 +28759,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Gate Smasher’s equip ability can target any creature. However, if that creature’s toughness is 3 or less as the equip ability resolves, Gate Smasher won’t become attached to it."
+          "text": "Gate Smasher's equip ability can target any creature. However, if that creature's toughness is 3 or less as the equip ability resolves, Gate Smasher won't become attached to it."
         },
         {
           "date": "2015-02-25",
@@ -28837,15 +28871,15 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Keeper of the Lens allows you to look at face-down creatures you don’t control whenever you want to, even if you don’t have priority. This action doesn’t use the stack."
+          "text": "Keeper of the Lens allows you to look at face-down creatures you don't control whenever you want to, even if you don't have priority. This action doesn't use the stack."
         },
         {
           "date": "2015-02-25",
-          "text": "Keeper of the Lens doesn’t stop your opponents from looking at face-down creatures they control."
+          "text": "Keeper of the Lens doesn't stop your opponents from looking at face-down creatures they control."
         },
         {
           "date": "2015-02-25",
-          "text": "Keeper of the Lens doesn’t let you look at other players’ face-down spells while they’re on the stack."
+          "text": "Keeper of the Lens doesn't let you look at other players' face-down spells while they're on the stack."
         }
       ],
       "subtypes": [
@@ -28958,7 +28992,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A Monument can’t attack on the turn it enters the battlefield."
+          "text": "A Monument can't attack on the turn it enters the battlefield."
         },
         {
           "date": "2015-02-25",
@@ -28966,11 +29000,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn’t a creature, but they will apply again if the Monument later becomes a creature."
+          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn't a creature, but they will apply again if the Monument later becomes a creature."
         },
         {
           "date": "2015-02-25",
-          "text": "Activating the last ability of a Monument while it’s already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
+          "text": "Activating the last ability of a Monument while it's already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
         }
       ],
       "text": "{T}: Add {B} or {R} to your mana pool.\n{4}{B}{R}: Kolaghan Monument becomes a 4/4 black and red Dragon artifact creature with flying until end of turn.",
@@ -29079,7 +29113,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A Monument can’t attack on the turn it enters the battlefield."
+          "text": "A Monument can't attack on the turn it enters the battlefield."
         },
         {
           "date": "2015-02-25",
@@ -29087,11 +29121,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn’t a creature, but they will apply again if the Monument later becomes a creature."
+          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn't a creature, but they will apply again if the Monument later becomes a creature."
         },
         {
           "date": "2015-02-25",
-          "text": "Activating the last ability of a Monument while it’s already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
+          "text": "Activating the last ability of a Monument while it's already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
         }
       ],
       "text": "{T}: Add {W} or {U} to your mana pool.\n{4}{W}{U}: Ojutai Monument becomes a 4/4 white and blue Dragon artifact creature with flying until end of turn.",
@@ -29200,7 +29234,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "A Monument can’t attack on the turn it enters the battlefield."
+          "text": "A Monument can't attack on the turn it enters the battlefield."
         },
         {
           "date": "2015-02-25",
@@ -29208,11 +29242,11 @@
         },
         {
           "date": "2015-02-25",
-          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn’t a creature, but they will apply again if the Monument later becomes a creature."
+          "text": "If a Monument has any +1/+1 counters on it, those counters will remain on the permanent after it stops being a creature. Those counters will have no effect as long as the Monument isn't a creature, but they will apply again if the Monument later becomes a creature."
         },
         {
           "date": "2015-02-25",
-          "text": "Activating the last ability of a Monument while it’s already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
+          "text": "Activating the last ability of a Monument while it's already a creature will override any effects that set its power or toughness to a specific value. Effects that modify power or toughness without directly setting them to a specific value will continue to apply."
         }
       ],
       "text": "{T}: Add {U} or {B} to your mana pool.\n{4}{U}{B}: Silumgar Monument becomes a 4/4 blue and black Dragon artifact creature with flying until end of turn.",
@@ -29422,7 +29456,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If the creature that entered the battlefield is no longer on the battlefield as Stormrider Rig’s second ability resolves, Stormrider Rig doesn’t move. This is also true if that creature can’t legally be equipped by Stormrider Rig."
+          "text": "If the creature that entered the battlefield is no longer on the battlefield as Stormrider Rig's second ability resolves, Stormrider Rig doesn't move. This is also true if that creature can't legally be equipped by Stormrider Rig."
         }
       ],
       "subtypes": [
@@ -29860,7 +29894,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "The mana produced by Haven of the Spirit Dragon’s second ability can be used to pay for any additional or alternative costs (such as dash costs) involved in casting a Dragon creature spell."
+          "text": "The mana produced by Haven of the Spirit Dragon's second ability can be used to pay for any additional or alternative costs (such as dash costs) involved in casting a Dragon creature spell."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a Dragon creature spell.\n{2}, {T}, Sacrifice Haven of the Spirit Dragon: Return target Dragon creature card or Ugin planeswalker card from your graveyard to your hand.",
@@ -29986,19 +30020,19 @@
           "multiverseid": 396761
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 396762
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 397289
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 396763
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 397290
         },
         {
-          "language": "Russian",
-          "name": "Равнина",
-          "multiverseid": 397025
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 397291
         }
       ],
       "id": "2c9386d2979ada162160c9217c8e62a52c0320de",
@@ -30366,19 +30400,19 @@
           "multiverseid": 396761
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 396762
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 397289
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 396763
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 397290
         },
         {
-          "language": "Russian",
-          "name": "Равнина",
-          "multiverseid": 397025
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 397291
         }
       ],
       "id": "1b30b26ecfd822dabfe77c9cb7861aaaeef42406",
@@ -31016,11 +31050,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "海岛",
-          "multiverseid": 394867
-        },
-        {
           "language": "Chinese Traditional",
           "name": "海島",
           "multiverseid": 395131
@@ -31131,14 +31160,19 @@
           "multiverseid": 396979
         },
         {
-          "language": "Russian",
-          "name": "Остров",
-          "multiverseid": 396980
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 397243
         },
         {
-          "language": "Russian",
-          "name": "Остров",
-          "multiverseid": 396981
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 397244
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 397245
         }
       ],
       "id": "bc4390fb406b0224d3e43b50f019b6d8ec43098a",
@@ -31772,11 +31806,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "海岛",
-          "multiverseid": 394867
-        },
-        {
           "language": "Chinese Traditional",
           "name": "海島",
           "multiverseid": 395131
@@ -31887,14 +31916,19 @@
           "multiverseid": 396979
         },
         {
-          "language": "Russian",
-          "name": "Остров",
-          "multiverseid": 396980
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 397243
         },
         {
-          "language": "Russian",
-          "name": "Остров",
-          "multiverseid": 396981
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 397244
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 397245
         }
       ],
       "id": "8029724b37e7fb6379cf946c6c8127cde0342408",
@@ -34451,6 +34485,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "树林",
+          "multiverseid": 394837
+        },
+        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 395101
@@ -34546,6 +34585,16 @@
           "multiverseid": 396685
         },
         {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 396686
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 396687
+        },
+        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 396949
@@ -34559,21 +34608,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 396951
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 397213
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 397214
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 397215
         }
       ],
       "id": "219c67c7af510d9a0705e0a3780a2755a56d6c76",
@@ -34833,6 +34867,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "树林",
+          "multiverseid": 394837
+        },
+        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 395101
@@ -34928,6 +34967,16 @@
           "multiverseid": 396685
         },
         {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 396686
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 396687
+        },
+        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 396949
@@ -34941,21 +34990,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 396951
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 397213
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 397214
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 397215
         }
       ],
       "id": "944d0c8fc1fb55f1dcb022295f983136ffc8ad11",
@@ -35215,6 +35249,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "树林",
+          "multiverseid": 394837
+        },
+        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 395101
@@ -35310,6 +35349,16 @@
           "multiverseid": 396685
         },
         {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 396686
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 396687
+        },
+        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 396949
@@ -35323,21 +35372,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 396951
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 397213
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 397214
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 397215
         }
       ],
       "id": "626ca0f9676aba92aba86dae779378162d4e035e",

--- a/json/E01.json
+++ b/json/E01.json
@@ -101,7 +101,7 @@
         },
         {
           "date": "2017-06-13",
-          "text": "Effects that reduce the generic mana cost of a spell can’t reduce that spell’s colored mana requirements."
+          "text": "Effects that reduce the generic mana cost of a spell can't reduce that spell's colored mana requirements."
         },
         {
           "date": "2017-06-13",
@@ -109,19 +109,19 @@
         },
         {
           "date": "2017-06-13",
-          "text": "For this scheme’s second ability to trigger, the players on the opposing team must have cast four spells total among them."
+          "text": "For this scheme's second ability to trigger, the players on the opposing team must have cast four spells total among them."
         },
         {
           "date": "2017-06-13",
-          "text": "If an opponent cast a spell during the opposing team’s turn and then left the game, that spell counts when determining whether the last ability of this scheme triggers."
+          "text": "If an opponent cast a spell during the opposing team's turn and then left the game, that spell counts when determining whether the last ability of this scheme triggers."
         },
         {
           "date": "2017-06-13",
-          "text": "The second ability only checks that four or more spells were cast. It doesn’t matter if those spells are countered or fail to resolve for other reasons."
+          "text": "The second ability only checks that four or more spells were cast. It doesn't matter if those spells are countered or fail to resolve for other reasons."
         },
         {
           "date": "2017-06-13",
-          "text": "In a Supervillain Rumble game, the last ability of this scheme triggers at the beginning of each opponent’s end step if that player alone has cast four or more spells that turn."
+          "text": "In a Supervillain Rumble game, the last ability of this scheme triggers at the beginning of each opponent's end step if that player alone has cast four or more spells that turn."
         }
       ],
       "supertypes": [
@@ -213,15 +213,15 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "This scheme’s first ability isn’t a mana ability. Opponents may respond to it before you have that mana."
+          "text": "This scheme's first ability isn't a mana ability. Opponents may respond to it before you have that mana."
         },
         {
           "date": "2017-06-13",
-          "text": "This scheme adds mana during your precombat main phase. If you don’t spend it before you move to your combat step, it will empty from your mana pool as your main phase ends."
+          "text": "This scheme adds mana during your precombat main phase. If you don't spend it before you move to your combat step, it will empty from your mana pool as your main phase ends."
         },
         {
           "date": "2017-06-13",
-          "text": "The number of lands you control is checked as you set this scheme in motion and again as its second ability resolves. Once this scheme has been set in motion, you can’t play a land or use an effect to put one onto the battlefield before the second ability could trigger."
+          "text": "The number of lands you control is checked as you set this scheme in motion and again as its second ability resolves. Once this scheme has been set in motion, you can't play a land or use an effect to put one onto the battlefield before the second ability could trigger."
         }
       ],
       "text": "When you set this scheme in motion, add {U}{B}{R} to your mana pool.\nWhen you set this scheme in motion, if you control six or more lands, you may search your library for a card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.",
@@ -302,27 +302,27 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "If the chosen player leaves the game, this scheme isn’t abandoned, but its middle ability won’t have any effect anymore. You won’t choose a new player."
+          "text": "If the chosen player leaves the game, this scheme isn't abandoned, but its middle ability won't have any effect anymore. You won't choose a new player."
         },
         {
           "date": "2017-06-13",
-          "text": "If multiple abilities trigger at the beginning of your opponents’ end step, first their abilities are put onto the stack in any order, and then you put your abilities onto the stack in any order. Your abilities resolve before theirs do."
+          "text": "If multiple abilities trigger at the beginning of your opponents' end step, first their abilities are put onto the stack in any order, and then you put your abilities onto the stack in any order. Your abilities resolve before theirs do."
         },
         {
           "date": "2017-06-13",
-          "text": "To pay the cost of this scheme’s second ability, your opponents collectively need to tap creatures with total power 8 or greater. Those creatures may be controlled by different teammates."
+          "text": "To pay the cost of this scheme's second ability, your opponents collectively need to tap creatures with total power 8 or greater. Those creatures may be controlled by different teammates."
         },
         {
           "date": "2017-06-13",
-          "text": "Your opponents may tap creatures that came under their control this turn to pay the cost of this scheme’s last ability."
+          "text": "Your opponents may tap creatures that came under their control this turn to pay the cost of this scheme's last ability."
         },
         {
           "date": "2017-06-13",
-          "text": "Once your opponents have chosen to tap creatures, you can’t take any action until they’re tapped and this scheme has been abandoned."
+          "text": "Once your opponents have chosen to tap creatures, you can't take any action until they're tapped and this scheme has been abandoned."
         },
         {
           "date": "2017-06-13",
-          "text": "In a Supervillain Rumble game, this scheme’s last ability triggers at the beginning of each opponent’s end step. Only that player may tap untapped creatures he or she controls."
+          "text": "In a Supervillain Rumble game, this scheme's last ability triggers at the beginning of each opponent's end step. Only that player may tap untapped creatures he or she controls."
         }
       ],
       "supertypes": [
@@ -418,11 +418,11 @@
         },
         {
           "date": "2017-06-13",
-          "text": "You don’t have to reveal the cards in the face-down pile, no matter which zone they’re put into. Resist the urge to gloat at the heroes if their decision serves your master plan."
+          "text": "You don't have to reveal the cards in the face-down pile, no matter which zone they're put into. Resist the urge to gloat at the heroes if their decision serves your master plan."
         },
         {
           "date": "2017-06-13",
-          "text": "The split doesn’t have to be even. The piles can be split with a single card in one pile and three cards in another. A pile can even have zero cards in it—in this case, an opponent chooses whether to put all the cards into your hand or into your graveyard."
+          "text": "The split doesn't have to be even. The piles can be split with a single card in one pile and three cards in another. A pile can even have zero cards in it—in this case, an opponent chooses whether to put all the cards into your hand or into your graveyard."
         }
       ],
       "text": "When you set this scheme in motion, look at the top four cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put the cards in that pile into your hand and the rest on the bottom of your library in any order.",
@@ -502,7 +502,7 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "This scheme’s effect prevents damage that would be dealt to any creature you control this turn, even those that come under your control later in the turn."
+          "text": "This scheme's effect prevents damage that would be dealt to any creature you control this turn, even those that come under your control later in the turn."
         }
       ],
       "text": "When you set this scheme in motion, create a 3/3 black Horror creature token and prevent all damage that would be dealt to creatures you control this turn.",
@@ -565,11 +565,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -691,15 +691,15 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "Each Horror token can attack only the player it was created for. It can’t attack a planeswalker that player controls."
+          "text": "Each Horror token can attack only the player it was created for. It can't attack a planeswalker that player controls."
         },
         {
           "date": "2017-06-13",
-          "text": "If two or more effects require a creature to attack different players or planeswalkers, such as that of this scheme and that of Gideon Jura’s first ability, that creature’s controller chooses one to fulfill."
+          "text": "If two or more effects require a creature to attack different players or planeswalkers, such as that of this scheme and that of Gideon Jura's first ability, that creature's controller chooses one to fulfill."
         },
         {
           "date": "2017-06-13",
-          "text": "If one of these creatures can’t attack its player during a given turn (perhaps because that player has left the game, or because a member of the opposing team has gained control of it), it may attack another player, attack a planeswalker an opponent controls, or not attack at all. If there’s a cost associated with having that creature attack its player, you aren’t forced to pay that cost, so it may attack another player, attack a planeswalker an opponent controls, or not attack at all."
+          "text": "If one of these creatures can't attack its player during a given turn (perhaps because that player has left the game, or because a member of the opposing team has gained control of it), it may attack another player, attack a planeswalker an opponent controls, or not attack at all. If there's a cost associated with having that creature attack its player, you aren't forced to pay that cost, so it may attack another player, attack a planeswalker an opponent controls, or not attack at all."
         }
       ],
       "text": "When you set this scheme in motion, for each opponent, create a 3/3 black Horror creature token that attacks that player each combat if able.",
@@ -754,7 +754,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Fiendslayer Paladin can be affected by black or red spells that don’t target it. For example, a red spell that “deals 3 damage to each creature” would deal damage to Fiendslayer Paladin."
+          "text": "Fiendslayer Paladin can be affected by black or red spells that don't target it. For example, a red spell that \"deals 3 damage to each creature\" would deal damage to Fiendslayer Paladin."
         }
       ],
       "subtypes": [
@@ -785,15 +785,15 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "You can’t target the same player more than once with this scheme’s ability. This ability doesn’t affect choosing targets for spells and other abilities."
+          "text": "You can't target the same player more than once with this scheme's ability. This ability doesn't affect choosing targets for spells and other abilities."
         },
         {
           "date": "2017-06-13",
-          "text": "The player who can’t cast noncreature spells can still play lands."
+          "text": "The player who can't cast noncreature spells can still play lands."
         },
         {
           "date": "2017-06-13",
-          "text": "If you don’t have three opponents left, you choose which effects won’t have a target. For example, if you have only one opponent left, you can choose no target for the first or second effect and just stop that player from casting noncreature spells."
+          "text": "If you don't have three opponents left, you choose which effects won't have a target. For example, if you have only one opponent left, you can choose no target for the first or second effect and just stop that player from casting noncreature spells."
         },
         {
           "date": "2017-06-13",
@@ -866,7 +866,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won’t trigger that turn."
+          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won't trigger that turn."
         }
       ],
       "subtypes": [
@@ -897,7 +897,7 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "If the target creature isn’t destroyed, most likely because it has indestructible, you won’t gain any life. The same is true if the target creature leaves the battlefield before this scheme’s triggered ability resolves."
+          "text": "If the target creature isn't destroyed, most likely because it has indestructible, you won't gain any life. The same is true if the target creature leaves the battlefield before this scheme's triggered ability resolves."
         }
       ],
       "text": "When you set this scheme in motion, destroy target creature an opponent controls. If a creature is destroyed this way, you gain life equal to its toughness.",
@@ -957,43 +957,43 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s first ability doesn’t lock in what it applies to. That’s because the effect states a true thing about a set of creatures, but doesn’t actually change the characteristics of those creatures. As a result, whatever creatures the targeted opponent controls during the declare attackers step of his or her next turn must attack Gideon Jura if able. This includes creatures that come under that player’s control after the ability has resolved and creatures that have lost all abilities."
+          "text": "Gideon Jura's first ability doesn't lock in what it applies to. That's because the effect states a true thing about a set of creatures, but doesn't actually change the characteristics of those creatures. As a result, whatever creatures the targeted opponent controls during the declare attackers step of his or her next turn must attack Gideon Jura if able. This includes creatures that come under that player's control after the ability has resolved and creatures that have lost all abilities."
         },
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s first ability causes creatures to attack him if able. If, during the affected player’s declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then that creature doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so the creature doesn’t have to attack in that case either."
+          "text": "Gideon Jura's first ability causes creatures to attack him if able. If, during the affected player's declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then that creature doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so the creature doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature controlled by the affected player can’t attack Gideon Jura (because he’s no longer on the battlefield, for example), that player may have it attack you, another one of your planeswalkers, or nothing at all."
+          "text": "If a creature controlled by the affected player can't attack Gideon Jura (because he's no longer on the battlefield, for example), that player may have it attack you, another one of your planeswalkers, or nothing at all."
         },
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s first ability applies during each combat phase of the affected player’s next turn (as opposed to applying during the affected player’s next combat phase). The distinction is relevant if there are no combat phases during that turn (due to Fatespinner’s effect, for example) or there are multiples (due to World at War, for example)."
+          "text": "Gideon Jura's first ability applies during each combat phase of the affected player's next turn (as opposed to applying during the affected player's next combat phase). The distinction is relevant if there are no combat phases during that turn (due to Fatespinner's effect, for example) or there are multiples (due to World at War, for example)."
         },
         {
           "date": "2010-06-15",
-          "text": "If Gideon Jura becomes a creature due to his third ability, that doesn’t count as having a creature enter the battlefield. Gideon Jura was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "If Gideon Jura becomes a creature due to his third ability, that doesn't count as having a creature enter the battlefield. Gideon Jura was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-06-15",
-          "text": "If Gideon Jura becomes a creature, he may be affected by “summoning sickness.” You can’t attack with him or use any of his {T} abilities (if he gains any) unless he began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when Gideon Jura came under your control, not when he became a creature."
+          "text": "If Gideon Jura becomes a creature, he may be affected by \"summoning sickness.\" You can't attack with him or use any of his {T} abilities (if he gains any) unless he began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when Gideon Jura came under your control, not when he became a creature."
         },
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s third ability causes him to become a creature with the creature types Human Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
+          "text": "Gideon Jura's third ability causes him to become a creature with the creature types Human Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you activate Gideon Jura’s third ability and then unpreventable damage is dealt to him (due to Unstable Footing, for example), that damage has all applicable results: specifically, the damage is marked on Gideon Jura (since he’s a creature) and that damage causes that many loyalty counters to be removed from him (since he’s a planeswalker). If the total amount of damage marked on Gideon Jura is lethal damage, he’s destroyed as a state-based action. If Gideon Jura has no loyalty counters on him, he’s put into his owner’s graveyard as a state-based action."
+          "text": "If you activate Gideon Jura's third ability and then unpreventable damage is dealt to him (due to Unstable Footing, for example), that damage has all applicable results: specifically, the damage is marked on Gideon Jura (since he's a creature) and that damage causes that many loyalty counters to be removed from him (since he's a planeswalker). If the total amount of damage marked on Gideon Jura is lethal damage, he's destroyed as a state-based action. If Gideon Jura has no loyalty counters on him, he's put into his owner's graveyard as a state-based action."
         },
         {
           "date": "2010-06-15",
-          "text": "Say you activate Gideon Jura’s third ability, then an opponent gains control of him before combat. You may have any of your creatures attack Gideon Jura (since he’s still a planeswalker). Then Gideon Jura may block (since he’s a creature). He may block any eligible attacking creature, including one that’s attacking him! During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he’s blocking, but he doesn’t deal combat damage to any unblocked creatures that are attacking him."
+          "text": "Say you activate Gideon Jura's third ability, then an opponent gains control of him before combat. You may have any of your creatures attack Gideon Jura (since he's still a planeswalker). Then Gideon Jura may block (since he's a creature). He may block any eligible attacking creature, including one that's attacking him! During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he's blocking, but he doesn't deal combat damage to any unblocked creatures that are attacking him."
         },
         {
           "date": "2011-01-22",
-          "text": "The first ability only affects the declaration of attackers. If a creature is put onto the battlefield attacking (thanks to Hero of Bladehold, Preeminent Captain, or the Ninjutsu ability, for example), that creature’s controller may choose the defending player or planeswalker that it will be attacking in the normal way."
+          "text": "The first ability only affects the declaration of attackers. If a creature is put onto the battlefield attacking (thanks to Hero of Bladehold, Preeminent Captain, or the Ninjutsu ability, for example), that creature's controller may choose the defending player or planeswalker that it will be attacking in the normal way."
         }
       ],
       "subtypes": [
@@ -1099,11 +1099,11 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "To pay the cost of this scheme’s second ability, your opponents need to sacrifice two creatures total. Those creatures may be controlled by different teammates."
+          "text": "To pay the cost of this scheme's second ability, your opponents need to sacrifice two creatures total. Those creatures may be controlled by different teammates."
         },
         {
           "date": "2017-06-13",
-          "text": "In a Supervillain Rumble game, this scheme’s last ability triggers at the beginning of each opponent’s end step. Only that player may sacrifice creatures."
+          "text": "In a Supervillain Rumble game, this scheme's last ability triggers at the beginning of each opponent's end step. Only that player may sacrifice creatures."
         }
       ],
       "supertypes": [
@@ -1163,11 +1163,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Grand Abolisher doesn’t stop your opponents from activating abilities of artifact, creature, or enchantment cards in zones other than the battlefield (like cycling abilities, for example)."
+          "text": "Grand Abolisher doesn't stop your opponents from activating abilities of artifact, creature, or enchantment cards in zones other than the battlefield (like cycling abilities, for example)."
         },
         {
           "date": "2011-09-22",
-          "text": "Grand Abolisher doesn’t affect triggered abilities or static abilities."
+          "text": "Grand Abolisher doesn't affect triggered abilities or static abilities."
         }
       ],
       "subtypes": [
@@ -1199,7 +1199,7 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "You may resolve the new non-ongoing scheme’s triggered ability before you decide whether or not to set it in motion again."
+          "text": "You may resolve the new non-ongoing scheme's triggered ability before you decide whether or not to set it in motion again."
         }
       ],
       "supertypes": [
@@ -1261,7 +1261,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The enchanted creature is the source of the triggered ability it gains, not Grasp of the Hieromancer. If the enchanted creature isn’t white, that ability can target a creature with protection from white, for example."
+          "text": "The enchanted creature is the source of the triggered ability it gains, not Grasp of the Hieromancer. If the enchanted creature isn't white, that ability can target a creature with protection from white, for example."
         }
       ],
       "subtypes": [
@@ -1291,7 +1291,7 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "If an opponent controls no creatures, that player isn’t affected by this scheme."
+          "text": "If an opponent controls no creatures, that player isn't affected by this scheme."
         },
         {
           "date": "2017-06-13",
@@ -1354,7 +1354,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Lands are colorless (even if their frames have some colored elements to them). You can’t target a Swamp, a Mountain, or any other land with Lightwielder Paladin’s ability (unless some other effect has turned that land black or red)."
+          "text": "Lands are colorless (even if their frames have some colored elements to them). You can't target a Swamp, a Mountain, or any other land with Lightwielder Paladin's ability (unless some other effect has turned that land black or red)."
         }
       ],
       "subtypes": [
@@ -1385,7 +1385,7 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "The number of lands you control is checked as this scheme’s triggered ability resolves. You can’t play a land during your turn before it resolves."
+          "text": "The number of lands you control is checked as this scheme's triggered ability resolves. You can't play a land during your turn before it resolves."
         },
         {
           "date": "2017-06-13",
@@ -1393,11 +1393,11 @@
         },
         {
           "date": "2017-06-13",
-          "text": "If a creature has an ability that triggers when it or another creature dies, that ability won’t resolve until after the scheme’s triggered ability has completely resolved."
+          "text": "If a creature has an ability that triggers when it or another creature dies, that ability won't resolve until after the scheme's triggered ability has completely resolved."
         },
         {
           "date": "2017-06-13",
-          "text": "If a creature has an ability that triggers when another creature dies, it will see other creatures sacrificed at the same time as it. If it’s sacrificed as one of the first creatures, it won’t see the creatures sacrificed the second time."
+          "text": "If a creature has an ability that triggers when another creature dies, it will see other creatures sacrificed at the same time as it. If it's sacrificed as one of the first creatures, it won't see the creatures sacrificed the second time."
         },
         {
           "date": "2017-06-13",
@@ -1467,7 +1467,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Apply power bonuses from counters the creature enters the battlefield with and continuous effects like Mayor of Avabruck’s when checking to see if Mentor of the Meek’s ability will trigger."
+          "text": "Apply power bonuses from counters the creature enters the battlefield with and continuous effects like Mayor of Avabruck's when checking to see if Mentor of the Meek's ability will trigger."
         },
         {
           "date": "2011-09-22",
@@ -1502,15 +1502,15 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "The number of lands you control is checked as this scheme’s triggered ability resolves. You can’t play a land during your turn before it resolves."
+          "text": "The number of lands you control is checked as this scheme's triggered ability resolves. You can't play a land during your turn before it resolves."
         },
         {
           "date": "2017-06-13",
-          "text": "If you control six or more lands, you’ll draw three cards and get to cast three spells for free. No player may take any actions between the time you draw three cards and the time you finish casting free spells."
+          "text": "If you control six or more lands, you'll draw three cards and get to cast three spells for free. No player may take any actions between the time you draw three cards and the time you finish casting free spells."
         },
         {
           "date": "2017-06-13",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
         },
         {
           "date": "2017-06-13",
@@ -1518,7 +1518,7 @@
         },
         {
           "date": "2017-06-13",
-          "text": "You must cast any of the three spells you wish to cast for free while this scheme’s ability is resolving. You’ll have to pay the mana cost of any spells cast later in the turn, even if you cast fewer than three as you resolved this ability. The spells will be added to the stack in the order that you cast them."
+          "text": "You must cast any of the three spells you wish to cast for free while this scheme's ability is resolving. You'll have to pay the mana cost of any spells cast later in the turn, even if you cast fewer than three as you resolved this ability. The spells will be added to the stack in the order that you cast them."
         }
       ],
       "text": "When you set this scheme in motion, draw three cards. You have no maximum hand size until your next turn. If you control six or more lands, you may cast up to three nonland cards from your hand without paying their mana costs.",
@@ -1656,7 +1656,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can decide that a creature won’t block."
+          "text": "You can decide that a creature won't block."
         },
         {
           "date": "2012-07-01",
@@ -1664,7 +1664,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If there’s a cost associated with having a creature block and you choose for that creature to block, its controller can choose to pay that cost or not. If that player decides to not pay that cost, you must propose a new set of blocking creatures."
+          "text": "If there's a cost associated with having a creature block and you choose for that creature to block, its controller can choose to pay that cost or not. If that player decides to not pay that cost, you must propose a new set of blocking creatures."
         }
       ],
       "subtypes": [
@@ -1699,19 +1699,19 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "If you choose a target creature and it becomes an illegal target by the time this scheme’s triggered ability would resolve, the entire ability is countered. You won’t create a Horror token."
+          "text": "If you choose a target creature and it becomes an illegal target by the time this scheme's triggered ability would resolve, the entire ability is countered. You won't create a Horror token."
         },
         {
           "date": "2017-06-13",
-          "text": "You can choose to target zero creatures. If you do, you’ll still create the Horror token."
+          "text": "You can choose to target zero creatures. If you do, you'll still create the Horror token."
         },
         {
           "date": "2017-06-13",
-          "text": "This scheme’s effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands."
+          "text": "This scheme's effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands."
         },
         {
           "date": "2017-06-13",
-          "text": "The effects of this scheme’s triggered ability in multiples within the same turn are cumulative. It’s also cumulative with other effects that let you play additional lands, such as that of Explore."
+          "text": "The effects of this scheme's triggered ability in multiples within the same turn are cumulative. It's also cumulative with other effects that let you play additional lands, such as that of Explore."
         }
       ],
       "text": "When you set this scheme in motion, it deals 3 damage to up to one target creature. Create a 3/3 black Horror creature token.",
@@ -1856,11 +1856,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -1905,11 +1905,11 @@
         },
         {
           "date": "2017-06-13",
-          "text": "This scheme doesn’t grant haste to the target creature. It won’t be able to attack during this turn unless it has haste or somehow gains haste."
+          "text": "This scheme doesn't grant haste to the target creature. It won't be able to attack during this turn unless it has haste or somehow gains haste."
         },
         {
           "date": "2017-06-13",
-          "text": "Auras and Equipment attached to that creature remain attached, but you don’t gain control of them."
+          "text": "Auras and Equipment attached to that creature remain attached, but you don't gain control of them."
         }
       ],
       "text": "When you set this scheme in motion, gain control of target creature an opponent controls and untap it.",
@@ -1972,11 +1972,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -2007,7 +2007,7 @@
       "rulings": [
         {
           "date": "2017-06-13",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
         },
         {
           "date": "2017-06-13",
@@ -2015,7 +2015,7 @@
         },
         {
           "date": "2017-06-13",
-          "text": "You must cast any of the exiled cards you wish to cast for free while this scheme’s ability is resolving. You can’t wait until later in the turn. Any cards not cast this way remain exiled for the rest of the game. The spells will be added to the stack in the order that you cast them."
+          "text": "You must cast any of the exiled cards you wish to cast for free while this scheme's ability is resolving. You can't wait until later in the turn. Any cards not cast this way remain exiled for the rest of the game. The spells will be added to the stack in the order that you cast them."
         },
         {
           "date": "2017-06-13",
@@ -2096,7 +2096,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         }
       ],
       "subtypes": [
@@ -2285,7 +2285,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Icefall Regent’s triggered ability can target any creature controlled by an opponent, including one that is already tapped. In that case, the creature stays tapped and won’t untap during its controller’s untap step."
+          "text": "Icefall Regent's triggered ability can target any creature controlled by an opponent, including one that is already tapped. In that case, the creature stays tapped and won't untap during its controller's untap step."
         },
         {
           "date": "2015-02-25",
@@ -2297,13 +2297,13 @@
         },
         {
           "date": "2015-02-25",
-          "text": "Icefall Regent’s last ability affects all spells cast by your opponents that target it, including Aura spells and spells with multiple targets. It doesn’t affect abilities."
+          "text": "Icefall Regent's last ability affects all spells cast by your opponents that target it, including Aura spells and spells with multiple targets. It doesn't affect abilities."
         }
       ],
       "subtypes": [
         "Dragon"
       ],
-      "text": "Flying\nWhen Icefall Regent enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Icefall Regent. \nSpells your opponents cast that target Icefall Regent cost {2} more to cast.",
+      "text": "Flying\nWhen Icefall Regent enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Icefall Regent.\nSpells your opponents cast that target Icefall Regent cost {2} more to cast.",
       "toughness": "3",
       "type": "Creature — Dragon",
       "types": [
@@ -2359,7 +2359,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -2423,7 +2423,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You can activate Prognostic Sphinx’s ability even if it’s already tapped."
+          "text": "You can activate Prognostic Sphinx's ability even if it's already tapped."
         },
         {
           "date": "2013-09-15",
@@ -2435,11 +2435,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -2572,11 +2572,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Essentially, Sphinx of Jwar Isle lets you play with the top card of your library revealed only to you. Knowing what that card is becomes part of the information you have access to, just like you can look at the cards in your hand. You may look at the top card of your library whenever you want, even if you don’t have priority. This action doesn’t use the stack."
+          "text": "Essentially, Sphinx of Jwar Isle lets you play with the top card of your library revealed only to you. Knowing what that card is becomes part of the information you have access to, just like you can look at the cards in your hand. You may look at the top card of your library whenever you want, even if you don't have priority. This action doesn't use the stack."
         },
         {
           "date": "2009-10-01",
-          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, you can’t look at the new top card until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
+          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, you can't look at the new top card until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
         }
       ],
       "subtypes": [
@@ -2695,7 +2695,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -2765,11 +2765,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The opponent chooses which creatures to spare, if any, as the ability resolves. This choice doesn’t target the creatures."
+          "text": "The opponent chooses which creatures to spare, if any, as the ability resolves. This choice doesn't target the creatures."
         },
         {
           "date": "2014-11-24",
-          "text": "The opponent may choose to spare one or no creatures. If the player doesn’t choose any creatures, he or she will sacrifice all creatures he or she controls."
+          "text": "The opponent may choose to spare one or no creatures. If the player doesn't choose any creatures, he or she will sacrifice all creatures he or she controls."
         }
       ],
       "subtypes": [
@@ -2834,11 +2834,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "If you cast a creature spell that enters the battlefield as a copy of Deathbringer Regent, the enters-the-battlefield ability will trigger (assuming the “five or more other creatures” requirement is also met)."
+          "text": "If you cast a creature spell that enters the battlefield as a copy of Deathbringer Regent, the enters-the-battlefield ability will trigger (assuming the \"five or more other creatures\" requirement is also met)."
         },
         {
           "date": "2015-02-25",
-          "text": "Deathbringer Regent’s last ability destroys all creatures except Deathbringer Regent, including the five other creatures required for the ability to have an effect."
+          "text": "Deathbringer Regent's last ability destroys all creatures except Deathbringer Regent, including the five other creatures required for the ability to have an effect."
         }
       ],
       "subtypes": [
@@ -3020,7 +3020,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -3040,7 +3040,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -3336,11 +3336,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Battle-Rattle Shaman’s ability triggers when the beginning of combat step starts during each of your turns. It resolves before you declare attackers."
+          "text": "Battle-Rattle Shaman's ability triggers when the beginning of combat step starts during each of your turns. It resolves before you declare attackers."
         },
         {
           "date": "2017-03-14",
-          "text": "If a spell or ability causes your turn to have multiple combat phases, Battle Rattle Shaman’s ability triggers during each of them."
+          "text": "If a spell or ability causes your turn to have multiple combat phases, Battle Rattle Shaman's ability triggers during each of them."
         }
       ],
       "subtypes": [
@@ -3462,31 +3462,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If the first ability resolves but the damage is prevented or redirected, the target creature still won’t be able to block that turn."
+          "text": "If the first ability resolves but the damage is prevented or redirected, the target creature still won't be able to block that turn."
         },
         {
           "date": "2014-07-18",
-          "text": "The card exiled by the second ability is exiled face up. Playing it follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if it’s a creature card, you can cast it only during your main phase while the stack is empty."
+          "text": "The card exiled by the second ability is exiled face up. Playing it follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if it's a creature card, you can cast it only during your main phase while the stack is empty."
         },
         {
           "date": "2014-07-18",
-          "text": "If you exile a land card using the second ability, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven’t played a land yet that turn."
+          "text": "If you exile a land card using the second ability, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven't played a land yet that turn."
         },
         {
           "date": "2014-07-18",
-          "text": "In the third ability, “exiled this way” means the cards you just exiled because of that ability resolving. Cards exiled with the second ability or with previous activations of the third ability don’t count."
+          "text": "In the third ability, \"exiled this way\" means the cards you just exiled because of that ability resolving. Cards exiled with the second ability or with previous activations of the third ability don't count."
         },
         {
           "date": "2014-07-18",
-          "text": "While resolving the third ability, you create the copies of the card in exile and cast them from exile. You can cast zero, one, two, or all three copies. The card itself isn’t cast. It remains exiled."
+          "text": "While resolving the third ability, you create the copies of the card in exile and cast them from exile. You can cast zero, one, two, or all three copies. The card itself isn't cast. It remains exiled."
         },
         {
           "date": "2014-07-18",
-          "text": "While casting the copies created by the third ability, timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” are not."
+          "text": "While casting the copies created by the third ability, timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" are not."
         },
         {
           "date": "2014-07-18",
-          "text": "Because you’re casting the copies “without paying their mana costs,” you can’t pay any alternative costs for the copies. You can pay additional costs, such as kicker costs. If the copies have any mandatory additional costs, you must pay those."
+          "text": "Because you're casting the copies \"without paying their mana costs,\" you can't pay any alternative costs for the copies. You can pay additional costs, such as kicker costs. If the copies have any mandatory additional costs, you must pay those."
         },
         {
           "date": "2014-07-18",
@@ -3552,7 +3552,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target creature is an illegal target by the time Chandra’s Outrage resolves, the entire spell is countered. No player is dealt damage."
+          "text": "If the target creature is an illegal target by the time Chandra's Outrage resolves, the entire spell is countered. No player is dealt damage."
         }
       ],
       "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
@@ -3715,23 +3715,23 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Dualcaster Mage’s triggered ability can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Dualcaster Mage's triggered ability can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2016-06-08",
-          "text": "As Dualcaster Mage’s triggered ability resolves, it creates a copy of a spell on the stack. The copy isn’t cast, so abilities that trigger when a player casts a spell won’t trigger."
+          "text": "As Dualcaster Mage's triggered ability resolves, it creates a copy of a spell on the stack. The copy isn't cast, so abilities that trigger when a player casts a spell won't trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs paid for the targeted spell are copied as though those same costs were paid for the copy."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs paid for the targeted spell are copied as though those same costs were paid for the copy."
         },
         {
           "date": "2016-06-08",
-          "text": "If the spell is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2016-06-08",
@@ -3739,7 +3739,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "subtypes": [
@@ -3809,7 +3809,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -4009,7 +4009,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The two cards are exiled as the cost of Grim Lavamancer’s ability is paid. Players can’t respond to the paying of costs by trying to move those cards to another zone."
+          "text": "The two cards are exiled as the cost of Grim Lavamancer's ability is paid. Players can't respond to the paying of costs by trying to move those cards to another zone."
         }
       ],
       "subtypes": [
@@ -4076,7 +4076,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Guttersnipe’s ability resolves and Guttersnipe deals damage before the instant or sorcery spell resolves."
+          "text": "Guttersnipe's ability resolves and Guttersnipe deals damage before the instant or sorcery spell resolves."
         }
       ],
       "subtypes": [
@@ -4191,7 +4191,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You divide the damage as you put Inferno Titan’s triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
+          "text": "You divide the damage as you put Inferno Titan's triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
         }
       ],
       "subtypes": [
@@ -4318,11 +4318,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As the reminder text indicates, whether the targeted land has the triggered ability that’s been granted to it depends only on whether it has a blaze counter on it, not on whether Obsidian Fireheart is still on the battlefield."
+          "text": "As the reminder text indicates, whether the targeted land has the triggered ability that's been granted to it depends only on whether it has a blaze counter on it, not on whether Obsidian Fireheart is still on the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "The ability gained by the land triggers at the beginning of the upkeep of the land’s controller, not the beginning of the upkeep of Obsidian Fireheart’s controller. The player who controls the land at the time the ability triggers is the one who’s dealt damage."
+          "text": "The ability gained by the land triggers at the beginning of the upkeep of the land's controller, not the beginning of the upkeep of Obsidian Fireheart's controller. The player who controls the land at the time the ability triggers is the one who's dealt damage."
         },
         {
           "date": "2009-10-01",
@@ -4330,7 +4330,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If all blaze counters on a land are moved to a different land, the triggered ability doesn’t follow them. The first land no longer has the ability because it no longer has a blaze counter on it. The second land doesn’t have the ability because Obsidian Fireheart didn’t target it."
+          "text": "If all blaze counters on a land are moved to a different land, the triggered ability doesn't follow them. The first land no longer has the ability because it no longer has a blaze counter on it. The second land doesn't have the ability because Obsidian Fireheart didn't target it."
         },
         {
           "date": "2009-10-01",
@@ -4449,7 +4449,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You can activate Skarrgan Firebird’s last ability if an opponent was dealt damage by any source, even if you didn’t control that source."
+          "text": "You can activate Skarrgan Firebird's last ability if an opponent was dealt damage by any source, even if you didn't control that source."
         }
       ],
       "subtypes": [
@@ -4561,7 +4561,7 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "You choose the value for X as you cast Sudden Demise. You don’t choose the color until it resolves."
+          "text": "You choose the value for X as you cast Sudden Demise. You don't choose the color until it resolves."
         },
         {
           "date": "2013-10-17",
@@ -4625,15 +4625,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When the third ability resolves, you must change the target if able. If you can’t choose a legal target for the spell when this ability resolves, that spell’s target doesn’t change."
+          "text": "When the third ability resolves, you must change the target if able. If you can't choose a legal target for the spell when this ability resolves, that spell's target doesn't change."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Torchling’s third ability, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Torchling's third ability, even if all but one of those targets has become illegal."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell has multiple targets, but it’s targeting Torchling with all of them (such as Seeds of Strength targeting Torchling three times), you can target that spell with Torchling’s third ability. In that case, you change all of those targets to the same new target, as long as it meets each of the spell’s targeting conditions."
+          "text": "If a spell has multiple targets, but it's targeting Torchling with all of them (such as Seeds of Strength targeting Torchling three times), you can target that spell with Torchling's third ability. In that case, you change all of those targets to the same new target, as long as it meets each of the spell's targeting conditions."
         }
       ],
       "subtypes": [
@@ -4816,15 +4816,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Explore’s effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don’t get to play a land as Explore resolves; Explore fully resolves first and draws a card, perhaps a land you’ll play later."
+          "text": "Explore's effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don't get to play a land as Explore resolves; Explore fully resolves first and draws a card, perhaps a land you'll play later."
         },
         {
           "date": "2017-03-14",
-          "text": "The effects of multiple Explores in the same turn are cumulative. They’re also cumulative with other effects that let you play additional lands, such as the one from Urban Evolution."
+          "text": "The effects of multiple Explores in the same turn are cumulative. They're also cumulative with other effects that let you play additional lands, such as the one from Urban Evolution."
         },
         {
           "date": "2017-03-14",
-          "text": "If you somehow manage to cast Explore when it’s not your turn, you’ll draw a card when it resolves, but you won’t be able to play a land that turn."
+          "text": "If you somehow manage to cast Explore when it's not your turn, you'll draw a card when it resolves, but you won't be able to play a land that turn."
         }
       ],
       "text": "You may play an additional land this turn.\nDraw a card.",
@@ -4887,7 +4887,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Although the targeted player doesn’t need to find a basic land card if he or she doesn’t want to, that player must shuffle his or her library."
+          "text": "Although the targeted player doesn't need to find a basic land card if he or she doesn't want to, that player must shuffle his or her library."
         }
       ],
       "subtypes": [
@@ -5080,7 +5080,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -5140,11 +5140,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The type-changing effects of the first and third abilities don’t have a duration. They last indefinitely."
+          "text": "The type-changing effects of the first and third abilities don't have a duration. They last indefinitely."
         },
         {
           "date": "2014-07-18",
-          "text": "If the land targeted by the first ability entered the battlefield this turn, it won’t be able to attack and its activated abilities with {T} in the cost (including its mana ability) can’t be activated (unless something gives it haste). The same is true for the lands put onto the battlefield with the third ability."
+          "text": "If the land targeted by the first ability entered the battlefield this turn, it won't be able to attack and its activated abilities with {T} in the cost (including its mana ability) can't be activated (unless something gives it haste). The same is true for the lands put onto the battlefield with the third ability."
         }
       ],
       "subtypes": [
@@ -5221,7 +5221,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -5348,7 +5348,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -5427,7 +5427,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "text": "Landfall — Whenever a land enters the battlefield under your control, choose one —\n• Put a +1/+1 counter on target creature.\n• You gain 2 life.",
@@ -5489,7 +5489,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Scute Mob’s ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control five or more lands as your upkeep starts, and (2) the ability will do nothing if you control fewer than five lands by the time it resolves."
+          "text": "Scute Mob's ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control five or more lands as your upkeep starts, and (2) the ability will do nothing if you control fewer than five lands by the time it resolves."
         }
       ],
       "subtypes": [
@@ -5555,7 +5555,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -5624,7 +5624,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Thragtusk’s second ability will trigger no matter what zone Thragtusk goes to."
+          "text": "Thragtusk's second ability will trigger no matter what zone Thragtusk goes to."
         }
       ],
       "subtypes": [
@@ -5688,7 +5688,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -5700,19 +5700,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Deciding to have the targeted creature block doesn’t force you to attack with Turntimber Basilisk that turn. If Turntimber Basilisk doesn’t attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "Deciding to have the targeted creature block doesn't force you to attack with Turntimber Basilisk that turn. If Turntimber Basilisk doesn't attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2009-10-01",
-          "text": "If you choose to have the targeted creature block but that creature isn’t able to block Turntimber Basilisk (for example, because the targeted creature can block only creatures with flying), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "If you choose to have the targeted creature block but that creature isn't able to block Turntimber Basilisk (for example, because the targeted creature can block only creatures with flying), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Tapped creatures, creatures that can’t block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren’t controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Turntimber Basilisk’s landfall ability, but the requirement to block does nothing."
+          "text": "Tapped creatures, creatures that can't block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren't controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Turntimber Basilisk's landfall ability, but the requirement to block does nothing."
         },
         {
           "date": "2009-10-01",
-          "text": "If Turntimber Basilisk’s landfall ability triggers multiple times during the same turn, you can have multiple creatures block it that turn if able."
+          "text": "If Turntimber Basilisk's landfall ability triggers multiple times during the same turn, you can have multiple creatures block it that turn if able."
         }
       ],
       "subtypes": [
@@ -5778,7 +5778,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-03-01",
@@ -5786,15 +5786,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon and the land it’s enchanting are destroyed at the same time (due to Akroma’s Vengeance, for example), the Zendikon’s last ability will still trigger."
+          "text": "If a Zendikon and the land it's enchanting are destroyed at the same time (due to Akroma's Vengeance, for example), the Zendikon's last ability will still trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon’s last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
+          "text": "If a Zendikon's last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
         }
       ],
       "subtypes": [
@@ -6038,15 +6038,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Blood Tyrant’s second ability causes each player to lose 1 life, including you. Blood Tyrant will count each player’s life loss, including yours, when determining how many +1/+1 counters it gets."
+          "text": "Blood Tyrant's second ability causes each player to lose 1 life, including you. Blood Tyrant will count each player's life loss, including yours, when determining how many +1/+1 counters it gets."
         },
         {
           "date": "2009-02-01",
-          "text": "Blood Tyrant’s third ability will trigger no matter how a player loses the game: due to a state-based action (as a result of having a life total of 0 or less, trying to draw a card from an empty library, or having ten poison counters), a spell or ability that says that player loses the game, a concession, or a game loss awarded by a judge."
+          "text": "Blood Tyrant's third ability will trigger no matter how a player loses the game: due to a state-based action (as a result of having a life total of 0 or less, trying to draw a card from an empty library, or having ten poison counters), a spell or ability that says that player loses the game, a concession, or a game loss awarded by a judge."
         },
         {
           "date": "2009-02-01",
-          "text": "In a multiplayer game using the limited range of influence option (such as a Grand Melee game), if a spell or ability says that you win the game, it instead causes all of your opponents within your range of influence to lose the game. This is another way by which Blood Tyrant’s third ability can trigger."
+          "text": "In a multiplayer game using the limited range of influence option (such as a Grand Melee game), if a spell or ability says that you win the game, it instead causes all of your opponents within your range of influence to lose the game. This is another way by which Blood Tyrant's third ability can trigger."
         }
       ],
       "subtypes": [
@@ -6117,7 +6117,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Cruel Ultimatum’s only target is an opponent. You don’t choose which creature card in your graveyard you’ll return to your hand until Cruel Ultimatum resolves."
+          "text": "Cruel Ultimatum's only target is an opponent. You don't choose which creature card in your graveyard you'll return to your hand until Cruel Ultimatum resolves."
         },
         {
           "date": "2017-03-14",
@@ -6125,7 +6125,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If, as Cruel Ultimatum begins to resolve, your opponent’s life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent’s life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You’ll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
+          "text": "If, as Cruel Ultimatum begins to resolve, your opponent's life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent's life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You'll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
         }
       ],
       "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
@@ -6234,7 +6234,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Extract from Darkness doesn’t target a creature card. You choose which card you’re putting onto the battlefield as it resolves. You can choose any creature card in a graveyard at that time, including one just put into a graveyard by Extract from Darkness. If there are no creature cards in graveyards at that time, Extract from Darkness simply finishes resolving."
+          "text": "Extract from Darkness doesn't target a creature card. You choose which card you're putting onto the battlefield as it resolves. You can choose any creature card in a graveyard at that time, including one just put into a graveyard by Extract from Darkness. If there are no creature cards in graveyards at that time, Extract from Darkness simply finishes resolving."
         }
       ],
       "text": "Each player puts the top two cards of his or her library into his or her graveyard. Then put a creature card from a graveyard onto the battlefield under your control.",
@@ -6303,7 +6303,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If the damage from Nicol Bolas’s third ability is prevented or redirected, the rest of the effect will still happen. Specifically, the number of cards discarded and permanents sacrificed isn’t tied to the amount of damage dealt."
+          "text": "If the damage from Nicol Bolas's third ability is prevented or redirected, the rest of the effect will still happen. Specifically, the number of cards discarded and permanents sacrificed isn't tied to the amount of damage dealt."
         },
         {
           "date": "2012-07-01",
@@ -6379,7 +6379,7 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you don’t control the targeted creature when the “at end of turn” ability resolves, it won’t be sacrificed. If it’s still on the battlefield but under another player’s control, the ability won’t try to have you sacrifice it again at the end of the turn after that."
+          "text": "If you don't control the targeted creature when the \"at end of turn\" ability resolves, it won't be sacrificed. If it's still on the battlefield but under another player's control, the ability won't try to have you sacrifice it again at the end of the turn after that."
         }
       ],
       "text": "Gain control of target creature. Untap that creature. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
@@ -6440,11 +6440,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "In most cases, you’ll enchant a creature controlled by an opponent, which will cause you to gain control of that creature. Any of your opponents can activate the last ability of Soul Ransom by discarding two cards. When that ability resolves, you’ll sacrifice Soul Ransom and draw two cards."
+          "text": "In most cases, you'll enchant a creature controlled by an opponent, which will cause you to gain control of that creature. Any of your opponents can activate the last ability of Soul Ransom by discarding two cards. When that ability resolves, you'll sacrifice Soul Ransom and draw two cards."
         },
         {
           "date": "2017-03-14",
-          "text": "You’ll draw two cards even if you can’t sacrifice Soul Ransom, perhaps because it left the battlefield in response to Soul Ransom’s ability."
+          "text": "You'll draw two cards even if you can't sacrifice Soul Ransom, perhaps because it left the battlefield in response to Soul Ransom's ability."
         }
       ],
       "subtypes": [
@@ -6758,11 +6758,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don’t have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don't have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
@@ -6815,11 +6815,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don’t have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don't have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",

--- a/json/EMA.json
+++ b/json/EMA.json
@@ -170,7 +170,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Balance doesn’t have targets, so permanents that can’t be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
+          "text": "Balance doesn't have targets, so permanents that can't be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
         },
         {
           "date": "2016-06-08",
@@ -453,15 +453,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Any player’s Flagbearer may be targeted. For example, if each player controls a Coalition Honor Guard, Seal of Strength’s ability may target any of them."
+          "text": "Any player's Flagbearer may be targeted. For example, if each player controls a Coalition Honor Guard, Seal of Strength's ability may target any of them."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text. Triggered abilities (written with “when,” “whenever,” or “at”) don’t have to target a Flagbearer."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text. Triggered abilities (written with \"when,\" \"whenever,\" or \"at\") don't have to target a Flagbearer."
         },
         {
           "date": "2016-06-08",
-          "text": "If a spell or ability’s targets are changed, or if a copy of a spell or ability is put onto the stack and has new targets chosen, it doesn’t have to target a Flagbearer."
+          "text": "If a spell or ability's targets are changed, or if a copy of a spell or ability is put onto the stack and has new targets chosen, it doesn't have to target a Flagbearer."
         }
       ],
       "subtypes": [
@@ -680,7 +680,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for an artifact or enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -752,11 +752,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Faith’s Fetters doesn’t stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
+          "text": "Faith's Fetters doesn't stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -826,7 +826,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A creature card that you own but don’t control will be put into your graveyard if that creature dies, and Field of Souls’s ability will trigger."
+          "text": "A creature card that you own but don't control will be put into your graveyard if that creature dies, and Field of Souls's ability will trigger."
         }
       ],
       "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, create a 1/1 white Spirit creature token with flying.",
@@ -897,7 +897,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If a token is exiled this way, it ceases to exist and won’t return to the battlefield."
+          "text": "If a token is exiled this way, it ceases to exist and won't return to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -905,11 +905,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything (so it could be attached to a permanent with shroud, for example), but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything (so it could be attached to a permanent with shroud, for example), but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled."
         },
         {
           "date": "2016-06-08",
-          "text": "If Glimmerpoint Stag somehow enters the battlefield during a turn’s end step, the exiled card won’t be returned to the battlefield until the beginning of the following turn’s end step."
+          "text": "If Glimmerpoint Stag somehow enters the battlefield during a turn's end step, the exiled card won't be returned to the battlefield until the beginning of the following turn's end step."
         }
       ],
       "subtypes": [
@@ -1049,11 +1049,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Humble overwrites all previous effects that set the creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Humble resolves will overwrite this effect."
+          "text": "Humble overwrites all previous effects that set the creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Humble resolves will overwrite this effect."
         },
         {
           "date": "2016-06-08",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the effect of Seal of Strength, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the effect of Seal of Strength, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
         },
         {
           "date": "2016-06-08",
@@ -1061,7 +1061,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Humble doesn’t counter abilities that have already triggered or been activated. In particular, casting this spell won’t stop a creature’s ability that says “At the beginning of your upkeep,” “When this creature enters the battlefield,” or similar from triggering."
+          "text": "Humble doesn't counter abilities that have already triggered or been activated. In particular, casting this spell won't stop a creature's ability that says \"At the beginning of your upkeep,\" \"When this creature enters the battlefield,\" or similar from triggering."
         }
       ],
       "text": "Until end of turn, target creature loses all abilities and has base power and toughness 0/1.",
@@ -1342,7 +1342,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Kor Hookmaster’s ability can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Kor Hookmaster's ability can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -1421,15 +1421,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Mesa Enchantress’s last ability will resolve before the spell that caused it to trigger."
+          "text": "Mesa Enchantress's last ability will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "If the enchantment spell is countered, Mesa Enchantress’s last ability still resolves and causes you to draw a card."
+          "text": "If the enchantment spell is countered, Mesa Enchantress's last ability still resolves and causes you to draw a card."
         },
         {
           "date": "2016-06-08",
-          "text": "Enchantments put onto the battlefield without being cast won’t cause Mesa Enchantress’s last ability to trigger."
+          "text": "Enchantments put onto the battlefield without being cast won't cause Mesa Enchantress's last ability to trigger."
         }
       ],
       "subtypes": [
@@ -2019,7 +2019,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature is an illegal target when Second Thoughts tries to resolve, the entire spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target when Second Thoughts tries to resolve, the entire spell is countered. You won't draw a card."
         }
       ],
       "text": "Exile target attacking creature.\nDraw a card.",
@@ -2182,7 +2182,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The legality of a spell’s target is checked only as that spell begins to resolve. If Shelter gives the targeted creature protection from white, you’ll still draw a card."
+          "text": "The legality of a spell's target is checked only as that spell begins to resolve. If Shelter gives the targeted creature protection from white, you'll still draw a card."
         }
       ],
       "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
@@ -2250,7 +2250,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If another creature with flying is dealt lethal damage at the same time as Soulcatcher, they’ll be destroyed at the same time. Soulcatcher’s ability won’t save it."
+          "text": "If another creature with flying is dealt lethal damage at the same time as Soulcatcher, they'll be destroyed at the same time. Soulcatcher's ability won't save it."
         }
       ],
       "subtypes": [
@@ -2409,7 +2409,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -2472,11 +2472,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are fewer than X cards in that player’s library, put that permanent on the bottom of that library."
+          "text": "If there are fewer than X cards in that player's library, put that permanent on the bottom of that library."
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose 0 as the value for X, put that permanent on top of its owner’s library."
+          "text": "If you choose 0 as the value for X, put that permanent on top of its owner's library."
         }
       ],
       "text": "Put target nonland permanent into its owner's library just beneath the top X cards of that library.",
@@ -2758,11 +2758,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -2916,7 +2916,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Arcanis’s last ability can only be activated while it’s on the battlefield."
+          "text": "Arcanis's last ability can only be activated while it's on the battlefield."
         }
       ],
       "subtypes": [
@@ -3070,11 +3070,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You draw three cards and discard two cards all while Cephalid Sage’s ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+          "text": "You draw three cards and discard two cards all while Cephalid Sage's ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
         },
         {
           "date": "2016-06-08",
-          "text": "If you don’t have enough cards in your graveyard at the moment Cephalid Sage enters the battlefield, its threshold ability won’t trigger. If the number of cards in your graveyard changes and Cephalid Sage loses the ability once it has triggered, the ability will still resolve."
+          "text": "If you don't have enough cards in your graveyard at the moment Cephalid Sage enters the battlefield, its threshold ability won't trigger. If the number of cards in your graveyard changes and Cephalid Sage loses the ability once it has triggered, the ability will still resolve."
         }
       ],
       "subtypes": [
@@ -3152,7 +3152,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -3451,11 +3451,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Diminishing Returns won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "Diminishing Returns won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         },
         {
           "date": "2016-06-08",
-          "text": "The exiled cards are exiled face up. You’ll see them before you choose how many cards to draw."
+          "text": "The exiled cards are exiled face up. You'll see them before you choose how many cards to draw."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library. You exile the top ten cards of your library. Then each player draws up to seven cards.",
@@ -3595,7 +3595,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Each pile may contain from zero to five cards; they don’t have to be split “evenly.”"
+          "text": "Each pile may contain from zero to five cards; they don't have to be split \"evenly.\""
         }
       ],
       "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
@@ -3733,7 +3733,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2016-06-08",
@@ -3745,7 +3745,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability (perhaps because that top card is the card you’re casting) the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability (perhaps because that top card is the card you're casting) the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2016-06-08",
@@ -4094,7 +4094,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         },
         {
           "date": "2016-06-08",
@@ -4242,11 +4242,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You draw three cards and put two cards back all while Jace’s second ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+          "text": "You draw three cards and put two cards back all while Jace's second ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
         },
         {
           "date": "2016-06-08",
-          "text": "If the targeted player for Jace’s last ability has no cards in hand, that player shuffles nothing into his or her library, and that player’s library will remain empty. That player won’t lose the game until he or she tries to draw from the empty library."
+          "text": "If the targeted player for Jace's last ability has no cards in hand, that player shuffles nothing into his or her library, and that player's library will remain empty. That player won't lose the game until he or she tries to draw from the empty library."
         }
       ],
       "subtypes": [
@@ -4394,7 +4394,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are no other creatures on the battlefield when Man-o’-War enters the battlefield, its ability must target itself."
+          "text": "If there are no other creatures on the battlefield when Man-o'-War enters the battlefield, its ability must target itself."
         }
       ],
       "subtypes": [
@@ -4470,7 +4470,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell’s destination from its owner’s library to exile."
+          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell's destination from its owner's library to exile."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
@@ -4614,7 +4614,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for an instant or sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -4684,7 +4684,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -4692,11 +4692,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Target player draws a card.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -4765,7 +4765,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -4910,15 +4910,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Phyrexian Ingester will get bonuses based on the card’s power and toughness in exile. Counters, Auras, and Equipment it had on it before it was exiled won’t add to those numbers."
+          "text": "Phyrexian Ingester will get bonuses based on the card's power and toughness in exile. Counters, Auras, and Equipment it had on it before it was exiled won't add to those numbers."
         },
         {
           "date": "2016-06-08",
-          "text": "Abilities that define a creature’s power and toughness apply while that card is in exile, but abilities that add or subtract from it don’t. For example, the ability of Battle Squadron applies to determine Phyrexian Ingester’s power and toughness, but the ability of Werebear doesn’t. Phyrexian Ingester’s power and toughness are constantly updated if the exiled card’s power and/or toughness change."
+          "text": "Abilities that define a creature's power and toughness apply while that card is in exile, but abilities that add or subtract from it don't. For example, the ability of Battle Squadron applies to determine Phyrexian Ingester's power and toughness, but the ability of Werebear doesn't. Phyrexian Ingester's power and toughness are constantly updated if the exiled card's power and/or toughness change."
         },
         {
           "date": "2016-06-08",
-          "text": "If the card in exile isn’t a creature card (perhaps because it was a land that was temporarily a creature while on the battlefield), Phyrexian Ingester doesn’t get a bonus."
+          "text": "If the card in exile isn't a creature card (perhaps because it was a land that was temporarily a creature while on the battlefield), Phyrexian Ingester doesn't get a bonus."
         }
       ],
       "subtypes": [
@@ -5467,11 +5467,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2016-06-08",
-          "text": "Unlike many similar abilities, Stupefying Touch’s last ability stops mana abilities from being activated."
+          "text": "Unlike many similar abilities, Stupefying Touch's last ability stops mana abilities from being activated."
         }
       ],
       "subtypes": [
@@ -5601,11 +5601,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A creature spell that doesn’t have flying won’t cost less even if the creature it will become will have flying once on the battlefield. For example, if you control an Island and Wonder is in your graveyard, creature spells won’t cost {1} less even though those creatures will have flying once they’re on the battlefield."
+          "text": "A creature spell that doesn't have flying won't cost less even if the creature it will become will have flying once on the battlefield. For example, if you control an Island and Wonder is in your graveyard, creature spells won't cost {1} less even though those creatures will have flying once they're on the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability can’t reduce the colored mana requirement of a creature spell with flying."
+          "text": "The ability can't reduce the colored mana requirement of a creature spell with flying."
         }
       ],
       "subtypes": [
@@ -5754,7 +5754,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -5762,11 +5762,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -5837,7 +5837,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature is an illegal target when Annihilate tries to resolve, the entire spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target when Annihilate tries to resolve, the entire spell is countered. You won't draw a card."
         }
       ],
       "text": "Destroy target nonblack creature. It can't be regenerated.\nDraw a card.",
@@ -6050,7 +6050,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "At the beginning of your upkeep, triggered abilities you control will resolve after triggered abilities your opponents control. If an opponent controls Braids and you control a triggered ability that puts a permanent onto the battlefield, you won’t be able to sacrifice that permanent to satisfy Braids’s ability."
+          "text": "At the beginning of your upkeep, triggered abilities you control will resolve after triggered abilities your opponents control. If an opponent controls Braids and you control a triggered ability that puts a permanent onto the battlefield, you won't be able to sacrifice that permanent to satisfy Braids's ability."
         }
       ],
       "subtypes": [
@@ -6533,6 +6533,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -6574,7 +6578,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -6645,7 +6649,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All creatures on the battlefield when Havoc Demon’s triggered ability resolves are affected. Ones that enter the battlefield or become creatures later in the turn are not."
+          "text": "All creatures on the battlefield when Havoc Demon's triggered ability resolves are affected. Ones that enter the battlefield or become creatures later in the turn are not."
         }
       ],
       "subtypes": [
@@ -6846,11 +6850,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If multiple Ichorids are in your graveyard, you can’t exile the same creature card to return each of them to the battlefield."
+          "text": "If multiple Ichorids are in your graveyard, you can't exile the same creature card to return each of them to the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "If one Ichorid’s ability exiles another, the exiled Ichorid’s ability can’t return it to the battlefield."
+          "text": "If one Ichorid's ability exiles another, the exiled Ichorid's ability can't return it to the battlefield."
         }
       ],
       "subtypes": [
@@ -6993,7 +6997,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The number of Elves you control is counted only as Lys Alana Scarblade’s ability resolves. If Lys Alana Scarblade is still on the battlefield, it’ll count itself."
+          "text": "The number of Elves you control is counted only as Lys Alana Scarblade's ability resolves. If Lys Alana Scarblade is still on the battlefield, it'll count itself."
         }
       ],
       "subtypes": [
@@ -7060,11 +7064,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The copy of Malicious Affliction is created on the stack. It’s not cast, so the copy won’t cause the morbid ability to trigger again."
+          "text": "The copy of Malicious Affliction is created on the stack. It's not cast, so the copy won't cause the morbid ability to trigger again."
         },
         {
           "date": "2016-06-08",
-          "text": "The copy will have the same target as the original spell unless you choose a new one. You don’t have to change this target if you don’t want to or can’t choose a new legal target (perhaps because there are no other nonblack creatures on the battlefield)."
+          "text": "The copy will have the same target as the original spell unless you choose a new one. You don't have to change this target if you don't want to or can't choose a new legal target (perhaps because there are no other nonblack creatures on the battlefield)."
         }
       ],
       "text": "Morbid — When you cast Malicious Affliction, if a creature died this turn, you may copy Malicious Affliction and may choose a new target for the copy.\nDestroy target nonblack creature.",
@@ -7206,11 +7210,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Necropotence’s last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
+          "text": "Necropotence's last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
         },
         {
           "date": "2016-06-08",
-          "text": "If the discarded card isn’t put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won’t be exiled."
+          "text": "If the discarded card isn't put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won't be exiled."
         }
       ],
       "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
@@ -7287,7 +7291,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it’s a creature you control."
+          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it's a creature you control."
         }
       ],
       "subtypes": [
@@ -7715,7 +7719,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sengir Autocrat’s last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
+          "text": "Sengir Autocrat's last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
         },
         {
           "date": "2016-06-08",
@@ -7852,7 +7856,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You’ll sacrifice Skulking Ghost even if you counter the spell or ability that targets it. If that spell has no other targets, it’ll be countered when it tries to resolve."
+          "text": "You'll sacrifice Skulking Ghost even if you counter the spell or ability that targets it. If that spell has no other targets, it'll be countered when it tries to resolve."
         }
       ],
       "subtypes": [
@@ -7922,7 +7926,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you cast Toxic Deluge without paying its mana cost, you’ll still choose a value for X and pay X life. This is because it doesn’t have {X} in its mana cost."
+          "text": "If you cast Toxic Deluge without paying its mana cost, you'll still choose a value for X and pay X life. This is because it doesn't have {X} in its mana cost."
         },
         {
           "date": "2016-06-08",
@@ -8073,7 +8077,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2016-06-08",
@@ -8161,7 +8165,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you chose at least one target and all targets are illegal on resolution, you won’t draw a card."
+          "text": "If you chose at least one target and all targets are illegal on resolution, you won't draw a card."
         }
       ],
       "text": "Return up to two target creature cards from your graveyard to your hand.\nDraw a card.",
@@ -8230,7 +8234,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
@@ -8300,19 +8304,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You must choose two targets. You can’t cast Victimize targeting only one creature card."
+          "text": "You must choose two targets. You can't cast Victimize targeting only one creature card."
         },
         {
           "date": "2016-06-08",
-          "text": "The creature you sacrifice isn’t chosen until Victimize resolves. You can’t return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
+          "text": "The creature you sacrifice isn't chosen until Victimize resolves. You can't return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
         },
         {
           "date": "2016-06-08",
-          "text": "As Victimize resolves, you must sacrifice a creature if able. You can’t change your mind and choose not to sacrifice anything."
+          "text": "As Victimize resolves, you must sacrifice a creature if able. You can't change your mind and choose not to sacrifice anything."
         },
         {
           "date": "2016-06-08",
-          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you’ll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won’t sacrifice a creature."
+          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you'll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won't sacrifice a creature."
         },
         {
           "date": "2016-06-08",
@@ -8404,7 +8408,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"So the vulture said to the griffin, ‘You gonna eat that?'\"\n—Azeworai, \"The Ugly Bird\"",
+      "flavor": "\"So the vulture said to the griffin, 'You gonna eat that?'\"\n—Azeworai, \"The Ugly Bird\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -8659,7 +8663,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Battle Squadron’s last ability applies in all zones. While it’s on the battlefield, it counts itself, so it’ll be at least 1/1."
+          "text": "Battle Squadron's last ability applies in all zones. While it's on the battlefield, it counts itself, so it'll be at least 1/1."
         }
       ],
       "subtypes": [
@@ -8874,11 +8878,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Burning Vengeance doesn’t trigger when you activate an ability of a card in your graveyard, such as unearth or the ability of Reassembling Skeleton."
+          "text": "Burning Vengeance doesn't trigger when you activate an ability of a card in your graveyard, such as unearth or the ability of Reassembling Skeleton."
         },
         {
           "date": "2016-06-08",
-          "text": "Burning Vengeance’s triggered ability will resolve before the spell you cast from your graveyard."
+          "text": "Burning Vengeance's triggered ability will resolve before the spell you cast from your graveyard."
         }
       ],
       "text": "Whenever you cast a spell from your graveyard, Burning Vengeance deals 2 damage to target creature or player.",
@@ -8944,7 +8948,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The targeted creature can’t be regenerated and is exiled if it would die no matter why it would die this turn. It doesn’t have to be destroyed because of the damage Carbonize deals to it."
+          "text": "The targeted creature can't be regenerated and is exiled if it would die no matter why it would die this turn. It doesn't have to be destroyed because of the damage Carbonize deals to it."
         }
       ],
       "text": "Carbonize deals 3 damage to target creature or player. That creature can't be regenerated this turn. If the creature would die this turn, exile it instead.",
@@ -9021,7 +9025,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who’s copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
+          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who's copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
         },
         {
           "date": "2016-06-08",
@@ -9029,11 +9033,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The copy of Chain Lightning is created on the stack, so it’s not cast. Abilities that trigger when a player casts a spell won’t trigger. Players may respond to that spell before it resolves."
+          "text": "The copy of Chain Lightning is created on the stack, so it's not cast. Abilities that trigger when a player casts a spell won't trigger. Players may respond to that spell before it resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can’t be copied."
+          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can't be copied."
         }
       ],
       "text": "Chain Lightning deals 3 damage to target creature or player. Then that player or that creature's controller may pay {R}{R}. If the player does, he or she may copy this spell and may choose a new target for that copy.",
@@ -9303,23 +9307,23 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Dualcaster Mage’s triggered ability can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Dualcaster Mage's triggered ability can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2016-06-08",
-          "text": "As Dualcaster Mage’s triggered ability resolves, it creates a copy of a spell on the stack. The copy isn’t cast, so abilities that trigger when a player casts a spell won’t trigger."
+          "text": "As Dualcaster Mage's triggered ability resolves, it creates a copy of a spell on the stack. The copy isn't cast, so abilities that trigger when a player casts a spell won't trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs paid for the targeted spell are copied as though those same costs were paid for the copy."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs paid for the targeted spell are copied as though those same costs were paid for the copy."
         },
         {
           "date": "2016-06-08",
-          "text": "If the spell is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2016-06-08",
@@ -9327,7 +9331,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "subtypes": [
@@ -9477,7 +9481,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The targeted creature can’t block any creatures this turn. The effect doesn’t merely restrict whether it can block Fervent Cathar."
+          "text": "The targeted creature can't block any creatures this turn. The effect doesn't merely restrict whether it can block Fervent Cathar."
         }
       ],
       "subtypes": [
@@ -9616,7 +9620,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -9624,11 +9628,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Flame Jab deals 1 damage to target creature or player.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -10121,7 +10125,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it’s too late to activate its ability before it’s destroyed."
+          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it's too late to activate its ability before it's destroyed."
         }
       ],
       "subtypes": [
@@ -10394,7 +10398,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         },
         {
           "date": "2016-06-08",
@@ -10745,11 +10749,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander’s activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
+          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander's activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
         },
         {
           "date": "2016-06-08",
-          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -10823,7 +10827,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You only sacrifice the creature if you still control it at end of turn. If that creature has left the battlefield, even if it came back, you don’t sacrifice it. Likewise, if an opponent has gained control of it, it won’t be sacrificed and will remain on the battlefield indefinitely."
+          "text": "You only sacrifice the creature if you still control it at end of turn. If that creature has left the battlefield, even if it came back, you don't sacrifice it. Likewise, if an opponent has gained control of it, it won't be sacrificed and will remain on the battlefield indefinitely."
         },
         {
           "date": "2016-06-08",
@@ -11090,7 +11094,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Undying Rage when it’s cast as a spell is an illegal target when Undying Rage tries to resolve, Undying Rage will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Undying Rage when it's cast as a spell is an illegal target when Undying Rage tries to resolve, Undying Rage will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -11235,15 +11239,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "It is possible for Worldgorger Dragon to leave the battlefield before its “enters the battlefield” trigger resolves. If this happens, then the “leaves the battlefield” trigger will have nothing to return. Then its “enters the battlefield” trigger resolves, and all other permanents you control are exiled forever."
+          "text": "It is possible for Worldgorger Dragon to leave the battlefield before its \"enters the battlefield\" trigger resolves. If this happens, then the \"leaves the battlefield\" trigger will have nothing to return. Then its \"enters the battlefield\" trigger resolves, and all other permanents you control are exiled forever."
         },
         {
           "date": "2016-06-08",
-          "text": "If an Aura is exiled with Worldgorger Dragon, the player who controls the Aura when it enters the battlefield chooses what it will enchant. It doesn’t have to go back to the same place. It can’t enter the battlefield enchanting a permanent that enters the battlefield at the same time."
+          "text": "If an Aura is exiled with Worldgorger Dragon, the player who controls the Aura when it enters the battlefield chooses what it will enchant. It doesn't have to go back to the same place. It can't enter the battlefield enchanting a permanent that enters the battlefield at the same time."
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead is put onto the battlefield enchanting Worldgorger Dragon, Worldgorger Dragon’s enters-the-battlefield trigger will exile Animate Dead, which causes you to sacrifice Worldgorger Dragon, which causes Animate Dead to return to the battlefield attached to a creature card in a graveyard of your choice. If you can choose a creature card other than Worldgorger Dragon, you must do so after as many iterations of this loop as you’d like. If you can’t choose a different card, and no player chooses to break the loop, the game ends in a draw."
+          "text": "If Animate Dead is put onto the battlefield enchanting Worldgorger Dragon, Worldgorger Dragon's enters-the-battlefield trigger will exile Animate Dead, which causes you to sacrifice Worldgorger Dragon, which causes Animate Dead to return to the battlefield attached to a creature card in a graveyard of your choice. If you can choose a creature card other than Worldgorger Dragon, you must do so after as many iterations of this loop as you'd like. If you can't choose a different card, and no player chooses to break the loop, the game ends in a draw."
         }
       ],
       "subtypes": [
@@ -11316,7 +11320,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Young Pyromancer’s triggered ability will resolve before the spell that caused it to trigger, but after targets have been chosen for that spell."
+          "text": "Young Pyromancer's triggered ability will resolve before the spell that caused it to trigger, but after targets have been chosen for that spell."
         }
       ],
       "subtypes": [
@@ -11390,7 +11394,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The enchanted land retains any other abilities it has. Activating one of the land’s activated abilities won’t cause the other(s) to be activated."
+          "text": "The enchanted land retains any other abilities it has. Activating one of the land's activated abilities won't cause the other(s) to be activated."
         }
       ],
       "subtypes": [
@@ -11523,15 +11527,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Argothian Enchantress’s last ability will resolve before the spell that caused it to trigger."
+          "text": "Argothian Enchantress's last ability will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "If the enchantment spell is countered, Argothian Enchantress’s last ability still resolves and causes you to draw a card."
+          "text": "If the enchantment spell is countered, Argothian Enchantress's last ability still resolves and causes you to draw a card."
         },
         {
           "date": "2016-06-08",
-          "text": "Enchantments put onto the battlefield without being cast won’t cause Argothian Enchantress’s last ability to trigger."
+          "text": "Enchantments put onto the battlefield without being cast won't cause Argothian Enchantress's last ability to trigger."
         }
       ],
       "subtypes": [
@@ -11554,7 +11558,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"‘I have arrived,' bellowed Brawn, and the plane shuddered.\"\n—Scroll of Beginnings",
+      "flavor": "\"'I have arrived,' bellowed Brawn, and the plane shuddered.\"\n—Scroll of Beginnings",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -11668,11 +11672,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All creatures under your control when Centaur Chieftain’s triggered ability resolves are affected, including Centaur Chieftain itself. Ones that come under your control or become creatures later in the turn are not."
+          "text": "All creatures under your control when Centaur Chieftain's triggered ability resolves are affected, including Centaur Chieftain itself. Ones that come under your control or become creatures later in the turn are not."
         },
         {
           "date": "2016-06-08",
-          "text": "If you don’t have enough cards in your graveyard at the moment Centaur Chieftain enters the battlefield, its threshold ability won’t trigger. If the number of cards in your graveyard changes and Centaur Chieftain loses the ability once it has triggered, the ability will still resolve."
+          "text": "If you don't have enough cards in your graveyard at the moment Centaur Chieftain enters the battlefield, its threshold ability won't trigger. If the number of cards in your graveyard changes and Centaur Chieftain loses the ability once it has triggered, the ability will still resolve."
         }
       ],
       "subtypes": [
@@ -11883,7 +11887,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If Elephant Guide enchants an opponent’s creature, you get the Elephant when that creature dies."
+          "text": "If Elephant Guide enchants an opponent's creature, you get the Elephant when that creature dies."
         }
       ],
       "subtypes": [
@@ -12031,7 +12035,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Emperor Crocodile’s ability will trigger if you don’t control another creature, even if it’s only for a brief moment during the resolution of another spell or ability (such as that of Brago, King Eternal)."
+          "text": "Emperor Crocodile's ability will trigger if you don't control another creature, even if it's only for a brief moment during the resolution of another spell or ability (such as that of Brago, King Eternal)."
         },
         {
           "date": "2016-06-08",
@@ -12263,11 +12267,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "When you cast Gaea’s Blessing, you can’t choose it as one of its own targets. This is because you choose the targets when casting this spell, and spells are not put into your graveyard until after they resolve."
+          "text": "When you cast Gaea's Blessing, you can't choose it as one of its own targets. This is because you choose the targets when casting this spell, and spells are not put into your graveyard until after they resolve."
         },
         {
           "date": "2016-06-08",
-          "text": "You must target a player as you cast Gaea’s Blessing. You may target zero, one, two, or three cards in that player’s graveyard."
+          "text": "You must target a player as you cast Gaea's Blessing. You may target zero, one, two, or three cards in that player's graveyard."
         }
       ],
       "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nDraw a card.\nWhen Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
@@ -12338,19 +12342,19 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         },
         {
           "date": "2016-06-08",
-          "text": "If Green Sun’s Zenith is countered, none of its effects will happen. Notably, it will be put into its owner’s graveyard rather than shuffled into its owner’s library."
+          "text": "If Green Sun's Zenith is countered, none of its effects will happen. Notably, it will be put into its owner's graveyard rather than shuffled into its owner's library."
         },
         {
           "date": "2016-06-08",
-          "text": "In most cases, if you own Green Sun’s Zenith and cast it, you’ll shuffle your library twice. In practice, shuffling once is sufficient, but effects that care about you shuffling your library (like Psychogenic Probe, for example) will see that you’ve shuffled twice."
+          "text": "In most cases, if you own Green Sun's Zenith and cast it, you'll shuffle your library twice. In practice, shuffling once is sufficient, but effects that care about you shuffling your library (like Psychogenic Probe, for example) will see that you've shuffled twice."
         },
         {
           "date": "2016-06-08",
-          "text": "If you own Green Sun’s Zenith, but an opponent casts it (due to Knowledge Pool’s effect, for example), that opponent searches his or her library for an appropriate creature card, then shuffles that library. That opponent then shuffles Green Sun’s Zenith into your library. You won’t shuffle any library in this case."
+          "text": "If you own Green Sun's Zenith, but an opponent casts it (due to Knowledge Pool's effect, for example), that opponent searches his or her library for an appropriate creature card, then shuffles that library. That opponent then shuffles Green Sun's Zenith into your library. You won't shuffle any library in this case."
         }
       ],
       "text": "Search your library for a green creature card with converted mana cost X or less, put it onto the battlefield, then shuffle your library. Shuffle Green Sun's Zenith into its owner's library.",
@@ -12501,7 +12505,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Since Heritage Druid’s activated ability doesn’t have a tap symbol in its cost, you can tap creatures that haven’t been under your control since your most recent turn began (including Heritage Druid itself) to pay the cost."
+          "text": "Since Heritage Druid's activated ability doesn't have a tap symbol in its cost, you can tap creatures that haven't been under your control since your most recent turn began (including Heritage Druid itself) to pay the cost."
         }
       ],
       "subtypes": [
@@ -12724,7 +12728,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If an effect says that an opponent can’t gain life, you can’t have that player gain life to pay Invigorate’s alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost’s action is replaced with nothing."
+          "text": "If an effect says that an opponent can't gain life, you can't have that player gain life to pay Invigorate's alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost's action is replaced with nothing."
         }
       ],
       "text": "If you control a Forest, rather than pay Invigorate's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
@@ -12890,7 +12894,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Lys Alana Huntmaster’s ability will resolve before the Elf spell that caused it to trigger."
+          "text": "Lys Alana Huntmaster's ability will resolve before the Elf spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -12963,11 +12967,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sacrificing a green creature is part of Natural Order’s cost. You can’t sacrifice more creatures to search for more creature cards, and you can’t cast Natural Order at all if you control no green creatures."
+          "text": "Sacrificing a green creature is part of Natural Order's cost. You can't sacrifice more creatures to search for more creature cards, and you can't cast Natural Order at all if you control no green creatures."
         },
         {
           "date": "2016-06-08",
-          "text": "Players can respond to this spell only after it’s been cast and all its costs have been paid. No one can try to destroy the creature you sacrificed to stop you from casting this spell or to make you sacrifice a different one."
+          "text": "Players can respond to this spell only after it's been cast and all its costs have been paid. No one can try to destroy the creature you sacrificed to stop you from casting this spell or to make you sacrifice a different one."
         }
       ],
       "text": "As an additional cost to cast Natural Order, sacrifice a green creature.\nSearch your library for a green creature card and put it onto the battlefield. Then shuffle your library.",
@@ -13038,7 +13042,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the targeted artifact or enchantment is an illegal target when Nature’s Claim tries to resolve, the entire spell is countered. No one gains any life."
+          "text": "If the targeted artifact or enchantment is an illegal target when Nature's Claim tries to resolve, the entire spell is countered. No one gains any life."
         }
       ],
       "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
@@ -13179,7 +13183,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -13638,19 +13642,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player’s draw step."
+          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player's draw step."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library’s ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
+          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library's ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
         },
         {
           "date": "2016-06-08",
-          "text": "Any cards drawn prior to Sylvan Library’s ability resolving, including in your upkeep or in response to Sylvan Library’s triggered ability, can be chosen to be put back using this effect. Sylvan Library’s controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
+          "text": "Any cards drawn prior to Sylvan Library's ability resolving, including in your upkeep or in response to Sylvan Library's triggered ability, can be chosen to be put back using this effect. Sylvan Library's controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don’t get to draw all the cards at once and then put them all back at once."
+          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don't get to draw all the cards at once and then put them all back at once."
         },
         {
           "date": "2016-06-08",
@@ -13658,11 +13662,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library’s ability still happens. If you’ve actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven’t actually drawn any cards that turn, the rest of the ability has no effect."
+          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library's ability still happens. If you've actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven't actually drawn any cards that turn, the rest of the ability has no effect."
         },
         {
           "date": "2016-06-08",
-          "text": "It’s not possible to take any actions between drawing the cards and choosing two cards. You can’t cast the cards you drew to avoid having two cards to choose."
+          "text": "It's not possible to take any actions between drawing the cards and choosing two cards. You can't cast the cards you drew to avoid having two cards to choose."
         }
       ],
       "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
@@ -13866,7 +13870,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf’s ability resolves. If Timberwatch Elf is still on the battlefield, it’ll count itself."
+          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf's ability resolves. If Timberwatch Elf is still on the battlefield, it'll count itself."
         }
       ],
       "subtypes": [
@@ -14071,7 +14075,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The defending player may cast spells before Xantid Swarm’s triggered ability resolves."
+          "text": "The defending player may cast spells before Xantid Swarm's triggered ability resolves."
         },
         {
           "date": "2016-06-08",
@@ -14225,11 +14229,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "While Armadillo Cloak’s last ability is similar to lifelink, it isn’t lifelink—it’s a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you’ll gain that much life for lifelink, and then Armadillo Cloak’s triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak’s triggered ability do trigger separately."
+          "text": "While Armadillo Cloak's last ability is similar to lifelink, it isn't lifelink—it's a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you'll gain that much life for lifelink, and then Armadillo Cloak's triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak's triggered ability do trigger separately."
         },
         {
           "date": "2016-06-08",
-          "text": "If Armadillo Cloak enchants a creature you don’t control, you’ll gain life when it deals damage, as long as that damage hasn’t already caused you to lose the game."
+          "text": "If Armadillo Cloak enchants a creature you don't control, you'll gain life when it deals damage, as long as that damage hasn't already caused you to lose the game."
         }
       ],
       "subtypes": [
@@ -14393,11 +14397,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -14472,7 +14476,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Brago’s last ability exiles and returns all the targets during the combat damage step, after combat damage is dealt. You can’t target any creature that didn’t survive combat."
+          "text": "Brago's last ability exiles and returns all the targets during the combat damage step, after combat damage is dealt. You can't target any creature that didn't survive combat."
         },
         {
           "date": "2016-06-08",
@@ -14480,7 +14484,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you exile an Aura with Brago’s last ability, the Aura’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything (so it could be attached to a permanent with shroud, for example), but the Aura’s enchant ability restricts what it can be attached to. The Aura can’t enter the battlefield enchanting a permanent that enters the battlefield at the same time. If the Aura can’t legally be attached to anything, it remains exiled."
+          "text": "If you exile an Aura with Brago's last ability, the Aura's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything (so it could be attached to a permanent with shroud, for example), but the Aura's enchant ability restricts what it can be attached to. The Aura can't enter the battlefield enchanting a permanent that enters the battlefield at the same time. If the Aura can't legally be attached to anything, it remains exiled."
         }
       ],
       "subtypes": [
@@ -14552,19 +14556,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The targeted player draws two cards and discards two cards all while Dack’s first ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+          "text": "The targeted player draws two cards and discards two cards all while Dack's first ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability of Dack’s emblem will resolve before the spell that caused it to trigger."
+          "text": "The ability of Dack's emblem will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "The effect of Dack’s second ability and the effect of the emblem’s ability last indefinitely. You won’t lose control of the permanents if Dack leaves the battlefield."
+          "text": "The effect of Dack's second ability and the effect of the emblem's ability last indefinitely. You won't lose control of the permanents if Dack leaves the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "If you gain control of a permanent, and you leave the game, the control-changing effect will end. Unless there’s another control-changing effect affecting that permanent, it will return to its owner’s control."
+          "text": "If you gain control of a permanent, and you leave the game, the control-changing effect will end. Unless there's another control-changing effect affecting that permanent, it will return to its owner's control."
         },
         {
           "date": "2016-06-08",
@@ -14636,7 +14640,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Extract from Darkness doesn’t target a creature card. You choose which card you’re putting onto the battlefield as it resolves. You can choose any creature card in a graveyard at that time, including one just put into a graveyard by Extract from Darkness. If there are no creature cards in graveyards at that time, Extract from Darkness simply finishes resolving."
+          "text": "Extract from Darkness doesn't target a creature card. You choose which card you're putting onto the battlefield as it resolves. You can choose any creature card in a graveyard at that time, including one just put into a graveyard by Extract from Darkness. If there are no creature cards in graveyards at that time, Extract from Darkness simply finishes resolving."
         }
       ],
       "text": "Each player puts the top two cards of his or her library into his or her graveyard. Then put a creature card from a graveyard onto the battlefield under your control.",
@@ -14710,7 +14714,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All creatures under your control when Flame-Kin Zealot’s triggered ability resolves are affected, including Flame-Kin Zealot itself. Ones that come under your control or become creatures later in the turn are not."
+          "text": "All creatures under your control when Flame-Kin Zealot's triggered ability resolves are affected, including Flame-Kin Zealot itself. Ones that come under your control or become creatures later in the turn are not."
         }
       ],
       "subtypes": [
@@ -14850,7 +14854,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The tokens are named “Goblin Soldier” and have the creature types “Goblin” and “Soldier”."
+          "text": "The tokens are named \"Goblin Soldier\" and have the creature types \"Goblin\" and \"Soldier\"."
         }
       ],
       "text": "{2}, Sacrifice a land: Create two 1/1 red and white Goblin Soldier creature tokens.",
@@ -14926,7 +14930,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "No matter what spell you cast with the first cascade trigger (or with any cascade triggers that result from casting that spell), the second cascade trigger will look for a spell with converted mana cost less than Maelstrom Wanderer’s converted mana cost of 8."
+          "text": "No matter what spell you cast with the first cascade trigger (or with any cascade triggers that result from casting that spell), the second cascade trigger will look for a spell with converted mana cost less than Maelstrom Wanderer's converted mana cost of 8."
         }
       ],
       "subtypes": [
@@ -15002,7 +15006,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Count the number of Elves you control as Shaman of the Pack’s ability resolves, including Shaman of the Pack if it’s still on the battlefield, to determine how much life is lost."
+          "text": "Count the number of Elves you control as Shaman of the Pack's ability resolves, including Shaman of the Pack if it's still on the battlefield, to determine how much life is lost."
         }
       ],
       "subtypes": [
@@ -15432,7 +15436,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The target player is chosen as you announce Void, but the number isn’t chosen until it’s resolving. No player may choose to take actions between you choosing a number and the rest of Void’s effects."
+          "text": "The target player is chosen as you announce Void, but the number isn't chosen until it's resolving. No player may choose to take actions between you choosing a number and the rest of Void's effects."
         }
       ],
       "text": "Choose a number. Destroy all artifacts and creatures with converted mana cost equal to that number. Then target player reveals his or her hand and discards all nonland cards with converted mana cost equal to the number.",
@@ -15507,7 +15511,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Wee Dragonauts’s triggered ability will resolve before the spell that caused it to trigger."
+          "text": "Wee Dragonauts's triggered ability will resolve before the spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -15654,7 +15658,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -15662,11 +15666,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Create a 5/5 blue and red Elemental creature token with flying.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -15742,7 +15746,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the target of any of Deathrite Shaman’s three abilities is an illegal target when that ability tries to resolve, it will be countered and none of its effects will happen. You won’t add mana to your mana pool, no opponent will lose life, or you won’t gain life, as appropriate."
+          "text": "If the target of any of Deathrite Shaman's three abilities is an illegal target when that ability tries to resolve, it will be countered and none of its effects will happen. You won't add mana to your mana pool, no opponent will lose life, or you won't gain life, as appropriate."
         }
       ],
       "subtypes": [
@@ -15896,7 +15900,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -16019,11 +16023,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If no card is imprinted on Chrome Mox, it can’t add mana to your mana pool. It can never add colorless mana to your mana pool, even if the imprinted card has a colorless mana symbol in its mana cost."
+          "text": "If no card is imprinted on Chrome Mox, it can't add mana to your mana pool. It can never add colorless mana to your mana pool, even if the imprinted card has a colorless mana symbol in its mana cost."
         },
         {
           "date": "2016-06-08",
-          "text": "If you imprinted a multicolored card, you choose one of that card’s colors each time Chrome Mox’s ability resolves."
+          "text": "If you imprinted a multicolored card, you choose one of that card's colors each time Chrome Mox's ability resolves."
         }
       ],
       "text": "Imprint — When Chrome Mox enters the battlefield, you may exile a nonartifact, nonland card from your hand.\n{T}: Add one mana of any of the exiled card's colors to your mana pool.",
@@ -16094,11 +16098,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Duplicant’s base power and toughness change to the imprinted card’s power and toughness. Counters and other effects that modify Duplicant’s power and toughness still apply."
+          "text": "Duplicant's base power and toughness change to the imprinted card's power and toughness. Counters and other effects that modify Duplicant's power and toughness still apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Abilities that define a creature’s power and toughness apply while that card is in exile, but abilities that add or subtract from it don’t. For example, the ability of Battle Squadron applies to determine Duplicant’s power and toughness, but the ability of Werebear doesn’t. Duplicant’s power and toughness are constantly updated if the exiled card’s power and/or toughness change."
+          "text": "Abilities that define a creature's power and toughness apply while that card is in exile, but abilities that add or subtract from it don't. For example, the ability of Battle Squadron applies to determine Duplicant's power and toughness, but the ability of Werebear doesn't. Duplicant's power and toughness are constantly updated if the exiled card's power and/or toughness change."
         },
         {
           "date": "2016-06-08",
@@ -16106,7 +16110,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If a melded permanent is exiled by Duplicant’s triggered ability, that ability’s controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
+          "text": "If a melded permanent is exiled by Duplicant's triggered ability, that ability's controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
         }
       ],
       "subtypes": [
@@ -16229,7 +16233,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You must choose a target for Goblin Charbelcher’s ability as you activate it, before you reveal any cards."
+          "text": "You must choose a target for Goblin Charbelcher's ability as you activate it, before you reveal any cards."
         },
         {
           "date": "2016-06-08",
@@ -16299,7 +16303,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the imprinted card leaves the exile zone while the activated ability is on the stack, the copy can’t be made."
+          "text": "If the imprinted card leaves the exile zone while the activated ability is on the stack, the copy can't be made."
         },
         {
           "date": "2016-06-08",
@@ -16311,7 +16315,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Because you’re already casting the spell using an alternative cost (by casting it without paying its mana cost), you can’t pay any other alternative costs for the card. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
+          "text": "Because you're already casting the spell using an alternative cost (by casting it without paying its mana cost), you can't pay any other alternative costs for the card. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2016-06-08",
@@ -16319,7 +16323,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you don’t want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
+          "text": "If you don't want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
         },
         {
           "date": "2017-04-18",
@@ -16401,11 +16405,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -16530,7 +16534,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If you activate Millikin’s ability while casting a spell, you can’t choose to rewind the ability once you see the card that was put into your graveyard."
+          "text": "If you activate Millikin's ability while casting a spell, you can't choose to rewind the ability once you see the card that was put into your graveyard."
         }
       ],
       "subtypes": [
@@ -16673,7 +16677,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -16875,11 +16879,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If you activate Relic of Progenitus’s first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
+          "text": "If you activate Relic of Progenitus's first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "You can activate Relic of Progenitus’s second ability even if no players have any cards in their graveyards. You’ll still draw a card."
+          "text": "You can activate Relic of Progenitus's second ability even if no players have any cards in their graveyards. You'll still draw a card."
         }
       ],
       "text": "{T}: Target player exiles a card from his or her graveyard.\n{1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.",
@@ -16943,11 +16947,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sensei’s Divining Top’s second ability may be activated in response to its first ability. If so, you’ll draw a card, put Sensei’s Divining Top on top of your library, and then look at the top three cards and rearrange them."
+          "text": "Sensei's Divining Top's second ability may be activated in response to its first ability. If so, you'll draw a card, put Sensei's Divining Top on top of your library, and then look at the top three cards and rearrange them."
         },
         {
           "date": "2016-06-08",
-          "text": "If Sensei’s Divining Top leaves the battlefield while its second ability is on the stack, you’ll draw a card and leave Sensei’s Divining Top in the zone it’s moved to."
+          "text": "If Sensei's Divining Top leaves the battlefield while its second ability is on the stack, you'll draw a card and leave Sensei's Divining Top in the zone it's moved to."
         }
       ],
       "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
@@ -17070,11 +17074,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All permanents untap during a player’s untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
+          "text": "All permanents untap during a player's untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
+          "text": "You can't tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
         }
       ],
       "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",
@@ -17491,11 +17495,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The creature isn’t removed from combat; it just has its damage prevented. It’s still an attacking creature until the combat phase is complete."
+          "text": "The creature isn't removed from combat; it just has its damage prevented. It's still an attacking creature until the combat phase is complete."
         },
         {
           "date": "2016-06-08",
-          "text": "You can activate Maze of Ith’s ability targeting an attacking creature you control during the combat damage step or the end of combat step. It’ll be untapped and the damage it had already dealt won’t be undone."
+          "text": "You can activate Maze of Ith's ability targeting an attacking creature you control during the combat damage step or the end of combat step. It'll be untapped and the damage it had already dealt won't be undone."
         }
       ],
       "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
@@ -17556,19 +17560,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Once turned into a creature, Mishra’s Factory’s last ability can target itself. If it’s already blocking, this won’t remove it from combat."
+          "text": "Once turned into a creature, Mishra's Factory's last ability can target itself. If it's already blocking, this won't remove it from combat."
         },
         {
           "date": "2016-06-08",
-          "text": "If you turn Mishra’s Factory into a creature but haven’t controlled it continuously since your most recent turn began, you won’t be able to activate its first or last ability."
+          "text": "If you turn Mishra's Factory into a creature but haven't controlled it continuously since your most recent turn began, you won't be able to activate its first or last ability."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",

--- a/json/EMN.json
+++ b/json/EMN.json
@@ -138,7 +138,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
@@ -146,19 +146,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -166,19 +166,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -293,15 +293,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The set of creatures affected by the triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn won’t get +2/+2 or trample."
+          "text": "The set of creatures affected by the triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn won't get +2/+2 or trample."
         },
         {
           "date": "2016-07-13",
-          "text": "The triggered ability resolves before Decimator of the Provinces enters the battlefield, so it won’t get +2/+2 from its own triggered ability."
+          "text": "The triggered ability resolves before Decimator of the Provinces enters the battlefield, so it won't get +2/+2 from its own triggered ability."
         },
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
@@ -309,19 +309,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -329,19 +329,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -456,11 +456,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Distended Mindbender’s last ability triggers after you’ve taken all the actions necessary to cast the spell."
+          "text": "Distended Mindbender's last ability triggers after you've taken all the actions necessary to cast the spell."
         },
         {
           "date": "2016-07-13",
-          "text": "If a card in a player’s hand has {X} in its mana cost, X is considered to be 0."
+          "text": "If a card in a player's hand has {X} in its mana cost, X is considered to be 0."
         },
         {
           "date": "2016-07-13",
@@ -468,11 +468,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If there aren’t two appropriate cards to choose, choose whichever you can and that player discards that card."
+          "text": "If there aren't two appropriate cards to choose, choose whichever you can and that player discards that card."
         },
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
@@ -480,19 +480,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -500,19 +500,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -627,7 +627,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "There is no moment during the turn Drownyard Behemoth enters the battlefield in which it doesn’t have hexproof. The earliest opportunity for an opponent to target it is during the next turn’s upkeep step."
+          "text": "There is no moment during the turn Drownyard Behemoth enters the battlefield in which it doesn't have hexproof. The earliest opportunity for an opponent to target it is during the next turn's upkeep step."
         },
         {
           "date": "2016-07-13",
@@ -635,19 +635,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -655,19 +655,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -782,7 +782,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
@@ -790,19 +790,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -810,19 +810,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -935,11 +935,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The card types that could appear in your graveyard are artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal (a card type that appears on some older cards). Supertypes (such as legendary and basic) and subtypes (such as Human and Equipment) are not counted. The maximum discount that Emrakul’s own ability can provide is {8}."
+          "text": "The card types that could appear in your graveyard are artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal (a card type that appears on some older cards). Supertypes (such as legendary and basic) and subtypes (such as Human and Equipment) are not counted. The maximum discount that Emrakul's own ability can provide is {8}."
         },
         {
           "date": "2016-07-13",
-          "text": "Protection from instants means that Emrakul can’t be the target of instant spells or activated or triggered abilities from instant cards, and damage that would be dealt to it by instant spells or cards is prevented. Instant spells may still affect it in other ways; for example, it would still receive the bonus from Borrowed Grace."
+          "text": "Protection from instants means that Emrakul can't be the target of instant spells or activated or triggered abilities from instant cards, and damage that would be dealt to it by instant spells or cards is prevented. Instant spells may still affect it in other ways; for example, it would still receive the bonus from Borrowed Grace."
         },
         {
           "date": "2016-07-13",
@@ -947,7 +947,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The player you’re controlling is still the active player during that turn."
+          "text": "The player you're controlling is still the active player during that turn."
         },
         {
           "date": "2016-07-13",
@@ -959,31 +959,31 @@
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t make the affected player concede. That player may choose to concede at any time, even while you’re controlling that player."
+          "text": "You can't make the affected player concede. That player may choose to concede at any time, even while you're controlling that player."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t make any illegal decisions or illegal choices—you can’t do anything that player couldn’t do. You can’t make choices or decisions for that player that aren’t called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the affected player would normally make (such as Master Warcraft does), that effect takes precedence. In other words, if the affected player wouldn’t make a decision, you wouldn’t make that decision on that player’s behalf."
+          "text": "You can't make any illegal decisions or illegal choices—you can't do anything that player couldn't do. You can't make choices or decisions for that player that aren't called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the affected player would normally make (such as Master Warcraft does), that effect takes precedence. In other words, if the affected player wouldn't make a decision, you wouldn't make that decision on that player's behalf."
         },
         {
           "date": "2016-07-13",
-          "text": "You also can’t make any choices or decisions for the player that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
+          "text": "You also can't make any choices or decisions for the player that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
         },
         {
           "date": "2016-07-13",
-          "text": "You can use only the affected player’s resources (cards, mana, and so on) to pay costs for that player; you can’t use your own. Similarly, you can use the affected player’s resources only to pay that player’s costs; you can’t spend them on your costs."
+          "text": "You can use only the affected player's resources (cards, mana, and so on) to pay costs for that player; you can't use your own. Similarly, you can use the affected player's resources only to pay that player's costs; you can't spend them on your costs."
         },
         {
           "date": "2016-07-13",
-          "text": "You only control the player. You don’t control any of that player’s permanents, spells, or abilities."
+          "text": "You only control the player. You don't control any of that player's permanents, spells, or abilities."
         },
         {
           "date": "2016-07-13",
-          "text": "If the targeted player skips his or her next turn, you’ll control the next turn the affected player actually takes, and the extra turn the player takes will be after that turn."
+          "text": "If the targeted player skips his or her next turn, you'll control the next turn the affected player actually takes, and the extra turn the player takes will be after that turn."
         },
         {
           "date": "2016-07-13",
-          "text": "Multiple player-controlling effects that affect the same player overwrite each other. The last one to be created is the one that works. If multiple players have cast Emrakul and targeted the same player, each ability’s effect will create an extra turn."
+          "text": "Multiple player-controlling effects that affect the same player overwrite each other. The last one to be created is the one that works. If multiple players have cast Emrakul and targeted the same player, each ability's effect will create an extra turn."
         },
         {
           "date": "2016-07-13",
@@ -995,15 +995,15 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "subtypes": [
@@ -1122,11 +1122,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Eternal Scourge’s triggered ability only triggers while it’s on the battlefield. For example, Convolute cast targeting Eternal Scourge won’t cause its ability to trigger."
+          "text": "Eternal Scourge's triggered ability only triggers while it's on the battlefield. For example, Convolute cast targeting Eternal Scourge won't cause its ability to trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "You’ll exile Eternal Scourge even if the spell or ability that targets it is countered."
+          "text": "You'll exile Eternal Scourge even if the spell or ability that targets it is countered."
         }
       ],
       "subtypes": [
@@ -1241,7 +1241,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
@@ -1249,19 +1249,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -1269,19 +1269,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -1397,7 +1397,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
@@ -1405,19 +1405,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -1425,19 +1425,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -1552,7 +1552,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
@@ -1560,19 +1560,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -1580,19 +1580,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -1707,7 +1707,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
@@ -1715,19 +1715,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -1735,19 +1735,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -1862,7 +1862,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         },
         {
           "date": "2016-07-13",
@@ -1870,19 +1870,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, is a melded permanent, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) that were paid as the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "Colored mana components of emerge costs can’t be reduced with emerge."
+          "text": "Colored mana components of emerge costs can't be reduced with emerge."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that’s not a copy of another permanent, to cast a spell for its emerge cost. You’ll just pay the full emerge cost with no reduction."
+          "text": "You may sacrifice a creature with a converted mana cost of 0, such as a token creature that's not a copy of another permanent, to cast a spell for its emerge cost. You'll just pay the full emerge cost with no reduction."
         },
         {
           "date": "2016-07-13",
-          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you’ll pay only the colored mana component of the emerge cost."
+          "text": "You may sacrifice a creature with converted mana cost greater than or equal to the emerge cost. If you do, you'll pay only the colored mana component of the emerge cost."
         },
         {
           "date": "2016-07-13",
@@ -1890,19 +1890,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of the back face of a double-faced card is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a creature spell with emerge isn’t affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend’s converted mana cost remains 8."
+          "text": "The converted mana cost of a creature spell with emerge isn't affected by whether its emerge cost is paid. For example, if you cast Elder Deep-Fiend for its emerge cost and sacrifice a creature whose converted mana cost is 3, Elder Deep-Fiend's converted mana cost remains 8."
         },
         {
           "date": "2016-07-13",
-          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell’s cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
+          "text": "The creature chosen to be sacrificed is still on the battlefield up through the time that you activate mana abilities. Its abilities may affect the spell's cost, be activated to generate mana, and so on. However, if it has an ability that triggers when a spell is cast, it will have been sacrificed before that ability can trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast a spell with emerge, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast a spell with emerge, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         }
       ],
       "subtypes": [
@@ -2023,19 +2023,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Untapping an attacking creature doesn’t cause it to be removed from combat."
+          "text": "Untapping an attacking creature doesn't cause it to be removed from combat."
         },
         {
           "date": "2016-07-13",
-          "text": "You choose all of your modes at once. You can’t wait to perform one mode’s actions and then decide to choose more modes."
+          "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t choose any one mode multiple times."
+          "text": "You can't choose any one mode multiple times."
         },
         {
           "date": "2016-07-13",
-          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode’s target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
+          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode's target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
         },
         {
           "date": "2016-07-13",
@@ -2051,7 +2051,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Additional costs don’t affect a spell’s converted mana cost."
+          "text": "Additional costs don't affect a spell's converted mana cost."
         }
       ],
       "text": "Escalate {2} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more —\n• Target player gains 4 life.\n• Untap up to two target creatures.\n• Target opponent sacrifices an attacking creature.",
@@ -2163,15 +2163,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose all of your modes at once. You can’t wait to perform one mode’s actions and then decide to choose more modes."
+          "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t choose any one mode multiple times."
+          "text": "You can't choose any one mode multiple times."
         },
         {
           "date": "2016-07-13",
-          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode’s target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
+          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode's target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
         },
         {
           "date": "2016-07-13",
@@ -2187,7 +2187,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Additional costs don’t affect a spell’s converted mana cost."
+          "text": "Additional costs don't affect a spell's converted mana cost."
         }
       ],
       "text": "Escalate {1}{W} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both —\n• Creatures you control get +2/+0 until end of turn.\n• Creatures you control get +0/+2 until end of turn.",
@@ -2309,7 +2309,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         }
       ],
       "subtypes": [
@@ -2439,7 +2439,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+          "text": "A \"when you cast\" triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
         }
       ],
       "subtypes": [
@@ -2452,6 +2452,132 @@
       "text": "When you cast Bruna, the Fading Light, you may return target Angel or Human creature card from your graveyard to the battlefield.\nFlying, vigilance\n(Melds with Gisela, the Broken Blade.)",
       "toughness": "7",
       "type": "Legendary Creature — Angel Horror",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Clint Cearley",
+      "flavor": "Upon discovering what had become of her sisters, Sigarda could only weep.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "梦魇异音布瑟拉",
+          "multiverseid": 414528
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "夢魘異音布瑟拉",
+          "multiverseid": 414751
+        },
+        {
+          "language": "French",
+          "name": "Brisela, voix des cauchemars",
+          "multiverseid": 415197
+        },
+        {
+          "language": "German",
+          "name": "Brisela, Stimme der Albträume",
+          "multiverseid": 414974
+        },
+        {
+          "language": "Italian",
+          "name": "Brisela, Voce degli Incubi",
+          "multiverseid": 415420
+        },
+        {
+          "language": "Japanese",
+          "name": "悪夢の声、ブリセラ",
+          "multiverseid": 415643
+        },
+        {
+          "language": "Korean",
+          "name": "악몽의 목소리 브리셀라",
+          "multiverseid": 415866
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Brisela, Voz dos Pesadelos",
+          "multiverseid": 416089
+        },
+        {
+          "language": "Russian",
+          "name": "Бризела, Голос Кошмаров",
+          "multiverseid": 416312
+        },
+        {
+          "language": "Spanish",
+          "name": "Brisela, Voz de las Pesadillas",
+          "multiverseid": 416535
+        }
+      ],
+      "id": "9a50ffe3772a2cd29b7943f4069dc601fd3a3619",
+      "imageName": "brisela, voice of nightmares1",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "multiverseid": 414305,
+      "name": "Brisela, Voice of Nightmares",
+      "names": [
+        "Bruna, the Fading Light",
+        "Brisela, Voice of Nightmares"
+      ],
+      "number": "15b",
+      "originalText": "Flying, first strike, vigilance, lifelink\nYour opponents can't cast spells with converted mana cost 3 or less.",
+      "originalType": "Legendary Creature — Eldrazi Angel",
+      "power": "9",
+      "printings": [
+        "EMN"
+      ],
+      "rarity": "Mythic Rare",
+      "rulings": [
+        {
+          "date": "2016-07-13",
+          "text": "Effects that increase or reduce the cost to cast a spell (such as those of escalate and emerge) don't affect the spell's converted mana cost, so they won't change whether Brisela's last ability restricts that spell from being cast."
+        },
+        {
+          "date": "2016-07-13",
+          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell's converted mana cost is 3 or less. For example, your opponent could cast Burn from Within (a spell with mana cost {X}{R}) with X equal to 3, but not with X equal to 2."
+        },
+        {
+          "date": "2016-07-13",
+          "text": "For more information on meld cards, see the Eldritch Moon mechanics article (http://magic.wizards.com/en/articles/archive/feature/eldritch-moon-mechanics)."
+        }
+      ],
+      "subtypes": [
+        "Eldrazi",
+        "Angel"
+      ],
+      "supertypes": [
+        "Legendary"
+      ],
+      "text": "Flying, first strike, vigilance, lifelink\nYour opponents can't cast spells with converted mana cost 3 or less.",
+      "toughness": "10",
+      "type": "Legendary Creature — Eldrazi Angel",
       "types": [
         "Creature"
       ]
@@ -2557,11 +2683,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Effects that increase or reduce the cost to cast a spell (such as those of escalate and emerge) don’t affect the spell’s converted mana cost, so they won’t change whether Brisela’s last ability restricts that spell from being cast."
+          "text": "Effects that increase or reduce the cost to cast a spell (such as those of escalate and emerge) don't affect the spell's converted mana cost, so they won't change whether Brisela's last ability restricts that spell from being cast."
         },
         {
           "date": "2016-07-13",
-          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell’s converted mana cost is 3 or less. For example, your opponent could cast Burn from Within (a spell with mana cost {X}{R}) with X equal to 3, but not with X equal to 2."
+          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell's converted mana cost is 3 or less. For example, your opponent could cast Burn from Within (a spell with mana cost {X}{R}) with X equal to 3, but not with X equal to 2."
         },
         {
           "date": "2016-07-13",
@@ -2683,137 +2809,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Effects that increase or reduce the cost to cast a spell (such as those of escalate and emerge) don’t affect the spell’s converted mana cost, so they won’t change whether Brisela’s last ability restricts that spell from being cast."
+          "text": "Effects that increase or reduce the cost to cast a spell (such as those of escalate and emerge) don't affect the spell's converted mana cost, so they won't change whether Brisela's last ability restricts that spell from being cast."
         },
         {
           "date": "2016-07-13",
-          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell’s converted mana cost is 3 or less. For example, your opponent could cast Burn from Within (a spell with mana cost {X}{R}) with X equal to 3, but not with X equal to 2."
-        },
-        {
-          "date": "2016-07-13",
-          "text": "For more information on meld cards, see the Eldritch Moon mechanics article (http://magic.wizards.com/en/articles/archive/feature/eldritch-moon-mechanics)."
-        }
-      ],
-      "subtypes": [
-        "Eldrazi",
-        "Angel"
-      ],
-      "supertypes": [
-        "Legendary"
-      ],
-      "text": "Flying, first strike, vigilance, lifelink\nYour opponents can't cast spells with converted mana cost 3 or less.",
-      "toughness": "10",
-      "type": "Legendary Creature — Eldrazi Angel",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Clint Cearley",
-      "flavor": "Upon discovering what had become of her sisters, Sigarda could only weep.",
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "梦魇异音布瑟拉",
-          "multiverseid": 414528
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "夢魘異音布瑟拉",
-          "multiverseid": 414751
-        },
-        {
-          "language": "French",
-          "name": "Brisela, voix des cauchemars",
-          "multiverseid": 415197
-        },
-        {
-          "language": "German",
-          "name": "Brisela, Stimme der Albträume",
-          "multiverseid": 414974
-        },
-        {
-          "language": "Italian",
-          "name": "Brisela, Voce degli Incubi",
-          "multiverseid": 415420
-        },
-        {
-          "language": "Japanese",
-          "name": "悪夢の声、ブリセラ",
-          "multiverseid": 415643
-        },
-        {
-          "language": "Korean",
-          "name": "악몽의 목소리 브리셀라",
-          "multiverseid": 415866
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Brisela, Voz dos Pesadelos",
-          "multiverseid": 416089
-        },
-        {
-          "language": "Russian",
-          "name": "Бризела, Голос Кошмаров",
-          "multiverseid": 416312
-        },
-        {
-          "language": "Spanish",
-          "name": "Brisela, Voz de las Pesadillas",
-          "multiverseid": 416535
-        }
-      ],
-      "id": "9a50ffe3772a2cd29b7943f4069dc601fd3a3619",
-      "imageName": "brisela, voice of nightmares1",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shadows over Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "multiverseid": 414305,
-      "name": "Brisela, Voice of Nightmares",
-      "names": [
-        "Bruna, the Fading Light",
-        "Brisela, Voice of Nightmares"
-      ],
-      "number": "15b",
-      "originalText": "Flying, first strike, vigilance, lifelink\nYour opponents can't cast spells with converted mana cost 3 or less.",
-      "originalType": "Legendary Creature — Eldrazi Angel",
-      "power": "9",
-      "printings": [
-        "EMN"
-      ],
-      "rarity": "Mythic Rare",
-      "rulings": [
-        {
-          "date": "2016-07-13",
-          "text": "Effects that increase or reduce the cost to cast a spell (such as those of escalate and emerge) don’t affect the spell’s converted mana cost, so they won’t change whether Brisela’s last ability restricts that spell from being cast."
-        },
-        {
-          "date": "2016-07-13",
-          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell’s converted mana cost is 3 or less. For example, your opponent could cast Burn from Within (a spell with mana cost {X}{R}) with X equal to 3, but not with X equal to 2."
+          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell's converted mana cost is 3 or less. For example, your opponent could cast Burn from Within (a spell with mana cost {X}{R}) with X equal to 3, but not with X equal to 2."
         },
         {
           "date": "2016-07-13",
@@ -3046,23 +3046,23 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You can tap any untapped creature you control to pay the escalate cost, including one you haven’t controlled continuously since the beginning of the turn."
+          "text": "You can tap any untapped creature you control to pay the escalate cost, including one you haven't controlled continuously since the beginning of the turn."
         },
         {
           "date": "2016-07-13",
-          "text": "If you choose the first and third modes, and destroying the creature ends an “exile until” effect (such as that of Lunarch Inquisitors), the creature will return to the battlefield before you put +1/+1 counters on creatures. The same is true if you choose the second and third modes and destroying the enchantment ends such an effect."
+          "text": "If you choose the first and third modes, and destroying the creature ends an \"exile until\" effect (such as that of Lunarch Inquisitors), the creature will return to the battlefield before you put +1/+1 counters on creatures. The same is true if you choose the second and third modes and destroying the enchantment ends such an effect."
         },
         {
           "date": "2016-07-13",
-          "text": "You choose all of your modes at once. You can’t wait to perform one mode’s actions and then decide to choose more modes."
+          "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t choose any one mode multiple times."
+          "text": "You can't choose any one mode multiple times."
         },
         {
           "date": "2016-07-13",
-          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode’s target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
+          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode's target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
         },
         {
           "date": "2016-07-13",
@@ -3078,7 +3078,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Additional costs don’t affect a spell’s converted mana cost."
+          "text": "Additional costs don't affect a spell's converted mana cost."
         }
       ],
       "text": "Escalate—Tap an untapped creature you control. (Pay this cost for each mode chosen beyond the first.)\nChoose one or more —\n• Destroy target creature with power 4 or greater.\n• Destroy target enchantment.\n• Put a +1/+1 counter on each creature target player controls.",
@@ -3752,7 +3752,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "While resolving Extricator of Sin’s first ability, you can’t sacrifice multiple permanents to get multiple Eldrazi Horror tokens."
+          "text": "While resolving Extricator of Sin's first ability, you can't sacrifice multiple permanents to get multiple Eldrazi Horror tokens."
         },
         {
           "date": "2016-07-13",
@@ -3986,23 +3986,23 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If Faith Unbroken leaves the battlefield before its triggered ability resolves, the targeted creature won’t be exiled."
+          "text": "If Faith Unbroken leaves the battlefield before its triggered ability resolves, the targeted creature won't be exiled."
         },
         {
           "date": "2016-07-13",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         },
         {
           "date": "2016-07-13",
-          "text": "If a token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2016-07-13",
-          "text": "The exiled card returns to the battlefield immediately after Faith Unbroken leaves the battlefield. Nothing happens between the two events, including state-based actions. However, if the creature Faith Unbroken enchants leaves the battlefield, Faith Unbroken won’t leave itself until state-based actions are checked."
+          "text": "The exiled card returns to the battlefield immediately after Faith Unbroken leaves the battlefield. Nothing happens between the two events, including state-based actions. However, if the creature Faith Unbroken enchants leaves the battlefield, Faith Unbroken won't leave itself until state-based actions are checked."
         },
         {
           "date": "2016-07-13",
-          "text": "In a multiplayer game, if Faith Unbroken’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Faith Unbroken's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "subtypes": [
@@ -4232,7 +4232,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "In a multiplayer game, Fiend Binder’s triggered ability can only target a creature controlled by the player it’s attacking (or by the controller of the planeswalker it’s attacking)."
+          "text": "In a multiplayer game, Fiend Binder's triggered ability can only target a creature controlled by the player it's attacking (or by the controller of the planeswalker it's attacking)."
         }
       ],
       "subtypes": [
@@ -4351,7 +4351,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Once you’ve attacked with Geist of the Lonely Vigil, lowering the number of card types in your graveyard won’t remove it from combat."
+          "text": "Once you've attacked with Geist of the Lonely Vigil, lowering the number of card types in your graveyard won't remove it from combat."
         }
       ],
       "subtypes": [
@@ -5040,19 +5040,19 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Lone Rider’s last ability triggers even if it wasn’t on the battlefield when you gained the life this turn."
+          "text": "Lone Rider's last ability triggers even if it wasn't on the battlefield when you gained the life this turn."
         },
         {
           "date": "2016-07-13",
-          "text": "Lone Rider’s ability checks how much life you’ve gained during the turn, not what your life total is compared to what it was when the turn began. For example, if you gained 4 life and then lost 7 life this turn, it still triggers."
+          "text": "Lone Rider's ability checks how much life you've gained during the turn, not what your life total is compared to what it was when the turn began. For example, if you gained 4 life and then lost 7 life this turn, it still triggers."
         },
         {
           "date": "2016-07-13",
-          "text": "You must have gained life before your end step begins. Lone Rider’s last ability won’t trigger if you haven’t, even if an ability triggering at the same time will cause you to gain life."
+          "text": "You must have gained life before your end step begins. Lone Rider's last ability won't trigger if you haven't, even if an ability triggering at the same time will cause you to gain life."
         },
         {
           "date": "2016-07-13",
-          "text": "In a Two-Headed Giant game, events that cause a player to gain life affect each player separately, even though the result affects the team’s life total. For example, if your teammate’s creatures with lifelink dealt 5 damage, your teammate gained life, not you, and Lone Rider’s last ability won’t trigger."
+          "text": "In a Two-Headed Giant game, events that cause a player to gain life affect each player separately, even though the result affects the team's life total. For example, if your teammate's creatures with lifelink dealt 5 damage, your teammate gained life, not you, and Lone Rider's last ability won't trigger."
         },
         {
           "date": "2016-07-13",
@@ -5287,19 +5287,19 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If that creature is exiled during an end step, it won’t come back until the next turn’s end step."
+          "text": "If that creature is exiled during an end step, it won't come back until the next turn's end step."
         },
         {
           "date": "2016-07-13",
-          "text": "If a creature token is exiled this way, it will cease to exist and won’t return to the battlefield."
+          "text": "If a creature token is exiled this way, it will cease to exist and won't return to the battlefield."
         },
         {
           "date": "2016-07-13",
-          "text": "At the time the creature is exiled, Auras attached to it will be put into their owners’ graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on it at that time will cease to exist."
+          "text": "At the time the creature is exiled, Auras attached to it will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on it at that time will cease to exist."
         },
         {
           "date": "2016-07-13",
-          "text": "If a double-faced card is exiled this way, it’ll return with its front face up. It gets a +1/+1 counter even if it isn’t a creature."
+          "text": "If a double-faced card is exiled this way, it'll return with its front face up. It gets a +1/+1 counter even if it isn't a creature."
         },
         {
           "date": "2016-07-13",
@@ -5416,7 +5416,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Only the enchanted creature’s controller can activate Lunarch Mantle’s ability."
+          "text": "Only the enchanted creature's controller can activate Lunarch Mantle's ability."
         },
         {
           "date": "2016-07-13",
@@ -5649,23 +5649,23 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "For a player’s life total to become 26, the player gains or loses the appropriate amount of life. For example, if your life total is 4 when Providence resolves, it will cause you to gain 22 life; alternatively, if your life total is 40 when it resolves, it will cause you to lose 14 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For a player's life total to become 26, the player gains or loses the appropriate amount of life. For example, if your life total is 4 when Providence resolves, it will cause you to gain 22 life; alternatively, if your life total is 40 when it resolves, it will cause you to lose 14 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2016-07-13",
-          "text": "Your “opening hand” is the hand of cards you decide to start the game with after taking any mulligans."
+          "text": "Your \"opening hand\" is the hand of cards you decide to start the game with after taking any mulligans."
         },
         {
           "date": "2016-07-13",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         },
         {
           "date": "2016-07-13",
-          "text": "Revealing multiples of Providence from your opening hand won’t cause your life total to become 32 or any number other than 26."
+          "text": "Revealing multiples of Providence from your opening hand won't cause your life total to become 32 or any number other than 26."
         },
         {
           "date": "2016-07-13",
-          "text": "In a Two-Headed Giant game, Providence causes the team’s life total to become 26, but only you actually gain or lose life. (Each team’s starting life total in a Two-Headed Giant game is normally 30.)"
+          "text": "In a Two-Headed Giant game, Providence causes the team's life total to become 26, but only you actually gain or lose life. (Each team's starting life total in a Two-Headed Giant game is normally 30.)"
         }
       ],
       "text": "You may reveal this card from your opening hand. If you do, at the beginning of the first upkeep, your life total becomes 26.\nYour life total becomes 26.",
@@ -5778,7 +5778,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Sources that have no creature type at all are non-Human sources, as are sources with creature types that don’t include Human. A creature that is Human and has other types, such as a Human Werewolf, is still a Human source."
+          "text": "Sources that have no creature type at all are non-Human sources, as are sources with creature types that don't include Human. A creature that is Human and has other types, such as a Human Werewolf, is still a Human source."
         },
         {
           "date": "2016-07-13",
@@ -5895,7 +5895,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The last ability functions only while Sanctifier of Souls is on the battlefield. You can’t activate it while Sanctifier of Souls is in your graveyard."
+          "text": "The last ability functions only while Sanctifier of Souls is on the battlefield. You can't activate it while Sanctifier of Souls is in your graveyard."
         }
       ],
       "subtypes": [
@@ -6014,7 +6014,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The set of creatures affected by Selfless Spirit’s last ability is determined as the ability resolves. Creatures you begin to control later in the turn won’t gain indestructible."
+          "text": "The set of creatures affected by Selfless Spirit's last ability is determined as the ability resolves. Creatures you begin to control later in the turn won't gain indestructible."
         }
       ],
       "subtypes": [
@@ -6240,7 +6240,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "A creature that is Human and has other types, such as a Human Werewolf, isn’t a non-Human creature."
+          "text": "A creature that is Human and has other types, such as a Human Werewolf, isn't a non-Human creature."
         }
       ],
       "subtypes": [
@@ -6691,11 +6691,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If an effect states that a creature or land enters the battlefield tapped unless a condition is met, Thalia’s last ability has it enter tapped even if that condition is true. For example, your opponent may reveal a Plains while playing Port Town (from the Shadows over Innistrad set), but Port Town will still enter tapped."
+          "text": "If an effect states that a creature or land enters the battlefield tapped unless a condition is met, Thalia's last ability has it enter tapped even if that condition is true. For example, your opponent may reveal a Plains while playing Port Town (from the Shadows over Innistrad set), but Port Town will still enter tapped."
         },
         {
           "date": "2016-07-13",
-          "text": "If Thalia enters the battlefield at the same time as an opponent’s creatures or nonbasic lands, those creatures and lands aren’t affected by Thalia’s last ability."
+          "text": "If Thalia enters the battlefield at the same time as an opponent's creatures or nonbasic lands, those creatures and lands aren't affected by Thalia's last ability."
         }
       ],
       "subtypes": [
@@ -7043,7 +7043,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Advanced Stitchwing’s last ability can only be activated while it’s in your graveyard."
+          "text": "Advanced Stitchwing's last ability can only be activated while it's in your graveyard."
         }
       ],
       "subtypes": [
@@ -7271,7 +7271,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "A card that is exiled face down has no characteristics. You can’t choose it, even if you’re allowed to look at it."
+          "text": "A card that is exiled face down has no characteristics. You can't choose it, even if you're allowed to look at it."
         },
         {
           "date": "2016-07-13",
@@ -7611,15 +7611,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If you don’t have enough instant and/or sorcery cards in your graveyard as your upkeep begins, Curious Homunculus’s last ability doesn’t trigger. If you don’t have enough as the ability resolves, the ability has no effect."
+          "text": "If you don't have enough instant and/or sorcery cards in your graveyard as your upkeep begins, Curious Homunculus's last ability doesn't trigger. If you don't have enough as the ability resolves, the ability has no effect."
         },
         {
           "date": "2016-07-13",
-          "text": "Mana from Curious Homunculus’s first ability can be spent to cast a spell that has generic mana in its additional cost, such as Borrowed Malevolence with both modes chosen. It can’t be spent to pay costs during a spell’s resolution, such as the cost Convolute prompts a player to pay."
+          "text": "Mana from Curious Homunculus's first ability can be spent to cast a spell that has generic mana in its additional cost, such as Borrowed Malevolence with both modes chosen. It can't be spent to pay costs during a spell's resolution, such as the cost Convolute prompts a player to pay."
         },
         {
           "date": "2016-07-13",
-          "text": "If you activate Curious Homunculus’s mana ability in response to its triggered ability, you can spend that mana to cast an instant spell during your upkeep after it has transformed into Voracious Reader. If you don’t spend the mana, it will leave your mana pool before your draw step begins; you can’t use it to cast the card you draw or to cast a sorcery."
+          "text": "If you activate Curious Homunculus's mana ability in response to its triggered ability, you can spend that mana to cast an instant spell during your upkeep after it has transformed into Voracious Reader. If you don't spend the mana, it will leave your mana pool before your draw step begins; you can't use it to cast the card you draw or to cast a sorcery."
         },
         {
           "date": "2016-07-13",
@@ -7867,7 +7867,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "After each creature returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won’t be in combat or have any additional abilities it may have had when it was exiled. Any counters on it cease to exist; Auras attached to it are put into their owner’s graveyards; and any Equipment will become unattached."
+          "text": "After each creature returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won't be in combat or have any additional abilities it may have had when it was exiled. Any counters on it cease to exist; Auras attached to it are put into their owner's graveyards; and any Equipment will become unattached."
         }
       ],
       "text": "Exile up to two target creatures you control, then return those cards to the battlefield under their owner's control.",
@@ -7985,11 +7985,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If you control three or more Wizards while you control Docent of Perfection, it won’t transform yet. It only transforms while its triggered ability is resolving after you cast an instant or sorcery spell."
+          "text": "If you control three or more Wizards while you control Docent of Perfection, it won't transform yet. It only transforms while its triggered ability is resolving after you cast an instant or sorcery spell."
         },
         {
           "date": "2016-07-13",
-          "text": "Docent of Perfection’s triggered ability resolves before the spell that caused it to trigger."
+          "text": "Docent of Perfection's triggered ability resolves before the spell that caused it to trigger."
         },
         {
           "date": "2016-07-13",
@@ -8111,11 +8111,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Final Iteration’s triggered ability resolves before the spell that caused it to trigger."
+          "text": "Final Iteration's triggered ability resolves before the spell that caused it to trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "When Docent of Perfection transforms into Final Iteration, the instant or sorcery spell that’s on the stack doesn’t cause Final Iteration’s triggered ability to trigger."
+          "text": "When Docent of Perfection transforms into Final Iteration, the instant or sorcery spell that's on the stack doesn't cause Final Iteration's triggered ability to trigger."
         },
         {
           "date": "2016-07-13",
@@ -8238,7 +8238,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If the targeted creature becomes an illegal target before Drag Under resolves, you won’t draw a card."
+          "text": "If the targeted creature becomes an illegal target before Drag Under resolves, you won't draw a card."
         }
       ],
       "text": "Return target creature to its owner's hand.\nDraw a card.",
@@ -8687,15 +8687,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose which pile to put into your hand and which to put into your graveyard. You can’t look at the face-down pile until after it’s moving to its new zone."
+          "text": "You choose which pile to put into your hand and which to put into your graveyard. You can't look at the face-down pile until after it's moving to its new zone."
         },
         {
           "date": "2016-07-13",
-          "text": "A pile can have no cards in it. In this case, you’ll choose whether to put all the cards into your hand or into your graveyard."
+          "text": "A pile can have no cards in it. In this case, you'll choose whether to put all the cards into your hand or into your graveyard."
         },
         {
           "date": "2016-07-13",
-          "text": "In a multiplayer game, the targeted opponent may choose what information to share with others if that player wants advice on how to split the cards, but that player doesn’t have to share any information at all."
+          "text": "In a multiplayer game, the targeted opponent may choose what information to share with others if that player wants advice on how to split the cards, but that player doesn't have to share any information at all."
         }
       ],
       "text": "Target opponent looks at the top four cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard.",
@@ -8925,7 +8925,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If you have a colorless creature card in your graveyard while you control Grizzled Angler, it won’t transform yet. It only transforms while its activated ability is resolving."
+          "text": "If you have a colorless creature card in your graveyard while you control Grizzled Angler, it won't transform yet. It only transforms while its activated ability is resolving."
         },
         {
           "date": "2016-07-13",
@@ -9047,7 +9047,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If a creature affected by Grisly Anglerfish’s effect hasn’t been under its controller’s control since the turn began, is tapped, or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If a creature affected by Grisly Anglerfish's effect hasn't been under its controller's control since the turn began, is tapped, or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -9165,31 +9165,31 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If the targeted creature has an ability that triggers when it attacks, it’ll be too late for it to trigger once Identity Thief has that ability. The same is true if another object has an ability that triggers when a creature with certain characteristics attacks and Identity Thief doesn’t have those characteristics until after it becomes a copy."
+          "text": "If the targeted creature has an ability that triggers when it attacks, it'll be too late for it to trigger once Identity Thief has that ability. The same is true if another object has an ability that triggers when a creature with certain characteristics attacks and Identity Thief doesn't have those characteristics until after it becomes a copy."
         },
         {
           "date": "2016-07-13",
-          "text": "Identity Thief copies the printed values of the targeted creature, plus any copy effects that have been applied to that creature. It won’t copy other effects that have changed the targeted creature’s power, toughness, types, color, or so on. It also won’t copy counters on the targeted creature."
+          "text": "Identity Thief copies the printed values of the targeted creature, plus any copy effects that have been applied to that creature. It won't copy other effects that have changed the targeted creature's power, toughness, types, color, or so on. It also won't copy counters on the targeted creature."
         },
         {
           "date": "2016-07-13",
-          "text": "If the targeted creature is a double-faced or melded permanent, Identity Thief copies the face shown. Because Identity Thief is not a double-faced card or meld card, it won’t be able to transform or meld. If it copies a melded permanent or the back face of a double-faced card, its converted mana cost will be 0. Exiled double-faced cards and exiled meld cards will return with their front faces up."
+          "text": "If the targeted creature is a double-faced or melded permanent, Identity Thief copies the face shown. Because Identity Thief is not a double-faced card or meld card, it won't be able to transform or meld. If it copies a melded permanent or the back face of a double-faced card, its converted mana cost will be 0. Exiled double-faced cards and exiled meld cards will return with their front faces up."
         },
         {
           "date": "2016-07-13",
-          "text": "If the targeted creature is itself copying a permanent, Identity Thief will become whatever it’s copying, as modified by that copy effect. For example, if you target a Hamlet Captain that has become a copy of Permeating Mass, Identity Thief will become a Permeating Mass."
+          "text": "If the targeted creature is itself copying a permanent, Identity Thief will become whatever it's copying, as modified by that copy effect. For example, if you target a Hamlet Captain that has become a copy of Permeating Mass, Identity Thief will become a Permeating Mass."
         },
         {
           "date": "2016-07-13",
-          "text": "This effect can cause Identity Thief to stop being a creature. For example, if you target an animated Gideon Jura (a planeswalker with a loyalty ability that turns him into a creature), only the printed wording will be copied; the “becomes a creature” effect won’t. Identity Thief will become a noncreature Gideon with no loyalty, be removed from combat, and then be put into its owner’s graveyard."
+          "text": "This effect can cause Identity Thief to stop being a creature. For example, if you target an animated Gideon Jura (a planeswalker with a loyalty ability that turns him into a creature), only the printed wording will be copied; the \"becomes a creature\" effect won't. Identity Thief will become a noncreature Gideon with no loyalty, be removed from combat, and then be put into its owner's graveyard."
         },
         {
           "date": "2016-07-13",
-          "text": "This effect can cause Identity Thief to become a copy of a creature that can’t normally attack, such as Lupine Prototype or a creature with defender. In these cases, it remains attacking."
+          "text": "This effect can cause Identity Thief to become a copy of a creature that can't normally attack, such as Lupine Prototype or a creature with defender. In these cases, it remains attacking."
         },
         {
           "date": "2016-07-13",
-          "text": "Noncopy effects that have already applied to Identity Thief will continue to apply to it. For example, if Woodcutter’s Grit gave Identity Thief +3/+3 and hexproof earlier in the turn, Identity Thief will still have those bonuses after copying a creature."
+          "text": "Noncopy effects that have already applied to Identity Thief will continue to apply to it. For example, if Woodcutter's Grit gave Identity Thief +3/+3 and hexproof earlier in the turn, Identity Thief will still have those bonuses after copying a creature."
         },
         {
           "date": "2016-07-13",
@@ -9197,7 +9197,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "subtypes": [
@@ -9322,15 +9322,15 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If the enchanted permanent is a land and has land types, it retains those types even though it loses any intrinsic mana abilities associated with them. For example, a Plains enchanted by Imprisoned in the Moon is still a Plains, but it can’t tap for {W}, only for {C}."
+          "text": "If the enchanted permanent is a land and has land types, it retains those types even though it loses any intrinsic mana abilities associated with them. For example, a Plains enchanted by Imprisoned in the Moon is still a Plains, but it can't tap for {W}, only for {C}."
         },
         {
           "date": "2016-07-13",
-          "text": "If you remove Imprisoned in the Moon from a planeswalker after tapping it for mana, you can still activate a loyalty ability of that planeswalker even though it’s tapped."
+          "text": "If you remove Imprisoned in the Moon from a planeswalker after tapping it for mana, you can still activate a loyalty ability of that planeswalker even though it's tapped."
         },
         {
           "date": "2016-07-13",
-          "text": "Becoming a land may cause other Auras to become illegally attached. These are put into their owner’s graveyard, and any Equipment attached to the land become unattached and remain on the battlefield. Counters on the land remain on it even if they don’t do anything."
+          "text": "Becoming a land may cause other Auras to become illegally attached. These are put into their owner's graveyard, and any Equipment attached to the land become unattached and remain on the battlefield. Counters on the land remain on it even if they don't do anything."
         }
       ],
       "subtypes": [
@@ -9672,15 +9672,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You can’t choose not to sacrifice Lunar Force."
+          "text": "You can't choose not to sacrifice Lunar Force."
         },
         {
           "date": "2016-07-13",
-          "text": "You sacrifice Lunar Force even if the spell’s already been countered, perhaps by the ability of another Lunar Force, or if the spell can’t be countered."
+          "text": "You sacrifice Lunar Force even if the spell's already been countered, perhaps by the ability of another Lunar Force, or if the spell can't be countered."
         },
         {
           "date": "2016-07-13",
-          "text": "The spell will be countered even if Lunar Force can’t be sacrificed, most likely because it has already left the battlefield. Casting a spell in response to an opponent’s Lunar Force’s triggered ability is generally a bad idea."
+          "text": "The spell will be countered even if Lunar Force can't be sacrificed, most likely because it has already left the battlefield. Casting a spell in response to an opponent's Lunar Force's triggered ability is generally a bad idea."
         }
       ],
       "text": "When an opponent casts a spell, sacrifice Lunar Force and counter that spell.",
@@ -9904,11 +9904,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If you cast the exiled card, you do so as part of the resolution of Mind’s Dilation’s ability. You can’t wait to cast it later in the turn. Timing permissions based on the card’s type are ignored, but other restrictions (such as “Cast [this card] only during combat”) are not."
+          "text": "If you cast the exiled card, you do so as part of the resolution of Mind's Dilation's ability. You can't wait to cast it later in the turn. Timing permissions based on the card's type are ignored, but other restrictions (such as \"Cast [this card] only during combat\") are not."
         },
         {
           "date": "2016-07-13",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs, such as escalate costs. If the card has any mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs, such as escalate costs. If the card has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2016-07-13",
@@ -9916,15 +9916,15 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If you cast the card this way, it will resolve before the spell that caused Mind’s Dilation’s ability to trigger."
+          "text": "If you cast the card this way, it will resolve before the spell that caused Mind's Dilation's ability to trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "If you cast an instant or sorcery card this way, it goes to its owner’s graveyard as normal. It doesn’t return to exile."
+          "text": "If you cast an instant or sorcery card this way, it goes to its owner's graveyard as normal. It doesn't return to exile."
         },
         {
           "date": "2016-07-13",
-          "text": "If you don’t cast the card, perhaps because you choose not to or because it’s a land card, it remains exiled."
+          "text": "If you don't cast the card, perhaps because you choose not to or because it's a land card, it remains exiled."
         }
       ],
       "text": "Whenever an opponent casts his or her first spell each turn, that player exiles the top card of his or her library. If it's a nonland card, you may cast it without paying its mana cost.",
@@ -10037,7 +10037,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If Nebelgast Herald and another Spirit enter the battlefield at the same time, Nebelgast Herald’s last ability triggers once for each."
+          "text": "If Nebelgast Herald and another Spirit enter the battlefield at the same time, Nebelgast Herald's last ability triggers once for each."
         }
       ],
       "subtypes": [
@@ -10154,7 +10154,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If multiple effects say that a creature doesn’t untap during its controller’s next untap step, those effects all apply during one untap step. For example, if you cast two instants in one turn and target the same creature twice with Niblis of Frost’s ability, that creature will only spend one untap step without untapping."
+          "text": "If multiple effects say that a creature doesn't untap during its controller's next untap step, those effects all apply during one untap step. For example, if you cast two instants in one turn and target the same creature twice with Niblis of Frost's ability, that creature will only spend one untap step without untapping."
         }
       ],
       "subtypes": [
@@ -10499,11 +10499,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Spells that can’t be countered are exiled by Summary Dismissal. They won’t resolve."
+          "text": "Spells that can't be countered are exiled by Summary Dismissal. They won't resolve."
         },
         {
           "date": "2016-07-13",
-          "text": "Only activated and triggered abilities on the stack are countered. Static abilities of objects remain unaffected, and activated and triggered abilities of objects may be activated or may trigger again later in the turn. Spells and abilities that have already resolved aren’t affected."
+          "text": "Only activated and triggered abilities on the stack are countered. Static abilities of objects remain unaffected, and activated and triggered abilities of objects may be activated or may trigger again later in the turn. Spells and abilities that have already resolved aren't affected."
         }
       ],
       "text": "Exile all other spells and counter all abilities.",
@@ -10616,7 +10616,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Because Take Inventory is still on the stack as it’s resolving, that spell card isn’t in your graveyard and won’t affect the number of cards you draw."
+          "text": "Because Take Inventory is still on the stack as it's resolving, that spell card isn't in your graveyard and won't affect the number of cards you draw."
         }
       ],
       "text": "Draw a card, then draw cards equal to the number of cards named Take Inventory in your graveyard.",
@@ -10959,11 +10959,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Spells that can’t be countered can be returned to their owner’s hand by Unsubstantiate. They won’t resolve."
+          "text": "Spells that can't be countered can be returned to their owner's hand by Unsubstantiate. They won't resolve."
         },
         {
           "date": "2016-07-13",
-          "text": "A spell that’s a copy ceases to exist as a state-based action after being returned to its owner’s hand. It can’t be cast, and it never counts as a “card” in the player’s hand."
+          "text": "A spell that's a copy ceases to exist as a state-based action after being returned to its owner's hand. It can't be cast, and it never counts as a \"card\" in the player's hand."
         }
       ],
       "text": "Return target spell or creature to its owner's hand.",
@@ -11076,11 +11076,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Wharf Infiltrator’s last ability triggers anytime you discard a creature card, not just when you discard a card because of Wharf Infiltrator’s other triggered ability."
+          "text": "Wharf Infiltrator's last ability triggers anytime you discard a creature card, not just when you discard a card because of Wharf Infiltrator's other triggered ability."
         },
         {
           "date": "2016-07-13",
-          "text": "While resolving Wharf Infiltrator’s last ability, you can’t pay {2} multiple times to get multiple Eldrazi Horror tokens."
+          "text": "While resolving Wharf Infiltrator's last ability, you can't pay {2} multiple times to get multiple Eldrazi Horror tokens."
         }
       ],
       "subtypes": [
@@ -11307,15 +11307,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose all of your modes at once. You can’t wait to perform one mode’s actions and then decide to choose more modes."
+          "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t choose any one mode multiple times."
+          "text": "You can't choose any one mode multiple times."
         },
         {
           "date": "2016-07-13",
-          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode’s target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
+          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode's target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
         },
         {
           "date": "2016-07-13",
@@ -11331,7 +11331,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Additional costs don’t affect a spell’s converted mana cost."
+          "text": "Additional costs don't affect a spell's converted mana cost."
         }
       ],
       "text": "Escalate {2} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both —\n• Target creature gets +1/+1 until end of turn.\n• Target creature gets -1/-1 until end of turn.",
@@ -11444,7 +11444,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If you target a Zombie card in your graveyard, drawing a card is an additional bonus. It doesn’t replace returning the Zombie card to your hand."
+          "text": "If you target a Zombie card in your graveyard, drawing a card is an additional bonus. It doesn't replace returning the Zombie card to your hand."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
@@ -11558,11 +11558,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The targeted creature will have already left the battlefield before its controller loses 2 life and you gain 2 life. If it has any abilities that care about gaining or losing life, they won’t apply."
+          "text": "The targeted creature will have already left the battlefield before its controller loses 2 life and you gain 2 life. If it has any abilities that care about gaining or losing life, they won't apply."
         },
         {
           "date": "2016-07-13",
-          "text": "If the creature becomes an illegal target for Certain Death, no player gains or loses life. If it’s a legal target but isn’t destroyed, most likely due to having indestructible, its controller still loses 2 life and you gain 2 life."
+          "text": "If the creature becomes an illegal target for Certain Death, no player gains or loses life. If it's a legal target but isn't destroyed, most likely due to having indestructible, its controller still loses 2 life and you gain 2 life."
         }
       ],
       "text": "Destroy target creature. Its controller loses 2 life and you gain 2 life.",
@@ -11674,15 +11674,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose all of your modes at once. You can’t wait to perform one mode’s actions and then decide to choose more modes."
+          "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t choose any one mode multiple times."
+          "text": "You can't choose any one mode multiple times."
         },
         {
           "date": "2016-07-13",
-          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode’s target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
+          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode's target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
         },
         {
           "date": "2016-07-13",
@@ -11698,7 +11698,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Additional costs don’t affect a spell’s converted mana cost."
+          "text": "Additional costs don't affect a spell's converted mana cost."
         }
       ],
       "text": "Escalate—Discard a card. (Pay this cost for each mode chosen beyond the first.)\nChoose one or more —\n• Target opponent reveals his or her hand. You choose an instant or sorcery card from it. That player discards that card.\n• Target creature gets -2/-2 until end of turn.\n• Target opponent loses 2 life and you gain 2 life.",
@@ -11811,7 +11811,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You can tap any three untapped Zombies you control, including ones you haven’t controlled continuously since the beginning of your most recent turn, to pay the cost of Cryptbreaker’s second activated ability. This includes Cryptbreaker itself."
+          "text": "You can tap any three untapped Zombies you control, including ones you haven't controlled continuously since the beginning of your most recent turn, to pay the cost of Cryptbreaker's second activated ability. This includes Cryptbreaker itself."
         }
       ],
       "subtypes": [
@@ -12162,7 +12162,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If Gavony Unhallowed and another creature you control die simultaneously (perhaps because they were both attacking or blocking), Gavony Unhallowed won’t be on the battlefield as its triggered ability resolves. It can’t be saved by the +1/+1 counter that would have been put on it."
+          "text": "If Gavony Unhallowed and another creature you control die simultaneously (perhaps because they were both attacking or blocking), Gavony Unhallowed won't be on the battlefield as its triggered ability resolves. It can't be saved by the +1/+1 counter that would have been put on it."
         }
       ],
       "subtypes": [
@@ -12500,7 +12500,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Haunted Dead’s last ability can only be activated while it’s in your graveyard."
+          "text": "Haunted Dead's last ability can only be activated while it's in your graveyard."
         }
       ],
       "subtypes": [
@@ -12617,15 +12617,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You can activate Liliana’s first ability without any targets just to add a loyalty counter to her."
+          "text": "You can activate Liliana's first ability without any targets just to add a loyalty counter to her."
         },
         {
           "date": "2016-07-13",
-          "text": "Liliana’s second ability doesn’t target the card to return to your hand. After putting the top two cards of your library into your graveyard, you may choose from among any creature cards there."
+          "text": "Liliana's second ability doesn't target the card to return to your hand. After putting the top two cards of your library into your graveyard, you may choose from among any creature cards there."
         },
         {
           "date": "2016-07-13",
-          "text": "While resolving the triggered ability of Liliana’s emblem, if you control zero Zombies, you’ll get two Zombie tokens."
+          "text": "While resolving the triggered ability of Liliana's emblem, if you control zero Zombies, you'll get two Zombie tokens."
         }
       ],
       "subtypes": [
@@ -12742,7 +12742,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The ability applies only while Liliana’s Elite is on the battlefield."
+          "text": "The ability applies only while Liliana's Elite is on the battlefield."
         }
       ],
       "subtypes": [
@@ -12860,7 +12860,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If Markov Crusader loses haste before the declare attackers step on the turn it enters the battlefield, it won’t be able to attack. Once you’ve attacked with Markov Crusader, causing it to lose haste won’t remove it from combat."
+          "text": "If Markov Crusader loses haste before the declare attackers step on the turn it enters the battlefield, it won't be able to attack. Once you've attacked with Markov Crusader, causing it to lose haste won't remove it from combat."
         }
       ],
       "subtypes": [
@@ -12982,7 +12982,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If a card in a player’s graveyard has {X} in its mana cost, X is considered to be 0."
+          "text": "If a card in a player's graveyard has {X} in its mana cost, X is considered to be 0."
         }
       ],
       "subtypes": [
@@ -13104,7 +13104,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If a card in a player’s graveyard has {X} in its mana cost, X is considered to be 0."
+          "text": "If a card in a player's graveyard has {X} in its mana cost, X is considered to be 0."
         }
       ],
       "subtypes": [
@@ -13172,8 +13172,8 @@
           "multiverseid": 416622
         }
       ],
-      "id": "d460e682b196030d3af831f6349cb9a05c9014e8",
-      "imageName": "chittering host1",
+      "id": "23cc484aad08a5e3dd14ab21b0b57d2350a0b5ff",
+      "imageName": "chittering host3",
       "layout": "normal",
       "legalities": [
         {
@@ -13218,7 +13218,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The set of creatures affected by Chittering Host’s triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn won’t get +1/+0 or gain menace."
+          "text": "The set of creatures affected by Chittering Host's triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn won't get +1/+0 or gain menace."
         },
         {
           "date": "2016-07-13",
@@ -13336,7 +13336,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The set of creatures affected by Chittering Host’s triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn won’t get +1/+0 or gain menace."
+          "text": "The set of creatures affected by Chittering Host's triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn won't get +1/+0 or gain menace."
         },
         {
           "date": "2016-07-13",
@@ -13408,8 +13408,8 @@
           "multiverseid": 416622
         }
       ],
-      "id": "23cc484aad08a5e3dd14ab21b0b57d2350a0b5ff",
-      "imageName": "chittering host3",
+      "id": "d460e682b196030d3af831f6349cb9a05c9014e8",
+      "imageName": "chittering host1",
       "layout": "normal",
       "legalities": [
         {
@@ -13454,7 +13454,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The set of creatures affected by Chittering Host’s triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn won’t get +1/+0 or gain menace."
+          "text": "The set of creatures affected by Chittering Host's triggered ability is determined as the ability resolves. Creatures you begin to control later in the turn won't get +1/+0 or gain menace."
         },
         {
           "date": "2016-07-13",
@@ -13685,15 +13685,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If Noosegraf Mob is no longer on the battlefield or no longer has +1/+1 counters on it as its triggered ability resolves, you can’t remove a counter from it and won’t get a Zombie token."
+          "text": "If Noosegraf Mob is no longer on the battlefield or no longer has +1/+1 counters on it as its triggered ability resolves, you can't remove a counter from it and won't get a Zombie token."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t remove more than one +1/+1 counter from Noosegraf Mob at once to get more Zombie tokens, and you can’t choose not to remove a counter."
+          "text": "You can't remove more than one +1/+1 counter from Noosegraf Mob at once to get more Zombie tokens, and you can't choose not to remove a counter."
         },
         {
           "date": "2016-07-13",
-          "text": "Noosegraf Mob’s triggered ability resolves before the spell that caused it to trigger."
+          "text": "Noosegraf Mob's triggered ability resolves before the spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -13810,7 +13810,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Oath of Liliana’s last ability will trigger even if the planeswalker that entered the battlefield under your control is no longer on the battlefield, no longer under your control, or no longer a planeswalker. This is also true if Oath of Liliana wasn’t on the battlefield when the planeswalker entered."
+          "text": "Oath of Liliana's last ability will trigger even if the planeswalker that entered the battlefield under your control is no longer on the battlefield, no longer under your control, or no longer a planeswalker. This is also true if Oath of Liliana wasn't on the battlefield when the planeswalker entered."
         },
         {
           "date": "2016-07-13",
@@ -13935,7 +13935,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You can activate the ability more than once in a turn, even if Olivia’s Dragoon already has flying."
+          "text": "You can activate the ability more than once in a turn, even if Olivia's Dragoon already has flying."
         }
       ],
       "subtypes": [
@@ -14175,19 +14175,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
+          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -14300,19 +14300,19 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Discarding a card and sacrificing a creature are both part of Ruthless Disposal’s cost. You can’t discard or sacrifice more to target more creatures, and you can’t cast Ruthless Disposal at all if you don’t have any other cards in hand or if you control no creatures."
+          "text": "Discarding a card and sacrificing a creature are both part of Ruthless Disposal's cost. You can't discard or sacrifice more to target more creatures, and you can't cast Ruthless Disposal at all if you don't have any other cards in hand or if you control no creatures."
         },
         {
           "date": "2016-07-13",
-          "text": "There’s no way to discard a creature card with madness, cast it, and sacrifice it to pay for both of Ruthless Disposal’s additional costs."
+          "text": "There's no way to discard a creature card with madness, cast it, and sacrifice it to pay for both of Ruthless Disposal's additional costs."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast Ruthless Disposal, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast Ruthless Disposal, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         },
         {
           "date": "2016-07-13",
-          "text": "You must target exactly two creatures to cast Ruthless Disposal. However, one of the targets can be the creature you intend to sacrifice to pay Ruthless Disposal’s cost."
+          "text": "You must target exactly two creatures to cast Ruthless Disposal. However, one of the targets can be the creature you intend to sacrifice to pay Ruthless Disposal's cost."
         },
         {
           "date": "2016-07-13",
@@ -14320,7 +14320,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t target one creature twice to give it -26/-26."
+          "text": "You can't target one creature twice to give it -26/-26."
         }
       ],
       "text": "As an additional cost to cast Ruthless Disposal, discard a card and sacrifice a creature.\nTwo target creatures each get -13/-13 until end of turn.",
@@ -14434,11 +14434,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If Skirsdag Supplicant’s ability causes each player’s life total to become 0 or less, the game ends in a draw."
+          "text": "If Skirsdag Supplicant's ability causes each player's life total to become 0 or less, the game ends in a draw."
         },
         {
           "date": "2016-07-13",
-          "text": "In a Two-Headed Giant game, Skirsdag Supplicant’s ability causes each player to lose 2 life, so each team loses a total of 4 life."
+          "text": "In a Two-Headed Giant game, Skirsdag Supplicant's ability causes each player to lose 2 life, so each team loses a total of 4 life."
         }
       ],
       "subtypes": [
@@ -14666,11 +14666,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If you discard a Vampire card with madness and cast it, it’ll enter the battlefield before Stromkirk Condemned’s ability resolves."
+          "text": "If you discard a Vampire card with madness and cast it, it'll enter the battlefield before Stromkirk Condemned's ability resolves."
         },
         {
           "date": "2016-07-13",
-          "text": "The set of creatures affected by Stromkirk Condemned’s ability is determined as the ability resolves. Vampires you begin to control later in the turn won’t get +1/+1."
+          "text": "The set of creatures affected by Stromkirk Condemned's ability is determined as the ability resolves. Vampires you begin to control later in the turn won't get +1/+1."
         }
       ],
       "subtypes": [
@@ -14896,7 +14896,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Menace only matters as blockers are chosen. Causing Thraben Foulbloods to gain menace after blockers are chosen won’t cause it to become unblocked."
+          "text": "Menace only matters as blockers are chosen. Causing Thraben Foulbloods to gain menace after blockers are chosen won't cause it to become unblocked."
         }
       ],
       "subtypes": [
@@ -15015,15 +15015,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If Tree of Perdition isn’t on the battlefield when the ability resolves, the exchange can’t happen and the ability will have no effect. Notably, activating the ability and giving Tree of Perdition -13/-13 in response won’t cause your opponent to lose the game."
+          "text": "If Tree of Perdition isn't on the battlefield when the ability resolves, the exchange can't happen and the ability will have no effect. Notably, activating the ability and giving Tree of Perdition -13/-13 in response won't cause your opponent to lose the game."
         },
         {
           "date": "2016-07-13",
-          "text": "When the ability resolves, Tree of Perdition’s toughness becomes the targeted opponent’s former life total and that player gains or loses an amount of life necessary so that his or her life total equals Tree of Perdition’s former toughness. Other effects that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "When the ability resolves, Tree of Perdition's toughness becomes the targeted opponent's former life total and that player gains or loses an amount of life necessary so that his or her life total equals Tree of Perdition's former toughness. Other effects that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2016-07-13",
-          "text": "Any toughness-modifying effects, counters, Auras, or Equipment will apply after its toughness is set to the player’s former life total. For example, say Tree of Perdition is equipped with Cultist’s Staff (which makes it 2/15) and the player’s life total is 7. After the exchange, Tree of Perdition would be a 2/9 creature (its toughness became 7, which was then modified by Cultist’s Staff) and the player’s life total would be 15."
+          "text": "Any toughness-modifying effects, counters, Auras, or Equipment will apply after its toughness is set to the player's former life total. For example, say Tree of Perdition is equipped with Cultist's Staff (which makes it 2/15) and the player's life total is 7. After the exchange, Tree of Perdition would be a 2/9 creature (its toughness became 7, which was then modified by Cultist's Staff) and the player's life total would be 15."
         }
       ],
       "subtypes": [
@@ -15376,7 +15376,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If the targeted opponent doesn’t control three creatures as the triggered ability of Abolisher of Bloodlines resolves, that player sacrifices as many creatures as able."
+          "text": "If the targeted opponent doesn't control three creatures as the triggered ability of Abolisher of Bloodlines resolves, that player sacrifices as many creatures as able."
         }
       ],
       "subtypes": [
@@ -15825,7 +15825,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You can’t target the same creature twice to have it get +2/+0."
+          "text": "You can't target the same creature twice to have it get +2/+0."
         }
       ],
       "text": "Up to two target creatures each get +1/+0 and gain first strike until end of turn.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
@@ -16046,11 +16046,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The triggered ability triggers once for each creature blocking or blocked by Assembled Alphas. The ability resolves and deals damage to that creature before combat damage is dealt. If that damage destroys all creatures blocking Assembled Alphas, Assembled Alphas doesn’t become unblocked."
+          "text": "The triggered ability triggers once for each creature blocking or blocked by Assembled Alphas. The ability resolves and deals damage to that creature before combat damage is dealt. If that damage destroys all creatures blocking Assembled Alphas, Assembled Alphas doesn't become unblocked."
         },
         {
           "date": "2016-07-13",
-          "text": "The triggered ability deals damage to the creature’s controller even if the creature isn’t dealt damage, perhaps because it has left the battlefield or because the damage was prevented."
+          "text": "The triggered ability deals damage to the creature's controller even if the creature isn't dealt damage, perhaps because it has left the battlefield or because the damage was prevented."
         }
       ],
       "subtypes": [
@@ -16167,11 +16167,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Bedlam Reveler’s first ability can reduce only the generic mana in its cost, not the red mana."
+          "text": "Bedlam Reveler's first ability can reduce only the generic mana in its cost, not the red mana."
         },
         {
           "date": "2016-07-13",
-          "text": "If you have no cards in hand as Bedlam Reveler’s last ability resolves, you’ll just draw three cards."
+          "text": "If you have no cards in hand as Bedlam Reveler's last ability resolves, you'll just draw three cards."
         }
       ],
       "subtypes": [
@@ -16508,15 +16508,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose all of your modes at once. You can’t wait to perform one mode’s actions and then decide to choose more modes."
+          "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t choose any one mode multiple times."
+          "text": "You can't choose any one mode multiple times."
         },
         {
           "date": "2016-07-13",
-          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode’s target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
+          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode's target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
         },
         {
           "date": "2016-07-13",
@@ -16532,7 +16532,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Additional costs don’t affect a spell’s converted mana cost."
+          "text": "Additional costs don't affect a spell's converted mana cost."
         }
       ],
       "text": "Escalate {3} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both —\n• Target creature gets +3/+0 until end of turn.\n• Target creature gains first strike until end of turn.",
@@ -16756,15 +16756,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose all of your modes at once. You can’t wait to perform one mode’s actions and then decide to choose more modes."
+          "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t choose any one mode multiple times."
+          "text": "You can't choose any one mode multiple times."
         },
         {
           "date": "2016-07-13",
-          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode’s target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
+          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode's target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
         },
         {
           "date": "2016-07-13",
@@ -16780,7 +16780,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Additional costs don’t affect a spell’s converted mana cost."
+          "text": "Additional costs don't affect a spell's converted mana cost."
         }
       ],
       "text": "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more —\n• Target player discards all the cards in his or her hand, then draws that many cards.\n• Collective Defiance deals 4 damage to target creature.\n• Collective Defiance deals 3 damage to target opponent.",
@@ -16898,11 +16898,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You’ll add mana to your mana pool at the beginning of the next main phase whether or not Conduit of Storms is still on the battlefield."
+          "text": "You'll add mana to your mana pool at the beginning of the next main phase whether or not Conduit of Storms is still on the battlefield."
         },
         {
           "date": "2016-07-13",
-          "text": "If Conduit of Storms attacks and you transform it into Conduit of Emrakul later in combat, you’ll add {R} to your mana pool, not {C}{C} and not {C}{C}{R}."
+          "text": "If Conduit of Storms attacks and you transform it into Conduit of Emrakul later in combat, you'll add {R} to your mana pool, not {C}{C} and not {C}{C}{R}."
         },
         {
           "date": "2016-07-13",
@@ -17025,11 +17025,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You’ll add mana to your mana pool at the beginning of the next main phase whether or not Conduit of Emrakul is still on the battlefield."
+          "text": "You'll add mana to your mana pool at the beginning of the next main phase whether or not Conduit of Emrakul is still on the battlefield."
         },
         {
           "date": "2016-07-13",
-          "text": "If Conduit of Storms attacks and you transform it into Conduit of Emrakul later in combat, you’ll add {R} to your mana pool, not {C}{C} and not {C}{C}{R}."
+          "text": "If Conduit of Storms attacks and you transform it into Conduit of Emrakul later in combat, you'll add {R} to your mana pool, not {C}{C} and not {C}{C}{R}."
         }
       ],
       "subtypes": [
@@ -17477,7 +17477,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "While resolving Furyblade Vampire’s triggered ability, you can’t discard multiple cards to multiply the bonus."
+          "text": "While resolving Furyblade Vampire's triggered ability, you can't discard multiple cards to multiply the bonus."
         }
       ],
       "subtypes": [
@@ -17713,15 +17713,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn’t have to be the same opponent or planeswalker that the trigger’s source is attacking, and the tokens don’t both have to attack the same player or planeswalker."
+          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn't have to be the same opponent or planeswalker that the trigger's source is attacking, and the tokens don't both have to attack the same player or planeswalker."
         },
         {
           "date": "2016-07-13",
-          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won’t cause any abilities that trigger “whenever a creature attacks” to trigger."
+          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won't cause any abilities that trigger \"whenever a creature attacks\" to trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir Garrison. If that ability has targets, it won’t be able to target the tokens."
+          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir Garrison. If that ability has targets, it won't be able to target the tokens."
         }
       ],
       "subtypes": [
@@ -17844,15 +17844,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn’t have to be the same opponent or planeswalker that the trigger’s source is attacking, and the tokens don’t both have to attack the same player or planeswalker."
+          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn't have to be the same opponent or planeswalker that the trigger's source is attacking, and the tokens don't both have to attack the same player or planeswalker."
         },
         {
           "date": "2016-07-13",
-          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won’t cause any abilities that trigger “whenever a creature attacks” to trigger."
+          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won't cause any abilities that trigger \"whenever a creature attacks\" to trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir Garrison. If that ability has targets, it won’t be able to target the tokens."
+          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir Garrison. If that ability has targets, it won't be able to target the tokens."
         }
       ],
       "subtypes": [
@@ -17966,144 +17966,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn’t have to be the same opponent or planeswalker that the trigger’s source is attacking, and the tokens don’t both have to attack the same player or planeswalker."
+          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn't have to be the same opponent or planeswalker that the trigger's source is attacking, and the tokens don't both have to attack the same player or planeswalker."
         },
         {
           "date": "2016-07-13",
-          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won’t cause any abilities that trigger “whenever a creature attacks” to trigger."
+          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won't cause any abilities that trigger \"whenever a creature attacks\" to trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir, the Writhing Township. If that ability has targets, it won’t be able to target the tokens."
-        },
-        {
-          "date": "2016-07-13",
-          "text": "For more information on meld cards, see the Eldritch Moon mechanics article (http://magic.wizards.com/en/articles/archive/feature/eldritch-moon-mechanics)."
-        }
-      ],
-      "subtypes": [
-        "Eldrazi",
-        "Ooze"
-      ],
-      "supertypes": [
-        "Legendary"
-      ],
-      "text": "Trample, haste\nWhenever Hanweir, the Writhing Township attacks, create two 3/2 colorless Eldrazi Horror creature tokens that are tapped and attacking.",
-      "toughness": "4",
-      "type": "Legendary Creature — Eldrazi Ooze",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Vincent Proce",
-      "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "纠拧镇区翰威",
-          "multiverseid": 414652
-        },
-        {
-          "language": "Chinese Traditional",
-          "name": "糾擰鎮區翰威",
-          "multiverseid": 414875
-        },
-        {
-          "language": "French",
-          "name": "Hanweir, le comté grouillant",
-          "multiverseid": 415321
-        },
-        {
-          "language": "German",
-          "name": "Hennweier, die schlingende Stadt",
-          "multiverseid": 415098
-        },
-        {
-          "language": "Italian",
-          "name": "Hanweir, il Villaggio Serpeggiante",
-          "multiverseid": 415544
-        },
-        {
-          "language": "Japanese",
-          "name": "のたうつ居住区、ハンウィアー",
-          "multiverseid": 415767
-        },
-        {
-          "language": "Korean",
-          "name": "몸부림치는 거주지 한웨이르",
-          "multiverseid": 415990
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Hanweir, a Cidade Contorcida",
-          "multiverseid": 416213
-        },
-        {
-          "language": "Russian",
-          "name": "Ханвир, Змеящийся Городок",
-          "multiverseid": 416436
-        },
-        {
-          "language": "Spanish",
-          "name": "Hanweir, pueblo enajenado",
-          "multiverseid": 416659
-        }
-      ],
-      "id": "2979be20151a221abedc1317e7120f34187763c7",
-      "imageName": "hanweir, the writhing township3",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shadows over Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "multiverseid": 414429,
-      "name": "Hanweir, the Writhing Township",
-      "names": [
-        "Hanweir Garrison",
-        "Hanweir, the Writhing Township"
-      ],
-      "number": "130b",
-      "originalText": "Trample, haste\nWhenever Hanweir, the Writhing Township attacks, put two 3/2 colorless Eldrazi Horror creature tokens onto the battlefield tapped and attacking.",
-      "originalType": "Legendary Creature — Eldrazi Ooze",
-      "power": "7",
-      "printings": [
-        "EMN"
-      ],
-      "rarity": "Rare",
-      "rulings": [
-        {
-          "date": "2016-07-13",
-          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn’t have to be the same opponent or planeswalker that the trigger’s source is attacking, and the tokens don’t both have to attack the same player or planeswalker."
-        },
-        {
-          "date": "2016-07-13",
-          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won’t cause any abilities that trigger “whenever a creature attacks” to trigger."
-        },
-        {
-          "date": "2016-07-13",
-          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir, the Writhing Township. If that ability has targets, it won’t be able to target the tokens."
+          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir, the Writhing Township. If that ability has targets, it won't be able to target the tokens."
         },
         {
           "date": "2016-07-13",
@@ -18224,15 +18095,144 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn’t have to be the same opponent or planeswalker that the trigger’s source is attacking, and the tokens don’t both have to attack the same player or planeswalker."
+          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn't have to be the same opponent or planeswalker that the trigger's source is attacking, and the tokens don't both have to attack the same player or planeswalker."
         },
         {
           "date": "2016-07-13",
-          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won’t cause any abilities that trigger “whenever a creature attacks” to trigger."
+          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won't cause any abilities that trigger \"whenever a creature attacks\" to trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir, the Writhing Township. If that ability has targets, it won’t be able to target the tokens."
+          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir, the Writhing Township. If that ability has targets, it won't be able to target the tokens."
+        },
+        {
+          "date": "2016-07-13",
+          "text": "For more information on meld cards, see the Eldritch Moon mechanics article (http://magic.wizards.com/en/articles/archive/feature/eldritch-moon-mechanics)."
+        }
+      ],
+      "subtypes": [
+        "Eldrazi",
+        "Ooze"
+      ],
+      "supertypes": [
+        "Legendary"
+      ],
+      "text": "Trample, haste\nWhenever Hanweir, the Writhing Township attacks, create two 3/2 colorless Eldrazi Horror creature tokens that are tapped and attacking.",
+      "toughness": "4",
+      "type": "Legendary Creature — Eldrazi Ooze",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Vincent Proce",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "纠拧镇区翰威",
+          "multiverseid": 414652
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "糾擰鎮區翰威",
+          "multiverseid": 414875
+        },
+        {
+          "language": "French",
+          "name": "Hanweir, le comté grouillant",
+          "multiverseid": 415321
+        },
+        {
+          "language": "German",
+          "name": "Hennweier, die schlingende Stadt",
+          "multiverseid": 415098
+        },
+        {
+          "language": "Italian",
+          "name": "Hanweir, il Villaggio Serpeggiante",
+          "multiverseid": 415544
+        },
+        {
+          "language": "Japanese",
+          "name": "のたうつ居住区、ハンウィアー",
+          "multiverseid": 415767
+        },
+        {
+          "language": "Korean",
+          "name": "몸부림치는 거주지 한웨이르",
+          "multiverseid": 415990
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Hanweir, a Cidade Contorcida",
+          "multiverseid": 416213
+        },
+        {
+          "language": "Russian",
+          "name": "Ханвир, Змеящийся Городок",
+          "multiverseid": 416436
+        },
+        {
+          "language": "Spanish",
+          "name": "Hanweir, pueblo enajenado",
+          "multiverseid": 416659
+        }
+      ],
+      "id": "2979be20151a221abedc1317e7120f34187763c7",
+      "imageName": "hanweir, the writhing township3",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "multiverseid": 414429,
+      "name": "Hanweir, the Writhing Township",
+      "names": [
+        "Hanweir Garrison",
+        "Hanweir, the Writhing Township"
+      ],
+      "number": "130b",
+      "originalText": "Trample, haste\nWhenever Hanweir, the Writhing Township attacks, put two 3/2 colorless Eldrazi Horror creature tokens onto the battlefield tapped and attacking.",
+      "originalType": "Legendary Creature — Eldrazi Ooze",
+      "power": "7",
+      "printings": [
+        "EMN"
+      ],
+      "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2016-07-13",
+          "text": "You choose which opponent or planeswalker controlled by an opponent each token is attacking as it enters the battlefield. It doesn't have to be the same opponent or planeswalker that the trigger's source is attacking, and the tokens don't both have to attack the same player or planeswalker."
+        },
+        {
+          "date": "2016-07-13",
+          "text": "On the turn they enter the battlefield, the tokens are never declared as attacking creatures. They simply enter the battlefield attacking. They won't cause any abilities that trigger \"whenever a creature attacks\" to trigger."
+        },
+        {
+          "date": "2016-07-13",
+          "text": "If another ability of a source you control triggers when attackers are declared, such as that of Hamlet Captain, you may have it resolve before or after that of Hanweir, the Writhing Township. If that ability has targets, it won't be able to target the tokens."
         },
         {
           "date": "2016-07-13",
@@ -18357,7 +18357,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Your opponent can’t refuse your generous donation."
+          "text": "Your opponent can't refuse your generous donation."
         }
       ],
       "text": "Target opponent gains control of target permanent you control.",
@@ -18470,7 +18470,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If a creature affected by the first triggered ability of Impetuous Devils is tapped or is affected by a spell or ability that says it can’t block, then it doesn’t block. If there’s a cost associated with having that creature block, its controller isn’t forced to pay that cost, so it doesn’t have to block in that case either."
+          "text": "If a creature affected by the first triggered ability of Impetuous Devils is tapped or is affected by a spell or ability that says it can't block, then it doesn't block. If there's a cost associated with having that creature block, its controller isn't forced to pay that cost, so it doesn't have to block in that case either."
         }
       ],
       "subtypes": [
@@ -18701,7 +18701,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If Insatiable Gorgers hasn’t been under your control since the turn began, is tapped, or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having it attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If Insatiable Gorgers hasn't been under your control since the turn began, is tapped, or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having it attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -18926,7 +18926,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The copies are only created targeting creatures that the spell’s controller controls. Copies are not created for all creatures on the battlefield, and the affected creatures may be controlled by a different player than the controller of Mirrorwing Dragon. Notably, if you cast Murder targeting your opponent’s Mirrorwing Dragon, your creatures will each get a Murder, not your opponent’s."
+          "text": "The copies are only created targeting creatures that the spell's controller controls. Copies are not created for all creatures on the battlefield, and the affected creatures may be controlled by a different player than the controller of Mirrorwing Dragon. Notably, if you cast Murder targeting your opponent's Mirrorwing Dragon, your creatures will each get a Murder, not your opponent's."
         },
         {
           "date": "2016-07-13",
@@ -18934,11 +18934,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If a player casts an instant or sorcery spell that has multiple targets and Mirrorwing Dragon is chosen as the target in each instance, Mirrorwing Dragon’s ability will trigger. Each of the copies will similarly be targeting only one of the player’s other creatures."
+          "text": "If a player casts an instant or sorcery spell that has multiple targets and Mirrorwing Dragon is chosen as the target in each instance, Mirrorwing Dragon's ability will trigger. Each of the copies will similarly be targeting only one of the player's other creatures."
         },
         {
           "date": "2016-07-13",
-          "text": "Any creature the player controls that couldn’t be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Mirrorwing Dragon’s ability. If the spell has multiple targets, a given creature must be a legal target for all of them or else a copy won’t be created for that creature."
+          "text": "Any creature the player controls that couldn't be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Mirrorwing Dragon's ability. If the spell has multiple targets, a given creature must be a legal target for all of them or else a copy won't be created for that creature."
         },
         {
           "date": "2016-07-13",
@@ -18946,19 +18946,19 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The copies that the ability creates are created on the stack, so they’re not cast. Abilities that trigger when a player casts a spell (like Mirrorwing Dragon’s ability itself) won’t trigger."
+          "text": "The copies that the ability creates are created on the stack, so they're not cast. Abilities that trigger when a player casts a spell (like Mirrorwing Dragon's ability itself) won't trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copies will have the same mode. A different mode cannot be chosen."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copies will have the same mode. A different mode cannot be chosen."
         },
         {
           "date": "2016-07-13",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Burn from Within does), the copies have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Burn from Within does), the copies have the same value of X."
         },
         {
           "date": "2016-07-13",
-          "text": "The controller of a copy can’t choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
+          "text": "The controller of a copy can't choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
         }
       ],
       "subtypes": [
@@ -19075,15 +19075,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Nahiri’s Wrath adds the converted mana costs of the discarded cards in whatever zone they were put into as a result of being discarded, even if they weren’t put into a graveyard (due to madness, for example) or are no longer in that zone."
+          "text": "Nahiri's Wrath adds the converted mana costs of the discarded cards in whatever zone they were put into as a result of being discarded, even if they weren't put into a graveyard (due to madness, for example) or are no longer in that zone."
         },
         {
           "date": "2016-07-13",
-          "text": "The damage is not divided. Nahiri’s Wrath will deal that much damage to each target."
+          "text": "The damage is not divided. Nahiri's Wrath will deal that much damage to each target."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t target the same creature or planeswalker multiple times to deal more damage to it."
+          "text": "You can't target the same creature or planeswalker multiple times to deal more damage to it."
         },
         {
           "date": "2016-07-13",
@@ -19091,11 +19091,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If you cast Nahiri’s Wrath without paying its mana cost, you’ll still choose a value for X and discard X cards."
+          "text": "If you cast Nahiri's Wrath without paying its mana cost, you'll still choose a value for X and discard X cards."
         },
         {
           "date": "2016-07-13",
-          "text": "If you copy Nahiri’s Wrath, it has the same number of targets and deals the same amount of damage as the original spell."
+          "text": "If you copy Nahiri's Wrath, it has the same number of targets and deals the same amount of damage as the original spell."
         }
       ],
       "text": "As an additional cost to cast Nahiri's Wrath, discard X cards.\nNahiri's Wrath deals damage equal to the total converted mana cost of the discarded cards to each of up to X target creatures and/or planeswalkers.",
@@ -19208,11 +19208,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If the targeted creature doesn’t die this turn, the delayed triggered ability simply won’t trigger."
+          "text": "If the targeted creature doesn't die this turn, the delayed triggered ability simply won't trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "If the targeted creature dies before Otherworldly Outburst resolves, the spell is countered. You won’t get an Eldrazi Horror token."
+          "text": "If the targeted creature dies before Otherworldly Outburst resolves, the spell is countered. You won't get an Eldrazi Horror token."
         }
       ],
       "text": "Target creature gets +1/+0 until end of turn. When that creature dies this turn, create a 3/2 colorless Eldrazi Horror creature token.",
@@ -19434,7 +19434,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "When determining how much damage a creature with trample may assign to the player or planeswalker it’s attacking, take into account damage that has already been dealt to the blocking creatures. For example, a 4/4 creature with trample blocked by a 4/4 creature with 2 damage marked on it may assign 2 damage to that creature and 2 damage to the defending player."
+          "text": "When determining how much damage a creature with trample may assign to the player or planeswalker it's attacking, take into account damage that has already been dealt to the blocking creatures. For example, a 4/4 creature with trample blocked by a 4/4 creature with 2 damage marked on it may assign 2 damage to that creature and 2 damage to the defending player."
         },
         {
           "date": "2016-07-13",
@@ -19442,15 +19442,15 @@
         },
         {
           "date": "2016-07-13",
-          "text": "You choose all of your modes at once. You can’t wait to perform one mode’s actions and then decide to choose more modes."
+          "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
         },
         {
           "date": "2016-07-13",
-          "text": "You can’t choose any one mode multiple times."
+          "text": "You can't choose any one mode multiple times."
         },
         {
           "date": "2016-07-13",
-          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode’s target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
+          "text": "If two of the chosen modes of an escalate spell target a creature, you may choose the same creature for each mode's target, or choose different creatures. The same is true if the chosen modes target a player (or opponent)."
         },
         {
           "date": "2016-07-13",
@@ -19466,7 +19466,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Additional costs don’t affect a spell’s converted mana cost."
+          "text": "Additional costs don't affect a spell's converted mana cost."
         }
       ],
       "text": "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more —\n• Creatures target player controls gain trample until end of turn.\n• Savage Alliance deals 2 damage to target creature.\n• Savage Alliance deals 1 damage to each creature target opponent controls.",
@@ -19587,7 +19587,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If you target two cards and one of the targeted cards becomes illegal, you’ll still return the other one, discard a card, and exile Shreds of Sanity. If each targeted card becomes illegal, Shreds of Sanity is countered and you won’t discard a card or exile Shreds of Sanity."
+          "text": "If you target two cards and one of the targeted cards becomes illegal, you'll still return the other one, discard a card, and exile Shreds of Sanity. If each targeted card becomes illegal, Shreds of Sanity is countered and you won't discard a card or exile Shreds of Sanity."
         }
       ],
       "text": "Return up to one target instant card and up to one target sorcery card from your graveyard to your hand, then discard a card. Exile Shreds of Sanity.",
@@ -19824,11 +19824,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Erupting Dreadwolf’s triggered ability resolves before blockers are chosen. A creature dealt lethal damage this way won’t be around to block."
+          "text": "Erupting Dreadwolf's triggered ability resolves before blockers are chosen. A creature dealt lethal damage this way won't be around to block."
         },
         {
           "date": "2016-07-13",
-          "text": "If you transform Smoldering Werewolf into Erupting Dreadwolf after it has attacked, Erupting Dreadwolf’s triggered ability won’t trigger that combat."
+          "text": "If you transform Smoldering Werewolf into Erupting Dreadwolf after it has attacked, Erupting Dreadwolf's triggered ability won't trigger that combat."
         }
       ],
       "subtypes": [
@@ -20063,7 +20063,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You may cast Stensia Banquet targeting an opponent even if you control no Vampires. You’ll still draw a card."
+          "text": "You may cast Stensia Banquet targeting an opponent even if you control no Vampires. You'll still draw a card."
         },
         {
           "date": "2016-07-13",
@@ -20292,7 +20292,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The card exiled by Stromkirk Occultist’s second ability is exiled face up."
+          "text": "The card exiled by Stromkirk Occultist's second ability is exiled face up."
         },
         {
           "date": "2016-07-13",
@@ -20300,7 +20300,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Playing the card exiled with Stromkirk Occultist’s second ability follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if the card is a creature card, you can cast that card by paying its mana cost only during your main phase while the stack is empty."
+          "text": "Playing the card exiled with Stromkirk Occultist's second ability follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if the card is a creature card, you can cast that card by paying its mana cost only during your main phase while the stack is empty."
         },
         {
           "date": "2016-07-13",
@@ -20308,11 +20308,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Unless an effect allows you to play additional lands that turn, you can play a land card exiled with Stromkirk Occultist’s second ability only if you haven’t played a land yet that turn."
+          "text": "Unless an effect allows you to play additional lands that turn, you can play a land card exiled with Stromkirk Occultist's second ability only if you haven't played a land yet that turn."
         },
         {
           "date": "2016-07-13",
-          "text": "If you don’t play the card, it will remain exiled."
+          "text": "If you don't play the card, it will remain exiled."
         }
       ],
       "subtypes": [
@@ -20431,11 +20431,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Thermo-Alchemist’s last ability resolves before the spell that caused it to trigger."
+          "text": "Thermo-Alchemist's last ability resolves before the spell that caused it to trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "In a Two-Headed Giant game, Thermo-Alchemist’s activated ability deals 1 damage to each opponent, so each opposing team takes a total of 2 damage."
+          "text": "In a Two-Headed Giant game, Thermo-Alchemist's activated ability deals 1 damage to each opponent, so each opposing team takes a total of 2 damage."
         }
       ],
       "subtypes": [
@@ -20789,7 +20789,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Weaver of Lightning’s triggered ability resolves before the spell that caused it to trigger, but after targets for that spell have been chosen."
+          "text": "Weaver of Lightning's triggered ability resolves before the spell that caused it to trigger, but after targets for that spell have been chosen."
         }
       ],
       "subtypes": [
@@ -21021,11 +21021,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Bloodbriar’s ability doesn’t give you permission to sacrifice permanents. You’ll need another effect that instructs or allows you to sacrifice them."
+          "text": "Bloodbriar's ability doesn't give you permission to sacrifice permanents. You'll need another effect that instructs or allows you to sacrifice them."
         },
         {
           "date": "2016-07-13",
-          "text": "If you sacrifice a permanent as part of a spell or activated ability’s cost, Bloodbriar’s ability will resolve before that spell or ability."
+          "text": "If you sacrifice a permanent as part of a spell or activated ability's cost, Bloodbriar's ability will resolve before that spell or ability."
         }
       ],
       "subtypes": [
@@ -21143,7 +21143,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "As Clear Shot tries to resolve, if either creature is an illegal target, the creature you control won’t deal damage. If the creature you control is a legal target but the other creature isn’t, your creature will still get +1/+1."
+          "text": "As Clear Shot tries to resolve, if either creature is an illegal target, the creature you control won't deal damage. If the creature you control is a legal target but the other creature isn't, your creature will still get +1/+1."
         }
       ],
       "text": "Target creature you control gets +1/+1 until end of turn. It deals damage equal to its power to target creature you don't control.",
@@ -21474,27 +21474,27 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Sacrificing a creature is part of Eldritch Evolution’s cost. You can’t sacrifice more creatures to search for more creature cards, and you can’t cast Eldritch Evolution at all if you control no creatures."
+          "text": "Sacrificing a creature is part of Eldritch Evolution's cost. You can't sacrifice more creatures to search for more creature cards, and you can't cast Eldritch Evolution at all if you control no creatures."
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast Eldritch Evolution, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast Eldritch Evolution, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         },
         {
           "date": "2016-07-13",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, a melded card, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it’s a single-faced card with no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is the back face of a double-faced card, a melded card, or is copying something else; see below). If the mana cost includes {X}, X is considered to be 0. If it's a single-faced card with no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
         },
         {
           "date": "2016-07-13",
-          "text": "A token that isn’t a copy of another permanent has a converted mana cost of 0. A token that is a copy or a creature that has become a copy of another permanent has the converted mana cost of what it’s copying."
+          "text": "A token that isn't a copy of another permanent has a converted mana cost of 0. A token that is a copy or a creature that has become a copy of another permanent has the converted mana cost of what it's copying."
         },
         {
           "date": "2016-07-13",
-          "text": "The converted mana cost of a permanent that’s a double-faced card with its back face up is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that’s a copy of either has a converted mana cost of 0."
+          "text": "The converted mana cost of a permanent that's a double-faced card with its back face up is the converted mana cost of its front face. The converted mana cost of a melded permanent is the sum of the converted mana costs of its front faces. A creature that's a copy of either has a converted mana cost of 0."
         },
         {
           "date": "2016-07-13",
-          "text": "If a card in a library has {X} in its mana cost, X is considered to be 0. If you find such a card this way, you won’t have an opportunity to spend mana on {X}."
+          "text": "If a card in a library has {X} in its mana cost, X is considered to be 0. If you find such a card this way, you won't have an opportunity to spend mana on {X}."
         }
       ],
       "text": "As an additional cost to cast Eldritch Evolution, sacrifice a creature.\nSearch your library for a creature card with converted mana cost X or less, where X is 2 plus the sacrificed creature's converted mana cost. Put that card onto the battlefield, then shuffle your library. Exile Eldritch Evolution.",
@@ -21608,7 +21608,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You may choose to sacrifice no other non-Eldrazi creatures this way. Emrakul’s Evangel’s ability counts itself, so you’ll get one Eldrazi Horror token."
+          "text": "You may choose to sacrifice no other non-Eldrazi creatures this way. Emrakul's Evangel's ability counts itself, so you'll get one Eldrazi Horror token."
         }
       ],
       "subtypes": [
@@ -21726,7 +21726,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Emrakul’s Influence doesn’t care about how much mana you paid for an Eldrazi creature spell, only what its converted mana cost is. Cost reductions, such as that of emerge, won’t change whether or not it triggers."
+          "text": "Emrakul's Influence doesn't care about how much mana you paid for an Eldrazi creature spell, only what its converted mana cost is. Cost reductions, such as that of emerge, won't change whether or not it triggers."
         }
       ],
       "text": "Whenever you cast an Eldrazi creature spell with converted mana cost 7 or greater, draw two cards.",
@@ -21839,7 +21839,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Foul Emissary’s last ability triggers if it’s sacrificed for any reason while you’re casting a spell with emerge, whether or not you’re casting that spell for its emerge cost. For example, if you sacrifice it to activate the ability of Ashnod’s Altar while casting Decimator of the Provinces for {10}, its ability will trigger."
+          "text": "Foul Emissary's last ability triggers if it's sacrificed for any reason while you're casting a spell with emerge, whether or not you're casting that spell for its emerge cost. For example, if you sacrifice it to activate the ability of Ashnod's Altar while casting Decimator of the Provinces for {10}, its ability will trigger."
         }
       ],
       "subtypes": [
@@ -22070,7 +22070,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Grapple with the Past doesn’t target the card to return to your hand. After putting the top three cards of your library into your graveyard, you may choose from among any creature or land cards there."
+          "text": "Grapple with the Past doesn't target the card to return to your hand. After putting the top three cards of your library into your graveyard, you may choose from among any creature or land cards there."
         }
       ],
       "text": "Put the top three cards of your library into your graveyard, then you may return a creature or land card from your graveyard to your hand.",
@@ -22302,7 +22302,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The number of Spiders you control is checked only as Ishkanah’s last ability resolves. The ability will count Ishkanah itself if it’s still on the battlefield."
+          "text": "The number of Spiders you control is checked only as Ishkanah's last ability resolves. The ability will count Ishkanah itself if it's still on the battlefield."
         }
       ],
       "subtypes": [
@@ -22546,7 +22546,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If Sinuous Predator gains menace, it can’t be blocked by only one creature and it can’t be blocked by more than one creature, so it simply can’t be blocked."
+          "text": "If Sinuous Predator gains menace, it can't be blocked by only one creature and it can't be blocked by more than one creature, so it simply can't be blocked."
         }
       ],
       "subtypes": [
@@ -22777,7 +22777,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "A creature dealt lethal damage during combat won’t survive long enough to become a copy of Permeating Mass. If Permeating Mass is dealt lethal damage during combat, the creature Permeating Mass dealt damage to still becomes a copy of it."
+          "text": "A creature dealt lethal damage during combat won't survive long enough to become a copy of Permeating Mass. If Permeating Mass is dealt lethal damage during combat, the creature Permeating Mass dealt damage to still becomes a copy of it."
         },
         {
           "date": "2016-07-13",
@@ -22785,7 +22785,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The damaged creature copies the printed values of Permeating Mass. It won’t copy counters on Permeating Mass or effects that have changed its power, toughness, types, color, or so on. Notably, this means that a creature that becomes a copy of Permeating Mass has the ability to permeate other creatures as well."
+          "text": "The damaged creature copies the printed values of Permeating Mass. It won't copy counters on Permeating Mass or effects that have changed its power, toughness, types, color, or so on. Notably, this means that a creature that becomes a copy of Permeating Mass has the ability to permeate other creatures as well."
         },
         {
           "date": "2016-07-13",
@@ -23154,7 +23154,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The power of the blocking creature and that of Shrill Howler are compared only at the moment that blockers are chosen. Changing either creature’s power later won’t cause Shrill Howler to become unblocked."
+          "text": "The power of the blocking creature and that of Shrill Howler are compared only at the moment that blockers are chosen. Changing either creature's power later won't cause Shrill Howler to become unblocked."
         },
         {
           "date": "2016-07-13",
@@ -23276,7 +23276,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The power of the blocking creature and that of Howling Chorus are compared only at the moment that blockers are chosen. Changing either creature’s power later won’t cause Howling Chorus to become unblocked."
+          "text": "The power of the blocking creature and that of Howling Chorus are compared only at the moment that blockers are chosen. Changing either creature's power later won't cause Howling Chorus to become unblocked."
         }
       ],
       "subtypes": [
@@ -23399,7 +23399,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If the targeted creature is an illegal target when Somberwald Stag’s ability tries to resolve, the ability is countered. If Somberwald Stag is no longer on the battlefield, the targeted creature won’t deal or be dealt damage."
+          "text": "If the targeted creature is an illegal target when Somberwald Stag's ability tries to resolve, the ability is countered. If Somberwald Stag is no longer on the battlefield, the targeted creature won't deal or be dealt damage."
         }
       ],
       "subtypes": [
@@ -23629,7 +23629,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If an effect states that a land enters the battlefield tapped unless a condition is met, Splendid Reclamation’s effect puts that land onto the battlefield tapped even if that condition is true. For example, you may reveal a Plains as Port Town (from the Shadows over Innistrad set) is returned to the battlefield, but Port Town will still enter tapped."
+          "text": "If an effect states that a land enters the battlefield tapped unless a condition is met, Splendid Reclamation's effect puts that land onto the battlefield tapped even if that condition is true. For example, you may reveal a Plains as Port Town (from the Shadows over Innistrad set) is returned to the battlefield, but Port Town will still enter tapped."
         }
       ],
       "text": "Return all land cards from your graveyard to the battlefield tapped.",
@@ -23742,7 +23742,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If the artifact or enchantment becomes an illegal target, Springsage Ritual is countered. You won’t gain 4 life."
+          "text": "If the artifact or enchantment becomes an illegal target, Springsage Ritual is countered. You won't gain 4 life."
         }
       ],
       "text": "Destroy target artifact or enchantment. You gain 4 life.",
@@ -24099,11 +24099,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If each creature that could block Fibrous Entangler is tapped or is affected by a spell or ability that says it can’t block, then none of them block. If there’s a cost associated with having each of those creatures block, its controller isn’t forced to pay the cost, so they don’t have to block in that case either."
+          "text": "If each creature that could block Fibrous Entangler is tapped or is affected by a spell or ability that says it can't block, then none of them block. If there's a cost associated with having each of those creatures block, its controller isn't forced to pay the cost, so they don't have to block in that case either."
         },
         {
           "date": "2016-07-13",
-          "text": "If Tangleclaw Werewolf transforms into Fibrous Entangler while it’s attacking, having vigilance won’t cause it to become untapped."
+          "text": "If Tangleclaw Werewolf transforms into Fibrous Entangler while it's attacking, having vigilance won't cause it to become untapped."
         }
       ],
       "subtypes": [
@@ -24233,7 +24233,7 @@
         "Werewolf",
         "Horror"
       ],
-      "text": "Defender\n{T}: Add {G} to your mana pool. \n{5}{G}{G}: Transform Ulvenwald Captive.",
+      "text": "Defender\n{T}: Add {G} to your mana pool.\n{5}{G}{G}: Transform Ulvenwald Captive.",
       "toughness": "2",
       "type": "Creature — Werewolf Horror",
       "types": [
@@ -24462,7 +24462,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If Ulvenwald Observer’s toughness is still 4 or greater at the time it dies, its ability triggers."
+          "text": "If Ulvenwald Observer's toughness is still 4 or greater at the time it dies, its ability triggers."
         }
       ],
       "subtypes": [
@@ -24579,7 +24579,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You may cast Waxing Moon without targeting a Werewolf. If you do choose a target, and that target becomes illegal, Waxing Moon is countered, and your creatures won’t gain trample."
+          "text": "You may cast Waxing Moon without targeting a Werewolf. If you do choose a target, and that target becomes illegal, Waxing Moon is countered, and your creatures won't gain trample."
         }
       ],
       "text": "Transform up to one target Werewolf you control. Creatures you control gain trample until end of turn.",
@@ -24691,7 +24691,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If the target becomes illegal while Wolfkin Bond is on the stack, the spell is countered. It won’t enter the battlefield and you won’t get a Wolf token."
+          "text": "If the target becomes illegal while Wolfkin Bond is on the stack, the spell is countered. It won't enter the battlefield and you won't get a Wolf token."
         }
       ],
       "subtypes": [
@@ -25029,11 +25029,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The triggered ability triggers both when Bloodhall Priest enters the battlefield and whenever it attacks. You don’t have to choose only one."
+          "text": "The triggered ability triggers both when Bloodhall Priest enters the battlefield and whenever it attacks. You don't have to choose only one."
         },
         {
           "date": "2016-07-13",
-          "text": "If you have a card in hand at the moment the trigger condition occurs, Bloodhall Priest’s ability won’t trigger, even if you can get that card out of your hand right afterward. If you have a card in hand as the ability resolves, it has no effect. No damage will be dealt."
+          "text": "If you have a card in hand at the moment the trigger condition occurs, Bloodhall Priest's ability won't trigger, even if you can get that card out of your hand right afterward. If you have a card in hand as the ability resolves, it has no effect. No damage will be dealt."
         }
       ],
       "subtypes": [
@@ -25161,7 +25161,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "In a Two-Headed Giant game, Campaign of Vengeance’s triggered ability has one defending player of your choice lose 1 life. The team doesn’t lose 2 life."
+          "text": "In a Two-Headed Giant game, Campaign of Vengeance's triggered ability has one defending player of your choice lose 1 life. The team doesn't lose 2 life."
         }
       ],
       "text": "Whenever a creature you control attacks, defending player loses 1 life and you gain 1 life.",
@@ -25285,7 +25285,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Once you begin to cast the Zombie card, losing control of Gisa and Geralf won’t affect the spell."
+          "text": "Once you begin to cast the Zombie card, losing control of Gisa and Geralf won't affect the spell."
         },
         {
           "date": "2016-07-13",
@@ -25297,11 +25297,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If multiple effects allow you to cast a Zombie creature card from your graveyard, such as those of Gisa and Geralf and Karador, Ghost Chieftain, you must announce which permission you’re using as you begin to cast the spell."
+          "text": "If multiple effects allow you to cast a Zombie creature card from your graveyard, such as those of Gisa and Geralf and Karador, Ghost Chieftain, you must announce which permission you're using as you begin to cast the spell."
         },
         {
           "date": "2016-07-13",
-          "text": "Even though the cards portray the same characters, Gisa and Geralf has a different name than Ghoulcaller Gisa and Stitcher Geralf. Controlling Gisa and Geralf along with Ghoulcaller Gisa or Stitcher Geralf won’t invoke the “legend rule.”"
+          "text": "Even though the cards portray the same characters, Gisa and Geralf has a different name than Ghoulcaller Gisa and Stitcher Geralf. Controlling Gisa and Geralf along with Ghoulcaller Gisa or Stitcher Geralf won't invoke the \"legend rule.\""
         }
       ],
       "subtypes": [
@@ -25767,7 +25767,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Because the last ability’s effect doesn’t change the characteristics of any permanents, the set of creatures affected is constantly updated. Any creature with power 2 or less at the moment blockers are chosen will be unable to block."
+          "text": "Because the last ability's effect doesn't change the characteristics of any permanents, the set of creatures affected is constantly updated. Any creature with power 2 or less at the moment blockers are chosen will be unable to block."
         }
       ],
       "subtypes": [
@@ -25900,7 +25900,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "In some rare cases, the blocking creature wasn’t declared as a blocking creature that combat (for example, if it entered the battlefield blocking). In that case, the attacking creatures it was blocking won’t gain trample even though the blocking creature is destroyed."
+          "text": "In some rare cases, the blocking creature wasn't declared as a blocking creature that combat (for example, if it entered the battlefield blocking). In that case, the attacking creatures it was blocking won't gain trample even though the blocking creature is destroyed."
         }
       ],
       "text": "Destroy target blocking creature. Creatures that were blocked by that creature this combat gain trample until end of turn.",
@@ -26015,23 +26015,23 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell’s converted mana cost is 4 or less."
+          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell's converted mana cost is 4 or less."
         },
         {
           "date": "2016-07-13",
-          "text": "Spells that can’t be countered can be exiled by Spell Queller’s ability. They won’t resolve."
+          "text": "Spells that can't be countered can be exiled by Spell Queller's ability. They won't resolve."
         },
         {
           "date": "2016-07-13",
-          "text": "If the exiled card’s owner casts it, the spell has no relation to the spell that player originally cast. Any choices made for the original spell or effects affecting the original spell aren’t carried over to the new one."
+          "text": "If the exiled card's owner casts it, the spell has no relation to the spell that player originally cast. Any choices made for the original spell or effects affecting the original spell aren't carried over to the new one."
         },
         {
           "date": "2016-07-13",
-          "text": "If the player casts the exiled card, he or she does so as part of the resolution of Spell Queller’s last ability. The player can’t wait to cast it later in the turn. Timing permissions based on the card’s type are ignored, but other restrictions (such as “Cast [this card] only during combat”) are not."
+          "text": "If the player casts the exiled card, he or she does so as part of the resolution of Spell Queller's last ability. The player can't wait to cast it later in the turn. Timing permissions based on the card's type are ignored, but other restrictions (such as \"Cast [this card] only during combat\") are not."
         },
         {
           "date": "2016-07-13",
-          "text": "If a player casts a card “without paying its mana cost,” he or she can’t pay any alternative costs, such as emerge costs. The player can, however, pay additional costs, such as escalate costs. If the card has any mandatory additional costs, those must be paid to cast the card."
+          "text": "If a player casts a card \"without paying its mana cost,\" he or she can't pay any alternative costs, such as emerge costs. The player can, however, pay additional costs, such as escalate costs. If the card has any mandatory additional costs, those must be paid to cast the card."
         },
         {
           "date": "2016-07-13",
@@ -26160,19 +26160,19 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Tamiyo’s first ability can target creatures you don’t control. You’ll draw a card, not their controller, if they deal combat damage."
+          "text": "Tamiyo's first ability can target creatures you don't control. You'll draw a card, not their controller, if they deal combat damage."
         },
         {
           "date": "2016-07-13",
-          "text": "Tamiyo’s first ability sets up a delayed triggered ability that triggers even if Tamiyo has left the battlefield before those creatures deal combat damage."
+          "text": "Tamiyo's first ability sets up a delayed triggered ability that triggers even if Tamiyo has left the battlefield before those creatures deal combat damage."
         },
         {
           "date": "2016-07-13",
-          "text": "You must follow the normal timing permissions and restrictions of each nonland card you cast once you get Tamiyo’s emblem."
+          "text": "You must follow the normal timing permissions and restrictions of each nonland card you cast once you get Tamiyo's emblem."
         },
         {
           "date": "2016-07-13",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs such as emerge costs. You can pay additional costs such as escalate costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs such as emerge costs. You can pay additional costs such as escalate costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2016-07-13",
@@ -26184,7 +26184,7 @@
         },
         {
           "date": "2016-08-23",
-          "text": "If Tamiyo’s first ability targets two creatures, and both deal combat damage at the same time, the delayed triggered ability triggers twice."
+          "text": "If Tamiyo's first ability targets two creatures, and both deal combat damage at the same time, the delayed triggered ability triggers twice."
         }
       ],
       "subtypes": [
@@ -26306,7 +26306,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -26436,27 +26436,27 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "You choose the target of the Ulrich, Uncontested Alpha’s first ability as it goes on the stack, but you choose whether or not to fight as that ability resolves."
+          "text": "You choose the target of the Ulrich, Uncontested Alpha's first ability as it goes on the stack, but you choose whether or not to fight as that ability resolves."
         },
         {
           "date": "2016-07-13",
-          "text": "If the targeted creature is an illegal target when Ulrich, Uncontested Alpha’s first ability tries to resolve, the ability is countered."
+          "text": "If the targeted creature is an illegal target when Ulrich, Uncontested Alpha's first ability tries to resolve, the ability is countered."
         },
         {
           "date": "2016-07-13",
-          "text": "If Ulrich is no longer on the battlefield as Ulrich, Uncontested Alpha’s first ability resolves, the targeted creature won’t deal or be dealt damage."
+          "text": "If Ulrich is no longer on the battlefield as Ulrich, Uncontested Alpha's first ability resolves, the targeted creature won't deal or be dealt damage."
         },
         {
           "date": "2016-07-13",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
-          "text": "Ulrich, Uncontested Alpha’s last ability only triggers if a single player has cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "Ulrich, Uncontested Alpha's last ability only triggers if a single player has cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -26677,19 +26677,19 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Cryptolith Fragment’s second ability is a mana ability. Players can’t respond to it or to the loss of life it causes."
+          "text": "Cryptolith Fragment's second ability is a mana ability. Players can't respond to it or to the loss of life it causes."
         },
         {
           "date": "2016-07-13",
-          "text": "If any player has 11 or more life as your upkeep begins, Cryptolith Fragment’s last ability doesn’t trigger. If any player has 11 or more life as the ability resolves, the ability has no effect."
+          "text": "If any player has 11 or more life as your upkeep begins, Cryptolith Fragment's last ability doesn't trigger. If any player has 11 or more life as the ability resolves, the ability has no effect."
         },
         {
           "date": "2016-07-13",
-          "text": "In a Two-Headed Giant game, Cryptolith Fragment’s mana ability causes each player to lose 1 life, so each team loses 2 life."
+          "text": "In a Two-Headed Giant game, Cryptolith Fragment's mana ability causes each player to lose 1 life, so each team loses 2 life."
         },
         {
           "date": "2016-07-13",
-          "text": "In a Two-Headed Giant game, Cryptolith Fragment’s last ability checks whether each team’s life total is 10 or less."
+          "text": "In a Two-Headed Giant game, Cryptolith Fragment's last ability checks whether each team's life total is 10 or less."
         },
         {
           "date": "2016-07-13",
@@ -27120,7 +27120,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Geist-Fueled Scarecrow’s ability applies to creature spells even if you’re casting them for an alternative cost (such as that of emerge). If you cast a creature spell without paying its mana cost, you’ll still have to pay {1}."
+          "text": "Geist-Fueled Scarecrow's ability applies to creature spells even if you're casting them for an alternative cost (such as that of emerge). If you cast a creature spell without paying its mana cost, you'll still have to pay {1}."
         },
         {
           "date": "2016-07-13",
@@ -27237,11 +27237,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "Lupine Prototype’s restriction applies only at the moment that attackers and blockers are chosen. If a player puts a card into his or her hand after Lupine Prototype has attacked or blocked, it won’t be removed from combat."
+          "text": "Lupine Prototype's restriction applies only at the moment that attackers and blockers are chosen. If a player puts a card into his or her hand after Lupine Prototype has attacked or blocked, it won't be removed from combat."
         },
         {
           "date": "2016-07-13",
-          "text": "If a creature can’t attack or block unless you return a permanent to your hand, and your hand is empty, you can attack or block with that creature and Lupine Prototype. This is because the legality of chosen attackers and blockers is checked before costs are paid."
+          "text": "If a creature can't attack or block unless you return a permanent to your hand, and your hand is empty, you can attack or block with that creature and Lupine Prototype. This is because the legality of chosen attackers and blockers is checked before costs are paid."
         }
       ],
       "subtypes": [
@@ -27362,11 +27362,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If each Eldrazi that could block the equipped creature is tapped or is affected by a spell or ability that says it can’t block, then none of them block. If there’s a cost associated with having each of those creatures block, its controller isn’t forced to pay the cost, so they don’t have to block in that case either."
+          "text": "If each Eldrazi that could block the equipped creature is tapped or is affected by a spell or ability that says it can't block, then none of them block. If there's a cost associated with having each of those creatures block, its controller isn't forced to pay the cost, so they don't have to block in that case either."
         },
         {
           "date": "2016-07-13",
-          "text": "One creature equipped with multiple Slayer’s Cleavers only requires a single Eldrazi to block it."
+          "text": "One creature equipped with multiple Slayer's Cleavers only requires a single Eldrazi to block it."
         }
       ],
       "subtypes": [
@@ -27475,7 +27475,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If you copy a double-faced creature card, the Spirit token won’t be able to transform."
+          "text": "If you copy a double-faced creature card, the Spirit token won't be able to transform."
         },
         {
           "date": "2016-07-13",
@@ -27483,7 +27483,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Any enters-the-battlefield abilities of the copied creature card will trigger when the Spirit token enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the creature card will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature card will trigger when the Spirit token enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the creature card will also work."
         },
         {
           "date": "2016-07-13",
@@ -27491,7 +27491,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Abilities that define a creature’s power and toughness apply while that card is in your graveyard, but abilities that add or subtract from it don’t. For example, the ability of Sage of Ancient Lore applies to determine the Zombie token’s power and toughness, but the ability of Liliana’s Elite doesn’t."
+          "text": "Abilities that define a creature's power and toughness apply while that card is in your graveyard, but abilities that add or subtract from it don't. For example, the ability of Sage of Ancient Lore applies to determine the Zombie token's power and toughness, but the ability of Liliana's Elite doesn't."
         },
         {
           "date": "2016-07-13",
@@ -27499,7 +27499,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "The power and toughness of the Zombie token are set as it’s created based on the card as it last existed in your graveyard. They won’t update if the exiled card’s power and toughness change."
+          "text": "The power and toughness of the Zombie token are set as it's created based on the card as it last existed in your graveyard. They won't update if the exiled card's power and toughness change."
         },
         {
           "date": "2016-07-13",
@@ -27609,15 +27609,15 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If multiple effects say that a creature doesn’t untap during your next untap step, those effects all apply during one untap step. For example, a creature that attacks while equipped with two Stitcher’s Grafts will only spend one untap step without untapping."
+          "text": "If multiple effects say that a creature doesn't untap during your next untap step, those effects all apply during one untap step. For example, a creature that attacks while equipped with two Stitcher's Grafts will only spend one untap step without untapping."
         },
         {
           "date": "2016-07-13",
-          "text": "Stitcher’s Graft becomes unattached from the creature it’s equipping if you equip it to a new creature, if Stitcher’s Graft leaves the battlefield, if the equipped creature ceases to be a creature, or if Stitcher’s Graft ceases to be an Equipment. (It also becomes unattached if the equipped creature leaves the battlefield, but the triggered ability won’t do anything in that case.)"
+          "text": "Stitcher's Graft becomes unattached from the creature it's equipping if you equip it to a new creature, if Stitcher's Graft leaves the battlefield, if the equipped creature ceases to be a creature, or if Stitcher's Graft ceases to be an Equipment. (It also becomes unattached if the equipped creature leaves the battlefield, but the triggered ability won't do anything in that case.)"
         },
         {
           "date": "2016-07-13",
-          "text": "If Stitcher’s Graft’s last triggered ability triggers, but you don’t control the permanent it became unattached from at the time that ability resolves (perhaps because another player has somehow gained control of it), you won’t be able to sacrifice it."
+          "text": "If Stitcher's Graft's last triggered ability triggers, but you don't control the permanent it became unattached from at the time that ability resolves (perhaps because another player has somehow gained control of it), you won't be able to sacrifice it."
         }
       ],
       "subtypes": [
@@ -27747,7 +27747,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Terrarion’s last ability triggers no matter how it’s put into a graveyard from the battlefield."
+          "text": "Terrarion's last ability triggers no matter how it's put into a graveyard from the battlefield."
         }
       ],
       "text": "Terrarion enters the battlefield tapped.\n{2}, {T}, Sacrifice Terrarion: Add two mana in any combination of colors to your mana pool.\nWhen Terrarion is put into a graveyard from the battlefield, draw a card.",
@@ -27854,11 +27854,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If the equipped creature dealt combat damage only to a player or planeswalker, Thirsting Axe’s triggered ability triggers. The same is true if the creature didn’t deal combat damage at all."
+          "text": "If the equipped creature dealt combat damage only to a player or planeswalker, Thirsting Axe's triggered ability triggers. The same is true if the creature didn't deal combat damage at all."
         },
         {
           "date": "2016-07-13",
-          "text": "Thirsting Axe’s triggered ability checks whether the creature it’s attached to at the moment your end step begins dealt combat damage to a creature earlier in the turn. It doesn’t matter whether Thirsting Axe was attached to it (or to any creature at all) as combat damage was dealt."
+          "text": "Thirsting Axe's triggered ability checks whether the creature it's attached to at the moment your end step begins dealt combat damage to a creature earlier in the turn. It doesn't matter whether Thirsting Axe was attached to it (or to any creature at all) as combat damage was dealt."
         }
       ],
       "subtypes": [
@@ -27966,7 +27966,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "When you activate Geier Reach Sanitarium’s last ability, first each player draws a card. Then the player whose turn it is selects a card from his or her hand and sets it aside without revealing it; proceeding in turn order, each other player does the same. Then the cards that were set aside are discarded at once."
+          "text": "When you activate Geier Reach Sanitarium's last ability, first each player draws a card. Then the player whose turn it is selects a card from his or her hand and sets it aside without revealing it; proceeding in turn order, each other player does the same. Then the cards that were set aside are discarded at once."
         },
         {
           "date": "2016-07-13",
@@ -28183,19 +28183,19 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "In a Magic game, cards are discarded only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "In a Magic game, cards are discarded only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-07-13",
-          "text": "When you apply Nephalia Academy’s effect, the card was still discarded. Abilities that trigger when a card is discarded will still trigger."
+          "text": "When you apply Nephalia Academy's effect, the card was still discarded. Abilities that trigger when a card is discarded will still trigger."
         },
         {
           "date": "2016-07-13",
-          "text": "If a spell or ability an opponent controls causes you to make a choice and you choose to discard a card, Nephalia Academy’s ability will apply."
+          "text": "If a spell or ability an opponent controls causes you to make a choice and you choose to discard a card, Nephalia Academy's ability will apply."
         },
         {
           "date": "2016-07-13",
-          "text": "If you discard a card with madness, you’ll choose whether to exile it or put it on top of your library. If you put it on top of your library, you can’t cast it using madness."
+          "text": "If you discard a card with madness, you'll choose whether to exile it or put it on top of your library. If you put it on top of your library, you can't cast it using madness."
         }
       ],
       "text": "If a spell or ability an opponent controls causes you to discard a card, you may reveal that card and put it on top of your library instead of putting it anywhere else.\n{T}: Add {C} to your mana pool.",

--- a/json/EVE.json
+++ b/json/EVE.json
@@ -329,7 +329,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -337,11 +337,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Create two 1/1 white Kithkin Soldier creature tokens.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -440,11 +440,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If Endless Horizons leaves the battlefield, the remaining Plains cards stay exiled. If Endless Horizons returns to the battlefield, it’s a new object with no relation to its previous existence. The previously exiled Plains cards will still stay exiled."
+          "text": "If Endless Horizons leaves the battlefield, the remaining Plains cards stay exiled. If Endless Horizons returns to the battlefield, it's a new object with no relation to its previous existence. The previously exiled Plains cards will still stay exiled."
         },
         {
           "date": "2008-08-01",
-          "text": "If a different player gains control of Endless Horizons, its ability will trigger at the beginning of that player’s upkeep, but it won’t do anything when it resolves."
+          "text": "If a different player gains control of Endless Horizons, its ability will trigger at the beginning of that player's upkeep, but it won't do anything when it resolves."
         }
       ],
       "text": "When Endless Horizons enters the battlefield, search your library for any number of Plains cards and exile them. Then shuffle your library.\nAt the beginning of your upkeep, you may put a card you own exiled with Endless Horizons into your hand.",
@@ -649,7 +649,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won’t trigger that turn."
+          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won't trigger that turn."
         }
       ],
       "subtypes": [
@@ -754,11 +754,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "All creatures leave the battlefield simultaneously. They’re not destroyed; they’re just put on the bottom of their owners’ libraries. This includes token creatures, though they’ll cease to exist as soon as Hallowed Burial finishes resolving."
+          "text": "All creatures leave the battlefield simultaneously. They're not destroyed; they're just put on the bottom of their owners' libraries. This includes token creatures, though they'll cease to exist as soon as Hallowed Burial finishes resolving."
         },
         {
           "date": "2008-08-01",
-          "text": "Each player chooses the relative order of the cards he or she is putting on the bottom of his or her library, regardless of who controlled them while they were on the battlefield. Players don’t reveal this order to other players."
+          "text": "Each player chooses the relative order of the cards he or she is putting on the bottom of his or her library, regardless of who controlled them while they were on the battlefield. Players don't reveal this order to other players."
         }
       ],
       "text": "Put all creatures on the bottom of their owners' libraries.",
@@ -866,23 +866,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -988,7 +988,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each permanent is counted only once. For example, if the targeted player controls a black creature, a red enchantment, and a black-red creature, you’ll gain 3 life."
+          "text": "Each permanent is counted only once. For example, if the targeted player controls a black creature, a red enchantment, and a black-red creature, you'll gain 3 life."
         }
       ],
       "subtypes": [
@@ -1093,7 +1093,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -1301,15 +1301,15 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-08-01",
-          "text": "The “summoning sickness” rule applies to {Q}. If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability. Ignore this rule if the creature also has haste."
+          "text": "The \"summoning sickness\" rule applies to {Q}. If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability. Ignore this rule if the creature also has haste."
         },
         {
           "date": "2008-08-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         }
       ],
       "subtypes": [
@@ -1415,7 +1415,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The triggered ability is on the Aura, not the creature. It triggers at the beginning of the upkeep of Recumbent Bliss’s controller, not the enchanted creature’s controller, and Recumbent Bliss’s controller will gain the life."
+          "text": "The triggered ability is on the Aura, not the creature. It triggers at the beginning of the upkeep of Recumbent Bliss's controller, not the enchanted creature's controller, and Recumbent Bliss's controller will gain the life."
         }
       ],
       "subtypes": [
@@ -1620,7 +1620,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -1833,11 +1833,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The targeted creature’s controller, not Banishing Knack’s controller, is the one who can activate the creature’s new ability."
+          "text": "The targeted creature's controller, not Banishing Knack's controller, is the one who can activate the creature's new ability."
         },
         {
           "date": "2008-08-01",
-          "text": "“Summoning sickness” applies. The new ability can’t be activated unless the targeted creature has been under its controller’s control since the beginning of that player’s most recent turn or it has haste."
+          "text": "\"Summoning sickness\" applies. The new ability can't be activated unless the targeted creature has been under its controller's control since the beginning of that player's most recent turn or it has haste."
         }
       ],
       "text": "Until end of turn, target creature gains \"{T}: Return target nonland permanent to its owner's hand.\"",
@@ -1939,7 +1939,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This ability isn’t targeted. You choose a permanent to return when the ability resolves. No one will be able to respond to the choice."
+          "text": "This ability isn't targeted. You choose a permanent to return when the ability resolves. No one will be able to respond to the choice."
         }
       ],
       "subtypes": [
@@ -2140,11 +2140,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Dream Thief doesn’t check whether you’ve cast another blue spell until its enters-the-battlefield ability resolves. If Dream Thief’s enters-the-battlefield ability triggers, then you cast a blue instant spell in response, you’ll get the bonus."
+          "text": "Dream Thief doesn't check whether you've cast another blue spell until its enters-the-battlefield ability resolves. If Dream Thief's enters-the-battlefield ability triggers, then you cast a blue instant spell in response, you'll get the bonus."
         },
         {
           "date": "2008-08-01",
-          "text": "Although Dream Thief says it looks for “another blue spell,” there’s no requirement that Dream Thief actually be cast as a spell (or be blue) for this part of its ability to work. For example, if a spell such as Zombify puts Dream Thief directly onto the battlefield, its ability will still check whether you’ve cast a blue spell this turn, even though you didn’t cast Dream Thief itself as a spell."
+          "text": "Although Dream Thief says it looks for \"another blue spell,\" there's no requirement that Dream Thief actually be cast as a spell (or be blue) for this part of its ability to work. For example, if a spell such as Zombify puts Dream Thief directly onto the battlefield, its ability will still check whether you've cast a blue spell this turn, even though you didn't cast Dream Thief itself as a spell."
         }
       ],
       "subtypes": [
@@ -2248,7 +2248,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -2256,35 +2256,35 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         },
         {
           "date": "2008-08-01",
-          "text": "Glamerdye’s effect has no duration. It will last until the game ends or the affected spell or permanent leaves the relevant zone, with the following exception: If Glamerdye affects an artifact, creature, enchantment, or planeswalker spell, it will also affect the permanent that spell becomes when it resolves."
+          "text": "Glamerdye's effect has no duration. It will last until the game ends or the affected spell or permanent leaves the relevant zone, with the following exception: If Glamerdye affects an artifact, creature, enchantment, or planeswalker spell, it will also affect the permanent that spell becomes when it resolves."
         },
         {
           "date": "2008-08-01",
-          "text": "You choose the two color words when Glamerdye resolves. You can’t change a word to the same word; you must choose a different word."
+          "text": "You choose the two color words when Glamerdye resolves. You can't change a word to the same word; you must choose a different word."
         },
         {
           "date": "2008-08-01",
-          "text": "Glamerdye affects each instance of the chosen word in the text box of the spell or permanent, as long as it’s being used as a color word. Glamerdye won’t change such words in card names, such as White Knight. It also won’t change mana symbols."
+          "text": "Glamerdye affects each instance of the chosen word in the text box of the spell or permanent, as long as it's being used as a color word. Glamerdye won't change such words in card names, such as White Knight. It also won't change mana symbols."
         },
         {
           "date": "2008-08-01",
-          "text": "Glamerdye can change color words preceded by “non.” For example, if you have it change “red” to “green,” it will also change “nonred” to “nongreen.”"
+          "text": "Glamerdye can change color words preceded by \"non.\" For example, if you have it change \"red\" to \"green,\" it will also change \"nonred\" to \"nongreen.\""
         },
         {
           "date": "2008-08-01",
-          "text": "Glamerdye changes only words actually printed on the spell or permanent (if it’s a card), words that are part of the spell or permanent’s original characteristics as stated by the effect that created it (if it’s a token or a copy of a spell), or words that were granted to the spell or permanent as part of a copy effect. It won’t change words that are granted to the spell or permanent by any other effects. For example, if an Aura grants a creature protection from blue, you can change that to protection from red by targeting the Aura, but not by targeting the creature. Glamerdye also can’t change what color was chosen for a permanent (such as Painter’s Servant) as it entered the battlefield."
+          "text": "Glamerdye changes only words actually printed on the spell or permanent (if it's a card), words that are part of the spell or permanent's original characteristics as stated by the effect that created it (if it's a token or a copy of a spell), or words that were granted to the spell or permanent as part of a copy effect. It won't change words that are granted to the spell or permanent by any other effects. For example, if an Aura grants a creature protection from blue, you can change that to protection from red by targeting the Aura, but not by targeting the creature. Glamerdye also can't change what color was chosen for a permanent (such as Painter's Servant) as it entered the battlefield."
         },
         {
           "date": "2008-08-01",
-          "text": "Glamerdye can’t affect the keyword fear."
+          "text": "Glamerdye can't affect the keyword fear."
         }
       ],
       "text": "Change the text of target spell or permanent by replacing all instances of one color word with another.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -2393,23 +2393,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -2514,7 +2514,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "You can activate the ability whether or not you have any cards in your hand. However, you’ll draw a card only if your hand is empty when the ability resolves. (This card works differently than the _Tempest_(TM) card Fool’s Tome.)"
+          "text": "You can activate the ability whether or not you have any cards in your hand. However, you'll draw a card only if your hand is empty when the ability resolves. (This card works differently than the _Tempest_(TM) card Fool's Tome.)"
         }
       ],
       "text": "{2}: Draw a card if you have no cards in hand.",
@@ -2615,15 +2615,15 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This ability doesn’t overwrite any previous colors. Rather, it adds another color."
+          "text": "This ability doesn't overwrite any previous colors. Rather, it adds another color."
         },
         {
           "date": "2008-08-01",
-          "text": "If something affected by Indigo Faerie’s ability is normally colorless, it will simply be blue. It won’t be both blue and colorless."
+          "text": "If something affected by Indigo Faerie's ability is normally colorless, it will simply be blue. It won't be both blue and colorless."
         },
         {
           "date": "2008-08-01",
-          "text": "After Indigo Faerie’s ability resolves, an effect that changes the affected permanent’s colors will overwrite Indigo Faerie’s effect. For example, if Indigo Faerie’s ability is activated on Llanowar Elves, the Elves will be blue and green; if Aphotic Wisps is then cast on the same creature, it’ll be just black."
+          "text": "After Indigo Faerie's ability resolves, an effect that changes the affected permanent's colors will overwrite Indigo Faerie's effect. For example, if Indigo Faerie's ability is activated on Llanowar Elves, the Elves will be blue and green; if Aphotic Wisps is then cast on the same creature, it'll be just black."
         }
       ],
       "subtypes": [
@@ -2728,7 +2728,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A hybrid creature that’s blue and another color is *not* a nonblue creature. Since it’s blue, it can’t be nonblue!"
+          "text": "A hybrid creature that's blue and another color is *not* a nonblue creature. Since it's blue, it can't be nonblue!"
         }
       ],
       "text": "Return all nonblue creatures to their owners' hands.",
@@ -2929,7 +2929,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -2937,11 +2937,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Target player draws a card.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -3042,7 +3042,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Razorfin Abolisher’s ability can target a creature with any kind of counter on it, not just a -1/-1 counter."
+          "text": "Razorfin Abolisher's ability can target a creature with any kind of counter on it, not just a -1/-1 counter."
         },
         {
           "date": "2008-08-01",
@@ -3150,7 +3150,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -3158,7 +3158,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If there are fewer than ten cards in your library, reveal them all. For each blue mana symbol in those cards’ mana costs, the targeted opponent puts the top card of his or her library into his or her graveyard. Then you reorder your entire library as you choose."
+          "text": "If there are fewer than ten cards in your library, reveal them all. For each blue mana symbol in those cards' mana costs, the targeted opponent puts the top card of his or her library into his or her graveyard. Then you reorder your entire library as you choose."
         }
       ],
       "text": "Chroma — Reveal the top ten cards of your library. For each blue mana symbol in the mana costs of the revealed cards, target opponent puts the top card of his or her library into his or her graveyard. Then put the cards you revealed this way on the bottom of your library in any order.",
@@ -3359,7 +3359,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If permanents you control become untapped during your untap step, Wake Thresher’s ability will trigger that many times. However, since no player gets priority during the untap step, those abilities wait to be put on the stack until your upkeep starts. At that time, all your “beginning of upkeep” triggers will also trigger. You can put them and Wake Thresher’s abilities on the stack in any order."
+          "text": "If permanents you control become untapped during your untap step, Wake Thresher's ability will trigger that many times. However, since no player gets priority during the untap step, those abilities wait to be put on the stack until your upkeep starts. At that time, all your \"beginning of upkeep\" triggers will also trigger. You can put them and Wake Thresher's abilities on the stack in any order."
         }
       ],
       "subtypes": [
@@ -3565,7 +3565,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "The target of the ability is chosen when Ashling’s ability is put on the stack. When the ability resolves, the player dealt combat damage by Ashling sacrifices that creature if he or she still controls it. Neither regeneration nor indestructibile can save a creature from being sacrificed."
+          "text": "The target of the ability is chosen when Ashling's ability is put on the stack. When the ability resolves, the player dealt combat damage by Ashling sacrifices that creature if he or she still controls it. Neither regeneration nor indestructibile can save a creature from being sacrificed."
         }
       ],
       "subtypes": [
@@ -3675,7 +3675,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the targeted card is removed from the graveyard before the ability resolves, the entire ability is countered. You won’t gain 1 life."
+          "text": "If the targeted card is removed from the graveyard before the ability resolves, the entire ability is countered. You won't gain 1 life."
         }
       ],
       "subtypes": [
@@ -3780,15 +3780,15 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This ability is mandatory. If you’re the only player who controls a creature with a -1/-1 counter on it as your upkeep begins, you must target one of your own creatures."
+          "text": "This ability is mandatory. If you're the only player who controls a creature with a -1/-1 counter on it as your upkeep begins, you must target one of your own creatures."
         },
         {
           "date": "2008-08-01",
-          "text": "You can’t target a creature unless it already has a -1/-1 counter on it as your upkeep begins. Putting a -1/-1 counter on a creature during your upkeep won’t let Crumbling Ashes destroy it that turn."
+          "text": "You can't target a creature unless it already has a -1/-1 counter on it as your upkeep begins. Putting a -1/-1 counter on a creature during your upkeep won't let Crumbling Ashes destroy it that turn."
         },
         {
           "date": "2008-08-01",
-          "text": "If the targeted creature loses all its -1/-1 counters by the time the ability resolves, the ability will be countered because its only target is illegal. The creature won’t be destroyed."
+          "text": "If the targeted creature loses all its -1/-1 counters by the time the ability resolves, the ability will be countered because its only target is illegal. The creature won't be destroyed."
         }
       ],
       "text": "At the beginning of your upkeep, destroy target creature with a -1/-1 counter on it.",
@@ -3897,23 +3897,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -4124,11 +4124,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "It doesn’t matter whose graveyard the creature is put into. It matters only that an opponent controlled it when it left the battlefield."
+          "text": "It doesn't matter whose graveyard the creature is put into. It matters only that an opponent controlled it when it left the battlefield."
         },
         {
           "date": "2008-08-01",
-          "text": "It doesn’t matter how many -1/-1 counters were on the creature when it was put into a graveyard from the battlefield, as long as it had at least one."
+          "text": "It doesn't matter how many -1/-1 counters were on the creature when it was put into a graveyard from the battlefield, as long as it had at least one."
         },
         {
           "date": "2008-08-01",
@@ -4434,7 +4434,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -4442,11 +4442,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Target player discards a card.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -4653,7 +4653,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A hybrid spell that’s black and another color is *not* a nonblack spell. Since it’s black, it can’t be nonblack!"
+          "text": "A hybrid spell that's black and another color is *not* a nonblack spell. Since it's black, it can't be nonblack!"
         }
       ],
       "subtypes": [
@@ -4757,15 +4757,15 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A hybrid creature that’s green and another color is *not* a nongreen creature. Since it’s green, it can’t be nongreen!"
+          "text": "A hybrid creature that's green and another color is *not* a nongreen creature. Since it's green, it can't be nongreen!"
         },
         {
           "date": "2008-08-01",
-          "text": "Soul Reap doesn’t check whether you’ve cast another black spell until Soul Reap resolves. If you cast Soul Reap, then cast a black instant in response, the creature’s controller will lose the life when Soul Reap resolves."
+          "text": "Soul Reap doesn't check whether you've cast another black spell until Soul Reap resolves. If you cast Soul Reap, then cast a black instant in response, the creature's controller will lose the life when Soul Reap resolves."
         },
         {
           "date": "2008-08-01",
-          "text": "Although Soul Reap says it looks for “another black spell,” there’s no requirement that Soul Reap actually be cast (or be black) for this part of its ability to work. For example, if a spell such as Commandeer causes you to gain control of Soul Reap, it’ll still check whether you cast a black spell this turn, even though you didn’t cast Soul Reap itself."
+          "text": "Although Soul Reap says it looks for \"another black spell,\" there's no requirement that Soul Reap actually be cast (or be black) for this part of its ability to work. For example, if a spell such as Commandeer causes you to gain control of Soul Reap, it'll still check whether you cast a black spell this turn, even though you didn't cast Soul Reap itself."
         }
       ],
       "text": "Destroy target nongreen creature. Its controller loses 3 life if you've cast another black spell this turn.",
@@ -4972,7 +4972,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -4980,11 +4980,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Target player loses 2 life and you gain 2 life.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -5084,7 +5084,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the creature card has “*” in its power or toughness, the ability that defines “*” works in all zones. Note that the card is in the opponent’s hand when Talara’s Bane checks its toughness."
+          "text": "If the creature card has \"*\" in its power or toughness, the ability that defines \"*\" works in all zones. Note that the card is in the opponent's hand when Talara's Bane checks its toughness."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose a green or white creature card from it. You gain life equal to that creature card's toughness, then that player discards that card.",
@@ -5185,11 +5185,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a characteristic-defining ability, which means it functions in all zones. You include the symbols in the Stalker’s own mana cost if you need to determine its power and/or toughness while it’s in the graveyard."
+          "text": "This is a characteristic-defining ability, which means it functions in all zones. You include the symbols in the Stalker's own mana cost if you need to determine its power and/or toughness while it's in the graveyard."
         },
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -5600,7 +5600,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -5705,7 +5705,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -5713,11 +5713,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Flame Jab deals 1 damage to target creature or player.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -5918,15 +5918,15 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-08-01",
-          "text": "The “summoning sickness” rule applies to {Q}. If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability. Ignore this rule if the creature also has haste."
+          "text": "The \"summoning sickness\" rule applies to {Q}. If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability. Ignore this rule if the creature also has haste."
         },
         {
           "date": "2008-08-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         },
         {
           "date": "2008-08-01",
@@ -6034,7 +6034,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -6148,11 +6148,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Hotheaded Giant doesn’t check whether you’ve cast another red spell until Hotheaded Giant enters the battlefield."
+          "text": "Hotheaded Giant doesn't check whether you've cast another red spell until Hotheaded Giant enters the battlefield."
         },
         {
           "date": "2008-08-01",
-          "text": "Although Hotheaded Giant says it looks for “another red spell,” there’s no requirement that Hotheaded Giant actually be cast as a spell (or be red) for this part of its ability to work. For example, if a spell such as Zombify puts Hotheaded Giant directly onto the battlefield, its ability will still check whether you’ve cast a red spell this turn even though you didn’t cast Hotheaded Giant itself as a spell."
+          "text": "Although Hotheaded Giant says it looks for \"another red spell,\" there's no requirement that Hotheaded Giant actually be cast as a spell (or be red) for this part of its ability to work. For example, if a spell such as Zombify puts Hotheaded Giant directly onto the battlefield, its ability will still check whether you've cast a red spell this turn even though you didn't cast Hotheaded Giant itself as a spell."
         }
       ],
       "subtypes": [
@@ -6257,7 +6257,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Since the activated ability doesn’t have a tap symbol in its cost, you can tap creatures that haven’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the activated ability doesn't have a tap symbol in its cost, you can tap creatures that haven't been under your control since your most recent turn began to pay the cost."
         },
         {
           "date": "2008-08-01",
@@ -6367,7 +6367,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -6579,11 +6579,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Rekindled Flame’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless one of your opponents already has no cards in hand as your upkeep begins, and (2) the ability will do nothing if each of your opponents manages to get a card in hand by the time it resolves."
+          "text": "Rekindled Flame's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless one of your opponents already has no cards in hand as your upkeep begins, and (2) the ability will do nothing if each of your opponents manages to get a card in hand by the time it resolves."
         },
         {
           "date": "2008-08-01",
-          "text": "You don’t specify an opponent; the ability will check all of them to see if at least one meets the condition. The opponent that meets the condition when the ability triggers and the one who meets the condition when it resolves can be different players."
+          "text": "You don't specify an opponent; the ability will check all of them to see if at least one meets the condition. The opponent that meets the condition when the ability triggers and the one who meets the condition when it resolves can be different players."
         }
       ],
       "text": "Rekindled Flame deals 4 damage to target creature or player.\nAt the beginning of your upkeep, if an opponent has no cards in hand, you may return Rekindled Flame from your graveyard to your hand.",
@@ -6684,11 +6684,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Once the last ability resolves, it will be in effect for the rest of the game. It doesn’t matter if Stigma Lasher remains on the battlefield or not."
+          "text": "Once the last ability resolves, it will be in effect for the rest of the game. It doesn't matter if Stigma Lasher remains on the battlefield or not."
         },
         {
           "date": "2008-08-01",
-          "text": "If a player has been dealt damage by Stigma Lasher, the following things are true: — Spells and abilities that would normally cause that player to gain life still resolve, but the life-gain part simply has no effect. — If a cost includes having that player gain life (like Invigorate’s alternative cost does), that cost can’t be paid. — Effects that would replace having that player gain life with some other effect won’t be able to do anything because it’s impossible for that player to gain life. — Effects that replace an event with having that player gain life (like Words of Worship’s effect does) will end up replacing the event with nothing. — If an effect says to set that player’s life total to a certain number, and that number is higher than the player’s current life total, that part of the effect won’t do anything. (If the number is lower than that player’s current life total, the effect will work as normal.)"
+          "text": "If a player has been dealt damage by Stigma Lasher, the following things are true: — Spells and abilities that would normally cause that player to gain life still resolve, but the life-gain part simply has no effect. — If a cost includes having that player gain life (like Invigorate's alternative cost does), that cost can't be paid. — Effects that would replace having that player gain life with some other effect won't be able to do anything because it's impossible for that player to gain life. — Effects that replace an event with having that player gain life (like Words of Worship's effect does) will end up replacing the event with nothing. — If an effect says to set that player's life total to a certain number, and that number is higher than the player's current life total, that part of the effect won't do anything. (If the number is lower than that player's current life total, the effect will work as normal.)"
         }
       ],
       "subtypes": [
@@ -6802,23 +6802,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -6922,7 +6922,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "You may target a creature you already control with Unwilling Recruit. If you do, you’ll gain control of that creature (which usually won’t have any visible effect), untap it, and it’ll get +X/+0 until end of turn."
+          "text": "You may target a creature you already control with Unwilling Recruit. If you do, you'll gain control of that creature (which usually won't have any visible effect), untap it, and it'll get +X/+0 until end of turn."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gets +X/+0 and gains haste until end of turn.",
@@ -7034,23 +7034,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -7155,15 +7155,15 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "For each color (white, blue, black, red, and green), check to see if you control a permanent of that color. You can count the same permanent for multiple colors. For example, if you control a green enchantment and a white-black creature, Bloom Tender’s ability produces {W}{B}{G}."
+          "text": "For each color (white, blue, black, red, and green), check to see if you control a permanent of that color. You can count the same permanent for multiple colors. For example, if you control a green enchantment and a white-black creature, Bloom Tender's ability produces {W}{B}{G}."
         },
         {
           "date": "2008-08-01",
-          "text": "Bloom Tender won’t add more than one mana of any particular color to your mana pool. At most, it will produce {W}{U}{B}{R}{G}."
+          "text": "Bloom Tender won't add more than one mana of any particular color to your mana pool. At most, it will produce {W}{U}{B}{R}{G}."
         },
         {
           "date": "2008-08-01",
-          "text": "Bloom Tender can’t add colorless mana to your mana pool, even if you control a colorless permanent."
+          "text": "Bloom Tender can't add colorless mana to your mana pool, even if you control a colorless permanent."
         }
       ],
       "subtypes": [
@@ -7369,7 +7369,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Helix Pinnacle’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless Helix Pinnacle already has 100 or more tower counters on it as your upkeep begins, and (2) the ability will do nothing if Helix Pinnacle has lost enough counters such that it has fewer than 100 counters on it when the ability resolves."
+          "text": "Helix Pinnacle's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless Helix Pinnacle already has 100 or more tower counters on it as your upkeep begins, and (2) the ability will do nothing if Helix Pinnacle has lost enough counters such that it has fewer than 100 counters on it when the ability resolves."
         },
         {
           "date": "2008-08-01",
@@ -7573,7 +7573,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -7581,11 +7581,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Target creature gets +4/+4 until end of turn.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -7790,7 +7790,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -7895,11 +7895,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This will count the number of symbols in its mana cost while it’s on the battlefield. The ability functions while it’s in other zones, but since it isn’t a permanent while in those zones it won’t count itself."
+          "text": "This will count the number of symbols in its mana cost while it's on the battlefield. The ability functions while it's in other zones, but since it isn't a permanent while in those zones it won't count itself."
         },
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -8113,7 +8113,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -8121,11 +8121,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Create a 3/3 green Beast creature token.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -8227,7 +8227,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "You can choose any color or combination of colors. You can’t choose colorless."
+          "text": "You can choose any color or combination of colors. You can't choose colorless."
         }
       ],
       "subtypes": [
@@ -8741,7 +8741,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn’t matter how much mana of that color was spent."
+          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn't matter how much mana of that color was spent."
         },
         {
           "date": "2008-08-01",
@@ -8856,11 +8856,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "Beckon Apparition will be on the stack when you choose its target. It can’t target itself."
+          "text": "Beckon Apparition will be on the stack when you choose its target. It can't target itself."
         },
         {
           "date": "2013-01-24",
-          "text": "If the target card is an illegal target when Beckon Apparition tries to resolve (if it’s no longer in the graveyard, for instance), the spell will be countered and none of its effects will happen. You won’t get a Spirit token."
+          "text": "If the target card is an illegal target when Beckon Apparition tries to resolve (if it's no longer in the graveyard, for instance), the spell will be countered and none of its effects will happen. You won't get a Spirit token."
         }
       ],
       "text": "Exile target card from a graveyard. Create a 1/1 white and black Spirit creature token with flying.",
@@ -9062,7 +9062,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If a nontoken creature that gains persist this way is put into a graveyard, that card will be returned to the battlefield with a -1/-1 counter on it. However, because it’s a new object with no relation to its previous existence, that permanent will not have persist."
+          "text": "If a nontoken creature that gains persist this way is put into a graveyard, that card will be returned to the battlefield with a -1/-1 counter on it. However, because it's a new object with no relation to its previous existence, that permanent will not have persist."
         },
         {
           "date": "2008-08-01",
@@ -9078,23 +9078,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "text": "Choose any number of target creatures. Each of those creatures gains persist until end of turn. (When it dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
@@ -9200,11 +9200,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s both white and black, the last two abilities will both trigger. You may use them together to destroy any creature. To do so, put the “destroy” ability on the stack first, then put the “tap” ability on the stack, with each one targeting the same creature. When the abilities resolve, they’ll tap the creature, then destroy it."
+          "text": "If you cast a spell that's both white and black, the last two abilities will both trigger. You may use them together to destroy any creature. To do so, put the \"destroy\" ability on the stack first, then put the \"tap\" ability on the stack, with each one targeting the same creature. When the abilities resolve, they'll tap the creature, then destroy it."
         },
         {
           "date": "2010-06-15",
-          "text": "The last ability can target any creature, not just a tapped creature (it doesn’t say “target tapped creature”). When the ability resolves, check whether the creature is tapped or not. If it’s tapped, you may destroy it. If it’s not tapped, the ability does nothing."
+          "text": "The last ability can target any creature, not just a tapped creature (it doesn't say \"target tapped creature\"). When the ability resolves, check whether the creature is tapped or not. If it's tapped, you may destroy it. If it's not tapped, the ability does nothing."
         }
       ],
       "subtypes": [
@@ -9519,19 +9519,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "You can activate Evershrike’s ability only while it’s in your graveyard."
+          "text": "You can activate Evershrike's ability only while it's in your graveyard."
         },
         {
           "date": "2008-08-01",
-          "text": "You can’t put an Aura onto the battlefield this way unless that Aura can legally be attached to Evershrike. For example, you can’t put an Aura card with “enchant player” onto the battlefield this way."
+          "text": "You can't put an Aura onto the battlefield this way unless that Aura can legally be attached to Evershrike. For example, you can't put an Aura card with \"enchant player\" onto the battlefield this way."
         },
         {
           "date": "2008-08-01",
-          "text": "You can activate Evershrike’s ability with X = 0. If you do, you’ll return Evershrike to the battlefield from your graveyard, then exile it. (There are no Aura cards with converted mana cost 0.)"
+          "text": "You can activate Evershrike's ability with X = 0. If you do, you'll return Evershrike to the battlefield from your graveyard, then exile it. (There are no Aura cards with converted mana cost 0.)"
         },
         {
           "date": "2008-08-01",
-          "text": "You can activate Evershrike’s ability even if you have no Auras in your hand, or if you have an Aura in your hand that you don’t want to put on it or can’t put on it. In either case, you’ll return Evershrike to the battlefield from your graveyard, then exile it. No player has the opportunity to cast spells or activate abilities while Evershrike is on the battlefield."
+          "text": "You can activate Evershrike's ability even if you have no Auras in your hand, or if you have an Aura in your hand that you don't want to put on it or can't put on it. In either case, you'll return Evershrike to the battlefield from your graveyard, then exile it. No player has the opportunity to cast spells or activate abilities while Evershrike is on the battlefield."
         }
       ],
       "subtypes": [
@@ -9640,7 +9640,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -9652,7 +9652,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -9861,11 +9861,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers whenever you cast a spell that’s both of its listed colors. It doesn’t matter whether that spell also happens to be any other colors."
+          "text": "The ability triggers whenever you cast a spell that's both of its listed colors. It doesn't matter whether that spell also happens to be any other colors."
         },
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
+          "text": "If you cast a spell that's the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
         },
         {
           "date": "2008-08-01",
@@ -9873,7 +9873,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -10080,7 +10080,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Pyrrhic Revival can cause creatures to be put onto the battlefield that have 0 toughness due to the -1/-1 counter from this effect. Those creatures are put right back into their owners’ graveyards as a state-based action. No spells or abilities that would remove counters or otherwise affect those creatures can be cast or activated before that happens. Still, the creatures did momentarily pop onto the battlefield, so any relevant triggered abilities (including their own enters-the-battlefield or leaves-the-battlefield abilities) will trigger. They’ll be put on the stack after state-based actions are checked."
+          "text": "Pyrrhic Revival can cause creatures to be put onto the battlefield that have 0 toughness due to the -1/-1 counter from this effect. Those creatures are put right back into their owners' graveyards as a state-based action. No spells or abilities that would remove counters or otherwise affect those creatures can be cast or activated before that happens. Still, the creatures did momentarily pop onto the battlefield, so any relevant triggered abilities (including their own enters-the-battlefield or leaves-the-battlefield abilities) will trigger. They'll be put on the stack after state-based actions are checked."
         }
       ],
       "text": "Each player returns each creature card from his or her graveyard to the battlefield with an additional -1/-1 counter on it.",
@@ -10191,23 +10191,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -10513,7 +10513,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s both of the listed colors, both abilities will trigger. You’ll remove a total of two -1/-1 counters from the Hatchling."
+          "text": "If you cast a spell that's both of the listed colors, both abilities will trigger. You'll remove a total of two -1/-1 counters from the Hatchling."
         },
         {
           "date": "2008-08-01",
@@ -10626,7 +10626,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -10634,11 +10634,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Create a 5/5 blue and red Elemental creature token with flying.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -10844,19 +10844,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-08-01",
-          "text": "The “summoning sickness” rule applies to {Q}. If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability. Ignore this rule if the creature also has haste."
+          "text": "The \"summoning sickness\" rule applies to {Q}. If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability. Ignore this rule if the creature also has haste."
         },
         {
           "date": "2008-08-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         },
         {
           "date": "2008-08-01",
-          "text": "To activate either ability, you’ll need Crackleburr plus two other creatures. Crackleburr must have been under your control since your most recent turn began (or have haste), but the other two creatures don’t."
+          "text": "To activate either ability, you'll need Crackleburr plus two other creatures. Crackleburr must have been under your control since your most recent turn began (or have haste), but the other two creatures don't."
         }
       ],
       "subtypes": [
@@ -10967,7 +10967,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -11075,7 +11075,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you already control the targeted permanent when the ability resolves, you still need to choose whether or not to apply the effect. If you choose to apply it, the permanent untaps and gains haste. If you don’t, it doesn’t."
+          "text": "If you already control the targeted permanent when the ability resolves, you still need to choose whether or not to apply the effect. If you choose to apply it, the permanent untaps and gains haste. If you don't, it doesn't."
         }
       ],
       "subtypes": [
@@ -11186,7 +11186,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "text": "Switch target creature's power and toughness until end of turn.\nDraw a card.",
@@ -11398,11 +11398,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "It doesn’t matter who controls the spell."
+          "text": "It doesn't matter who controls the spell."
         },
         {
           "date": "2008-08-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them."
         }
       ],
       "text": "{1}{U/R}{U/R}: Copy target instant or sorcery spell that targets you. You may choose new targets for the copy.",
@@ -11708,7 +11708,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -11720,7 +11720,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -12041,11 +12041,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers whenever you cast a spell that’s both of its listed colors. It doesn’t matter whether that spell also happens to be any other colors."
+          "text": "The ability triggers whenever you cast a spell that's both of its listed colors. It doesn't matter whether that spell also happens to be any other colors."
         },
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
+          "text": "If you cast a spell that's the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
         },
         {
           "date": "2008-08-01",
@@ -12053,7 +12053,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -12161,7 +12161,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s both of the listed colors, both abilities will trigger. You’ll remove a total of two -1/-1 counters from the Hatchling."
+          "text": "If you cast a spell that's both of the listed colors, both abilities will trigger. You'll remove a total of two -1/-1 counters from the Hatchling."
         },
         {
           "date": "2008-08-01",
@@ -12376,7 +12376,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn’t matter how much mana of that color was spent."
+          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn't matter how much mana of that color was spent."
         },
         {
           "date": "2008-08-01",
@@ -12384,11 +12384,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Unnerving Assault affects only creatures on the battlefield at the time it resolves. If a creature enters the battlefield later that turn, it won’t be affected."
+          "text": "Unnerving Assault affects only creatures on the battlefield at the time it resolves. If a creature enters the battlefield later that turn, it won't be affected."
         },
         {
           "date": "2008-08-01",
-          "text": "If a creature changes controllers later in the turn, that won’t change how Unnerving Assault affected it."
+          "text": "If a creature changes controllers later in the turn, that won't change how Unnerving Assault affected it."
         }
       ],
       "text": "Creatures your opponents control get -1/-0 until end of turn if {U} was spent to cast Unnerving Assault, and creatures you control get +1/+0 until end of turn if {R} was spent to cast it. (Do both if {U}{R} was spent.)",
@@ -12600,7 +12600,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn’t matter how much mana of that color was spent."
+          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn't matter how much mana of that color was spent."
         },
         {
           "date": "2008-08-01",
@@ -12822,15 +12822,15 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "You can pay {B/G} and remove a -1/-1 counter to activate the ability any time you want. Deity of Scars doesn’t need to be in danger of being destroyed."
+          "text": "You can pay {B/G} and remove a -1/-1 counter to activate the ability any time you want. Deity of Scars doesn't need to be in danger of being destroyed."
         },
         {
           "date": "2008-08-01",
-          "text": "Removing a -1/-1 counter from Deity of Scars is a cost of activating its activated ability. You can’t activate the ability if there are no -1/-1 counters on Deity of Scars."
+          "text": "Removing a -1/-1 counter from Deity of Scars is a cost of activating its activated ability. You can't activate the ability if there are no -1/-1 counters on Deity of Scars."
         },
         {
           "date": "2008-08-01",
-          "text": "Deity of Scars’s ability causes it to have more toughness when you activate the ability (as a result of losing a -1/-1 counter) and then puts a regeneration shield on it when the ability resolves. If you activate the ability in advance of Deity of Scars being dealt 5 damage, for example, Deity of Scars will be 6/6 before the damage is dealt to it. It won’t use the regeneration shield unless it’s dealt more damage that turn."
+          "text": "Deity of Scars's ability causes it to have more toughness when you activate the ability (as a result of losing a -1/-1 counter) and then puts a regeneration shield on it when the ability resolves. If you activate the ability in advance of Deity of Scars being dealt 5 damage, for example, Deity of Scars will be 6/6 before the damage is dealt to it. It won't use the regeneration shield unless it's dealt more damage that turn."
         }
       ],
       "subtypes": [
@@ -12939,11 +12939,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This ability doesn’t target a card. It will determine which card is returned to your hand as it resolves. If there’s a tie, you choose which of the tied cards to return to your hand at that time."
+          "text": "This ability doesn't target a card. It will determine which card is returned to your hand as it resolves. If there's a tie, you choose which of the tied cards to return to your hand at that time."
         },
         {
           "date": "2008-08-01",
-          "text": "If the creature card has “*” in its power or toughness, the ability that defines “*” works in all zones."
+          "text": "If the creature card has \"*\" in its power or toughness, the ability that defines \"*\" works in all zones."
         }
       ],
       "subtypes": [
@@ -13051,7 +13051,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you have no other creatures to sacrifice, you’ll have to sacrifice Doomgape itself. You’ll gain life equal to its toughness."
+          "text": "If you have no other creatures to sacrifice, you'll have to sacrifice Doomgape itself. You'll gain life equal to its toughness."
         }
       ],
       "subtypes": [
@@ -13357,7 +13357,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -13369,7 +13369,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -13476,7 +13476,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s both of the listed colors, both abilities will trigger. You’ll remove a total of two -1/-1 counters from the Hatchling."
+          "text": "If you cast a spell that's both of the listed colors, both abilities will trigger. You'll remove a total of two -1/-1 counters from the Hatchling."
         },
         {
           "date": "2008-08-01",
@@ -13796,23 +13796,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -13923,7 +13923,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If a creature card has “*” in its power or toughness, the ability that defines “*” works in all zones. Note that the card is in your library when Sapling of Colfenor’s ability checks the card’s power and toughness."
+          "text": "If a creature card has \"*\" in its power or toughness, the ability that defines \"*\" works in all zones. Note that the card is in your library when Sapling of Colfenor's ability checks the card's power and toughness."
         },
         {
           "date": "2008-08-01",
@@ -13931,7 +13931,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause Sapling of Colfenor to be put into the graveyard. However, Sapling of Colfenor could be put into the graveyard if its toughness becomes 0 or less, if it’s sacrificed, or if you control another Sapling of Colfenor (due to the “legend rule”)."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause Sapling of Colfenor to be put into the graveyard. However, Sapling of Colfenor could be put into the graveyard if its toughness becomes 0 or less, if it's sacrificed, or if you control another Sapling of Colfenor (due to the \"legend rule\")."
         }
       ],
       "subtypes": [
@@ -14143,11 +14143,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers whenever you cast a spell that’s both of its listed colors. It doesn’t matter whether that spell also happens to be any other colors."
+          "text": "The ability triggers whenever you cast a spell that's both of its listed colors. It doesn't matter whether that spell also happens to be any other colors."
         },
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
+          "text": "If you cast a spell that's the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
         },
         {
           "date": "2008-08-01",
@@ -14155,7 +14155,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -14262,7 +14262,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -14270,11 +14270,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         },
         {
           "date": "2008-08-01",
@@ -14490,11 +14490,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers whenever you cast a spell that’s both of its listed colors. It doesn’t matter whether that spell also happens to be any other colors."
+          "text": "The ability triggers whenever you cast a spell that's both of its listed colors. It doesn't matter whether that spell also happens to be any other colors."
         },
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
+          "text": "If you cast a spell that's the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
         },
         {
           "date": "2008-08-01",
@@ -14502,7 +14502,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -14608,7 +14608,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s both of the listed colors, both abilities will trigger. You’ll remove a total of two -1/-1 counters from the Hatchling."
+          "text": "If you cast a spell that's both of the listed colors, both abilities will trigger. You'll remove a total of two -1/-1 counters from the Hatchling."
         },
         {
           "date": "2008-08-01",
@@ -14921,7 +14921,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -14933,7 +14933,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -15041,19 +15041,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-08-01",
-          "text": "The “summoning sickness” rule applies to {Q}. If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability. Ignore this rule if the creature also has haste."
+          "text": "The \"summoning sickness\" rule applies to {Q}. If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability. Ignore this rule if the creature also has haste."
         },
         {
           "date": "2008-08-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         },
         {
           "date": "2008-08-01",
-          "text": "This ability affects only creatures that are attacking at the time it resolves. It won’t affect creatures that attack later in the turn."
+          "text": "This ability affects only creatures that are attacking at the time it resolves. It won't affect creatures that attack later in the turn."
         }
       ],
       "subtypes": [
@@ -15168,19 +15168,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Figure of Destiny’s abilities overwrite its power, toughness, and creature types. Typically, those abilities are activated in the order they appear on the card. However, if Figure of Destiny is an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike, and you activate its first ability, it will become a 2/2 Kithkin Spirit that still has flying and first strike."
+          "text": "Figure of Destiny's abilities overwrite its power, toughness, and creature types. Typically, those abilities are activated in the order they appear on the card. However, if Figure of Destiny is an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike, and you activate its first ability, it will become a 2/2 Kithkin Spirit that still has flying and first strike."
         },
         {
           "date": "2008-08-01",
-          "text": "You can activate Figure of Destiny’s second and third abilities regardless of what creature types it is. Each of those abilities checks Figure of Destiny’s creature types when that ability resolves. If Figure of Destiny isn’t the appropriate creature type at that time, the ability does nothing."
+          "text": "You can activate Figure of Destiny's second and third abilities regardless of what creature types it is. Each of those abilities checks Figure of Destiny's creature types when that ability resolves. If Figure of Destiny isn't the appropriate creature type at that time, the ability does nothing."
         },
         {
           "date": "2008-08-01",
-          "text": "Figure of Destiny’s second ability checks whether it’s a Spirit, and its third ability checks whether it’s a Warrior. It doesn’t matter how it became the appropriate creature type."
+          "text": "Figure of Destiny's second ability checks whether it's a Spirit, and its third ability checks whether it's a Warrior. It doesn't matter how it became the appropriate creature type."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -15605,7 +15605,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn’t matter how much mana of that color was spent."
+          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn't matter how much mana of that color was spent."
         },
         {
           "date": "2008-08-01",
@@ -15617,7 +15617,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Moonhold doesn’t stop effects that “put a card onto the battlefield.”"
+          "text": "Moonhold doesn't stop effects that \"put a card onto the battlefield.\""
         }
       ],
       "text": "Target player can't play lands this turn if {R} was spent to cast Moonhold and can't cast creature spells this turn if {W} was spent to cast it. (Do both if {R}{W} was spent.)",
@@ -15722,7 +15722,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a static ability. Attacking creatures you control will get +2/+0 from the moment they’re declared as attackers (or enter the battlefield attacking) until the moment the combat phase ends, they’re removed from combat, or Nobilis of War leaves the battlefield, whichever comes first."
+          "text": "This is a static ability. Attacking creatures you control will get +2/+0 from the moment they're declared as attackers (or enter the battlefield attacking) until the moment the combat phase ends, they're removed from combat, or Nobilis of War leaves the battlefield, whichever comes first."
         }
       ],
       "subtypes": [
@@ -16045,7 +16045,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Even if the amount of damage dealt to Spitemare is enough to destroy it, Spitemare’s ability will trigger and it will deal the full amount of damage to the target."
+          "text": "Even if the amount of damage dealt to Spitemare is enough to destroy it, Spitemare's ability will trigger and it will deal the full amount of damage to the target."
         }
       ],
       "subtypes": [
@@ -16150,7 +16150,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -16158,11 +16158,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         },
         {
           "date": "2008-08-01",
@@ -16170,7 +16170,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If it’s somehow not a main phase when Waves of Aggression resolves, all it does is untap all creatures that attacked that turn. No new phases are created."
+          "text": "If it's somehow not a main phase when Waves of Aggression resolves, all it does is untap all creatures that attacked that turn. No new phases are created."
         }
       ],
       "text": "Untap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -16578,19 +16578,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-08-01",
-          "text": "The “summoning sickness” rule applies to {Q}. If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability. Ignore this rule if the creature also has haste."
+          "text": "The \"summoning sickness\" rule applies to {Q}. If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability. Ignore this rule if the creature also has haste."
         },
         {
           "date": "2008-08-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         },
         {
           "date": "2008-08-01",
-          "text": "Gilder Bairn’s ability will replicate each kind of counter on the targeted permanent, not just +1/+1 or -1/-1 counters."
+          "text": "Gilder Bairn's ability will replicate each kind of counter on the targeted permanent, not just +1/+1 or -1/-1 counters."
         }
       ],
       "subtypes": [
@@ -16704,23 +16704,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -16827,7 +16827,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "It matters that an opponent controls a creature with flying only as you activate this ability. Once you’ve activated it, Groundling Pouncer will still get +1/+3 and gain flying, even if all of your opponents’ creatures with flying leave the battlefield in response to the ability or after the ability resolves."
+          "text": "It matters that an opponent controls a creature with flying only as you activate this ability. Once you've activated it, Groundling Pouncer will still get +1/+3 and gain flying, even if all of your opponents' creatures with flying leave the battlefield in response to the ability or after the ability resolves."
         }
       ],
       "subtypes": [
@@ -16936,7 +16936,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn’t matter how much mana of that color was spent."
+          "text": "The spell checks on resolution to see if any mana of the stated colors was spent to pay its cost. If so, it doesn't matter how much mana of that color was spent."
         },
         {
           "date": "2008-08-01",
@@ -16944,11 +16944,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Invert the Skies affects only creatures on the battlefield at the time it resolves. If a creature enters the battlefield later that turn, it won’t be affected."
+          "text": "Invert the Skies affects only creatures on the battlefield at the time it resolves. If a creature enters the battlefield later that turn, it won't be affected."
         },
         {
           "date": "2008-08-01",
-          "text": "If a creature changes controllers later in the turn, that won’t change how Invert the Skies affected it."
+          "text": "If a creature changes controllers later in the turn, that won't change how Invert the Skies affected it."
         }
       ],
       "text": "Creatures your opponents control lose flying until end of turn if {G} was spent to cast Invert the Skies, and creatures you control gain flying until end of turn if {U} was spent to cast it. (Do both if {G}{U} was spent.)",
@@ -17056,15 +17056,15 @@
         },
         {
           "date": "2008-08-01",
-          "text": "All your green and/or blue creatures untap during each other player’s untap step. You have no choice about what untaps. Those creatures untap at the same time as the active player’s permanents."
+          "text": "All your green and/or blue creatures untap during each other player's untap step. You have no choice about what untaps. Those creatures untap at the same time as the active player's permanents."
         },
         {
           "date": "2008-08-01",
-          "text": "During each other player’s untap step, effects that would otherwise cause your green and/or blue creatures to stay tapped don’t apply because they only apply during *your* untap step. For example, if you control Nettle Sentinel (a green creature that says “Nettle Sentinel doesn’t untap during your untap step”), you untap it during each other player’s untap step."
+          "text": "During each other player's untap step, effects that would otherwise cause your green and/or blue creatures to stay tapped don't apply because they only apply during *your* untap step. For example, if you control Nettle Sentinel (a green creature that says \"Nettle Sentinel doesn't untap during your untap step\"), you untap it during each other player's untap step."
         },
         {
           "date": "2008-08-01",
-          "text": "Multiple Murkfiend Lieges are redundant when it comes to the untap effect. You can’t untap your permanents more than once in a single untap step."
+          "text": "Multiple Murkfiend Lieges are redundant when it comes to the untap effect. You can't untap your permanents more than once in a single untap step."
         }
       ],
       "subtypes": [
@@ -17274,7 +17274,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -17286,7 +17286,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -17394,11 +17394,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers whenever you cast a spell that’s both of its listed colors. It doesn’t matter whether that spell also happens to be any other colors."
+          "text": "The ability triggers whenever you cast a spell that's both of its listed colors. It doesn't matter whether that spell also happens to be any other colors."
         },
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
+          "text": "If you cast a spell that's the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
         },
         {
           "date": "2008-08-01",
@@ -17406,7 +17406,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -17614,7 +17614,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Snakeform doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering."
+          "text": "Snakeform doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering."
         },
         {
           "date": "2008-08-01",
@@ -17626,7 +17626,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The power/toughness-setting effect overwrites other effects that set power and toughness only if those effects existed before this spell resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after this spell resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The power/toughness-setting effect overwrites other effects that set power and toughness only if those effects existed before this spell resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after this spell resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "text": "Until end of turn, target creature loses all abilities and becomes a green Snake with base power and toughness 1/1.\nDraw a card.",
@@ -17729,7 +17729,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -17737,15 +17737,15 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         },
         {
           "date": "2008-08-01",
-          "text": "As the token is created, it checks the printed values of the creature it’s copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "As the token is created, it checks the printed values of the creature it's copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, or so on."
         }
       ],
       "text": "Create a token that's a copy of target creature.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -17847,7 +17847,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s both of the listed colors, both abilities will trigger. You’ll remove a total of two -1/-1 counters from the Hatchling."
+          "text": "If you cast a spell that's both of the listed colors, both abilities will trigger. You'll remove a total of two -1/-1 counters from the Hatchling."
         },
         {
           "date": "2008-08-01",
@@ -17966,23 +17966,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -18277,7 +18277,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If a nontoken creature that gains persist this way is put into a graveyard, that card will be returned to the battlefield with a -1/-1 counter on it. However, because it’s a new object with no relation to its previous existence, that permanent will not have persist."
+          "text": "If a nontoken creature that gains persist this way is put into a graveyard, that card will be returned to the battlefield with a -1/-1 counter on it. However, because it's a new object with no relation to its previous existence, that permanent will not have persist."
         },
         {
           "date": "2008-08-01",
@@ -18293,23 +18293,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -18975,7 +18975,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Spelling this out completely: — Each opponent who controls more creatures than you can’t play creature cards. — Each opponent who controls more artifacts than you can’t play artifact cards. — Each opponent who controls more enchantments than you can’t play enchantment cards. — Each opponent who controls more lands than you can’t play land cards."
+          "text": "Spelling this out completely: — Each opponent who controls more creatures than you can't play creature cards. — Each opponent who controls more artifacts than you can't play artifact cards. — Each opponent who controls more enchantments than you can't play enchantment cards. — Each opponent who controls more lands than you can't play land cards."
         }
       ],
       "text": "Each opponent who controls more creatures than you can't cast creature spells. The same is true for artifacts and enchantments.\nEach opponent who controls more lands than you can't play lands.",
@@ -19431,11 +19431,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Springjack Pasture’s last ability is a mana ability. The whole ability — including the life gain — doesn’t use the stack and therefore can’t be responded to."
+          "text": "Springjack Pasture's last ability is a mana ability. The whole ability — including the life gain — doesn't use the stack and therefore can't be responded to."
         },
         {
           "date": "2008-08-01",
-          "text": "If you sacrifice no Goats, you’ll add no mana to your mana pool and you’ll gain no life."
+          "text": "If you sacrifice no Goats, you'll add no mana to your mana pool and you'll gain no life."
         },
         {
           "date": "2008-08-01",

--- a/json/EVG.json
+++ b/json/EVG.json
@@ -55,7 +55,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -120,19 +120,19 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Paying the alternative cost doesn’t change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
+          "text": "Paying the alternative cost doesn't change when you can cast the spell. A creature spell you cast this way, for example, can still only be cast during your main phase while the stack is empty."
         },
         {
           "date": "2006-07-15",
-          "text": "You may pay the alternative cost rather than the card’s mana cost. Any additional costs are paid as normal."
+          "text": "You may pay the alternative cost rather than the card's mana cost. Any additional costs are paid as normal."
         },
         {
           "date": "2006-07-15",
-          "text": "If you don’t have two cards of the right color in your hand, you can’t choose to cast the spell using the alternative cost."
+          "text": "If you don't have two cards of the right color in your hand, you can't choose to cast the spell using the alternative cost."
         },
         {
           "date": "2006-07-15",
-          "text": "You can’t exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
+          "text": "You can't exile a card from your hand to pay for itself. At the time you would pay costs, that card is on the stack, not in your hand."
         }
       ],
       "subtypes": [
@@ -392,11 +392,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -665,7 +665,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Lys Alana Huntmaster’s ability will resolve before the Elf spell that caused it to trigger."
+          "text": "Lys Alana Huntmaster's ability will resolve before the Elf spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -845,7 +845,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf’s ability resolves. If Timberwatch Elf is still on the battlefield, it’ll count itself."
+          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf's ability resolves. If Timberwatch Elf is still on the battlefield, it'll count itself."
         }
       ],
       "subtypes": [
@@ -1153,7 +1153,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -2770,11 +2770,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander’s activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
+          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander's activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
         },
         {
           "date": "2016-06-08",
-          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -3073,7 +3073,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The target of the ability can’t be a creature with Protection from Creatures, with Protection from Goblins, or with Protection from Red."
+          "text": "The target of the ability can't be a creature with Protection from Creatures, with Protection from Goblins, or with Protection from Red."
         },
         {
           "date": "2008-10-01",
@@ -3085,11 +3085,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -3214,11 +3214,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type “Summon Goblin” and “Summon Goblins” also count. You can’t search for cards that have Goblin in the name but don’t have the creature type Goblin."
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
         }
       ],
       "subtypes": [
@@ -3296,7 +3296,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Let's play ‘sled.' Here's how it works: you're the sled.\"",
+      "flavor": "\"Let's play 'sled.' Here's how it works: you're the sled.\"",
       "id": "ad4edb282de70e13ebc6e29c38d0046c416843fa",
       "imageName": "goblin sledder",
       "layout": "normal",
@@ -3453,7 +3453,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If you don’t actually sacrifice the Goblin (because it was removed from the battlefield before the ability resolved, for example), no damage is dealt."
+          "text": "If you don't actually sacrifice the Goblin (because it was removed from the battlefield before the ability resolved, for example), no damage is dealt."
         }
       ],
       "subtypes": [
@@ -3529,7 +3529,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it’s too late to activate its ability before it’s destroyed."
+          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it's too late to activate its ability before it's destroyed."
         }
       ],
       "subtypes": [

--- a/json/EXO.json
+++ b/json/EXO.json
@@ -203,7 +203,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Each permanent not chosen by a player will be sacrificed. If a permanent has none of the listed types (for example, a Planeswalker with no other types), it can’t be chosen."
+          "text": "Each permanent not chosen by a player will be sacrificed. If a permanent has none of the listed types (for example, a Planeswalker with no other types), it can't be chosen."
         }
       ],
       "text": "Each player chooses from among the permanents he or she controls an artifact, a creature, an enchantment, and a land, then sacrifices the rest.",
@@ -436,11 +436,11 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "High Ground’s effect is cumulative. If you have a creature that can already block an additional creature, now it can block three creatures."
+          "text": "High Ground's effect is cumulative. If you have a creature that can already block an additional creature, now it can block three creatures."
         },
         {
           "date": "2007-07-15",
-          "text": "High Ground allows you to make some complicated blocks. For example, if you’re being attacked by three creatures (call them A, B, and C) and you control three creatures (X, Y, and Z), you can have X block A and B, Y block B and C, and Z block just C, among many other possible options. The defending player chooses how each blocking creature’s combat damage will be divided among the creatures it’s blocking."
+          "text": "High Ground allows you to make some complicated blocks. For example, if you're being attacked by three creatures (call them A, B, and C) and you control three creatures (X, Y, and Z), you can have X block A and B, Y block B and C, and Z block just C, among many other possible options. The defending player chooses how each blocking creature's combat damage will be divided among the creatures it's blocking."
         }
       ],
       "text": "Each creature you control can block an additional creature each combat.",
@@ -614,7 +614,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can put lands onto the battlefield using effects, you just can’t play lands from your hand as an action."
+          "text": "You can put lands onto the battlefield using effects, you just can't play lands from your hand as an action."
         }
       ],
       "text": "When Limited Resources enters the battlefield, each player chooses five lands he or she controls and sacrifices the rest.\nPlayers can't play lands as long as ten or more lands are on the battlefield.",
@@ -667,11 +667,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land card enters the battlefield under the current player’s control."
+          "text": "The land card enters the battlefield under the current player's control."
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -683,7 +683,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted player controlling more lands than the current player is a part of the targeting requirement. A player can’t be targeted by this ability unless it’s true, and the ability will be countered on resolution if it’s no longer true at that time."
+          "text": "The targeted player controlling more lands than the current player is a part of the targeting requirement. A player can't be targeted by this ability unless it's true, and the ability will be countered on resolution if it's no longer true at that time."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player chooses target player who controls more lands than he or she does and is his or her opponent. The first player may search his or her library for a basic land card, put that card onto the battlefield, then shuffle his or her library.",
@@ -1253,7 +1253,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other’s ability to trigger."
+          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other's ability to trigger."
         },
         {
           "date": "2005-08-01",
@@ -1721,7 +1721,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If put on your opponent’s creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
+          "text": "If put on your opponent's creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
         },
         {
           "date": "2007-02-01",
@@ -1729,7 +1729,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "“You” refers to the controller of Curiosity, which may be different from the controller of the enchanted creature. “An opponent” refers to an opponent of Curiosity’s controller."
+          "text": "\"You\" refers to the controller of Curiosity, which may be different from the controller of the enchanted creature. \"An opponent\" refers to an opponent of Curiosity's controller."
         },
         {
           "date": "2011-09-22",
@@ -1737,7 +1737,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Curiosity doesn’t trigger if the enchanted creature deals damage to a planeswalker controlled by an opponent."
+          "text": "Curiosity doesn't trigger if the enchanted creature deals damage to a planeswalker controlled by an opponent."
         }
       ],
       "subtypes": [
@@ -1799,11 +1799,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -1917,11 +1917,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         },
         {
           "date": "2008-08-01",
-          "text": "The ability is put on the stack immediately after you cast a creature spell, which means the creature that spell will become won’t be a legal target."
+          "text": "The ability is put on the stack immediately after you cast a creature spell, which means the creature that spell will become won't be a legal target."
         },
         {
           "date": "2008-08-01",
@@ -2043,7 +2043,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "At the beginning of the resolution, each player counts up the number of creatures they control, then they make the required number of payments and/or sacrifices. The active player announces their choices first followed by the other players, but all the sacrifices are done at the same time. Because of this, you can’t sacrifice one creature in order to pay for another and thereby avoid payment for the first."
+          "text": "At the beginning of the resolution, each player counts up the number of creatures they control, then they make the required number of payments and/or sacrifices. The active player announces their choices first followed by the other players, but all the sacrifices are done at the same time. Because of this, you can't sacrifice one creature in order to pay for another and thereby avoid payment for the first."
         },
         {
           "date": "2004-10-04",
@@ -2100,7 +2100,8 @@
       "printings": [
         "EXO",
         "pFNM",
-        "TPR"
+        "TPR",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Buyback—Discard two cards. (You may discard two cards in addition to any other costs as you cast this spell. If you do, put this card into your hand as it resolves.)\nCounter target spell.",
@@ -2274,7 +2275,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability itself is controlled by Mana Breach’s controller."
+          "text": "The ability itself is controlled by Mana Breach's controller."
         },
         {
           "date": "2004-10-04",
@@ -2451,7 +2452,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Triggers on any spell or ability being announced which targets this card. This means it returns to owner’s hand before that spell resolves."
+          "text": "Triggers on any spell or ability being announced which targets this card. This means it returns to owner's hand before that spell resolves."
         }
       ],
       "subtypes": [
@@ -2512,7 +2513,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted player having more cards in his or her hand than the current player is a part of the targeting requirement. A player can’t be targeted by this ability unless it’s true, and the ability will be countered on resolution if it’s no longer true at that time."
+          "text": "The targeted player having more cards in his or her hand than the current player is a part of the targeting requirement. A player can't be targeted by this ability unless it's true, and the ability will be countered on resolution if it's no longer true at that time."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player chooses target player who has more cards in hand than he or she does and is his or her opponent. The first player may discard his or her hand and draw three cards.",
@@ -3237,7 +3238,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You sacrifice a creature when casting the spell and you can’t sacrifice more than one creature to get extra mana."
+          "text": "You sacrifice a creature when casting the spell and you can't sacrifice more than one creature to get extra mana."
         },
         {
           "date": "2013-04-15",
@@ -4043,7 +4044,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted player’s graveyard having fewer creature cards in it than the current player’s is a part of the targeting requirement. A player can’t be targeted by this ability unless it’s true, and the ability will be countered on resolution if it’s no longer true at that time."
+          "text": "The targeted player's graveyard having fewer creature cards in it than the current player's is a part of the targeting requirement. A player can't be targeted by this ability unless it's true, and the ability will be countered on resolution if it's no longer true at that time."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player chooses target player whose graveyard has fewer creature cards in it than his or her graveyard does and is his or her opponent. The first player may return a creature card from his or her graveyard to his or her hand.",
@@ -4211,7 +4212,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "text": "Sacrifice a creature, Return Recurring Nightmare to its owner's hand: Return target creature card from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery.",
@@ -4312,7 +4313,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay the buyback if you have less than 4 life, even if an effect would keep you from losing for having 0 or less life."
+          "text": "You can't pay the buyback if you have less than 4 life, even if an effect would keep you from losing for having 0 or less life."
         }
       ],
       "text": "Buyback—Pay 4 life. (You may pay 4 life in addition to any other costs as you cast this spell. If you do, put this card into your hand as it resolves.)\nDestroy target nonblack creature. It can't be regenerated.",
@@ -4703,7 +4704,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Dizzying Gaze can’t be cast targeting an opponent’s creature. And this card is put into the graveyard if ever on a creature you do not control."
+          "text": "Dizzying Gaze can't be cast targeting an opponent's creature. And this card is put into the graveyard if ever on a creature you do not control."
         }
       ],
       "subtypes": [
@@ -4807,7 +4808,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay the Buyback cost unless you have at least one card in your hand to discard."
+          "text": "You can't pay the Buyback cost unless you have at least one card in your hand to discard."
         }
       ],
       "text": "Buyback—Pay 3 life, Discard a card at random. (You may pay 3 life and discard a card at random in addition to any other costs as you cast this spell. If you do, put this card into your hand as it resolves.)\nDestroy target land.",
@@ -4980,7 +4981,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You must discard a card as part of the activation cost. You can’t announce the ability unless you have a card in hand."
+          "text": "You must discard a card as part of the activation cost. You can't announce the ability unless you have a card in hand."
         }
       ],
       "subtypes": [
@@ -5222,7 +5223,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted player having more life than the current player is a part of the targeting requirement. A player can’t be targeted by this ability unless it’s true, and the ability will be countered on resolution if it’s no longer true at that time."
+          "text": "The targeted player having more life than the current player is a part of the targeting requirement. A player can't be targeted by this ability unless it's true, and the ability will be countered on resolution if it's no longer true at that time."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player chooses target player who has more life than he or she does and is his or her opponent. The first player may have Oath of Mages deal 1 damage to the second player.",
@@ -5339,7 +5340,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Whenever you cast a creature spell, tap target creature.",
@@ -5403,11 +5404,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The triggered ability does not check the creature’s power until the ability resolves. If the creature is not on the battlefield when the ability resolves, it does damage equal to the power of the creature right before it left the battlefield. This means that if a creature enters the battlefield which can destroy itself as a “enters the battlefield” ability, the order of resolution of the triggered abilities does not matter."
+          "text": "The triggered ability does not check the creature's power until the ability resolves. If the creature is not on the battlefield when the ability resolves, it does damage equal to the power of the creature right before it left the battlefield. This means that if a creature enters the battlefield which can destroy itself as a \"enters the battlefield\" ability, the order of resolution of the triggered abilities does not matter."
         },
         {
           "date": "2006-09-25",
-          "text": "If player A controls Pandemonium when a creature enters the battlefield under player B’s control, player A controls the triggered ability even though player B chooses the target and chooses whether to have the creature deal damage, which could be important if multiple abilities controlled by multiple players trigger."
+          "text": "If player A controls Pandemonium when a creature enters the battlefield under player B's control, player A controls the triggered ability even though player B chooses the target and chooses whether to have the creature deal damage, which could be important if multiple abilities controlled by multiple players trigger."
         }
       ],
       "text": "Whenever a creature enters the battlefield, that creature's controller may have it deal damage equal to its power to target creature or player of his or her choice.",
@@ -5970,7 +5971,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t discard more than once to target more than one creature (or player) or to do multiple amounts of damage to a single creature (or player)."
+          "text": "You can't discard more than once to target more than one creature (or player) or to do multiple amounts of damage to a single creature (or player)."
         },
         {
           "date": "2004-10-04",
@@ -6683,7 +6684,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can’t be targeted by this ability unless it’s true, and the ability will be countered on resolution if it’s no longer true at that time."
+          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can't be targeted by this ability unless it's true, and the ability will be countered on resolution if it's no longer true at that time."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player chooses target player who controls more creatures than he or she does and is his or her opponent. The first player may reveal cards from the top of his or her library until he or she reveals a creature card. If he or she does, that player puts that card onto the battlefield and all other cards revealed this way into his or her graveyard.",
@@ -6739,7 +6740,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -6797,7 +6798,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -6818,7 +6819,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"Who you callin' ‘shorty'?\"",
+      "flavor": "\"Who you callin' 'shorty'?\"",
       "id": "2002ffb9548e4c249123b0e4529c4faf65b6701f",
       "imageName": "pygmy troll",
       "layout": "normal",
@@ -7450,7 +7451,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "{G}, Discard a creature card: Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -7521,7 +7522,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -7595,7 +7596,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Coat of Arms counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Coat of Arms counts creatures, not creature types."
         }
       ],
       "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
@@ -7728,7 +7729,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t reduce the cost below zero."
+          "text": "Can't reduce the cost below zero."
         },
         {
           "date": "2004-10-04",
@@ -7850,7 +7851,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "{2}, {T}, Discard your hand: Counter target noncreature spell.",
@@ -7950,7 +7951,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.",
@@ -8105,11 +8106,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         },
         {
           "date": "2013-09-20",

--- a/json/EXP.json
+++ b/json/EXP.json
@@ -58,11 +58,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -129,11 +129,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -200,11 +200,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -271,11 +271,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -342,11 +342,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Even though these lands have basic land types, they are not basic lands because “basic” doesn’t appear on their type line. Notably, controlling two or more of them won’t allow others to enter the battlefield untapped."
+          "text": "Even though these lands have basic land types, they are not basic lands because \"basic\" doesn't appear on their type line. Notably, controlling two or more of them won't allow others to enter the battlefield untapped."
         },
         {
           "date": "2015-08-25",
-          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads “Destroy target Forest” can target Canopy Vista, while one that reads “Destroy target basic Forest” cannot."
+          "text": "However, because these cards have basic land types, effects that specify a basic land type without also specifying that the land be basic can affect them. For example, a spell or ability that reads \"Destroy target Forest\" can target Canopy Vista, while one that reads \"Destroy target basic Forest\" cannot."
         },
         {
           "date": "2015-08-25",
@@ -413,15 +413,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -484,15 +484,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -555,15 +555,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -626,15 +626,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -697,15 +697,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -768,15 +768,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -839,15 +839,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -910,15 +910,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -981,15 +981,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -1052,15 +1052,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -1694,7 +1694,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "{B/R}, {T}” is the same as saying “{B}, {T} or {R}, {T}."
+          "text": "{B/R}, {T}\" is the same as saying \"{B}, {T} or {R}, {T}."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{B/R}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
@@ -2163,11 +2163,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Eye of Ugin doesn’t have a mana ability."
+          "text": "Eye of Ugin doesn't have a mana ability."
         },
         {
           "date": "2010-03-01",
-          "text": "Eye of Ugin’s second ability lets you find any colorless creature card in your deck, such as an artifact creature card that has no colored mana symbols in its mana cost, or a creature card that’s become colorless due to Mycosynth Lattice."
+          "text": "Eye of Ugin's second ability lets you find any colorless creature card in your deck, such as an artifact creature card that has no colored mana symbols in its mana cost, or a creature card that's become colorless due to Mycosynth Lattice."
         },
         {
           "date": "2013-04-15",
@@ -2451,11 +2451,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Tectonic Edge’s second ability checks how many lands an opponent controls only at the time you activate the ability."
+          "text": "Tectonic Edge's second ability checks how many lands an opponent controls only at the time you activate the ability."
         },
         {
           "date": "2010-03-01",
-          "text": "Assuming you can activate Tectonic Edge’s second ability, you can target any nonbasic land with it (not just one controlled by an opponent that controls four or more lands)."
+          "text": "Assuming you can activate Tectonic Edge's second ability, you can target any nonbasic land with it (not just one controlled by an opponent that controls four or more lands)."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}, {T}, Sacrifice Tectonic Edge: Destroy target nonbasic land. Activate this ability only if an opponent controls four or more lands.",

--- a/json/FEM.json
+++ b/json/FEM.json
@@ -555,7 +555,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -1108,7 +1108,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You draw two cards, then put one back as part of the same effect. You can’t do anything in between. Anything that triggers off of card drawing will wait until you finish resolving this ability before going on the stack."
+          "text": "You draw two cards, then put one back as part of the same effect. You can't do anything in between. Anything that triggers off of card drawing will wait until you finish resolving this ability before going on the stack."
         }
       ],
       "text": "{1}, {T}, Sacrifice Conch Horn: Draw two cards, then put a card from your hand on top of your library.",
@@ -1199,7 +1199,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you use the ability after blockers are declared, it won’t trigger at all. So you want to use it before blockers are declared."
+          "text": "If you use the ability after blockers are declared, it won't trigger at all. So you want to use it before blockers are declared."
         },
         {
           "date": "2004-10-04",
@@ -1207,7 +1207,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "text": "{T}, Sacrifice Delif's Cone: This turn, when target creature you control attacks and isn't blocked, you may gain life equal to its power. If you do, it assigns no combat damage this turn.",
@@ -1250,7 +1250,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you use the ability after blockers are declared, it won’t trigger at all. So you want to use it before blockers are declared."
+          "text": "If you use the ability after blockers are declared, it won't trigger at all. So you want to use it before blockers are declared."
         },
         {
           "date": "2004-10-04",
@@ -1258,7 +1258,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "text": "{2}, {T}: This turn, when target creature you control attacks and isn't blocked, it assigns no combat damage this turn and you put a cube counter on Delif's Cube.\n{2}, Remove a cube counter from Delif's Cube: Regenerate target creature.",
@@ -1505,7 +1505,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -2191,15 +2191,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target any creature with this ability. It doesn’t have to be tapped."
+          "text": "You may target any creature with this ability. It doesn't have to be tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "If the targeted creature is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when the targeted creature is tapped."
+          "text": "If the targeted creature is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when the targeted creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Elvish Hunter doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, Elvish Hunter will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Elvish Hunter doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, Elvish Hunter will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -2258,15 +2258,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target any creature with this ability. It doesn’t have to be tapped."
+          "text": "You may target any creature with this ability. It doesn't have to be tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "If the targeted creature is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when the targeted creature is tapped."
+          "text": "If the targeted creature is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when the targeted creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Elvish Hunter doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, Elvish Hunter will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Elvish Hunter doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, Elvish Hunter will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -2325,15 +2325,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target any creature with this ability. It doesn’t have to be tapped."
+          "text": "You may target any creature with this ability. It doesn't have to be tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "If the targeted creature is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when the targeted creature is tapped."
+          "text": "If the targeted creature is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when the targeted creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Elvish Hunter doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, Elvish Hunter will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Elvish Hunter doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, Elvish Hunter will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -2547,27 +2547,27 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you put this on your opponent’s creature, they decide whether or not to make their creature deal no damage to you."
+          "text": "If you put this on your opponent's creature, they decide whether or not to make their creature deal no damage to you."
         },
         {
           "date": "2008-10-01",
-          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won’t be around to deal its combat damage."
+          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won't be around to deal its combat damage."
         },
         {
           "date": "2008-10-01",
-          "text": "If the same creature is enchanted with more than one Farrel’s Mantle, they’ll each trigger if that creature attacks and isn’t blocked. The creature’s controller may have it deal damage multiple times. As long as the enchanted creature’s controller chooses to use Farrel’s Mantle’s ability at least once to deal damage, the enchanted creature will deal no combat damage."
+          "text": "If the same creature is enchanted with more than one Farrel's Mantle, they'll each trigger if that creature attacks and isn't blocked. The creature's controller may have it deal damage multiple times. As long as the enchanted creature's controller chooses to use Farrel's Mantle's ability at least once to deal damage, the enchanted creature will deal no combat damage."
         },
         {
           "date": "2008-10-01",
-          "text": "If the enchanted creature’s controller chooses to have it deal no combat damage, that combat damage is not prevented. It’s simply not dealt. A creature whose damage can’t be prevented (such as Excruciator) would deal no combat damage this way."
+          "text": "If the enchanted creature's controller chooses to have it deal no combat damage, that combat damage is not prevented. It's simply not dealt. A creature whose damage can't be prevented (such as Excruciator) would deal no combat damage this way."
         },
         {
           "date": "2011-01-25",
-          "text": "The enchanted creature’s controller cannot choose to have the enchanted creature deal damage to itself. If there are no other creatures on the battlefield, then a legal target cannot be chosen so the ability does nothing."
+          "text": "The enchanted creature's controller cannot choose to have the enchanted creature deal damage to itself. If there are no other creatures on the battlefield, then a legal target cannot be chosen so the ability does nothing."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -2624,15 +2624,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won’t be around to deal its combat damage."
+          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won't be around to deal its combat damage."
         },
         {
           "date": "2008-10-01",
-          "text": "If there are no other creatures on the battlefield, Farrel’s Zealot will have to target itself. Of course, you can choose not to use the ability when it resolves."
+          "text": "If there are no other creatures on the battlefield, Farrel's Zealot will have to target itself. Of course, you can choose not to use the ability when it resolves."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -2694,15 +2694,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won’t be around to deal its combat damage."
+          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won't be around to deal its combat damage."
         },
         {
           "date": "2008-10-01",
-          "text": "If there are no other creatures on the battlefield, Farrel’s Zealot will have to target itself. Of course, you can choose not to use the ability when it resolves."
+          "text": "If there are no other creatures on the battlefield, Farrel's Zealot will have to target itself. Of course, you can choose not to use the ability when it resolves."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -2764,15 +2764,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won’t be around to deal its combat damage."
+          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won't be around to deal its combat damage."
         },
         {
           "date": "2008-10-01",
-          "text": "If there are no other creatures on the battlefield, Farrel’s Zealot will have to target itself. Of course, you can choose not to use the ability when it resolves."
+          "text": "If there are no other creatures on the battlefield, Farrel's Zealot will have to target itself. Of course, you can choose not to use the ability when it resolves."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -3067,7 +3067,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"I asked one of my aides how they do it, but all he'd say was, ‘Trust me, Mayor, you don't want to know.'\"\n—Lydia Wynforth, Mayor of Trokair",
+      "flavor": "\"I asked one of my aides how they do it, but all he'd say was, 'Trust me, Mayor, you don't want to know.'\"\n—Lydia Wynforth, Mayor of Trokair",
       "id": "976694af815b0844e474d7a83eb76f653b66daa7",
       "imageName": "goblin chirurgeon2",
       "layout": "normal",
@@ -3216,7 +3216,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t sacrifice more than one Goblin to get a greater effect."
+          "text": "You can't sacrifice more than one Goblin to get a greater effect."
         },
         {
           "date": "2011-09-22",
@@ -3224,7 +3224,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn’t have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
+          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn't have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
         }
       ],
       "text": "As an additional cost to cast Goblin Grenade, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to target creature or player.",
@@ -3283,7 +3283,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t sacrifice more than one Goblin to get a greater effect."
+          "text": "You can't sacrifice more than one Goblin to get a greater effect."
         },
         {
           "date": "2011-09-22",
@@ -3291,7 +3291,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn’t have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
+          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn't have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
         }
       ],
       "text": "As an additional cost to cast Goblin Grenade, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to target creature or player.",
@@ -3350,7 +3350,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t sacrifice more than one Goblin to get a greater effect."
+          "text": "You can't sacrifice more than one Goblin to get a greater effect."
         },
         {
           "date": "2011-09-22",
@@ -3358,7 +3358,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn’t have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
+          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn't have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
         }
       ],
       "text": "As an additional cost to cast Goblin Grenade, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to target creature or player.",
@@ -3454,7 +3454,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When combined with an effect that reads “Each creature you control can’t be blocked by more than one creature,” none of your creatures can be blocked."
+          "text": "When combined with an effect that reads \"Each creature you control can't be blocked by more than one creature,\" none of your creatures can be blocked."
         },
         {
           "date": "2004-10-04",
@@ -3513,7 +3513,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When combined with an effect that reads “Each creature you control can’t be blocked by more than one creature,” none of your creatures can be blocked."
+          "text": "When combined with an effect that reads \"Each creature you control can't be blocked by more than one creature,\" none of your creatures can be blocked."
         },
         {
           "date": "2004-10-04",
@@ -3572,7 +3572,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When combined with an effect that reads “Each creature you control can’t be blocked by more than one creature,” none of your creatures can be blocked."
+          "text": "When combined with an effect that reads \"Each creature you control can't be blocked by more than one creature,\" none of your creatures can be blocked."
         },
         {
           "date": "2004-10-04",
@@ -3631,7 +3631,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When combined with an effect that reads “Each creature you control can’t be blocked by more than one creature,” none of your creatures can be blocked."
+          "text": "When combined with an effect that reads \"Each creature you control can't be blocked by more than one creature,\" none of your creatures can be blocked."
         },
         {
           "date": "2004-10-04",
@@ -3841,7 +3841,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The cost to avoid the penalty must be paid when the ability resolves. You can’t wait until later to do so."
+          "text": "The cost to avoid the penalty must be paid when the ability resolves. You can't wait until later to do so."
         },
         {
           "date": "2004-10-04",
@@ -4066,7 +4066,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -4822,7 +4822,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -4893,7 +4893,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -4964,7 +4964,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -5035,7 +5035,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -5502,7 +5502,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -5850,7 +5850,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -5911,7 +5911,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -6061,7 +6061,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Mana which “changes color” as it goes through the Hand forgets its original source because the old mana gets used up and new mana gets generated."
+          "text": "Mana which \"changes color\" as it goes through the Hand forgets its original source because the old mana gets used up and new mana gets generated."
         }
       ],
       "subtypes": [
@@ -6119,7 +6119,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Mana which “changes color” as it goes through the Hand forgets its original source because the old mana gets used up and new mana gets generated."
+          "text": "Mana which \"changes color\" as it goes through the Hand forgets its original source because the old mana gets used up and new mana gets generated."
         }
       ],
       "subtypes": [
@@ -6177,7 +6177,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Mana which “changes color” as it goes through the Hand forgets its original source because the old mana gets used up and new mana gets generated."
+          "text": "Mana which \"changes color\" as it goes through the Hand forgets its original source because the old mana gets used up and new mana gets generated."
         }
       ],
       "subtypes": [
@@ -6475,7 +6475,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6537,7 +6537,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6599,7 +6599,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6658,7 +6658,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6717,7 +6717,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6776,7 +6776,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6834,11 +6834,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-10-01",
-          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can’t be paid."
+          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can't be paid."
         }
       ],
       "text": "{1}, Exile two creature cards from a single graveyard: Create a 1/1 green Saproling creature token.",
@@ -6892,11 +6892,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-10-01",
-          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can’t be paid."
+          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can't be paid."
         }
       ],
       "text": "{1}, Exile two creature cards from a single graveyard: Create a 1/1 green Saproling creature token.",
@@ -6950,11 +6950,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-10-01",
-          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can’t be paid."
+          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can't be paid."
         }
       ],
       "text": "{1}, Exile two creature cards from a single graveyard: Create a 1/1 green Saproling creature token.",
@@ -7010,7 +7010,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You choose the target when you activate the ability. You don’t flip a coin until the ability resolves."
+          "text": "You choose the target when you activate the ability. You don't flip a coin until the ability resolves."
         }
       ],
       "subtypes": [
@@ -7835,7 +7835,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The color of creature to be tapped is set when the effect is announced and even if you use Sleight of Mind after that, you can’t change what color creature needs to be tapped to prevent the destruction."
+          "text": "The color of creature to be tapped is set when the effect is announced and even if you use Sleight of Mind after that, you can't change what color creature needs to be tapped to prevent the destruction."
         },
         {
           "date": "2004-10-04",
@@ -7890,19 +7890,19 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If control of Rainbow Vale has somehow changed before the “at end of turn” ability resolves, the player who activated the mana ability (not the current controller of Rainbow Vale) chooses one of his or her opponents to gain control of it."
+          "text": "If control of Rainbow Vale has somehow changed before the \"at end of turn\" ability resolves, the player who activated the mana ability (not the current controller of Rainbow Vale) chooses one of his or her opponents to gain control of it."
         },
         {
           "date": "2007-09-16",
-          "text": "If Rainbow Vale’s ability is activated during an End step, its “at the beginning of the end step” trigger won’t trigger until the End step of the next turn. If its ability is activated again during that turn, its “at the beginning of the end step” ability will trigger twice at the End step of that turn."
+          "text": "If Rainbow Vale's ability is activated during an End step, its \"at the beginning of the end step\" trigger won't trigger until the End step of the next turn. If its ability is activated again during that turn, its \"at the beginning of the end step\" ability will trigger twice at the End step of that turn."
         },
         {
           "date": "2007-09-16",
-          "text": "If more than one player manages to tap it for mana in a given turn, then two control-change abilities will trigger at end of the turn. These abilities resolve using the standard order for such things, so the active player’s triggers are put on the stack first, then the opponents’."
+          "text": "If more than one player manages to tap it for mana in a given turn, then two control-change abilities will trigger at end of the turn. These abilities resolve using the standard order for such things, so the active player's triggers are put on the stack first, then the opponents'."
         },
         {
           "date": "2007-09-16",
-          "text": "The opponent is chosen when the “at end of turn” triggered ability resolves."
+          "text": "The opponent is chosen when the \"at end of turn\" triggered ability resolves."
         }
       ],
       "text": "{T}: Add one mana of any color to your mana pool. An opponent gains control of Rainbow Vale at the beginning of the next end step.",
@@ -8075,7 +8075,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “tapped for mana” if you activate its mana ability and generate mana from it."
+          "text": "It is only considered \"tapped for mana\" if you activate its mana ability and generate mana from it."
         },
         {
           "date": "2004-10-04",
@@ -8146,11 +8146,11 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If a creature’s controller doesn’t control an Island, that creature is an illegal target. Whether that player controls an Island is checked both when Seasinger’s ability is activated and when it resolves. However, targeting restrictions aren’t checked continually while a spell or ability is on the stack."
+          "text": "If a creature's controller doesn't control an Island, that creature is an illegal target. Whether that player controls an Island is checked both when Seasinger's ability is activated and when it resolves. However, targeting restrictions aren't checked continually while a spell or ability is on the stack."
         },
         {
           "date": "2007-09-16",
-          "text": "Whether you control Seasinger is checked continually, starting when the ability is activated. If, before the ability resolves, there’s any point at which you don’t control Seasinger, the ability has no effect — even if you control Seasinger again by the time the ability resolves. The same is true regarding whether Seasinger remains tapped."
+          "text": "Whether you control Seasinger is checked continually, starting when the ability is activated. If, before the ability resolves, there's any point at which you don't control Seasinger, the ability has no effect — even if you control Seasinger again by the time the ability resolves. The same is true regarding whether Seasinger remains tapped."
         }
       ],
       "subtypes": [
@@ -8207,11 +8207,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You exile exactly one creature. You can’t exile more than one in an attempt to get a larger effect."
+          "text": "You exile exactly one creature. You can't exile more than one in an attempt to get a larger effect."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "As an additional cost to cast Soul Exchange, exile a creature you control.\nReturn target creature card from your graveyard to the battlefield. Put a +2/+2 counter on that creature if the exiled creature was a Thrull.",
@@ -8301,11 +8301,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature affected by Spore Cloud is untapped at the time its controller’s next untap step begins, the “doesn’t untap” effect doesn’t do anything. It won’t apply at some later time when that creature is tapped."
+          "text": "If a creature affected by Spore Cloud is untapped at the time its controller's next untap step begins, the \"doesn't untap\" effect doesn't do anything. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Spore Cloud doesn’t track the creatures’ controllers. If an affected creature changes controllers before its old controller’s next untap step, Spore Cloud will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Spore Cloud doesn't track the creatures' controllers. If an affected creature changes controllers before its old controller's next untap step, Spore Cloud will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "text": "Tap all blocking creatures. Prevent all combat damage that would be dealt this turn. Each attacking creature and each blocking creature doesn't untap during its controller's next untap step.",
@@ -8361,11 +8361,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature affected by Spore Cloud is untapped at the time its controller’s next untap step begins, the “doesn’t untap” effect doesn’t do anything. It won’t apply at some later time when that creature is tapped."
+          "text": "If a creature affected by Spore Cloud is untapped at the time its controller's next untap step begins, the \"doesn't untap\" effect doesn't do anything. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Spore Cloud doesn’t track the creatures’ controllers. If an affected creature changes controllers before its old controller’s next untap step, Spore Cloud will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Spore Cloud doesn't track the creatures' controllers. If an affected creature changes controllers before its old controller's next untap step, Spore Cloud will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "text": "Tap all blocking creatures. Prevent all combat damage that would be dealt this turn. Each attacking creature and each blocking creature doesn't untap during its controller's next untap step.",
@@ -8421,11 +8421,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature affected by Spore Cloud is untapped at the time its controller’s next untap step begins, the “doesn’t untap” effect doesn’t do anything. It won’t apply at some later time when that creature is tapped."
+          "text": "If a creature affected by Spore Cloud is untapped at the time its controller's next untap step begins, the \"doesn't untap\" effect doesn't do anything. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Spore Cloud doesn’t track the creatures’ controllers. If an affected creature changes controllers before its old controller’s next untap step, Spore Cloud will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Spore Cloud doesn't track the creatures' controllers. If an affected creature changes controllers before its old controller's next untap step, Spore Cloud will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "text": "Tap all blocking creatures. Prevent all combat damage that would be dealt this turn. Each attacking creature and each blocking creature doesn't untap during its controller's next untap step.",
@@ -9036,7 +9036,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -9371,7 +9371,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Unlike many similar creatures, Thrull Champion untaps as normal during your untap step. Whether it’s tapped or untapped has no bearing on the control-change effect."
+          "text": "Unlike many similar creatures, Thrull Champion untaps as normal during your untap step. Whether it's tapped or untapped has no bearing on the control-change effect."
         }
       ],
       "subtypes": [
@@ -9426,7 +9426,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won’t be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
+          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won't be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
         }
       ],
       "subtypes": [
@@ -10272,7 +10272,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The Merfolk are tapped during announcement and as a cost. The ability can’t be announced if the Merfolk are not in an untapped state."
+          "text": "The Merfolk are tapped during announcement and as a cost. The ability can't be announced if the Merfolk are not in an untapped state."
         }
       ],
       "subtypes": [

--- a/json/FRF.json
+++ b/json/FRF.json
@@ -143,7 +143,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Ugin, the Spirit Dragon is not a Dragon card; that is, he doesn’t have the creature type Dragon. Spells and abilities that refer to Dragon cards or Dragons don’t apply to Ugin."
+          "text": "Ugin, the Spirit Dragon is not a Dragon card; that is, he doesn't have the creature type Dragon. Spells and abilities that refer to Dragon cards or Dragons don't apply to Ugin."
         }
       ],
       "subtypes": [
@@ -256,7 +256,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You can target any player with Abzan Advantage, even if that player doesn’t control an enchantment."
+          "text": "You can target any player with Abzan Advantage, even if that player doesn't control an enchantment."
         },
         {
           "date": "2014-11-24",
@@ -264,7 +264,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -487,7 +487,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -828,7 +828,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Channel Harm’s only target is the creature it may deal damage to. You choose that target as you cast Channel Harm, not at the time it prevents damage."
+          "text": "Channel Harm's only target is the creature it may deal damage to. You choose that target as you cast Channel Harm, not at the time it prevents damage."
         },
         {
           "date": "2014-11-24",
@@ -836,19 +836,19 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Whether the target creature is still a legal target is not checked after Channel Harm resolves. Damage will still be prevented, even if Channel Harm can’t deal damage to that creature."
+          "text": "Whether the target creature is still a legal target is not checked after Channel Harm resolves. Damage will still be prevented, even if Channel Harm can't deal damage to that creature."
         },
         {
           "date": "2014-11-24",
-          "text": "Channel Harm’s effect is not a redirection effect. If it prevents damage, you may have Channel Harm (not the original source) deal damage to the creature as part of that prevention effect. Channel Harm is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don’t affect the new damage. The new damage is not combat damage, even if the prevented damage was."
+          "text": "Channel Harm's effect is not a redirection effect. If it prevents damage, you may have Channel Harm (not the original source) deal damage to the creature as part of that prevention effect. Channel Harm is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don't affect the new damage. The new damage is not combat damage, even if the prevented damage was."
         },
         {
           "date": "2014-11-24",
-          "text": "You can choose a creature you control as the target. If you do, the damage Channel Harm deals to that creature won’t be prevented."
+          "text": "You can choose a creature you control as the target. If you do, the damage Channel Harm deals to that creature won't be prevented."
         },
         {
           "date": "2014-11-24",
-          "text": "If two players have each cast Channel Harm targeting a creature the other controls, and a source one player controls would deal damage to the second player or a permanent that player controls, one Channel Harm will prevent that damage and try to deal damage to the creature controlled by the first player. That player’s Channel Harm will then prevent that damage and try to deal damage to the creature controlled by the second player. This forms a loop that either player can break by choosing to not have Channel Harm try to deal damage. It doesn’t matter which player breaks the loop, as no damage will be dealt in either case."
+          "text": "If two players have each cast Channel Harm targeting a creature the other controls, and a source one player controls would deal damage to the second player or a permanent that player controls, one Channel Harm will prevent that damage and try to deal damage to the creature controlled by the first player. That player's Channel Harm will then prevent that damage and try to deal damage to the creature controlled by the second player. This forms a loop that either player can break by choosing to not have Channel Harm try to deal damage. It doesn't matter which player breaks the loop, as no damage will be dealt in either case."
         }
       ],
       "text": "Prevent all damage that would be dealt to you and permanents you control this turn by sources you don't control. If damage is prevented this way, you may have Channel Harm deal that much damage to target creature.",
@@ -962,11 +962,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The words “Khans” and “Dragons” are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. “[Anchor word] — [Ability]” means “As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].” Notably, the anchor word “Dragons” has no connection to the creature type Dragon."
+          "text": "The words \"Khans\" and \"Dragons\" are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. \"[Anchor word] — [Ability]\" means \"As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].\" Notably, the anchor word \"Dragons\" has no connection to the creature type Dragon."
         },
         {
           "date": "2014-11-24",
-          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won’t depend on the choice made for the original permanent."
+          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won't depend on the choice made for the original permanent."
         }
       ],
       "text": "As Citadel Siege enters the battlefield, choose Khans or Dragons.\n• Khans — At the beginning of combat on your turn, put two +1/+1 counters on target creature you control.\n• Dragons — At the beginning of combat on each opponent's turn, tap target creature that player controls.",
@@ -1208,7 +1208,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-11-24",
@@ -1220,7 +1220,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -1343,11 +1343,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The creature you put the counters on doesn’t have to be one of the tapped creatures."
+          "text": "The creature you put the counters on doesn't have to be one of the tapped creatures."
         },
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -1468,7 +1468,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -1695,7 +1695,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -1918,11 +1918,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -1930,27 +1930,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -1958,27 +1958,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         },
         {
           "date": "2014-11-24",
-          "text": "You’ll still manifest the top card of your library even if the “Form” isn’t on the battlefield as its enters-the-battlefield ability resolves."
+          "text": "You'll still manifest the top card of your library even if the \"Form\" isn't on the battlefield as its enters-the-battlefield ability resolves."
         },
         {
           "date": "2014-11-24",
-          "text": "If you have no cards in your library as the ability resolves, the “Form” will be put into its owner’s graveyard as a state-based action."
+          "text": "If you have no cards in your library as the ability resolves, the \"Form\" will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-11-24",
-          "text": "If the enchanted creature is turned face up, the “Form” will continue to enchant it."
+          "text": "If the enchanted creature is turned face up, the \"Form\" will continue to enchant it."
         }
       ],
       "text": "When Lightform enters the battlefield, it becomes an Aura with enchant creature. Manifest the top card of your library and attach Lightform to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has flying and lifelink.",
@@ -2089,7 +2089,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-11-24",
@@ -2101,7 +2101,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -2329,11 +2329,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -2341,27 +2341,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -2369,15 +2369,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Whenever a permanent you control is turned face up, you gain 1 life for each creature you control.\n{3}{W}: Manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -2488,15 +2488,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Casting a noncreature spell will cause both prowess and Monastery Mentor’s other ability to trigger. You can put these abilities on the stack in either order. Whichever ability is put on the stack last will resolve first."
+          "text": "Casting a noncreature spell will cause both prowess and Monastery Mentor's other ability to trigger. You can put these abilities on the stack in either order. Whichever ability is put on the stack last will resolve first."
         },
         {
           "date": "2014-11-24",
-          "text": "The spell that causes Monastery Mentor’s second ability to trigger will not cause the prowess ability of the Monk token that’s created to trigger."
+          "text": "The spell that causes Monastery Mentor's second ability to trigger will not cause the prowess ability of the Monk token that's created to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-11-24",
@@ -2508,7 +2508,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -2841,11 +2841,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "An Aura doesn’t necessarily need the enchant creature ability for the abilities of Sage’s Reverie to count it. For example, an Aura with enchant permanent that’s attached to a creature will count."
+          "text": "An Aura doesn't necessarily need the enchant creature ability for the abilities of Sage's Reverie to count it. For example, an Aura with enchant permanent that's attached to a creature will count."
         },
         {
           "date": "2014-11-24",
-          "text": "Count the number of Auras you control attached to creatures as the enters-the-battlefield ability resolves to determine how many cards to draw. This will include Sage’s Reverie as long as it’s still on the battlefield at that time."
+          "text": "Count the number of Auras you control attached to creatures as the enters-the-battlefield ability resolves to determine how many cards to draw. This will include Sage's Reverie as long as it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -2923,6 +2923,10 @@
       "imageName": "sandblast",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -3067,7 +3071,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose which mode you’re using as you put the ability on the stack, after the creature has entered the battlefield. Once you’ve chosen a mode, you can’t change that mode even if the creature leaves the battlefield in response to that ability."
+          "text": "You choose which mode you're using as you put the ability on the stack, after the creature has entered the battlefield. Once you've chosen a mode, you can't change that mode even if the creature leaves the battlefield in response to that ability."
         },
         {
           "date": "2014-11-24",
@@ -3187,11 +3191,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -3199,27 +3203,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -3227,15 +3231,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -3348,15 +3352,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "An instant or sorcery spell with lifelink causes its controller to gain life only if it’s the source of any damage that’s dealt. An instant or sorcery spell with lifelink that causes another source to deal damage won’t cause its controller to gain life."
+          "text": "An instant or sorcery spell with lifelink causes its controller to gain life only if it's the source of any damage that's dealt. An instant or sorcery spell with lifelink that causes another source to deal damage won't cause its controller to gain life."
         },
         {
           "date": "2014-11-24",
-          "text": "After you activate Soulfire Grand Master’s last ability, if the next instant or sorcery spell you cast from your hand is countered, it won’t be put into your hand and the effect won’t be applied to the next spell you cast."
+          "text": "After you activate Soulfire Grand Master's last ability, if the next instant or sorcery spell you cast from your hand is countered, it won't be put into your hand and the effect won't be applied to the next spell you cast."
         },
         {
           "date": "2014-11-24",
-          "text": "A spell that instructs you to exile it (for example, Temporal Trespass) won’t be put into your hand because it’s not put into your graveyard as it resolves."
+          "text": "A spell that instructs you to exile it (for example, Temporal Trespass) won't be put into your hand because it's not put into your graveyard as it resolves."
         }
       ],
       "subtypes": [
@@ -3689,7 +3693,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "“Defending player” refers to the player Wardscale Dragon is attacking or the controller of the planeswalker Wardscale Dragon is attacking. In multiplayer formats that allow attacking multiple players, your other opponents can still cast spells, even if you control other creatures attacking those players or planeswalkers those players control."
+          "text": "\"Defending player\" refers to the player Wardscale Dragon is attacking or the controller of the planeswalker Wardscale Dragon is attacking. In multiplayer formats that allow attacking multiple players, your other opponents can still cast spells, even if you control other creatures attacking those players or planeswalkers those players control."
         },
         {
           "date": "2014-11-24",
@@ -3808,7 +3812,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose which mode you’re using as you put the ability on the stack, after the creature has entered the battlefield. Once you’ve chosen a mode, you can’t change that mode even if the creature leaves the battlefield in response to that ability."
+          "text": "You choose which mode you're using as you put the ability on the stack, after the creature has entered the battlefield. Once you've chosen a mode, you can't change that mode even if the creature leaves the battlefield in response to that ability."
         },
         {
           "date": "2014-11-24",
@@ -3926,11 +3930,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -3938,27 +3942,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -3966,27 +3970,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         },
         {
           "date": "2014-11-24",
-          "text": "You’ll still manifest the top card of your library even if the “Form” isn’t on the battlefield as its enters-the-battlefield ability resolves."
+          "text": "You'll still manifest the top card of your library even if the \"Form\" isn't on the battlefield as its enters-the-battlefield ability resolves."
         },
         {
           "date": "2014-11-24",
-          "text": "If you have no cards in your library as the ability resolves, the “Form” will be put into its owner’s graveyard as a state-based action."
+          "text": "If you have no cards in your library as the ability resolves, the \"Form\" will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-11-24",
-          "text": "If the enchanted creature is turned face up, the “Form” will continue to enchant it."
+          "text": "If the enchanted creature is turned face up, the \"Form\" will continue to enchant it."
         }
       ],
       "text": "When Cloudform enters the battlefield, it becomes an Aura with enchant creature. Manifest the top card of your library and attach Cloudform to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has flying and hexproof.",
@@ -4305,7 +4309,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If Frost Walker becomes the target of a spell or ability, its ability triggers and is put on the stack on top of that spell or ability. Frost Walker’s ability will resolve (causing it to be sacrificed) first. Unless the spell or ability has another target, it will be countered as it tries to resolve for having no legal targets."
+          "text": "If Frost Walker becomes the target of a spell or ability, its ability triggers and is put on the stack on top of that spell or ability. Frost Walker's ability will resolve (causing it to be sacrificed) first. Unless the spell or ability has another target, it will be countered as it tries to resolve for having no legal targets."
         }
       ],
       "subtypes": [
@@ -4426,11 +4430,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If Jeskai Infiltrator isn’t on the battlefield as its triggered ability resolves, you’ll manifest just the top card of your library."
+          "text": "If Jeskai Infiltrator isn't on the battlefield as its triggered ability resolves, you'll manifest just the top card of your library."
         },
         {
           "date": "2014-11-24",
-          "text": "A card’s owner is public information at all times. If the two cards you exile are owned by different players (perhaps because you gained control of a Jeskai Infiltrator owned by your opponent), which card is which is no longer hidden from your opponent. That player will know which face-down creature he or she owns."
+          "text": "A card's owner is public information at all times. If the two cards you exile are owned by different players (perhaps because you gained control of a Jeskai Infiltrator owned by your opponent), which card is which is no longer hidden from your opponent. That player will know which face-down creature he or she owns."
         },
         {
           "date": "2014-11-24",
@@ -4438,11 +4442,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -4450,27 +4454,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -4478,15 +4482,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "subtypes": [
@@ -4601,7 +4605,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Whether a creature has flying is checked as blocking creatures are declared. Once the enchanted creature blocks or is blocked, losing flying won’t change or undo that block."
+          "text": "Whether a creature has flying is checked as blocking creatures are declared. Once the enchanted creature blocks or is blocked, losing flying won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -4716,7 +4720,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-11-24",
@@ -4728,7 +4732,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -4845,7 +4849,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-11-24",
@@ -4857,7 +4861,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -4974,11 +4978,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Marang River Prowler’s ability doesn’t change when you can cast it. You must still pay the spell’s costs."
+          "text": "Marang River Prowler's ability doesn't change when you can cast it. You must still pay the spell's costs."
         },
         {
           "date": "2014-11-24",
-          "text": "Marang River Prowler checks if you control a black or green permanent only as you begin to cast it. Once you begin to cast Marang River Prowler from your graveyard, it doesn’t matter what happens to the black or green permanents you control."
+          "text": "Marang River Prowler checks if you control a black or green permanent only as you begin to cast it. Once you begin to cast Marang River Prowler from your graveyard, it doesn't matter what happens to the black or green permanents you control."
         }
       ],
       "subtypes": [
@@ -5205,7 +5209,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-11-24",
@@ -5217,7 +5221,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -5332,11 +5336,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The “Khans” ability happens after you draw the card you normally draw during your draw step. That card and the additional card will be in your hand when you have to discard a card."
+          "text": "The \"Khans\" ability happens after you draw the card you normally draw during your draw step. That card and the additional card will be in your hand when you have to discard a card."
         },
         {
           "date": "2014-11-24",
-          "text": "The “Dragons” ability adds {2} per spell, not per target. It won’t cause a spell to cost more than {2} more to cast, even if that spell targets you and a permanent you control or more than one permanent you control."
+          "text": "The \"Dragons\" ability adds {2} per spell, not per target. It won't cause a spell to cost more than {2} more to cast, even if that spell targets you and a permanent you control or more than one permanent you control."
         },
         {
           "date": "2014-11-24",
@@ -5344,11 +5348,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The words “Khans” and “Dragons” are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. “[Anchor word] — [Ability]” means “As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].” Notably, the anchor word “Dragons” has no connection to the creature type Dragon."
+          "text": "The words \"Khans\" and \"Dragons\" are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. \"[Anchor word] — [Ability]\" means \"As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].\" Notably, the anchor word \"Dragons\" has no connection to the creature type Dragon."
         },
         {
           "date": "2014-11-24",
-          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won’t depend on the choice made for the original permanent."
+          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won't depend on the choice made for the original permanent."
         }
       ],
       "text": "As Monastery Siege enters the battlefield, choose Khans or Dragons.\n• Khans — At the beginning of your draw step, draw an additional card, then discard a card.\n• Dragons — Spells your opponents cast that target you or a permanent you control cost {2} more to cast.",
@@ -5562,7 +5566,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Count the number of cards in your graveyard as Rakshasa’s Disdain resolves to determine how much mana the controller of the target spell must pay to avoid the spell being countered. Rakshasa’s Disdain is still on the stack at this time and won’t count toward this number."
+          "text": "Count the number of cards in your graveyard as Rakshasa's Disdain resolves to determine how much mana the controller of the target spell must pay to avoid the spell being countered. Rakshasa's Disdain is still on the stack at this time and won't count toward this number."
         }
       ],
       "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.",
@@ -5672,11 +5676,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -5684,27 +5688,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -5712,15 +5716,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Exile target creature. Its controller manifests the top card of his or her library. (That player puts the top card of his or her library onto the battlefield face down as a 2/2 creature. If it's a creature card, it can be turned face up any time for its mana cost.)",
@@ -5934,23 +5938,23 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You can use mana generated by the first ability to pay an alternative cost or an additional cost to cast an artifact spell. It’s not limited to paying just that spell’s mana cost."
+          "text": "You can use mana generated by the first ability to pay an alternative cost or an additional cost to cast an artifact spell. It's not limited to paying just that spell's mana cost."
         },
         {
           "date": "2014-11-24",
-          "text": "An activated ability appears in the form “Cost: Effect.” Some keywords, including equip, are activated abilities."
+          "text": "An activated ability appears in the form \"Cost: Effect.\" Some keywords, including equip, are activated abilities."
         },
         {
           "date": "2014-11-24",
-          "text": "Notably, turning a face-down creature face up isn’t an activated ability. If you manifest an artifact creature card or cast an artifact card face down using the morph ability, you can’t use mana generated by the first ability to turn it face up."
+          "text": "Notably, turning a face-down creature face up isn't an activated ability. If you manifest an artifact creature card or cast an artifact card face down using the morph ability, you can't use mana generated by the first ability to turn it face up."
         },
         {
           "date": "2014-11-24",
-          "text": "The mana generated by the first ability can’t be spent to activate abilities of artifact sources that aren’t on the battlefield."
+          "text": "The mana generated by the first ability can't be spent to activate abilities of artifact sources that aren't on the battlefield."
         },
         {
           "date": "2014-11-24",
-          "text": "Heart-Piercer Bow is a card from the Khans of Tarkir set. Vial of Dragonfire doesn’t appear to have been invented yet. Curious."
+          "text": "Heart-Piercer Bow is a card from the Khans of Tarkir set. Vial of Dragonfire doesn't appear to have been invented yet. Curious."
         }
       ],
       "subtypes": [
@@ -6064,23 +6068,23 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "You exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-11-24",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, the converted mana cost of Tasigur’s Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, the converted mana cost of Tasigur's Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than five cards from your graveyard to cast Tasigur’s Cruelty."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than five cards from your graveyard to cast Tasigur's Cruelty."
         },
         {
           "date": "2014-11-24",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nReturn target nonland permanent you control and target nonland permanent you don't control to their owners' hands.",
@@ -6194,7 +6198,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-11-24",
@@ -6206,7 +6210,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -6322,7 +6326,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If one of the target permanents is an illegal target when Shifting Loyalties resolves, the exchange won’t happen. If both permanents are illegal targets (perhaps because they no longer share a card type), Shifting Loyalties will be countered."
+          "text": "If one of the target permanents is an illegal target when Shifting Loyalties resolves, the exchange won't happen. If both permanents are illegal targets (perhaps because they no longer share a card type), Shifting Loyalties will be countered."
         },
         {
           "date": "2014-11-24",
@@ -6330,7 +6334,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You don’t have to control either target permanent."
+          "text": "You don't have to control either target permanent."
         },
         {
           "date": "2014-11-24",
@@ -6338,11 +6342,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Gaining control of an Aura or Equipment doesn’t cause it to move, though gaining control of an Equipment will allow you to activate its equip ability later to attach it to a creature you control."
+          "text": "Gaining control of an Aura or Equipment doesn't cause it to move, though gaining control of an Equipment will allow you to activate its equip ability later to attach it to a creature you control."
         },
         {
           "date": "2014-11-24",
-          "text": "If another spell or ability allows you to change the targets of Shifting Loyalties (or perhaps copy it and choose new targets for the copy), you can change the targets only such that the final set of targets is still legal. For example, if Shifting Loyalties targets a creature you control and a creature an opponent controls, you couldn’t change just the second target to a noncreature permanent controlled by that player. You could, however, change just the second target to a creature controlled by a different opponent. The two new targets can share a different card type than the two original targets did."
+          "text": "If another spell or ability allows you to change the targets of Shifting Loyalties (or perhaps copy it and choose new targets for the copy), you can change the targets only such that the final set of targets is still legal. For example, if Shifting Loyalties targets a creature you control and a creature an opponent controls, you couldn't change just the second target to a noncreature permanent controlled by that player. You could, however, change just the second target to a creature controlled by a different opponent. The two new targets can share a different card type than the two original targets did."
         }
       ],
       "text": "Exchange control of two target permanents that share a card type. (Artifact, creature, enchantment, land, and planeswalker are card types.)",
@@ -6455,7 +6459,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-11-24",
@@ -6467,7 +6471,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -6699,11 +6703,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The token copies exactly what was printed on the creature and nothing else (unless that creature was copying something else or was a token; see below). It doesn’t copy whether that creature was tapped or untapped, whether it had any counters on it or Auras and/or Equipment attached to it, or any non-copy effects that changed its power, toughness, types, color, and so on."
+          "text": "The token copies exactly what was printed on the creature and nothing else (unless that creature was copying something else or was a token; see below). It doesn't copy whether that creature was tapped or untapped, whether it had any counters on it or Auras and/or Equipment attached to it, or any non-copy effects that changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2014-11-24",
-          "text": "If you return a face-down creature to its owner’s hand, the token will be a face-up colorless 2/2 creature with no name, no abilities, and no creature types. (The face-down creature card will be revealed to all players as it leaves the battlefield.)"
+          "text": "If you return a face-down creature to its owner's hand, the token will be a face-up colorless 2/2 creature with no name, no abilities, and no creature types. (The face-down creature card will be revealed to all players as it leaves the battlefield.)"
         },
         {
           "date": "2014-11-24",
@@ -6719,7 +6723,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “As [this creature] enters the battlefield” or “[This creature] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"As [this creature] enters the battlefield\" or \"[This creature] enters the battlefield with\" abilities of the copied creature will also work."
         }
       ],
       "text": "Return target creature to its owner's hand. You create a token that's a copy of that creature.",
@@ -6829,23 +6833,23 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "You exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-11-24",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, the converted mana cost of Tasigur’s Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, the converted mana cost of Tasigur's Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than five cards from your graveyard to cast Tasigur’s Cruelty."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than five cards from your graveyard to cast Tasigur's Cruelty."
         },
         {
           "date": "2014-11-24",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTake an extra turn after this one. Exile Temporal Trespass.",
@@ -6959,7 +6963,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "“Defending player” refers to the player Torrent Elemental is attacking or the controller of the planeswalker Torrent Elemental is attacking. In multiplayer formats that allow attacking multiple players, creatures controlled by other players won’t be tapped, even if you control other creatures attacking those players or planeswalkers those players control. In a Two-Headed Giant game, choose one member of the opposing team as the triggered ability resolves."
+          "text": "\"Defending player\" refers to the player Torrent Elemental is attacking or the controller of the planeswalker Torrent Elemental is attacking. In multiplayer formats that allow attacking multiple players, creatures controlled by other players won't be tapped, even if you control other creatures attacking those players or planeswalkers those players control. In a Two-Headed Giant game, choose one member of the opposing team as the triggered ability resolves."
         }
       ],
       "subtypes": [
@@ -7178,35 +7182,35 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Will of the Naga can target creatures that are already tapped. Those creatures won’t untap during their controller’s next untap step."
+          "text": "Will of the Naga can target creatures that are already tapped. Those creatures won't untap during their controller's next untap step."
         },
         {
           "date": "2014-11-24",
-          "text": "Will of the Naga tracks the creatures, but not their controllers. If any of those creatures changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "Will of the Naga tracks the creatures, but not their controllers. If any of those creatures changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-11-24",
-          "text": "If you chose two targets and one is an illegal target as Will of the Naga resolves, that creature won’t become tapped and it won’t be stopped from untapping during its controller’s next untap step. It won’t be affected by Will of the Naga in any way."
+          "text": "If you chose two targets and one is an illegal target as Will of the Naga resolves, that creature won't become tapped and it won't be stopped from untapping during its controller's next untap step. It won't be affected by Will of the Naga in any way."
         },
         {
           "date": "2014-11-24",
-          "text": "You exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "You exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-11-24",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, the converted mana cost of Tasigur’s Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, the converted mana cost of Tasigur's Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than five cards from your graveyard to cast Tasigur’s Cruelty."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than five cards from your graveyard to cast Tasigur's Cruelty."
         },
         {
           "date": "2014-11-24",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
@@ -7317,11 +7321,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Other players won’t know whether the card you manifest is the top card or second card of that library."
+          "text": "Other players won't know whether the card you manifest is the top card or second card of that library."
         },
         {
           "date": "2014-11-24",
-          "text": "If you’re playing with the top card of your library revealed, you’ll manifest one of the cards, then the other one will be revealed, then you can choose to put that card on the bottom of your library or leave it on top."
+          "text": "If you're playing with the top card of your library revealed, you'll manifest one of the cards, then the other one will be revealed, then you can choose to put that card on the bottom of your library or leave it on top."
         }
       ],
       "text": "Look at the top two cards of your library. Manifest one of those cards, then put the other on the top or bottom of your library. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -7432,19 +7436,19 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2014-11-24",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2014-11-24",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2014-11-24",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -7560,11 +7564,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If the creature targeted by Ancestral Vengeance’s enchant creature ability is an illegal target as Ancestral Vengeance tries to resolve, Ancestral Vengeance will be countered. It won’t enter the battlefield, and its enters-the-battlefield ability won’t trigger."
+          "text": "If the creature targeted by Ancestral Vengeance's enchant creature ability is an illegal target as Ancestral Vengeance tries to resolve, Ancestral Vengeance will be countered. It won't enter the battlefield, and its enters-the-battlefield ability won't trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "If Ancestral Vengeance causes the enchanted creature to have toughness 0, that creature and Ancestral Vengeance will be put into their owners’ graveyards. The enters-the-battlefield ability will still apply."
+          "text": "If Ancestral Vengeance causes the enchanted creature to have toughness 0, that creature and Ancestral Vengeance will be put into their owners' graveyards. The enters-the-battlefield ability will still apply."
         }
       ],
       "subtypes": [
@@ -7681,11 +7685,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The opponent chooses which creatures to spare, if any, as the ability resolves. This choice doesn’t target the creatures."
+          "text": "The opponent chooses which creatures to spare, if any, as the ability resolves. This choice doesn't target the creatures."
         },
         {
           "date": "2014-11-24",
-          "text": "The opponent may choose to spare one or no creatures. If the player doesn’t choose any creatures, he or she will sacrifice all creatures he or she controls."
+          "text": "The opponent may choose to spare one or no creatures. If the player doesn't choose any creatures, he or she will sacrifice all creatures he or she controls."
         }
       ],
       "subtypes": [
@@ -7801,7 +7805,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If Battle Brawler assigns combat damage during the first combat damage step, and then it loses first strike before the second combat damage step (perhaps because you no longer control a red or white permanent), it won’t assign combat damage again in the second combat damage step."
+          "text": "If Battle Brawler assigns combat damage during the first combat damage step, and then it loses first strike before the second combat damage step (perhaps because you no longer control a red or white permanent), it won't assign combat damage again in the second combat damage step."
         }
       ],
       "subtypes": [
@@ -7925,19 +7929,19 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If there’s a cost associated with having a creature block and you choose for that creature to block, its controller can choose to pay that cost or not. If that player decides to not pay that cost, you must propose a new set of blocking creatures."
+          "text": "If there's a cost associated with having a creature block and you choose for that creature to block, its controller can choose to pay that cost or not. If that player decides to not pay that cost, you must propose a new set of blocking creatures."
         },
         {
           "date": "2014-11-24",
-          "text": "You’ll choose how each creature controlled by an opponent blocks, even if that creature wasn’t on the battlefield or wasn’t controlled by an opponent as the activated ability resolved."
+          "text": "You'll choose how each creature controlled by an opponent blocks, even if that creature wasn't on the battlefield or wasn't controlled by an opponent as the activated ability resolved."
         },
         {
           "date": "2014-11-24",
-          "text": "In a multiplayer game, if more than one player activates Brutal Hordechief’s activated ability on the same turn, the controller of the last ability to resolve will choose how any creatures controlled by players who didn’t resolve this ability will block."
+          "text": "In a multiplayer game, if more than one player activates Brutal Hordechief's activated ability on the same turn, the controller of the last ability to resolve will choose how any creatures controlled by players who didn't resolve this ability will block."
         },
         {
           "date": "2014-11-24",
-          "text": "The defending player affected by Brutal Hordechief’s triggered ability is determined relative to the creature that attacked. For example, if Brutal Hordechief attacked one opponent and two other creatures you control attacked another opponent, the first opponent would lose 1 life and the second opponent would lose 2 life. You’d gain a total of 3 life."
+          "text": "The defending player affected by Brutal Hordechief's triggered ability is determined relative to the creature that attacked. For example, if Brutal Hordechief attacked one opponent and two other creatures you control attacked another opponent, the first opponent would lose 1 life and the second opponent would lose 2 life. You'd gain a total of 3 life."
         }
       ],
       "subtypes": [
@@ -8157,7 +8161,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If a player had one card or no cards in his or her hand, that player won’t draw any cards."
+          "text": "If a player had one card or no cards in his or her hand, that player won't draw any cards."
         }
       ],
       "text": "Each player discards all the cards in his or her hand, then draws that many cards minus one.",
@@ -8267,7 +8271,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you control a Warrior as Diplomacy of the Wastes resolves, the target opponent will lose 2 life even if that player didn’t discard a card (perhaps because he or she had no cards in hand)."
+          "text": "If you control a Warrior as Diplomacy of the Wastes resolves, the target opponent will lose 2 life even if that player didn't discard a card (perhaps because he or she had no cards in hand)."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose a nonland card from it. That player discards that card. If you control a Warrior, that player loses 2 life.",
@@ -8486,7 +8490,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "No player can cast spells or activate abilities between returning the creature card to the battlefield and checking whether it’s a Dragon."
+          "text": "No player can cast spells or activate abilities between returning the creature card to the battlefield and checking whether it's a Dragon."
         }
       ],
       "text": "Return target creature card from your graveyard to the battlefield. If it's a Dragon, put two +1/+1 counters on it.",
@@ -8604,11 +8608,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -8616,27 +8620,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -8644,15 +8648,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Exile all creature cards from target player's graveyard in a face-down pile, shuffle that pile, then manifest those cards. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -8867,23 +8871,23 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "You exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-11-24",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, the converted mana cost of Tasigur’s Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, the converted mana cost of Tasigur's Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than five cards from your graveyard to cast Tasigur’s Cruelty."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than five cards from your graveyard to cast Tasigur's Cruelty."
         },
         {
           "date": "2014-11-24",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "subtypes": [
@@ -9003,7 +9007,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You choose which mode you’re using as you put the ability on the stack, after the creature has entered the battlefield. Once you’ve chosen a mode, you can’t change that mode even if the creature leaves the battlefield in response to that ability."
+          "text": "You choose which mode you're using as you put the ability on the stack, after the creature has entered the battlefield. Once you've chosen a mode, you can't change that mode even if the creature leaves the battlefield in response to that ability."
         },
         {
           "date": "2014-11-24",
@@ -9123,19 +9127,19 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2014-11-24",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2014-11-24",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2014-11-24",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -9252,19 +9256,19 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2014-11-24",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2014-11-24",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2014-11-24",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -9381,7 +9385,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you control no other creatures as Merciless Executioner’s ability resolves, you’ll have to sacrifice Merciless Executioner."
+          "text": "If you control no other creatures as Merciless Executioner's ability resolves, you'll have to sacrifice Merciless Executioner."
         }
       ],
       "subtypes": [
@@ -9498,7 +9502,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "A face-down creature has a converted mana cost of 0. However, its converted mana cost changes when it’s turned face up. Thus, if a creature is turned face up in response to being targeted by Noxious Dragon’s ability, it may become an illegal target."
+          "text": "A face-down creature has a converted mana cost of 0. However, its converted mana cost changes when it's turned face up. Thus, if a creature is turned face up in response to being targeted by Noxious Dragon's ability, it may become an illegal target."
         }
       ],
       "subtypes": [
@@ -9733,11 +9737,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The words “Khans” and “Dragons” are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. “[Anchor word] — [Ability]” means “As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].” Notably, the anchor word “Dragons” has no connection to the creature type Dragon."
+          "text": "The words \"Khans\" and \"Dragons\" are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. \"[Anchor word] — [Ability]\" means \"As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].\" Notably, the anchor word \"Dragons\" has no connection to the creature type Dragon."
         },
         {
           "date": "2014-11-24",
-          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won’t depend on the choice made for the original permanent."
+          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won't depend on the choice made for the original permanent."
         }
       ],
       "text": "As Palace Siege enters the battlefield, choose Khans or Dragons.\n• Khans — At the beginning of your upkeep, return target creature card from your graveyard to your hand.\n• Dragons — At the beginning of your upkeep, each opponent loses 2 life and you gain 2 life.",
@@ -9848,11 +9852,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -9860,27 +9864,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -9888,15 +9892,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "subtypes": [
@@ -10226,23 +10230,23 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "You exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-11-24",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, the converted mana cost of Tasigur’s Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, the converted mana cost of Tasigur's Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than five cards from your graveyard to cast Tasigur’s Cruelty."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than five cards from your graveyard to cast Tasigur's Cruelty."
         },
         {
           "date": "2014-11-24",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "subtypes": [
@@ -10358,31 +10362,31 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Creature cards that have abilities that grant the listed keyword abilities to themselves won’t count. For example, exiling a Battle Brawler (a creature with “As long as you control a red or white permanent, Battle Brawler gets +1/+0 and has first strike”) with Soulflayer’s delve ability won’t cause Soulflayer to have first strike, even if you control a red or white permanent."
+          "text": "Creature cards that have abilities that grant the listed keyword abilities to themselves won't count. For example, exiling a Battle Brawler (a creature with \"As long as you control a red or white permanent, Battle Brawler gets +1/+0 and has first strike\") with Soulflayer's delve ability won't cause Soulflayer to have first strike, even if you control a red or white permanent."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile more cards from your graveyard than you’d need to pay Soulflayer’s generic mana requirement. In most situations, this means you can’t exile more than four cards, even if you want to exile more to give it extra abilities."
+          "text": "You can't exile more cards from your graveyard than you'd need to pay Soulflayer's generic mana requirement. In most situations, this means you can't exile more than four cards, even if you want to exile more to give it extra abilities."
         },
         {
           "date": "2014-11-24",
-          "text": "You exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "You exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-11-24",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, the converted mana cost of Tasigur’s Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, the converted mana cost of Tasigur's Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than five cards from your graveyard to cast Tasigur’s Cruelty."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than five cards from your graveyard to cast Tasigur's Cruelty."
         },
         {
           "date": "2014-11-24",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "subtypes": [
@@ -10499,11 +10503,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -10511,27 +10515,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -10539,15 +10543,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "subtypes": [
@@ -10773,31 +10777,31 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The last ability doesn’t target any card or player. You choose an opponent as the ability resolves and that player chooses a nonland card."
+          "text": "The last ability doesn't target any card or player. You choose an opponent as the ability resolves and that player chooses a nonland card."
         },
         {
           "date": "2014-11-24",
-          "text": "The chosen opponent can choose any nonland card in your graveyard, not just one of the cards that was just put there. The player must choose a nonland card if there’s one in your graveyard."
+          "text": "The chosen opponent can choose any nonland card in your graveyard, not just one of the cards that was just put there. The player must choose a nonland card if there's one in your graveyard."
         },
         {
           "date": "2014-11-24",
-          "text": "You exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "You exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-11-24",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, the converted mana cost of Tasigur’s Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, the converted mana cost of Tasigur's Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than five cards from your graveyard to cast Tasigur’s Cruelty."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than five cards from your graveyard to cast Tasigur's Cruelty."
         },
         {
           "date": "2014-11-24",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "subtypes": [
@@ -10916,23 +10920,23 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "You exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-11-24",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, the converted mana cost of Tasigur’s Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, the converted mana cost of Tasigur's Cruelty (with mana cost {5}{B}) is 6 even if you exile three cards to cast it."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than five cards from your graveyard to cast Tasigur’s Cruelty."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than five cards from your graveyard to cast Tasigur's Cruelty."
         },
         {
           "date": "2014-11-24",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nEach opponent discards two cards.",
@@ -11165,7 +11169,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose which opponent or opposing planeswalker the creature is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Alesha is attacking."
+          "text": "You choose which opponent or opposing planeswalker the creature is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Alesha is attacking."
         },
         {
           "date": "2014-11-24",
@@ -11297,11 +11301,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Damage dealt by the creature because of the ability Arcbond creates isn’t combat damage, even if it was combat damage that caused the ability to trigger."
+          "text": "Damage dealt by the creature because of the ability Arcbond creates isn't combat damage, even if it was combat damage that caused the ability to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "If two Arcbonds have resolved targeting different creatures, and damage is dealt to one of them, the delayed triggered ability will cause that creature to deal damage to each other creature and player. This will cause the delayed triggered ability from the other Arcbond to trigger. The second creature will then deal damage to each other creature and player. This will continue until one or both of the creatures die or the game ends. If this doesn’t happen (perhaps because both creatures have indestructible and damage dealt to the players is being prevented), and no player breaks the loop, the game will be a draw."
+          "text": "If two Arcbonds have resolved targeting different creatures, and damage is dealt to one of them, the delayed triggered ability will cause that creature to deal damage to each other creature and player. This will cause the delayed triggered ability from the other Arcbond to trigger. The second creature will then deal damage to each other creature and player. This will continue until one or both of the creatures die or the game ends. If this doesn't happen (perhaps because both creatures have indestructible and damage dealt to the players is being prevented), and no player breaks the loop, the game will be a draw."
         }
       ],
       "text": "Choose target creature. Whenever that creature is dealt damage this turn, it deals that much damage to each other creature and each player.",
@@ -11626,7 +11630,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If the creature’s power is greater than 2 as the activated ability tries to resolve, the ability will be countered and none of its effects will happen. However, if the creature’s power is raised above 2 after the ability resolves, it will still have haste and can’t be blocked that turn."
+          "text": "If the creature's power is greater than 2 as the activated ability tries to resolve, the ability will be countered and none of its effects will happen. However, if the creature's power is raised above 2 after the ability resolves, it will still have haste and can't be blocked that turn."
         }
       ],
       "text": "{R}: Target creature with power 2 or less gains haste until end of turn and can't be blocked this turn.",
@@ -11736,15 +11740,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         },
         {
           "date": "2014-11-24",
-          "text": "You must sacrifice exactly one creature to cast this spell; you can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast this spell; you can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2014-11-24",
-          "text": "Players can respond to Collateral Damage only after it’s been cast and all its costs have been paid. No one can try to destroy the creature you sacrificed to stop you from casting this spell."
+          "text": "Players can respond to Collateral Damage only after it's been cast and all its costs have been paid. No one can try to destroy the creature you sacrificed to stop you from casting this spell."
         }
       ],
       "text": "As an additional cost to cast Collateral Damage, sacrifice a creature.\nCollateral Damage deals 3 damage to target creature or player.",
@@ -11855,7 +11859,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose which mode you’re using as you put the ability on the stack, after the creature has entered the battlefield. Once you’ve chosen a mode, you can’t change that mode even if the creature leaves the battlefield in response to that ability."
+          "text": "You choose which mode you're using as you put the ability on the stack, after the creature has entered the battlefield. Once you've chosen a mode, you can't change that mode even if the creature leaves the battlefield in response to that ability."
         },
         {
           "date": "2014-11-24",
@@ -11974,15 +11978,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Even though it can generate mana, Dragonrage isn’t a mana ability. It uses the stack and can be responded to."
+          "text": "Even though it can generate mana, Dragonrage isn't a mana ability. It uses the stack and can be responded to."
         },
         {
           "date": "2014-11-24",
-          "text": "Only creatures that are attacking as Dragonrage resolves will count toward how much mana is generated, and only those creatures will gain the “firebreathing” activated ability. In other words, casting Dragonrage before you’ve declared attackers usually won’t do anything."
+          "text": "Only creatures that are attacking as Dragonrage resolves will count toward how much mana is generated, and only those creatures will gain the \"firebreathing\" activated ability. In other words, casting Dragonrage before you've declared attackers usually won't do anything."
         },
         {
           "date": "2014-11-24",
-          "text": "Remember that unused mana empties from players’ mana pools at the end of each step and phase. For example, if you cast Dragonrage during your declare attackers step, except in very rare cases, the mana Dragonrage generates won’t last until the declare blockers step or the postcombat main phase."
+          "text": "Remember that unused mana empties from players' mana pools at the end of each step and phase. For example, if you cast Dragonrage during your declare attackers step, except in very rare cases, the mana Dragonrage generates won't last until the declare blockers step or the postcombat main phase."
         }
       ],
       "text": "Add {R} to your mana pool for each attacking creature you control. Until end of turn, attacking creatures you control gain \"{R}: This creature gets +1/+0 until end of turn.\"",
@@ -12093,11 +12097,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -12105,27 +12109,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -12133,15 +12137,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Manifest the top card of your library, then put two +1/+1 counters on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -12253,7 +12257,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose which opponent or opposing planeswalker the token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Flamerush Rider is attacking."
+          "text": "You choose which opponent or opposing planeswalker the token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Flamerush Rider is attacking."
         },
         {
           "date": "2014-11-24",
@@ -12261,7 +12265,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that creature has any counters on it or Auras and/or Equipment attached to it, or any non-copy effects that changed its power, toughness, types, color, and so on. Notably, it doesn’t copy any effects that may have turned a noncreature permanent into a creature. If the token isn’t a creature as it enters the battlefield, it won’t be attacking."
+          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that creature has any counters on it or Auras and/or Equipment attached to it, or any non-copy effects that changed its power, toughness, types, color, and so on. Notably, it doesn't copy any effects that may have turned a noncreature permanent into a creature. If the token isn't a creature as it enters the battlefield, it won't be attacking."
         },
         {
           "date": "2014-11-24",
@@ -12277,27 +12281,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “As [this creature] enters the battlefield” or “[This creature] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"As [this creature] enters the battlefield\" or \"[This creature] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2014-11-24",
-          "text": "If another creature becomes or enters the battlefield as a copy of the token, you won’t exile that creature at end of combat. However, if Flamerush Rider creates multiple tokens due to a replacement effect (like the one Doubling Season creates), you’ll exile each of those tokens."
+          "text": "If another creature becomes or enters the battlefield as a copy of the token, you won't exile that creature at end of combat. However, if Flamerush Rider creates multiple tokens due to a replacement effect (like the one Doubling Season creates), you'll exile each of those tokens."
         },
         {
           "date": "2014-11-24",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2014-11-24",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2014-11-24",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2014-11-24",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -12414,7 +12418,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Flamewake Phoenix’s ferocious ability triggers only if Flamewake Phoenix is in your graveyard and you control a creature with power 4 or greater at the beginning of combat on your turn. Additionally, the ability will check to see if you control a creature with power 4 or greater again as it resolves. If you don’t, the ability will have no effect."
+          "text": "Flamewake Phoenix's ferocious ability triggers only if Flamewake Phoenix is in your graveyard and you control a creature with power 4 or greater at the beginning of combat on your turn. Additionally, the ability will check to see if you control a creature with power 4 or greater again as it resolves. If you don't, the ability will have no effect."
         },
         {
           "date": "2014-11-24",
@@ -12422,11 +12426,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If, during your declare attackers step, Flamewake Phoenix is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having Flamewake Phoenix attack, you’re not forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Flamewake Phoenix is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having Flamewake Phoenix attack, you're not forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2014-11-24",
-          "text": "If Flamewake Phoenix enters the battlefield before the combat phase, it will attack that turn if able. If it enters the battlefield after combat, it won’t attack that turn and will usually be available to block on the following turn."
+          "text": "If Flamewake Phoenix enters the battlefield before the combat phase, it will attack that turn if able. If it enters the battlefield after combat, it won't attack that turn and will usually be available to block on the following turn."
         }
       ],
       "subtypes": [
@@ -12449,7 +12453,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Never tell goblins to ‘fire at will.'\"\n—Urut Barzeel, Mardu hordechief",
+      "flavor": "\"Never tell goblins to 'fire at will.'\"\n—Urut Barzeel, Mardu hordechief",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -12541,7 +12545,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Cards that don’t have mana costs, such as land cards, have a converted mana cost of 0."
+          "text": "Cards that don't have mana costs, such as land cards, have a converted mana cost of 0."
         },
         {
           "date": "2014-11-24",
@@ -12655,19 +12659,19 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2014-11-24",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2014-11-24",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2014-11-24",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -12892,11 +12896,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Humble Defector’s ability can be activated any time during your turn, including in response to a spell or ability."
+          "text": "Humble Defector's ability can be activated any time during your turn, including in response to a spell or ability."
         },
         {
           "date": "2014-11-24",
-          "text": "If Humble Defector isn’t on the battlefield as its ability resolves, but the target player is still a legal target, the ability will resolve. You’ll draw two cards, even though the player won’t gain control of Humble Defector."
+          "text": "If Humble Defector isn't on the battlefield as its ability resolves, but the target player is still a legal target, the ability will resolve. You'll draw two cards, even though the player won't gain control of Humble Defector."
         },
         {
           "date": "2014-11-24",
@@ -13017,7 +13021,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Hungering Yeti checks if you control a green or blue permanent only as you begin to cast it. Once you begin to cast Hungering Yeti as though it had flash, it doesn’t matter what happens to the green or blue permanents you control."
+          "text": "Hungering Yeti checks if you control a green or blue permanent only as you begin to cast it. Once you begin to cast Hungering Yeti as though it had flash, it doesn't matter what happens to the green or blue permanents you control."
         }
       ],
       "subtypes": [
@@ -13133,7 +13137,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Lightning Shrieker’s owner shuffles it into his or her library only if it’s on the battlefield as its ability resolves."
+          "text": "Lightning Shrieker's owner shuffles it into his or her library only if it's on the battlefield as its ability resolves."
         }
       ],
       "subtypes": [
@@ -13247,7 +13251,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If the enchanted creature assigns combat damage during the first combat damage step, and then it loses first strike before the second combat damage step, it won’t assign combat damage again in the second combat damage step."
+          "text": "If the enchanted creature assigns combat damage during the first combat damage step, and then it loses first strike before the second combat damage step, it won't assign combat damage again in the second combat damage step."
         }
       ],
       "subtypes": [
@@ -13362,19 +13366,19 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2014-11-24",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2014-11-24",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2014-11-24",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -13489,11 +13493,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose which mode you’re using as you cast Mob Rule. Once it’s cast, you can’t change its mode, even if creatures’ powers change in response."
+          "text": "You choose which mode you're using as you cast Mob Rule. Once it's cast, you can't change its mode, even if creatures' powers change in response."
         },
         {
           "date": "2014-11-24",
-          "text": "Once you gain control of a creature, it doesn’t matter what happens to its power."
+          "text": "Once you gain control of a creature, it doesn't matter what happens to its power."
         },
         {
           "date": "2014-11-24",
@@ -13501,7 +13505,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "text": "Choose one —\n• Gain control of all creatures with power 4 or greater until end of turn. Untap those creatures. They gain haste until end of turn.\n• Gain control of all creatures with power 3 or less until end of turn. Untap those creatures. They gain haste until end of turn.",
@@ -13610,15 +13614,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The card exiled by the “Khans” ability is exiled face up. Playing a card exiled with the “Khans” ability follows the normal rules for playing the card. You must pay its costs, and you must follow all applicable timing rules. For example, if it’s a creature card, you can cast it only during your main phase while the stack is empty."
+          "text": "The card exiled by the \"Khans\" ability is exiled face up. Playing a card exiled with the \"Khans\" ability follows the normal rules for playing the card. You must pay its costs, and you must follow all applicable timing rules. For example, if it's a creature card, you can cast it only during your main phase while the stack is empty."
         },
         {
           "date": "2014-11-24",
-          "text": "If you exile a land card using the “Khans” ability, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven’t played a land yet that turn."
+          "text": "If you exile a land card using the \"Khans\" ability, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven't played a land yet that turn."
         },
         {
           "date": "2014-11-24",
-          "text": "If a noncreature card is manifested and then leaves the battlefield while face down, the “Dragons” ability will trigger."
+          "text": "If a noncreature card is manifested and then leaves the battlefield while face down, the \"Dragons\" ability will trigger."
         },
         {
           "date": "2014-11-24",
@@ -13626,11 +13630,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The words “Khans” and “Dragons” are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. “[Anchor word] — [Ability]” means “As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].” Notably, the anchor word “Dragons” has no connection to the creature type Dragon."
+          "text": "The words \"Khans\" and \"Dragons\" are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. \"[Anchor word] — [Ability]\" means \"As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].\" Notably, the anchor word \"Dragons\" has no connection to the creature type Dragon."
         },
         {
           "date": "2014-11-24",
-          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won’t depend on the choice made for the original permanent."
+          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won't depend on the choice made for the original permanent."
         }
       ],
       "text": "As Outpost Siege enters the battlefield, choose Khans or Dragons.\n• Khans — At the beginning of your upkeep, exile the top card of your library. Until end of turn, you may play that card.\n• Dragons — Whenever a creature you control leaves the battlefield, Outpost Siege deals 1 damage to target creature or player.",
@@ -13754,15 +13758,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If some but not all of Pyrotechnics’s targets become illegal, you can’t change the division of damage. Damage that would have been dealt to illegal targets simply isn’t dealt."
+          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can’t deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
         },
         {
           "date": "2014-11-24",
-          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can’t be changed. The effect that creates the copy may allow you to change the targets, however."
+          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
         }
       ],
       "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
@@ -13871,11 +13875,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -13883,27 +13887,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -13911,27 +13915,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         },
         {
           "date": "2014-11-24",
-          "text": "You’ll still manifest the top card of your library even if the “Form” isn’t on the battlefield as its enters-the-battlefield ability resolves."
+          "text": "You'll still manifest the top card of your library even if the \"Form\" isn't on the battlefield as its enters-the-battlefield ability resolves."
         },
         {
           "date": "2014-11-24",
-          "text": "If you have no cards in your library as the ability resolves, the “Form” will be put into its owner’s graveyard as a state-based action."
+          "text": "If you have no cards in your library as the ability resolves, the \"Form\" will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-11-24",
-          "text": "If the enchanted creature is turned face up, the “Form” will continue to enchant it."
+          "text": "If the enchanted creature is turned face up, the \"Form\" will continue to enchant it."
         }
       ],
       "text": "When Rageform enters the battlefield, it becomes an Aura with enchant creature. Manifest the top card of your library and attach Rageform to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
@@ -14378,7 +14382,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)\nFerocious — That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
@@ -14489,19 +14493,19 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2014-11-24",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2014-11-24",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2014-11-24",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -14617,15 +14621,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Wild Slash’s ferocious ability applies to all damage that would be dealt that turn, including the damage Wild Slash deals."
+          "text": "Wild Slash's ferocious ability applies to all damage that would be dealt that turn, including the damage Wild Slash deals."
         },
         {
           "date": "2014-11-24",
-          "text": "If you control a creature with power 4 or greater as Wild Slash resolves, the ferocious ability will apply. Damage dealt that turn can’t be prevented, even if you no longer control a creature with power 4 or greater as that damage would be dealt."
+          "text": "If you control a creature with power 4 or greater as Wild Slash resolves, the ferocious ability will apply. Damage dealt that turn can't be prevented, even if you no longer control a creature with power 4 or greater as that damage would be dealt."
         },
         {
           "date": "2014-11-24",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Ferocious — If you control a creature with power 4 or greater, damage can't be prevented this turn.\nWild Slash deals 2 damage to target creature or player.",
@@ -14742,7 +14746,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You’ll draw a maximum of one card, even if you control multiple creatures tied for the greatest toughness."
+          "text": "You'll draw a maximum of one card, even if you control multiple creatures tied for the greatest toughness."
         }
       ],
       "subtypes": [
@@ -14969,7 +14973,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose which mode you’re using as you put the ability on the stack, after the creature has entered the battlefield. Once you’ve chosen a mode, you can’t change that mode even if the creature leaves the battlefield in response to that ability."
+          "text": "You choose which mode you're using as you put the ability on the stack, after the creature has entered the battlefield. Once you've chosen a mode, you can't change that mode even if the creature leaves the battlefield in response to that ability."
         },
         {
           "date": "2014-11-24",
@@ -15089,11 +15093,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you control no other creatures as Ambush Krotiq’s triggered ability resolves, nothing happens. Ambush Krotiq remains on the battlefield."
+          "text": "If you control no other creatures as Ambush Krotiq's triggered ability resolves, nothing happens. Ambush Krotiq remains on the battlefield."
         },
         {
           "date": "2014-11-24",
-          "text": "The triggered ability doesn’t target any permanent. You choose which one to return as the ability resolves. No player can respond to this choice once the ability starts resolving."
+          "text": "The triggered ability doesn't target any permanent. You choose which one to return as the ability resolves. No player can respond to this choice once the ability starts resolving."
         }
       ],
       "subtypes": [
@@ -15209,15 +15213,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Arashin War Beast’s ability will trigger only once per combat damage step, no matter how many creatures are blocking it."
+          "text": "Arashin War Beast's ability will trigger only once per combat damage step, no matter how many creatures are blocking it."
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -15225,27 +15229,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -15253,15 +15257,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "subtypes": [
@@ -15488,7 +15492,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The second ability applies only as blockers are declared. If a creature you control with no +1/+1 counters on it becomes blocked by more than one creature, putting a +1/+1 counter on it won’t change or undo the block."
+          "text": "The second ability applies only as blockers are declared. If a creature you control with no +1/+1 counters on it becomes blocked by more than one creature, putting a +1/+1 counter on it won't change or undo the block."
         }
       ],
       "subtypes": [
@@ -15603,7 +15607,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -15935,11 +15939,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -15947,27 +15951,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -15975,15 +15979,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Manifest the top card of your library, then put a +1/+1 counter on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -16094,7 +16098,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Frontier Mastodon’s ferocious ability checks if you control a creature with power 4 or greater as Frontier Mastodon enters the battlefield. Because Frontier Mastodon isn’t on the battlefield at this time, it won’t count itself."
+          "text": "Frontier Mastodon's ferocious ability checks if you control a creature with power 4 or greater as Frontier Mastodon enters the battlefield. Because Frontier Mastodon isn't on the battlefield at this time, it won't count itself."
         }
       ],
       "subtypes": [
@@ -16208,11 +16212,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The “Khans” ability triggers at the beginning of both your precombat main phase and your postcombat main phase. Unused mana empties from players’ mana pools at the end of each step and phase."
+          "text": "The \"Khans\" ability triggers at the beginning of both your precombat main phase and your postcombat main phase. Unused mana empties from players' mana pools at the end of each step and phase."
         },
         {
           "date": "2014-11-24",
-          "text": "For the “Dragons” ability, you decide whether the creature with flying will fight the target creature you don’t control as the ability resolves."
+          "text": "For the \"Dragons\" ability, you decide whether the creature with flying will fight the target creature you don't control as the ability resolves."
         },
         {
           "date": "2014-11-24",
@@ -16220,11 +16224,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The words “Khans” and “Dragons” are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. “[Anchor word] — [Ability]” means “As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].” Notably, the anchor word “Dragons” has no connection to the creature type Dragon."
+          "text": "The words \"Khans\" and \"Dragons\" are anchor words, connecting your choice to the appropriate ability. Anchor words are a new rules concept. \"[Anchor word] — [Ability]\" means \"As long as you chose [anchor word] as this permanent entered the battlefield, this permanent has [ability].\" Notably, the anchor word \"Dragons\" has no connection to the creature type Dragon."
         },
         {
           "date": "2014-11-24",
-          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won’t depend on the choice made for the original permanent."
+          "text": "Each of the last two abilities is linked to the first ability. They each refer only to the choice made as a result of the first ability. If a permanent enters the battlefield as a copy of one of the Sieges, its controller will make a new choice for that Siege. Which ability the copy has won't depend on the choice made for the original permanent."
         }
       ],
       "text": "As Frontier Siege enters the battlefield, choose Khans or Dragons.\n• Khans — At the beginning of each of your main phases, add {G}{G} to your mana pool.\n• Dragons — Whenever a creature with flying enters the battlefield under your control, you may have it fight target creature you don't control.",
@@ -16334,11 +16338,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Use the creature’s toughness when it left the battlefield to determine the value of X. If that number is 0 or less, you won’t gain life or draw cards. (You won’t lose life or discard cards either.)"
+          "text": "Use the creature's toughness when it left the battlefield to determine the value of X. If that number is 0 or less, you won't gain life or draw cards. (You won't lose life or discard cards either.)"
         },
         {
           "date": "2014-11-24",
-          "text": "Fruit of the First Tree can enchant any creature, but Fruit of the First Tree’s controller will gain life and draw cards."
+          "text": "Fruit of the First Tree can enchant any creature, but Fruit of the First Tree's controller will gain life and draw cards."
         }
       ],
       "subtypes": [
@@ -16461,16 +16465,8 @@
       "rarity": "Common",
       "rulings": [
         {
-          "date": "2014-11-24",
-          "text": "If either target is an illegal target as Hunt the Weak tries to resolve, neither creature will deal or be dealt damage."
-        },
-        {
-          "date": "2014-11-24",
-          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won’t put a +1/+1 counter on it. If that creature is a legal target but the creature you don’t control isn’t, you’ll still put the counter on the creature you control."
-        },
-        {
           "date": "2016-09-20",
-          "text": "You can’t cast Hunt the Weak unless you choose both a creature you control and a creature you don’t control as targets."
+          "text": "You can't cast Hunt the Weak unless you choose both a creature you control and a creature you don't control as targets."
         },
         {
           "date": "2016-09-20",
@@ -16478,7 +16474,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won’t put a +1/+1 counter on it. If that creature is a legal target but the other creature isn’t, you’ll still put the counter on the creature you control."
+          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won't put a +1/+1 counter on it. If that creature is a legal target but the other creature isn't, you'll still put the counter on the creature you control."
         }
       ],
       "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
@@ -16587,7 +16583,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -16919,7 +16915,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -17041,7 +17037,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Draw a card for each creature you control.\nFerocious — You gain 4 life for each creature you control with power 4 or greater.",
@@ -17152,7 +17148,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose which creature card and land card to return to your hand as Sudden Reclamation resolves. This doesn’t target either card."
+          "text": "You choose which creature card and land card to return to your hand as Sudden Reclamation resolves. This doesn't target either card."
         },
         {
           "date": "2014-11-24",
@@ -17374,7 +17370,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You choose whether to return a creature and which creature to return as the activated ability resolves. This doesn’t target any creature."
+          "text": "You choose whether to return a creature and which creature to return as the activated ability resolves. This doesn't target any creature."
         }
       ],
       "subtypes": [
@@ -17490,11 +17486,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -17502,27 +17498,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -17530,15 +17526,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "subtypes": [
@@ -17665,11 +17661,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The first ability overwrites any previous effects that set the creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after the first ability resolves will overwrite this effect."
+          "text": "The first ability overwrites any previous effects that set the creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after the first ability resolves will overwrite this effect."
         },
         {
           "date": "2014-11-24",
-          "text": "Effects that modify Warden of the First Tree’s power or toughness, such as the one created by Titanic Growth, will apply to Warden of the First Tree no matter when they started to take effect. The same is true for any +1/+1 counters on Warden of the First Tree and effects that switch its power and toughness."
+          "text": "Effects that modify Warden of the First Tree's power or toughness, such as the one created by Titanic Growth, will apply to Warden of the First Tree no matter when they started to take effect. The same is true for any +1/+1 counters on Warden of the First Tree and effects that switch its power and toughness."
         }
       ],
       "subtypes": [
@@ -17895,15 +17891,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The last ability grants that ability to face-up nontoken creatures you control as that ability resolves. Creatures that come under your control later in the turn won’t have that ability."
+          "text": "The last ability grants that ability to face-up nontoken creatures you control as that ability resolves. Creatures that come under your control later in the turn won't have that ability."
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -17911,27 +17907,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -17939,15 +17935,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "subtypes": [
@@ -18064,15 +18060,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you choose 0 for X, you’ll just manifest the top card of your library."
+          "text": "If you choose 0 for X, you'll just manifest the top card of your library."
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -18080,27 +18076,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -18108,15 +18104,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Manifest the top card of your library, then put X +1/+1 counters on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -18339,11 +18335,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The powers of the target creature and Yasova Dragonclaw are checked as you put the ability on the stack and again as the ability resolves. Once the ability resolves, it doesn’t matter what happens to either creature’s power."
+          "text": "The powers of the target creature and Yasova Dragonclaw are checked as you put the ability on the stack and again as the ability resolves. Once the ability resolves, it doesn't matter what happens to either creature's power."
         },
         {
           "date": "2014-11-24",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -18580,7 +18576,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You can’t cast Cunning Strike unless you target both a creature and a player. If one target (but not both) is illegal as Cunning Strike resolves, it deals damage to the remaining legal target and you draw a card. If both targets are illegal, the spell will be countered and none of its effects will happen. You won’t draw a card in that case."
+          "text": "You can't cast Cunning Strike unless you target both a creature and a player. If one target (but not both) is illegal as Cunning Strike resolves, it deals damage to the remaining legal target and you draw a card. If both targets are illegal, the spell will be countered and none of its effects will happen. You won't draw a card in that case."
         }
       ],
       "text": "Cunning Strike deals 2 damage to target creature and 2 damage to target player.\nDraw a card.",
@@ -18695,11 +18691,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Each Dragon you attack with will cause Dromoka’s triggered ability to trigger. For each instance of the ability, you’ll determine which creature to put +1/+1 counters on as it resolves. Specifically, the creature you control with the lowest toughness as the first such ability resolves may not have the lowest toughness as the second such ability resolves."
+          "text": "Each Dragon you attack with will cause Dromoka's triggered ability to trigger. For each instance of the ability, you'll determine which creature to put +1/+1 counters on as it resolves. Specifically, the creature you control with the lowest toughness as the first such ability resolves may not have the lowest toughness as the second such ability resolves."
         },
         {
           "date": "2014-11-24",
-          "text": "Bolster itself doesn’t target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain’s bolster ability."
+          "text": "Bolster itself doesn't target any creature, though some spells and abilities that bolster may have other effects that target creatures. For example, you could put counters on a creature with protection from white with Abzan Skycaptain's bolster ability."
         },
         {
           "date": "2014-11-24",
@@ -18827,15 +18823,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If you’re playing with the top card of your library revealed as Ethereal Ambush resolves (perhaps because you control a card such as Courser of Kruphix), you’ll manifest the top card, reveal the next card (now the top card), and then manifest that card."
+          "text": "If you're playing with the top card of your library revealed as Ethereal Ambush resolves (perhaps because you control a card such as Courser of Kruphix), you'll manifest the top card, reveal the next card (now the top card), and then manifest that card."
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -18843,27 +18839,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -18871,15 +18867,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Manifest the top two cards of your library. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -19210,19 +19206,19 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you choose to pay the dash cost rather than the mana cost, you’re still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
+          "text": "If you choose to pay the dash cost rather than the mana cost, you're still casting the spell. It goes on the stack and can be responded to and countered. You can cast a creature spell for its dash cost only when you otherwise could cast that creature spell. Most of the time, this means during your main phase when the stack is empty."
         },
         {
           "date": "2014-11-24",
-          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner’s hand only if it’s still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
+          "text": "If you pay the dash cost to cast a creature spell, that card will be returned to its owner's hand only if it's still on the battlefield when its triggered ability resolves. If it dies or goes to another zone before then, it will stay where it is."
         },
         {
           "date": "2014-11-24",
-          "text": "You don’t have to attack with the creature with dash unless another ability says you do."
+          "text": "You don't have to attack with the creature with dash unless another ability says you do."
         },
         {
           "date": "2014-11-24",
-          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won’t have haste and won’t be returned to its owner’s hand."
+          "text": "If a creature enters the battlefield as a copy of or becomes a copy of a creature whose dash cost was paid, the copy won't have haste and won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -19344,15 +19340,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The triggered ability can target a nonland permanent that’s already tapped. That permanent won’t untap during its controller’s next untap step."
+          "text": "The triggered ability can target a nonland permanent that's already tapped. That permanent won't untap during its controller's next untap step."
         },
         {
           "date": "2014-11-24",
-          "text": "The ability tracks the permanent, but not its controller. If the permanent changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "The ability tracks the permanent, but not its controller. If the permanent changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-11-24",
-          "text": "The ability only applies during the controller’s next untap step, even if the permanent has been the target of Ojutai’s triggered ability more than once. The permanent won’t stay tapped through multiple untap steps."
+          "text": "The ability only applies during the controller's next untap step, even if the permanent has been the target of Ojutai's triggered ability more than once. The permanent won't stay tapped through multiple untap steps."
         }
       ],
       "subtypes": [
@@ -19474,7 +19470,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The creatures affected by Silumgar’s triggered ability are determined relative to the Dragon that attacked. For example, if Silumgar attacked one opponent and two other Dragons attacked another opponent, creatures controlled by the first opponent would get -1/-1 until end of turn and creatures controlled by the second opponent would get -2/-2 until end of turn. In a Two-Headed Giant game, each creature controlled by either member of the defending team will get -1/-1."
+          "text": "The creatures affected by Silumgar's triggered ability are determined relative to the Dragon that attacked. For example, if Silumgar attacked one opponent and two other Dragons attacked another opponent, creatures controlled by the first opponent would get -1/-1 until end of turn and creatures controlled by the second opponent would get -2/-2 until end of turn. In a Two-Headed Giant game, each creature controlled by either member of the defending team will get -1/-1."
         }
       ],
       "subtypes": [
@@ -19790,7 +19786,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The triggered ability will trigger when one of the Gods from Theros block enters the battlefield only if your devotion is high enough that it’s a creature when it enters. If Hero’s Blade is attached to a God that stops being a creature (or any creature that stops being a creature), it will become unattached."
+          "text": "The triggered ability will trigger when one of the Gods from Theros block enters the battlefield only if your devotion is high enough that it's a creature when it enters. If Hero's Blade is attached to a God that stops being a creature (or any creature that stops being a creature), it will become unattached."
         }
       ],
       "subtypes": [
@@ -19899,7 +19895,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "It doesn’t matter whether the other spell resolved. It could have been countered or, if you’ve somehow cast Hewed Stone Retainers as though it had flash, it could still be on the stack."
+          "text": "It doesn't matter whether the other spell resolved. It could have been countered or, if you've somehow cast Hewed Stone Retainers as though it had flash, it could still be on the stack."
         }
       ],
       "subtypes": [
@@ -20111,11 +20107,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Count the number of lore counters on Scroll of the Masters as the activated ability resolves to determine how big a bonus the target creature gets. If Scroll of the Masters isn’t on the battlefield at that time, use the number of lore counters on it when it left the battlefield."
+          "text": "Count the number of lore counters on Scroll of the Masters as the activated ability resolves to determine how big a bonus the target creature gets. If Scroll of the Masters isn't on the battlefield at that time, use the number of lore counters on it when it left the battlefield."
         },
         {
           "date": "2014-11-24",
-          "text": "Once the activated ability has resolved, changing the number of lore counters on Scroll of the Masters won’t affect the bonus that activation granted."
+          "text": "Once the activated ability has resolved, changing the number of lore counters on Scroll of the Masters won't affect the bonus that activation granted."
         }
       ],
       "text": "Whenever you cast a noncreature spell, put a lore counter on Scroll of the Masters.\n{3}, {T}: Target creature you control gets +1/+1 until end of turn for each lore counter on Scroll of the Masters.",
@@ -20221,7 +20217,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you control only colorless permanents as the ability resolves (for example, basic lands and face-down permanents), you won’t sacrifice anything."
+          "text": "If you control only colorless permanents as the ability resolves (for example, basic lands and face-down permanents), you won't sacrifice anything."
         }
       ],
       "subtypes": [
@@ -20529,19 +20525,19 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "You can use mana generated by the last ability to pay an alternative cost (such as a dash cost) or an additional cost to cast a Dragon spell. It’s not limited to paying just that spell’s mana cost."
+          "text": "You can use mana generated by the last ability to pay an alternative cost (such as a dash cost) or an additional cost to cast a Dragon spell. It's not limited to paying just that spell's mana cost."
         },
         {
           "date": "2014-11-24",
-          "text": "An activated ability appears in the form “Cost: Effect.”"
+          "text": "An activated ability appears in the form \"Cost: Effect.\""
         },
         {
           "date": "2014-11-24",
-          "text": "Notably, turning a face-down creature face up isn’t an activated ability. If you manifest a Dragon creature card or cast a Dragon creature card face down using the morph ability, you can’t use mana generated by the last ability to turn that card face up."
+          "text": "Notably, turning a face-down creature face up isn't an activated ability. If you manifest a Dragon creature card or cast a Dragon creature card face down using the morph ability, you can't use mana generated by the last ability to turn that card face up."
         },
         {
           "date": "2014-11-24",
-          "text": "The mana generated by the last ability can’t be spent to activate abilities of Dragon sources that aren’t on the battlefield."
+          "text": "The mana generated by the last ability can't be spent to activate abilities of Dragon sources that aren't on the battlefield."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Put a storage counter on Crucible of the Spirit Dragon.\n{T}, Remove X storage counters from Crucible of the Spirit Dragon: Add X mana in any combination of colors to your mana pool. Spend this mana only to cast Dragon spells or activate abilities of Dragons.",

--- a/json/FRF_UGIN.json
+++ b/json/FRF_UGIN.json
@@ -120,7 +120,7 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Ugin, the Spirit Dragon is not a Dragon card; that is, he doesn’t have the creature type Dragon. Spells and abilities that refer to Dragon cards or Dragons don’t apply to Ugin."
+          "text": "Ugin, the Spirit Dragon is not a Dragon card; that is, he doesn't have the creature type Dragon. Spells and abilities that refer to Dragon cards or Dragons don't apply to Ugin."
         }
       ],
       "subtypes": [
@@ -234,11 +234,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -246,27 +246,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -274,15 +274,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Whenever a permanent you control is turned face up, you gain 1 life for each creature you control.\n{3}{W}: Manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -513,11 +513,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -525,27 +525,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -553,15 +553,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -680,27 +680,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -825,11 +825,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If Jeskai Infiltrator isn’t on the battlefield as its triggered ability resolves, you’ll manifest just the top card of your library."
+          "text": "If Jeskai Infiltrator isn't on the battlefield as its triggered ability resolves, you'll manifest just the top card of your library."
         },
         {
           "date": "2014-11-24",
-          "text": "A card’s owner is public information at all times. If the two cards you exile are owned by different players (perhaps because you gained control of a Jeskai Infiltrator owned by your opponent), which card is which is no longer hidden from your opponent. That player will know which face-down creature he or she owns."
+          "text": "A card's owner is public information at all times. If the two cards you exile are owned by different players (perhaps because you gained control of a Jeskai Infiltrator owned by your opponent), which card is which is no longer hidden from your opponent. That player will know which face-down creature he or she owns."
         },
         {
           "date": "2014-11-24",
@@ -837,11 +837,11 @@
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -849,27 +849,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -877,15 +877,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "subtypes": [
@@ -1001,11 +1001,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -1013,27 +1013,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -1041,15 +1041,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Exile target creature. Its controller manifests the top card of his or her library. (That player puts the top card of his or her library onto the battlefield face down as a 2/2 creature. If it's a creature card, it can be turned face up any time for its mana cost.)",
@@ -1173,27 +1173,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -1312,11 +1312,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Other players won’t know whether the card you manifest is the top card or second card of that library."
+          "text": "Other players won't know whether the card you manifest is the top card or second card of that library."
         },
         {
           "date": "2014-11-24",
-          "text": "If you’re playing with the top card of your library revealed, you’ll manifest one of the cards, then the other one will be revealed, then you can choose to put that card on the bottom of your library or leave it on top."
+          "text": "If you're playing with the top card of your library revealed, you'll manifest one of the cards, then the other one will be revealed, then you can choose to put that card on the bottom of your library or leave it on top."
         }
       ],
       "text": "Look at the top two cards of your library. Manifest one of those cards, then put the other on the top or bottom of your library. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -1545,27 +1545,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -1686,11 +1686,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -1698,27 +1698,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -1726,15 +1726,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "subtypes": [
@@ -1859,27 +1859,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -2008,27 +2008,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -2271,11 +2271,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -2283,27 +2283,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -2311,15 +2311,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Manifest the top card of your library, then put two +1/+1 counters on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -2431,11 +2431,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Jeering Instigator’s last ability can target any creature, even one that’s untapped or one you already control."
+          "text": "Jeering Instigator's last ability can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2014-09-20",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to that creature."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to that creature."
         },
         {
           "date": "2014-09-20",
@@ -2447,27 +2447,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -2587,15 +2587,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "Arashin War Beast’s ability will trigger only once per combat damage step, no matter how many creatures are blocking it."
+          "text": "Arashin War Beast's ability will trigger only once per combat damage step, no matter how many creatures are blocking it."
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -2603,27 +2603,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -2631,15 +2631,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "subtypes": [
@@ -2754,11 +2754,11 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -2766,27 +2766,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -2794,15 +2794,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Manifest the top card of your library, then put a +1/+1 counter on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -2913,7 +2913,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Dragonscale Boon can target any creature, including one that’s already untapped."
+          "text": "Dragonscale Boon can target any creature, including one that's already untapped."
         }
       ],
       "text": "Put two +1/+1 counters on target creature and untap it.",
@@ -3025,15 +3025,15 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you choose 0 for X, you’ll just manifest the top card of your library."
+          "text": "If you choose 0 for X, you'll just manifest the top card of your library."
         },
         {
           "date": "2014-11-24",
-          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
+          "text": "The face-down permanent is a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the permanent can still grant or change any of these characteristics."
         },
         {
           "date": "2014-11-24",
-          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it’s a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn’t use the stack and can’t be responded to."
+          "text": "Any time you have priority, you may turn a manifested creature face up by revealing that it's a creature card (ignoring any copy effects or type-changing effects that might be applying to it) and paying its mana cost. This is a special action. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-11-24",
@@ -3041,27 +3041,27 @@
         },
         {
           "date": "2014-11-24",
-          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it’s a creature card."
+          "text": "Unlike a face-down creature that was cast using the morph ability, a manifested creature may still be turned face up after it loses its abilities if it's a creature card."
         },
         {
           "date": "2014-11-24",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-11-24",
-          "text": "Because face-down creatures don’t have names, they can’t have the same name as any other creature, even another face-down creature."
+          "text": "Because face-down creatures don't have names, they can't have the same name as any other creature, even another face-down creature."
         },
         {
           "date": "2014-11-24",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-11-24",
-          "text": "Turning a permanent face up or face down doesn’t change whether that permanent is tapped or untapped."
+          "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
         },
         {
           "date": "2014-11-24",
-          "text": "At any time, you can look at a face-down permanent you control. You can’t look at face-down permanents you don’t control unless an effect allows you to or instructs you to."
+          "text": "At any time, you can look at a face-down permanent you control. You can't look at face-down permanents you don't control unless an effect allows you to or instructs you to."
         },
         {
           "date": "2014-11-24",
@@ -3069,15 +3069,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for indicating this include using markers or dice, or simply placing them in order on the battlefield. You must also track how each became face down (manifested, cast face down using the morph ability, and so on)."
         },
         {
           "date": "2014-11-24",
-          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it’s an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won’t trigger, because even though you revealed the card, it never turned face up."
+          "text": "There are no cards in the Fate Reforged set that would turn a face-down instant or sorcery card on the battlefield face up, but some older cards can try to do this. If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
         },
         {
           "date": "2014-11-24",
-          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can’t transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can’t be turned face down."
+          "text": "Some older Magic sets feature double-faced cards, which have a Magic card face on each side rather than a Magic card face on one side and a Magic card back on the other. The rules for double-faced cards are changing slightly to account for the possibility that they are manifested. If a double-faced card is manifested, it will be put onto the battlefield face down. While face down, it can't transform. If the front face of the card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced permanent on the battlefield still can't be turned face down."
         }
       ],
       "text": "Manifest the top card of your library, then put X +1/+1 counters on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
@@ -3183,7 +3183,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "It doesn’t matter whether the other spell resolved. It could have been countered or, if you’ve somehow cast Hewed Stone Retainers as though it had flash, it could still be on the stack."
+          "text": "It doesn't matter whether the other spell resolved. It could have been countered or, if you've somehow cast Hewed Stone Retainers as though it had flash, it could still be on the stack."
         }
       ],
       "subtypes": [
@@ -3294,7 +3294,7 @@
       "rulings": [
         {
           "date": "2014-11-24",
-          "text": "If you control only colorless permanents as the ability resolves (for example, basic lands and face-down permanents), you won’t sacrifice anything."
+          "text": "If you control only colorless permanents as the ability resolves (for example, basic lands and face-down permanents), you won't sacrifice anything."
         }
       ],
       "subtypes": [
@@ -3509,11 +3509,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Activating the ability targeting a creature that’s already attacking or blocking won’t remove it from combat or affect that attack or block."
+          "text": "Activating the ability targeting a creature that's already attacking or blocking won't remove it from combat or affect that attack or block."
         },
         {
           "date": "2014-09-20",
-          "text": "If Briber’s Purse has no gem counters on it, it remains on the battlefield, although you can’t activate its last ability."
+          "text": "If Briber's Purse has no gem counters on it, it remains on the battlefield, although you can't activate its last ability."
         }
       ],
       "text": "Briber's Purse enters the battlefield with X gem counters on it.\n{1}, {T}, Remove a gem counter from Briber's Purse: Target creature can't attack or block this turn.",

--- a/json/FUT.json
+++ b/json/FUT.json
@@ -177,31 +177,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -405,7 +405,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Both conditions need to be true for Barren Glory’s ability to trigger, and they both need to be true when the ability resolves or it will do nothing. In between, you can control permanents and/or have cards in hand."
+          "text": "Both conditions need to be true for Barren Glory's ability to trigger, and they both need to be true when the ability resolves or it will do nothing. In between, you can control permanents and/or have cards in hand."
         }
       ],
       "text": "At the beginning of your upkeep, if you control no permanents other than Barren Glory and have no cards in hand, you win the game.",
@@ -504,43 +504,43 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Chronomantic Escape can affect creatures that aren’t on the battlefield at the time it resolves, because it modifies the announcement of an attack, not the creatures on the battlefield. For example, if Chronomantic Escape resolves on your turn, then on your opponent’s turn he or she casts a creature with haste, that creature can’t attack that turn."
+          "text": "Chronomantic Escape can affect creatures that aren't on the battlefield at the time it resolves, because it modifies the announcement of an attack, not the creatures on the battlefield. For example, if Chronomantic Escape resolves on your turn, then on your opponent's turn he or she casts a creature with haste, that creature can't attack that turn."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -548,7 +548,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Until your next turn, creatures can't attack you. Exile Chronomantic Escape with three time counters on it.\nSuspend 3—{2}{W} (Rather than cast this card from your hand, you may pay {2}{W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
@@ -741,7 +741,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "It doesn’t matter how many creatures you control as Even the Odds resolves."
+          "text": "It doesn't matter how many creatures you control as Even the Odds resolves."
         }
       ],
       "text": "Cast Even the Odds only if you control fewer creatures than each opponent.\nCreate three 1/1 white Soldier creature tokens.",
@@ -941,7 +941,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain life equal to the damage prevented this way.\nAt the beginning of your next upkeep, pay {1}{W}{W}. If you don't, you lose the game.",
@@ -1134,39 +1134,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1275,7 +1275,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Lost Auramancers doesn’t have to have been sacrificed as part of the vanishing ability for its last ability to trigger. It will trigger no matter why it was put into a graveyard from the battlefield, as long as it had no time counters on it at the time."
+          "text": "Lost Auramancers doesn't have to have been sacrificed as part of the vanishing ability for its last ability to trigger. It will trigger no matter why it was put into a graveyard from the battlefield, as long as it had no time counters on it at the time."
         }
       ],
       "subtypes": [
@@ -1579,7 +1579,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If a creature enters the battlefield after “at the beginning of the end step” abilities have triggered during that turn, Saltskitter won’t return to the battlefield until the end of the following turn."
+          "text": "If a creature enters the battlefield after \"at the beginning of the end step\" abilities have triggered during that turn, Saltskitter won't return to the battlefield until the end of the following turn."
         }
       ],
       "subtypes": [
@@ -1790,31 +1790,31 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Scout’s Warning works just like Quicken, except for creatures instead of sorceries."
+          "text": "Scout's Warning works just like Quicken, except for creatures instead of sorceries."
         },
         {
           "date": "2007-05-01",
-          "text": "Scout’s Warning affects only the next creature card cast that turn, even if that creature already had flash."
+          "text": "Scout's Warning affects only the next creature card cast that turn, even if that creature already had flash."
         },
         {
           "date": "2007-05-01",
-          "text": "Scout’s Warning allows you to cast a noncreature card with morph (such as Lumithread Field) face down as though it had flash. It won’t affect that card if you cast it face up."
+          "text": "Scout's Warning allows you to cast a noncreature card with morph (such as Lumithread Field) face down as though it had flash. It won't affect that card if you cast it face up."
         },
         {
           "date": "2013-04-15",
-          "text": "You don’t choose a creature card when Scout’s Warning resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a creature card, even if you cast that creature at a time you normally could."
+          "text": "You don't choose a creature card when Scout's Warning resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a creature card, even if you cast that creature at a time you normally could."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast multiple Scout’s Warnings on the same turn, they’ll all apply to the very next creature spell you cast."
+          "text": "If you cast multiple Scout's Warnings on the same turn, they'll all apply to the very next creature spell you cast."
         },
         {
           "date": "2013-04-15",
-          "text": "After Scout’s Warning resolves, you can suspend a creature card in your hand any time you can cast an instant. As soon as you actually cast a creature card, you lose this capability."
+          "text": "After Scout's Warning resolves, you can suspend a creature card in your hand any time you can cast an instant. As soon as you actually cast a creature card, you lose this capability."
         },
         {
           "date": "2013-04-15",
-          "text": "You cannot use this effect to play Dryad Arbor during an opponent’s turn."
+          "text": "You cannot use this effect to play Dryad Arbor during an opponent's turn."
         }
       ],
       "text": "The next creature card you play this turn can be played as though it had flash.\nDraw a card.",
@@ -1993,6 +1993,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Time Spiral Block",
           "legality": "Legal"
         },
@@ -2018,7 +2022,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Each search works exactly the same as normal except that the opponent doing the searching sees only the top four cards of that library. He or she can’t look at the other cards in that library at all. Cards not in the top four cards of the library can’t be found in the search, even if they’re identifiable in some manner."
+          "text": "Each search works exactly the same as normal except that the opponent doing the searching sees only the top four cards of that library. He or she can't look at the other cards in that library at all. Cards not in the top four cards of the library can't be found in the search, even if they're identifiable in some manner."
         },
         {
           "date": "2017-04-18",
@@ -2026,7 +2030,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "If an effect uses the word “search” once but allows an opponent to search for multiple cards, the top four cards remain the same throughout the entire search. Finding one card won’t cause the fifth card to be included in the search."
+          "text": "If an effect uses the word \"search\" once but allows an opponent to search for multiple cards, the top four cards remain the same throughout the entire search. Finding one card won't cause the fifth card to be included in the search."
         },
         {
           "date": "2017-04-18",
@@ -2235,11 +2239,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you put Bound in Silence onto the battlefield without casting it, perhaps using the “recruiting” ability of a card like Amrou Scout, it will enter attached to a creature. You choose that creature as you’re putting it onto the battlefield. If there’s no creature on the battlefield it can be attached to, it stays in whatever zone it was in."
+          "text": "If you put Bound in Silence onto the battlefield without casting it, perhaps using the \"recruiting\" ability of a card like Amrou Scout, it will enter attached to a creature. You choose that creature as you're putting it onto the battlefield. If there's no creature on the battlefield it can be attached to, it stays in whatever zone it was in."
         },
         {
           "date": "2007-05-01",
-          "text": "Bound in Silence isn’t a creature and isn’t affected by any effect that affects creatures or Rebel creatures."
+          "text": "Bound in Silence isn't a creature and isn't affected by any effect that affects creatures or Rebel creatures."
         }
       ],
       "subtypes": [
@@ -2345,11 +2349,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If all other Auras attached to the enchanted creature stop enchanting it, Daybreak Coronet will be attached to an illegal permanent and will be put into its owner’s graveyard."
+          "text": "If all other Auras attached to the enchanted creature stop enchanting it, Daybreak Coronet will be attached to an illegal permanent and will be put into its owner's graveyard."
         },
         {
           "date": "2007-05-01",
-          "text": "Because Retether returns all Auras to the battlefield at the same time, it won’t let you attach Daybreak Coronet to a creature unless that creature is already enchanted."
+          "text": "Because Retether returns all Auras to the battlefield at the same time, it won't let you attach Daybreak Coronet to a creature unless that creature is already enchanted."
         }
       ],
       "subtypes": [
@@ -2556,7 +2560,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Only teammates within the range of influence of Imperial Mask’s controller will get a token. Imperial Mask’s controller doesn’t get a token; that player just gets the Imperial Mask."
+          "text": "Only teammates within the range of influence of Imperial Mask's controller will get a token. Imperial Mask's controller doesn't get a token; that player just gets the Imperial Mask."
         },
         {
           "date": "2007-05-01",
@@ -2670,7 +2674,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Lucent Liminid is an enchantment creature, in much the same way that Ornithopter is an artifact creature. It’s affected by anything that affects creatures and anything that affects enchantments."
+          "text": "Lucent Liminid is an enchantment creature, in much the same way that Ornithopter is an artifact creature. It's affected by anything that affects creatures and anything that affects enchantments."
         }
       ],
       "subtypes": [
@@ -2872,11 +2876,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -2987,15 +2991,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "While a spell with X in its cost is on the stack, its converted mana cost takes the chosen value of X into account. Mistmeadow Skulk can be chosen as a target for a Blaze (which has mana cost {X}{R}) if X is 0 or 1, for example, but it can’t be chosen as a target for a Blaze if X is 2 or more."
+          "text": "While a spell with X in its cost is on the stack, its converted mana cost takes the chosen value of X into account. Mistmeadow Skulk can be chosen as a target for a Blaze (which has mana cost {X}{R}) if X is 0 or 1, for example, but it can't be chosen as a target for a Blaze if X is 2 or more."
         },
         {
           "date": "2007-05-01",
-          "text": "A face-down creature has a converted mana cost of 0, so Mistmeadow Skulk doesn’t have protection from it ."
+          "text": "A face-down creature has a converted mana cost of 0, so Mistmeadow Skulk doesn't have protection from it ."
         },
         {
           "date": "2008-05-01",
-          "text": "The protection ability means the following: - Mistmeadow Skulk can’t be blocked by creatures with converted mana cost 3 or greater. - Mistmeadow Skulk can’t be enchanted by Auras with converted mana cost 3 or greater. It also can’t be equipped by Equipment with converted mana cost 3 or greater. - Mistmeadow Skulk can’t be targeted by spells with converted mana cost 3 or greater. It also can’t be targeted by abilities from sources with converted mana cost 3 or greater. - All damage that would be dealt to Mistmeadow Skulk by sources with converted mana cost 3 or greater is prevented."
+          "text": "The protection ability means the following: - Mistmeadow Skulk can't be blocked by creatures with converted mana cost 3 or greater. - Mistmeadow Skulk can't be enchanted by Auras with converted mana cost 3 or greater. It also can't be equipped by Equipment with converted mana cost 3 or greater. - Mistmeadow Skulk can't be targeted by spells with converted mana cost 3 or greater. It also can't be targeted by abilities from sources with converted mana cost 3 or greater. - All damage that would be dealt to Mistmeadow Skulk by sources with converted mana cost 3 or greater is prevented."
         }
       ],
       "subtypes": [
@@ -3300,7 +3304,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "A “permanent card” is an artifact card, a creature card, an enchantment card, a planeswalker card, or a land card. Most “Rebel permanent cards” are creature cards."
+          "text": "A \"permanent card\" is an artifact card, a creature card, an enchantment card, a planeswalker card, or a land card. Most \"Rebel permanent cards\" are creature cards."
         }
       ],
       "subtypes": [
@@ -3706,7 +3710,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "You do the three different scry actions in sequence, in the order they’re printed on the card."
+          "text": "You do the three different scry actions in sequence, in the order they're printed on the card."
         }
       ],
       "subtypes": [
@@ -3810,11 +3814,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "When the last time counter is removed from the exiled card, it’s cast as a completely new spell. Modes and targets are chosen again. If the spell has any additional costs, they must be paid again. If they can’t be, the spell can’t be cast and stays exiled."
+          "text": "When the last time counter is removed from the exiled card, it's cast as a completely new spell. Modes and targets are chosen again. If the spell has any additional costs, they must be paid again. If they can't be, the spell can't be cast and stays exiled."
         },
         {
           "date": "2007-05-01",
-          "text": "If the spell targeted by Delay was cast with flashback, Delay’s effect will exile it, not the flashback effect. The card will get time counters and gain suspend (if it didn’t already have suspend)."
+          "text": "If the spell targeted by Delay was cast with flashback, Delay's effect will exile it, not the flashback effect. The card will get time counters and gain suspend (if it didn't already have suspend)."
         }
       ],
       "text": "Counter target spell. If the spell is countered this way, exile it with three time counters on it instead of putting it into its owner's graveyard. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, remove a time counter from that card. When the last is removed, the player plays it without paying its mana cost. If it's a creature, it has haste.)",
@@ -4009,39 +4013,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -4246,7 +4250,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Maelstrom Djinn turns face up and then is somehow turned face down, it will still have vanishing and time counters. The vanishing ability will continue to work as normal. If it’s turned face up again, it will get more time counters on it, but it will also get another copy of vanishing. Both abilities would trigger during its controller’s upkeep."
+          "text": "If Maelstrom Djinn turns face up and then is somehow turned face down, it will still have vanishing and time counters. The vanishing ability will continue to work as normal. If it's turned face up again, it will get more time counters on it, but it will also get another copy of vanishing. Both abilities would trigger during its controller's upkeep."
         }
       ],
       "subtypes": [
@@ -4351,7 +4355,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2016-06-08",
@@ -4363,7 +4367,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability (perhaps because that top card is the card you’re casting) the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability (perhaps because that top card is the card you're casting) the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2016-06-08",
@@ -4567,7 +4571,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Counter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
@@ -4666,39 +4670,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -4806,23 +4810,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -5026,15 +5030,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Venser’s triggered ability targets a spell cast with flashback, that spell will be exiled instead of returning to its owner’s hand."
+          "text": "If Venser's triggered ability targets a spell cast with flashback, that spell will be exiled instead of returning to its owner's hand."
         },
         {
           "date": "2017-03-14",
-          "text": "If a spell is returned to its owner’s hand, it’s removed from the stack and thus will not resolve. The spell isn’t countered; it just no longer exists. This works against a spell that can’t be countered."
+          "text": "If a spell is returned to its owner's hand, it's removed from the stack and thus will not resolve. The spell isn't countered; it just no longer exists. This works against a spell that can't be countered."
         },
         {
           "date": "2017-03-14",
-          "text": "If a copy of a spell is returned to its owner’s hand, it’s moved there, then it will cease to exist as a state-based action. It can’t be recast."
+          "text": "If a copy of a spell is returned to its owner's hand, it's moved there, then it will cease to exist as a state-based action. It can't be recast."
         }
       ],
       "subtypes": [
@@ -5240,7 +5244,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If on resolution, half the exchange can’t be completed (such as if the only Aura in your hand can’t enchant the permanent), nothing happens."
+          "text": "If on resolution, half the exchange can't be completed (such as if the only Aura in your hand can't enchant the permanent), nothing happens."
         }
       ],
       "subtypes": [
@@ -5541,7 +5545,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Linessa’s grandeur ability targets only a player. That player chooses which permanents to return as the ability resolves. The permanents are returned one at a time, in a specific sequence. The player can’t return an artifact creature and have that count as both the artifact and the creature, for example."
+          "text": "Linessa's grandeur ability targets only a player. That player chooses which permanents to return as the ability resolves. The permanents are returned one at a time, in a specific sequence. The player can't return an artifact creature and have that count as both the artifact and the creature, for example."
         }
       ],
       "subtypes": [
@@ -5650,7 +5654,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Using delve doesn’t reduce the value of X. It just reduces the amount of mana Logic Knot’s controller has to pay."
+          "text": "Using delve doesn't reduce the value of X. It just reduces the amount of mana Logic Knot's controller has to pay."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nCounter target spell unless its controller pays {X}.",
@@ -5755,11 +5759,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -5866,11 +5870,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Narcomoeba is revealed or looked at while moving from your library to your graveyard (such as with Mind Funeral), its ability will trigger when it’s put into your graveyard. It was still in your library while it was revealed or being looked at."
+          "text": "If Narcomoeba is revealed or looked at while moving from your library to your graveyard (such as with Mind Funeral), its ability will trigger when it's put into your graveyard. It was still in your library while it was revealed or being looked at."
         },
         {
           "date": "2007-05-01",
-          "text": "If Narcomoeba is removed from your graveyard before its ability resolves, it won’t be put onto the battlefield."
+          "text": "If Narcomoeba is removed from your graveyard before its ability resolves, it won't be put onto the battlefield."
         }
       ],
       "subtypes": [
@@ -5979,11 +5983,11 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Nix doesn’t check whether a spell’s mana cost is 0. Rather, it checks how much mana was actually spent to cast it. It can counter a spell with mana cost 0 (such as Slaughter Pact), a spell cast via an alternative nonmana cost (such as Allosaurus Rider) or alternative cost of {0} (such as Basking Rootwalla), a spell whose cost to cast it was reduced to 0 (such as Frogmite), a spell cast without paying its cost due to an effect (such as suspend or Mindleech Mass’s ability), or a copy of a spell, among other possibilities. It will not counter a spell that had an additional or alternative mana cost paid to cast it, regardless of that spell’s converted mana cost (such as a face-down spell cast with morph, or an Ornithopter cast while Trinisphere is on the battlefield, for example)."
+          "text": "Nix doesn't check whether a spell's mana cost is 0. Rather, it checks how much mana was actually spent to cast it. It can counter a spell with mana cost 0 (such as Slaughter Pact), a spell cast via an alternative nonmana cost (such as Allosaurus Rider) or alternative cost of {0} (such as Basking Rootwalla), a spell whose cost to cast it was reduced to 0 (such as Frogmite), a spell cast without paying its cost due to an effect (such as suspend or Mindleech Mass's ability), or a copy of a spell, among other possibilities. It will not counter a spell that had an additional or alternative mana cost paid to cast it, regardless of that spell's converted mana cost (such as a face-down spell cast with morph, or an Ornithopter cast while Trinisphere is on the battlefield, for example)."
         },
         {
           "date": "2007-05-01",
-          "text": "Nix checks whether any player paid mana to cast the spell, not whether its current controller did. If Commandeer is cast on a spell, then Nix is cast on that spell, Nix won’t counter it unless the player who originally cast that spell spent no mana to cast it."
+          "text": "Nix checks whether any player paid mana to cast the spell, not whether its current controller did. If Commandeer is cast on a spell, then Nix is cast on that spell, Nix won't counter it unless the player who originally cast that spell spent no mana to cast it."
         }
       ],
       "text": "Counter target spell if no mana was spent to cast it.",
@@ -6192,7 +6196,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "These abilities are abilities of the Aura, not abilities granted to the creature. Only the Aura’s controller can activate them."
+          "text": "These abilities are abilities of the Aura, not abilities granted to the creature. Only the Aura's controller can activate them."
         }
       ],
       "subtypes": [
@@ -6295,15 +6299,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If the revealed card isn’t a creature card, it stays on top of that player’s library. Shapeshifter’s Marrow remains an enchantment."
+          "text": "If the revealed card isn't a creature card, it stays on top of that player's library. Shapeshifter's Marrow remains an enchantment."
         },
         {
           "date": "2007-05-01",
-          "text": "If the revealed card is a creature card, Shapeshifter’s Marrow becomes a copy of that card permanently. It’s no longer an enchantment."
+          "text": "If the revealed card is a creature card, Shapeshifter's Marrow becomes a copy of that card permanently. It's no longer an enchantment."
         },
         {
           "date": "2007-05-01",
-          "text": "In a Two-Headed Giant game, this ability triggers separately for each player at the start of the opposing team’s turn. If the first ability to resolve reveals a creature card, Shapeshifter’s Marrow becomes a creature. If the second ability to resolve also reveals a creature card, the ex-Shapeshifter’s Marrow then becomes a copy of that creature."
+          "text": "In a Two-Headed Giant game, this ability triggers separately for each player at the start of the opposing team's turn. If the first ability to resolve reveals a creature card, Shapeshifter's Marrow becomes a creature. If the second ability to resolve also reveals a creature card, the ex-Shapeshifter's Marrow then becomes a copy of that creature."
         }
       ],
       "text": "At the beginning of each opponent's upkeep, that player reveals the top card of his or her library. If it's a creature card, the player puts the card into his or her graveyard and Shapeshifter's Marrow becomes a copy of that card. (If it does, it loses this ability.)",
@@ -6403,27 +6407,27 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "This Aura targets, and enchants, an instant card in a graveyard. This is the first Aura that enchants something that’s neither a permanent nor a player."
+          "text": "This Aura targets, and enchants, an instant card in a graveyard. This is the first Aura that enchants something that's neither a permanent nor a player."
         },
         {
           "date": "2007-05-01",
-          "text": "The Aura will be on the battlefield attached to a card in a different zone. The Aura won’t be in the graveyard. The enchanted card won’t be on the battlefield."
+          "text": "The Aura will be on the battlefield attached to a card in a different zone. The Aura won't be in the graveyard. The enchanted card won't be on the battlefield."
         },
         {
           "date": "2007-05-01",
-          "text": "If the enchanted card changes zones (due to being cast with flashback, or being exiled with Cremate, for example), Spellweaver Volute “falls off” and is put into its owner’s graveyard as a state-based action."
+          "text": "If the enchanted card changes zones (due to being cast with flashback, or being exiled with Cremate, for example), Spellweaver Volute \"falls off\" and is put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2007-05-01",
-          "text": "When you cast a sorcery spell, Spellweaver Volute’s ability triggers. It will make a copy of the enchanted card. The copy will exist in the graveyard. You’ll have the option to cast the copy. If you don’t, the copy remains in the graveyard and ceases to exist the next time state-based actions are checked. If you do cast the copy, the copy is cast from the graveyard. After you finish casting it, the enchanted card is exiled and you must choose a new instant card in a graveyard to attach Spellweaver Volute to. If you can’t, Spellweaver Volute remains on the battlefield attached to nothing and is then put into the graveyard the next time state-based actions are checked."
+          "text": "When you cast a sorcery spell, Spellweaver Volute's ability triggers. It will make a copy of the enchanted card. The copy will exist in the graveyard. You'll have the option to cast the copy. If you don't, the copy remains in the graveyard and ceases to exist the next time state-based actions are checked. If you do cast the copy, the copy is cast from the graveyard. After you finish casting it, the enchanted card is exiled and you must choose a new instant card in a graveyard to attach Spellweaver Volute to. If you can't, Spellweaver Volute remains on the battlefield attached to nothing and is then put into the graveyard the next time state-based actions are checked."
         },
         {
           "date": "2007-05-01",
-          "text": "Say Spellweaver Volute’s ability triggers, then the enchanted instant card is exiled in response. Spellweaver Volute, which is now enchanting nothing, is put into its owner’s graveyard as a state-based action. When the Volute’s ability resolves, it will check its last existence on the battlefield and identify the “enchanted card” as “nothing,” so no copy is created."
+          "text": "Say Spellweaver Volute's ability triggers, then the enchanted instant card is exiled in response. Spellweaver Volute, which is now enchanting nothing, is put into its owner's graveyard as a state-based action. When the Volute's ability resolves, it will check its last existence on the battlefield and identify the \"enchanted card\" as \"nothing,\" so no copy is created."
         },
         {
           "date": "2007-05-01",
-          "text": "Say Spellweaver Volute’s ability triggers, then Spellweaver Volute leaves the battlefield in response. Then the instant card that was enchanted is removed from the graveyard in response. When the Volute’s ability resolves, it will check its last existence on the battlefield and identify the “enchanted card” as that instant card, so the card is copied and controller of the triggered ability may cast it."
+          "text": "Say Spellweaver Volute's ability triggers, then Spellweaver Volute leaves the battlefield in response. Then the instant card that was enchanted is removed from the graveyard in response. When the Volute's ability resolves, it will check its last existence on the battlefield and identify the \"enchanted card\" as that instant card, so the card is copied and controller of the triggered ability may cast it."
         }
       ],
       "subtypes": [
@@ -6527,7 +6531,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The opponent chosen for the fateseal action doesn’t have to be the player who controlled the target creature."
+          "text": "The opponent chosen for the fateseal action doesn't have to be the player who controlled the target creature."
         }
       ],
       "text": "Put target creature on top of its owner's library, then fateseal 2. (To fateseal 2, look at the top two cards of an opponent's library, then put any number of them on the bottom of that player's library and the rest on top in any order.)",
@@ -6627,7 +6631,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Wizardcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Wizard card. After you find a Wizard card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Wizardcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Wizard card. After you find a Wizard card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -6639,7 +6643,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "You can choose to find any card with the Wizard creature type, even if it isn’t a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Wizard card in your library."
+          "text": "You can choose to find any card with the Wizard creature type, even if it isn't a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Wizard card in your library."
         }
       ],
       "subtypes": [
@@ -7045,39 +7049,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -7285,7 +7289,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If multiple nonblack creatures enter the battlefield at the same time, Grave Peril will destroy only one of them. Grave Peril’s ability will trigger multiple times, but only the first one to resolve will do anything."
+          "text": "If multiple nonblack creatures enter the battlefield at the same time, Grave Peril will destroy only one of them. Grave Peril's ability will trigger multiple times, but only the first one to resolve will do anything."
         },
         {
           "date": "2007-05-01",
@@ -7798,43 +7802,43 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If a token is put into an opponent’s graveyard from the battlefield, or a copy of a spell is put into an opponent’s graveyard from the stack, Nihilith’s ability will not trigger, because the ability references “a card.”"
+          "text": "If a token is put into an opponent's graveyard from the battlefield, or a copy of a spell is put into an opponent's graveyard from the stack, Nihilith's ability will not trigger, because the ability references \"a card.\""
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -8038,11 +8042,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The triggered ability triggers whenever the enchanted land becomes tapped, not just when it’s tapped for mana."
+          "text": "The triggered ability triggers whenever the enchanted land becomes tapped, not just when it's tapped for mana."
         },
         {
           "date": "2007-05-01",
-          "text": "Only Pooling Venom’s controller can activate the activated ability."
+          "text": "Only Pooling Venom's controller can activate the activated ability."
         }
       ],
       "subtypes": [
@@ -8245,11 +8249,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The cards you’re searching for must be found and exiled if they’re in the graveyard because it’s a public zone. Finding those cards in the hand and library is optional, because those zones are hidden (even if the hand is temporarily revealed)."
+          "text": "The cards you're searching for must be found and exiled if they're in the graveyard because it's a public zone. Finding those cards in the hand and library is optional, because those zones are hidden (even if the hand is temporarily revealed)."
         },
         {
           "date": "2012-07-01",
-          "text": "If the player has no nonland cards in his or her hand, you can still search that player’s library and have him or her shuffle it."
+          "text": "If the player has no nonland cards in his or her hand, you can still search that player's library and have him or her shuffle it."
         }
       ],
       "subtypes": [
@@ -8447,13 +8451,14 @@
       "originalType": "Instant",
       "printings": [
         "FUT",
-        "MMA"
+        "MMA",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Destroy target nonblack creature.\nAt the beginning of your next upkeep, pay {2}{B}. If you don't, you lose the game.",
@@ -8554,7 +8559,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "First the active player chooses a card to discard, then each other player in turn order chooses, then all cards are discarded simultaneously. Although the chosen cards will be indicated (so a player can’t change his or her mind later), they’ll remain face down until they’re discarded. You won’t know what your opponent is going to discard when making your choice."
+          "text": "First the active player chooses a card to discard, then each other player in turn order chooses, then all cards are discarded simultaneously. Although the chosen cards will be indicated (so a player can't change his or her mind later), they'll remain face down until they're discarded. You won't know what your opponent is going to discard when making your choice."
         }
       ],
       "subtypes": [
@@ -8752,7 +8757,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "While Bridge from Below is on the battlefield, it has no effect. It does something only if it’s in a graveyard."
+          "text": "While Bridge from Below is on the battlefield, it has no effect. It does something only if it's in a graveyard."
         },
         {
           "date": "2007-05-01",
@@ -8861,7 +8866,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell’s cost."
+          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell's cost."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDestroy target nongreen creature. It can't be regenerated.",
@@ -8963,7 +8968,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you have no cards in hand, you can’t pay the echo cost and Deepcavern Imp will be sacrificed."
+          "text": "If you have no cards in hand, you can't pay the echo cost and Deepcavern Imp will be sacrificed."
         }
       ],
       "subtypes": [
@@ -9176,15 +9181,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -9289,15 +9294,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The second ability checks if Grave Scrabbler was cast as a result of its madness ability. It doesn’t matter if the specific cost wasn’t paid (for example, if the cost was reduced due to a effect like Cloud Key)."
+          "text": "The second ability checks if Grave Scrabbler was cast as a result of its madness ability. It doesn't matter if the specific cost wasn't paid (for example, if the cost was reduced due to a effect like Cloud Key)."
         },
         {
           "date": "2007-05-01",
-          "text": "When Grave Scrabbler enters the battlefield, its ability triggers only if it was cast with madness. If it triggers, you must choose a target, but you don’t decide whether to actually return the card until the ability resolves."
+          "text": "When Grave Scrabbler enters the battlefield, its ability triggers only if it was cast with madness. If it triggers, you must choose a target, but you don't decide whether to actually return the card until the ability resolves."
         },
         {
           "date": "2007-05-01",
-          "text": "You can return a card in a different player’s graveyard to that player’s hand."
+          "text": "You can return a card in a different player's graveyard to that player's hand."
         }
       ],
       "subtypes": [
@@ -9814,7 +9819,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell’s cost."
+          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell's cost."
         }
       ],
       "subtypes": [
@@ -9919,11 +9924,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If all damage that would be dealt to a creature is prevented, no damage is actually dealt and that creature can’t be targeted by Witch’s Mist."
+          "text": "If all damage that would be dealt to a creature is prevented, no damage is actually dealt and that creature can't be targeted by Witch's Mist."
         },
         {
           "date": "2007-05-01",
-          "text": "If a creature is lethally damaged and regenerates, all damage is removed from that creature. But since it was actually dealt damage earlier in the turn, it can be targeted by Witch’s Mist."
+          "text": "If a creature is lethally damaged and regenerates, all damage is removed from that creature. But since it was actually dealt damage earlier in the turn, it can be targeted by Witch's Mist."
         }
       ],
       "text": "{2}{B}, {T}: Destroy target creature that was dealt damage this turn.",
@@ -10026,11 +10031,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "This removes all abilities on all cards in all graveyards — both the ones that matter in a graveyard (dredge, Chronosavant’s ability, etc.) and those that don’t."
+          "text": "This removes all abilities on all cards in all graveyards — both the ones that matter in a graveyard (dredge, Chronosavant's ability, etc.) and those that don't."
         },
         {
           "date": "2007-05-01",
-          "text": "If an ability triggers when the object that has it is put into a graveyard from the battlefield, that ability triggers from the battlefield (such as Deadwood Treefolk or Epochrasite, for example), they won’t be affected by Yixlid Jailer."
+          "text": "If an ability triggers when the object that has it is put into a graveyard from the battlefield, that ability triggers from the battlefield (such as Deadwood Treefolk or Epochrasite, for example), they won't be affected by Yixlid Jailer."
         },
         {
           "date": "2007-05-01",
@@ -10042,15 +10047,15 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Some replacement effects cause a card to be put somewhere else instead of being put into a graveyard (such as Legacy Weapon). These effects mean the card is never actually put into the graveyard, so Yixlid Jailer can’t affect it."
+          "text": "Some replacement effects cause a card to be put somewhere else instead of being put into a graveyard (such as Legacy Weapon). These effects mean the card is never actually put into the graveyard, so Yixlid Jailer can't affect it."
         },
         {
           "date": "2007-05-01",
-          "text": "Some cards have abilities that modify how they’re put onto the battlefield. For example, Scarwood Treefolk says “Scarwood Treefolk is put onto the battlefield tapped” and Triskelion says “Triskelion enters the battlefield with three +1/+1 counters on it.” Although these cards won’t have these abilities in the graveyard, they will be applied if the cards are put onto the battlefield from the graveyard (due to Zombify, perhaps). What matters is that these cards will have these abilities on the battlefield."
+          "text": "Some cards have abilities that modify how they're put onto the battlefield. For example, Scarwood Treefolk says \"Scarwood Treefolk is put onto the battlefield tapped\" and Triskelion says \"Triskelion enters the battlefield with three +1/+1 counters on it.\" Although these cards won't have these abilities in the graveyard, they will be applied if the cards are put onto the battlefield from the graveyard (due to Zombify, perhaps). What matters is that these cards will have these abilities on the battlefield."
         },
         {
           "date": "2007-05-01",
-          "text": "If Mistform Ultimus is in the graveyard, the Ultimus will lose its ability that says “Mistform Ultimus is every creature type,” but it will still *be* all creature types. The way continuous effects work, Mistform Ultimus’s type-changing ability is applied before Yixlid Jailer’s ability removes it."
+          "text": "If Mistform Ultimus is in the graveyard, the Ultimus will lose its ability that says \"Mistform Ultimus is every creature type,\" but it will still *be* all creature types. The way continuous effects work, Mistform Ultimus's type-changing ability is applied before Yixlid Jailer's ability removes it."
         }
       ],
       "subtypes": [
@@ -10155,39 +10160,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -10391,7 +10396,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Yes, Char-Rumbler’s printed power is -1. While its power is -1 or 0, it simply deals no combat damage."
+          "text": "Yes, Char-Rumbler's printed power is -1. While its power is -1 or 0, it simply deals no combat damage."
         },
         {
           "date": "2007-05-01",
@@ -10399,7 +10404,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If Char-Rumbler’s power changes between the assignment of first-strike combat damage and the assignment of normal combat damage, Char-Rumbler will deal a different amount of damage in each combat damage step."
+          "text": "If Char-Rumbler's power changes between the assignment of first-strike combat damage and the assignment of normal combat damage, Char-Rumbler will deal a different amount of damage in each combat damage step."
         }
       ],
       "subtypes": [
@@ -10800,15 +10805,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -10913,11 +10918,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Nonbasic lands that are turned into Mountains are still nonbasic. Magus of the Moon does nothing to change the land’s supertype."
+          "text": "Nonbasic lands that are turned into Mountains are still nonbasic. Magus of the Moon does nothing to change the land's supertype."
         },
         {
           "date": "2008-04-01",
-          "text": "Lands that are turned into Mountains will have “{T}: Add {R} to your mana pool."
+          "text": "Lands that are turned into Mountains will have \"{T}: Add {R} to your mana pool."
         }
       ],
       "subtypes": [
@@ -11023,7 +11028,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Molten Disaster was kicked, Molten Disaster has split second as long as it’s on the stack."
+          "text": "If Molten Disaster was kicked, Molten Disaster has split second as long as it's on the stack."
         },
         {
           "date": "2013-06-07",
@@ -11031,23 +11036,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nIf Molten Disaster was kicked, it has split second. (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nMolten Disaster deals X damage to each creature without flying and each player.",
@@ -11146,7 +11151,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Create a 4/4 red Giant creature token.\nAt the beginning of your next upkeep, pay {4}{R}. If you don't, you lose the game.",
@@ -11246,11 +11251,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Pyromancer’s Swath doesn’t change the source or recipient of the damage."
+          "text": "Pyromancer's Swath doesn't change the source or recipient of the damage."
         },
         {
           "date": "2007-05-01",
-          "text": "If all damage from a source is prevented (because of Pay No Heed, for example) or if a source would deal 0 damage, the effect of Pyromancer’s Swath will not apply as that source is no longer dealing damage."
+          "text": "If all damage from a source is prevented (because of Pay No Heed, for example) or if a source would deal 0 damage, the effect of Pyromancer's Swath will not apply as that source is no longer dealing damage."
         },
         {
           "date": "2007-05-01",
@@ -11454,11 +11459,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The counter is removed as a cost, so it can’t be responded to."
+          "text": "The counter is removed as a cost, so it can't be responded to."
         },
         {
           "date": "2007-05-01",
-          "text": "If an suspended card’s last time counter is removed this way, the suspend triggered ability is put on the stack on top of the Rift Elemental ability. The same is true for the vanishing ability of a permanent that loses its last time counter."
+          "text": "If an suspended card's last time counter is removed this way, the suspend triggered ability is put on the stack on top of the Rift Elemental ability. The same is true for the vanishing ability of a permanent that loses its last time counter."
         }
       ],
       "subtypes": [
@@ -11667,43 +11672,43 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "When Shivan Sand-Mage enters the battlefield, if there are no suspended cards and no permanents with time counters on them, you can’t choose the second mode. You’ll have to choose the first mode, and will have to choose a permanent as a target (though, in this case, the ability won’t do anything when it resolves)."
+          "text": "When Shivan Sand-Mage enters the battlefield, if there are no suspended cards and no permanents with time counters on them, you can't choose the second mode. You'll have to choose the first mode, and will have to choose a permanent as a target (though, in this case, the ability won't do anything when it resolves)."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -11918,7 +11923,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Once Bloodshot Trainee’s ability is activated, it will resolve as normal even if Bloodshot Trainee’s power is less than 4 by the time the ability resolves."
+          "text": "Once Bloodshot Trainee's ability is activated, it will resolve as normal even if Bloodshot Trainee's power is less than 4 by the time the ability resolves."
         }
       ],
       "subtypes": [
@@ -12249,7 +12254,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "This ability is an ability of the Aura, not an ability granted to the creature. Only the Aura’s controller can activate it."
+          "text": "This ability is an ability of the Aura, not an ability granted to the creature. Only the Aura's controller can activate it."
         }
       ],
       "subtypes": [
@@ -12552,11 +12557,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Although Grinning Ignus’s ability has a timing restriction, it’s still a mana ability. It doesn’t use the stack and it can’t be responded to."
+          "text": "Although Grinning Ignus's ability has a timing restriction, it's still a mana ability. It doesn't use the stack and it can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -12762,7 +12767,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Slivercycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Sliver card. After you find a Sliver card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Slivercycling doesn't allow you to draw a card. Instead, it lets you search your library for a Sliver card. After you find a Sliver card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -12774,15 +12779,15 @@
         },
         {
           "date": "2009-02-01",
-          "text": "You can choose to find any card with the Sliver creature type, even if it isn’t a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Sliver card in your library."
+          "text": "You can choose to find any card with the Sliver creature type, even if it isn't a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Sliver card in your library."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -12891,7 +12896,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If you use Thick-Skinned Goblin’s ability to pay {0} instead of Shah of Naar Isle’s echo cost, the Shah’s last ability will trigger."
+          "text": "If you use Thick-Skinned Goblin's ability to pay {0} instead of Shah of Naar Isle's echo cost, the Shah's last ability will trigger."
         },
         {
           "date": "2007-05-01",
@@ -13100,7 +13105,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Contraption is a new artifact type. There are currently no artifacts with this type. And there’s no current game meaning of “assemble.”"
+          "text": "Contraption is a new artifact type. There are currently no artifacts with this type. And there's no current game meaning of \"assemble.\""
         }
       ],
       "subtypes": [
@@ -13314,7 +13319,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The +X/+X bonus is based on Tarox Bladewing’s power at the time the ability resolves. It won’t change if Tarox’s power changes later in the turn."
+          "text": "The +X/+X bonus is based on Tarox Bladewing's power at the time the ability resolves. It won't change if Tarox's power changes later in the turn."
         }
       ],
       "subtypes": [
@@ -13525,39 +13530,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -13662,7 +13667,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Yes, Force of Savagery has 0 toughness. It will be put into its owner’s graveyard as a state-based action immediately upon entering the battlefield unless an effect puts it onto the battlefield with a counter on it (such as Chorus of the Conclave would) or a static ability boosts its toughness (such as Glorious Anthem would). A triggered or activated ability that boosts toughness won’t have its effect fast enough to save it."
+          "text": "Yes, Force of Savagery has 0 toughness. It will be put into its owner's graveyard as a state-based action immediately upon entering the battlefield unless an effect puts it onto the battlefield with a counter on it (such as Chorus of the Conclave would) or a static ability boosts its toughness (such as Glorious Anthem would). A triggered or activated ability that boosts toughness won't have its effect fast enough to save it."
         }
       ],
       "subtypes": [
@@ -13866,31 +13871,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -14399,39 +14404,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -14540,11 +14545,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you choose the “destroy” mode and Quiet Disrepair is moved to a different permanent while the ability is on the stack, the newly enchanted permanent will be destroyed when the ability resolves."
+          "text": "If you choose the \"destroy\" mode and Quiet Disrepair is moved to a different permanent while the ability is on the stack, the newly enchanted permanent will be destroyed when the ability resolves."
         },
         {
           "date": "2007-05-01",
-          "text": "If you choose the “destroy” mode and Quiet Disrepair leaves the battlefield while the ability is on the stack, the last permanent it enchanted will be destroyed."
+          "text": "If you choose the \"destroy\" mode and Quiet Disrepair leaves the battlefield while the ability is on the stack, the last permanent it enchanted will be destroyed."
         }
       ],
       "subtypes": [
@@ -14747,7 +14752,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "It doesn’t matter why the card was exiled or who owns it."
+          "text": "It doesn't matter why the card was exiled or who owns it."
         },
         {
           "date": "2007-05-01",
@@ -14755,7 +14760,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If Riftsweeper affects a card that’s haunting a creature, the haunt effect ends."
+          "text": "If Riftsweeper affects a card that's haunting a creature, the haunt effect ends."
         }
       ],
       "subtypes": [
@@ -14961,31 +14966,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nBuyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nCreate a 1/1 green Saproling creature token.",
@@ -15085,7 +15090,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Search your library for a green creature card, reveal it, and put it into your hand. Then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
@@ -15384,11 +15389,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The first ability triggers when a Forest enters the battlefield under any player’s control, but only your creatures get the bonus."
+          "text": "The first ability triggers when a Forest enters the battlefield under any player's control, but only your creatures get the bonus."
         },
         {
           "date": "2007-05-01",
-          "text": "The size of the Wurm token is determined when the activated ability resolves. It won’t change as the number of lands you control changes."
+          "text": "The size of the Wurm token is determined when the activated ability resolves. It won't change as the number of lands you control changes."
         }
       ],
       "subtypes": [
@@ -15705,15 +15710,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Mana from any source other than a land with the supertype “basic” can’t be spent to cast Imperiosaur."
+          "text": "Mana from any source other than a land with the supertype \"basic\" can't be spent to cast Imperiosaur."
         },
         {
           "date": "2007-05-01",
-          "text": "Many mana-producing effects (such as Heartbeat of Spring or Utopia Sprawl, for example) add mana to a player’s mana pool whenever a land becomes tapped. This mana is produced by the enchantment, not the land, so it can’t be used to pay for Imperiosaur."
+          "text": "Many mana-producing effects (such as Heartbeat of Spring or Utopia Sprawl, for example) add mana to a player's mana pool whenever a land becomes tapped. This mana is produced by the enchantment, not the land, so it can't be used to pay for Imperiosaur."
         },
         {
           "date": "2007-05-01",
-          "text": "A small number of effects (Pulse of Llanowar and Hall of Gemstone, for example) state that a land “produces” certain mana instead of what it would normally produce. If the land is basic, then mana produced this way can be spent to cast Imperiosaur."
+          "text": "A small number of effects (Pulse of Llanowar and Hall of Gemstone, for example) state that a land \"produces\" certain mana instead of what it would normally produce. If the land is basic, then mana produced this way can be spent to cast Imperiosaur."
         },
         {
           "date": "2007-05-01",
@@ -15721,7 +15726,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Imperiosaur’s restriction applies to the total cost to cast it. If there are any additional costs (such as from Feroz’s Ban, for example), those costs would have to be paid with mana produced by basic lands as well."
+          "text": "Imperiosaur's restriction applies to the total cost to cast it. If there are any additional costs (such as from Feroz's Ban, for example), those costs would have to be paid with mana produced by basic lands as well."
         }
       ],
       "subtypes": [
@@ -15826,15 +15831,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Muraganda Petroglyphs gives a bonus only to creatures that have no rules text at all. This includes true vanilla creatures (such as Grizzly Bears), face-down creatures, many tokens, and creatures that have lost their abilities (due to Ovinize, for example). Any ability of any kind, whether or not the ability functions in the on the battlefield zone, including things like “Cycling {2}” means the creature doesn’t get the bonus."
+          "text": "Muraganda Petroglyphs gives a bonus only to creatures that have no rules text at all. This includes true vanilla creatures (such as Grizzly Bears), face-down creatures, many tokens, and creatures that have lost their abilities (due to Ovinize, for example). Any ability of any kind, whether or not the ability functions in the on the battlefield zone, including things like \"Cycling {2}\" means the creature doesn't get the bonus."
         },
         {
           "date": "2007-05-01",
-          "text": "Animated basic lands have mana abilities, so they won’t get the bonus."
+          "text": "Animated basic lands have mana abilities, so they won't get the bonus."
         },
         {
           "date": "2007-05-01",
-          "text": "Some Auras and Equipment grant abilities to creatures, meaning the affected creature would no longer get the +2/+2 bonus. For example, Flight grants flying to the enchanted creature. Other Auras and Equipment do not, meaning the affected creature would continue to get the +2/+2 bonus. For example, Dehydration states something now true about the enchanted creature, but doesn’t give it any abilities. Auras and Equipment that grant abilities will use the words “gains” or “has,” and they’ll list a keyword ability or an ability in quotation marks."
+          "text": "Some Auras and Equipment grant abilities to creatures, meaning the affected creature would no longer get the +2/+2 bonus. For example, Flight grants flying to the enchanted creature. Other Auras and Equipment do not, meaning the affected creature would continue to get the +2/+2 bonus. For example, Dehydration states something now true about the enchanted creature, but doesn't give it any abilities. Auras and Equipment that grant abilities will use the words \"gains\" or \"has,\" and they'll list a keyword ability or an ability in quotation marks."
         },
         {
           "date": "2013-07-01",
@@ -15939,7 +15944,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If it’s impossible for Nacatl War-Pride to be blocked by exactly one creature, then the defending player may block it with multiple creatures or may leave it unblocked."
+          "text": "If it's impossible for Nacatl War-Pride to be blocked by exactly one creature, then the defending player may block it with multiple creatures or may leave it unblocked."
         },
         {
           "date": "2007-05-01",
@@ -15951,15 +15956,15 @@
         },
         {
           "date": "2007-05-01",
-          "text": "The tokens enter the battlefield attacking, even if the attack couldn’t legally be declared."
+          "text": "The tokens enter the battlefield attacking, even if the attack couldn't legally be declared."
         },
         {
           "date": "2007-05-01",
-          "text": "Putting an attacking creature onto the battlefield doesn’t trigger “When this creature attacks” abilities. It also won’t check attacking restrictions, costs, or requirements."
+          "text": "Putting an attacking creature onto the battlefield doesn't trigger \"When this creature attacks\" abilities. It also won't check attacking restrictions, costs, or requirements."
         },
         {
           "date": "2007-05-01",
-          "text": "In a multiplayer game in which you’re allowed to attack only one player each combat, the new creatures will be attacking the same player as Nacatl War-Pride. In a multiplayer game in which you may attack multiple players, you choose the player each new creature is attacking. It must be a player you’re allowed to attack."
+          "text": "In a multiplayer game in which you're allowed to attack only one player each combat, the new creatures will be attacking the same player as Nacatl War-Pride. In a multiplayer game in which you may attack multiple players, you choose the player each new creature is attacking. It must be a player you're allowed to attack."
         }
       ],
       "subtypes": [
@@ -16173,7 +16178,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
         },
         {
           "date": "2008-08-01",
@@ -16278,7 +16283,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Quagnoth is discarded normally (it moves from your hand to your graveyard), its last ability triggers from your graveyard. If Yixlid Jailer is on the battlefield, it won’t trigger."
+          "text": "If Quagnoth is discarded normally (it moves from your hand to your graveyard), its last ability triggers from your graveyard. If Yixlid Jailer is on the battlefield, it won't trigger."
         },
         {
           "date": "2007-05-01",
@@ -16294,23 +16299,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -16424,7 +16429,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "The spell may have any number of other targets; that won’t affect the cost reduction unless the spell targets other Spellwild Ouphes as well. In that case, the spell costs {2} less to cast for each different Spellwild Ouphe it targets."
+          "text": "The spell may have any number of other targets; that won't affect the cost reduction unless the spell targets other Spellwild Ouphes as well. In that case, the spell costs {2} less to cast for each different Spellwild Ouphe it targets."
         }
       ],
       "subtypes": [
@@ -16642,7 +16647,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Tarmogoyf’s ability works in all zones, not just while Tarmogoyf is on the battlefield."
+          "text": "Tarmogoyf's ability works in all zones, not just while Tarmogoyf is on the battlefield."
         },
         {
           "date": "2017-03-14",
@@ -16861,11 +16866,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -16984,11 +16989,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t have Glittering Wish retrieve itself. You can have it retrieve a Glittering Wish from your sideboard."
+          "text": "You can't have Glittering Wish retrieve itself. You can have it retrieve a Glittering Wish from your sideboard."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t get an exiled card because those cards are still in one of the game zones."
+          "text": "You can't get an exiled card because those cards are still in one of the game zones."
         }
       ],
       "text": "You may choose a multicolored card you own from outside the game, reveal that card, and put it into your hand. Exile Glittering Wish.",
@@ -17092,31 +17097,31 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -17241,11 +17246,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -17630,39 +17635,39 @@
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -17951,7 +17956,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The triggered ability checks the power and toughness of a creature that enters the battlefield as it exists once it’s on the battlefield. For example, Triskelion has 1/1 printed on it, but it enters the battlefield with three +1/+1 counters on it, so it actually enters the battlefield as a 4/4 creature. Sword of the Meek’s ability wouldn’t trigger. Ditto for a Llanowar Elves that enters the battlefield while you control Gaea’s Anthem."
+          "text": "The triggered ability checks the power and toughness of a creature that enters the battlefield as it exists once it's on the battlefield. For example, Triskelion has 1/1 printed on it, but it enters the battlefield with three +1/+1 counters on it, so it actually enters the battlefield as a 4/4 creature. Sword of the Meek's ability wouldn't trigger. Ditto for a Llanowar Elves that enters the battlefield while you control Gaea's Anthem."
         },
         {
           "date": "2007-05-01",
@@ -17959,7 +17964,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If multiple 1/1 creatures enter the battlefield at the same time, the Sword’s ability will trigger that many times. Only the first ability to resolve will return the Sword to the battlefield and attach it to a creature."
+          "text": "If multiple 1/1 creatures enter the battlefield at the same time, the Sword's ability will trigger that many times. Only the first ability to resolve will return the Sword to the battlefield and attach it to a creature."
         }
       ],
       "subtypes": [
@@ -18151,11 +18156,11 @@
         },
         {
           "date": "2007-05-01",
-          "text": "The second ability triggers whenever the fortified land becomes tapped, not just when it’s tapped for mana."
+          "text": "The second ability triggers whenever the fortified land becomes tapped, not just when it's tapped for mana."
         },
         {
           "date": "2007-05-01",
-          "text": "The triggered ability is mandatory. If you don’t have a creature to target, you must target another player’s creature, if possible."
+          "text": "The triggered ability is mandatory. If you don't have a creature to target, you must target another player's creature, if possible."
         }
       ],
       "subtypes": [
@@ -18347,11 +18352,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "text": "Dakmor Salvage enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
@@ -18447,7 +18452,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "It doesn’t matter how many cards you have in your hand when the ability resolves."
+          "text": "It doesn't matter how many cards you have in your hand when the ability resolves."
         }
       ],
       "text": "Keldon Megaliths enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\nHellbent — {1}{R}, {T}: Keldon Megaliths deals 1 damage to target creature or player. Activate this ability only if you have no cards in hand.",
@@ -18545,7 +18550,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The +1/+1 counter won’t affect Llanowar Reborn in any way unless another effect turns it into a creature."
+          "text": "The +1/+1 counter won't affect Llanowar Reborn in any way unless another effect turns it into a creature."
         }
       ],
       "text": "Llanowar Reborn enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nGraft 1 (This land enters the battlefield with a +1/+1 counter on it. Whenever a creature enters the battlefield, you may move a +1/+1 counter from this land onto it.)",
@@ -18836,19 +18841,19 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Dryad Arbor is played as a land. It doesn’t use the stack, it’s not a spell, it can’t be responded to, it has no mana cost, and it counts as your land play for the turn."
+          "text": "Dryad Arbor is played as a land. It doesn't use the stack, it's not a spell, it can't be responded to, it has no mana cost, and it counts as your land play for the turn."
         },
         {
           "date": "2007-05-01",
-          "text": "If a Dryad Arbor gains flash, or you have the ability to play Dryad Arbor as though it had flash (due to Teferi, Mage of Zhalfir or Scout’s Warning, for example), you can ignore the normal timing rules for playing a land, but not any other restrictions. You can’t play Dryad Arbor during another player’s turn, and you can’t play Dryad Arbor if it’s your turn and you’ve already played a land."
+          "text": "If a Dryad Arbor gains flash, or you have the ability to play Dryad Arbor as though it had flash (due to Teferi, Mage of Zhalfir or Scout's Warning, for example), you can ignore the normal timing rules for playing a land, but not any other restrictions. You can't play Dryad Arbor during another player's turn, and you can't play Dryad Arbor if it's your turn and you've already played a land."
         },
         {
           "date": "2011-09-22",
-          "text": "If Dryad Arbor is changed into another basic land type (such as by Sea’s Claim), it continues to be a creature and a Dryad."
+          "text": "If Dryad Arbor is changed into another basic land type (such as by Sea's Claim), it continues to be a creature and a Dryad."
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -18957,7 +18962,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "{B/R}, {T}” is the same as saying “{B}, {T} or {R}, {T}."
+          "text": "{B/R}, {T}\" is the same as saying \"{B}, {T} or {R}, {T}."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{B/R}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
@@ -19333,7 +19338,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "The land produces {B} only after you’ve played a land, not after you’ve put a land directly onto the battlefield (such as with Rampant Growth)."
+          "text": "The land produces {B} only after you've played a land, not after you've put a land directly onto the battlefield (such as with Rampant Growth)."
         }
       ],
       "text": "{T}: Add {U} to your mana pool. If you played a land this turn, add {B} to your mana pool instead.",

--- a/json/GPT.json
+++ b/json/GPT.json
@@ -325,7 +325,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "“For each player” means for each player currently in the game, which is normally two. A Two-Headed Giant game has four players. In a Free-for-All multiplayer game, players who have been eliminated or who are outside your range of influence don’t count toward the total."
+          "text": "\"For each player\" means for each player currently in the game, which is normally two. A Two-Headed Giant game has four players. In a Free-for-All multiplayer game, players who have been eliminated or who are outside your range of influence don't count toward the total."
         }
       ],
       "text": "You gain 1 life for each player.\nHaunt (When this spell card is put into a graveyard after resolving, exile it haunting target creature.)\nWhen the creature Benediction of Moons haunts dies, you gain 1 life for each player.",
@@ -427,11 +427,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Droning Bureaucrats’s ability affects all creatures with converted mana cost equal to exactly X, regardless of whether they were on the battlefield at the time the ability resolved. For example, if the ability resolves with an X of 4, then Giant Solifuge is put onto the battlefield, the Solifuge can’t attack or block that turn."
+          "text": "Droning Bureaucrats's ability affects all creatures with converted mana cost equal to exactly X, regardless of whether they were on the battlefield at the time the ability resolved. For example, if the ability resolves with an X of 4, then Giant Solifuge is put onto the battlefield, the Solifuge can't attack or block that turn."
         },
         {
           "date": "2006-02-01",
-          "text": "If you use Droning Bureaucrats’s ability after you have declared attackers but before your opponent declares blockers, the restriction will apply to only your opponent’s creatures. Creatures that are already attacking will be unaffected."
+          "text": "If you use Droning Bureaucrats's ability after you have declared attackers but before your opponent declares blockers, the restriction will apply to only your opponent's creatures. Creatures that are already attacking will be unaffected."
         },
         {
           "date": "2006-02-01",
@@ -644,11 +644,11 @@
         },
         {
           "date": "2006-02-01",
-          "text": "Normally, the creatures will return to the battlefield at the end of the same turn they were exiled. But if they’re exiled during the End step, it’s too late to return them this turn. They have to wait to return to the battlefield until the next End step."
+          "text": "Normally, the creatures will return to the battlefield at the end of the same turn they were exiled. But if they're exiled during the End step, it's too late to return them this turn. They have to wait to return to the battlefield until the next End step."
         },
         {
           "date": "2006-02-01",
-          "text": "All cards exiled with Ghostway will return to the battlefield, even if they’re no longer creatures."
+          "text": "All cards exiled with Ghostway will return to the battlefield, even if they're no longer creatures."
         }
       ],
       "text": "Exile each creature you control. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
@@ -748,11 +748,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If Night of Souls’ Betrayal is on the battlefield when Graven Dominator’s ability resolves, all other creatures will become 0/0 and die."
+          "text": "If Night of Souls' Betrayal is on the battlefield when Graven Dominator's ability resolves, all other creatures will become 0/0 and die."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -1059,11 +1059,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Leyline of the Meek gives a bonus to creatures only if they’re tokens. Cards such as Clone that are copying tokens aren’t tokens."
+          "text": "Leyline of the Meek gives a bonus to creatures only if they're tokens. Cards such as Clone that are copying tokens aren't tokens."
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of the Meek is in your opening hand, you may begin the game with it on the battlefield.\nCreature tokens get +1/+1.",
@@ -2253,15 +2253,15 @@
         },
         {
           "date": "2006-02-01",
-          "text": "If you want, you can return Aetherplasm to your hand and not put anything onto the battlefield. The attacking creature will still be considered blocked, so it won’t be able to deal combat damage to you unless it has trample or a similar ability."
+          "text": "If you want, you can return Aetherplasm to your hand and not put anything onto the battlefield. The attacking creature will still be considered blocked, so it won't be able to deal combat damage to you unless it has trample or a similar ability."
         },
         {
           "date": "2006-02-01",
-          "text": "The creature you put onto the battlefield may be the Aetherplasm you just returned to your hand. This allows it to dodge abilities like Deathgazer’s."
+          "text": "The creature you put onto the battlefield may be the Aetherplasm you just returned to your hand. This allows it to dodge abilities like Deathgazer's."
         },
         {
           "date": "2006-02-01",
-          "text": "The creature you put onto the battlefield from your hand is blocking the attacking creature, even if the block couldn’t legally be declared (for example, if that creature enters the battlefield tapped, or it can’t block, or the attacking creature has protection from it)."
+          "text": "The creature you put onto the battlefield from your hand is blocking the attacking creature, even if the block couldn't legally be declared (for example, if that creature enters the battlefield tapped, or it can't block, or the attacking creature has protection from it)."
         }
       ],
       "subtypes": [
@@ -2466,7 +2466,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Unlike many similar cards, Drowned Rusalka’s ability causes you to discard a card first and then draw a card. If your hand is empty, you will just draw a card."
+          "text": "Unlike many similar cards, Drowned Rusalka's ability causes you to discard a card first and then draw a card. If your hand is empty, you will just draw a card."
         }
       ],
       "subtypes": [
@@ -2949,19 +2949,19 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Adding a supertype doesn’t overwrite other supertypes. Each nonland permanent will be legendary in addition to its other supertypes."
+          "text": "Adding a supertype doesn't overwrite other supertypes. Each nonland permanent will be legendary in addition to its other supertypes."
         },
         {
           "date": "2013-07-01",
-          "text": "The “legend rule” says that if a player controls two or more legendary permanents with the same name, that player chooses one of them and the rest are put into their owners’ graveyards. Notably, if you control Leyline of Singularity and two or more creature tokens with the same name, only one of the tokens will be allowed to remain on the battlefield."
+          "text": "The \"legend rule\" says that if a player controls two or more legendary permanents with the same name, that player chooses one of them and the rest are put into their owners' graveyards. Notably, if you control Leyline of Singularity and two or more creature tokens with the same name, only one of the tokens will be allowed to remain on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "If the game starts with more than one Leyline of Singularity under a single player’s control, all but one of them will be put into their owners’ graveyards right after the upkeep of the first turn starts. If the game started with multiple copies of any other Leylines under a single player’s control, that player will also put all but one of them into his or her graveyard at that time."
+          "text": "If the game starts with more than one Leyline of Singularity under a single player's control, all but one of them will be put into their owners' graveyards right after the upkeep of the first turn starts. If the game started with multiple copies of any other Leylines under a single player's control, that player will also put all but one of them into his or her graveyard at that time."
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of Singularity is in your opening hand, you may begin the game with it on the battlefield.\nAll nonland permanents are legendary.",
@@ -3157,11 +3157,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You don’t choose a sorcery card when Quicken resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a sorcery card, even if you cast that sorcery at a time you normally could."
+          "text": "You don't choose a sorcery card when Quicken resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a sorcery card, even if you cast that sorcery at a time you normally could."
         },
         {
           "date": "2006-02-01",
-          "text": "If you cast multiple Quickens on the same turn, they’ll all apply to the very next sorcery spell you cast."
+          "text": "If you cast multiple Quickens on the same turn, they'll all apply to the very next sorcery spell you cast."
         },
         {
           "date": "2006-09-25",
@@ -3169,7 +3169,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Casting a copy of a sorcery card won’t “use up” Quicken’s effect because the copy isn’t a card."
+          "text": "Casting a copy of a sorcery card won't \"use up\" Quicken's effect because the copy isn't a card."
         }
       ],
       "text": "The next sorcery card you cast this turn can be cast as though it had flash. (It can be cast any time you could cast an instant.)\nDraw a card.",
@@ -3467,11 +3467,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Auras your opponent gains control of won’t move from where they are."
+          "text": "Auras your opponent gains control of won't move from where they are."
         },
         {
           "date": "2006-02-01",
-          "text": "The permanents don’t return to your control when Sky Swallower leaves the battlefield."
+          "text": "The permanents don't return to your control when Sky Swallower leaves the battlefield."
         }
       ],
       "subtypes": [
@@ -4167,7 +4167,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If either land becomes an illegal target (or leaves the battlefield) before the ability resolves, the exchange won’t happen. There’s no way for you to gain a land without losing another one in the process."
+          "text": "If either land becomes an illegal target (or leaves the battlefield) before the ability resolves, the exchange won't happen. There's no way for you to gain a land without losing another one in the process."
         }
       ],
       "subtypes": [
@@ -4273,11 +4273,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If the creature was already tapped when Vertigo Spawn blocked it, that creature still won’t untap during its controller’s next untap step."
+          "text": "If the creature was already tapped when Vertigo Spawn blocked it, that creature still won't untap during its controller's next untap step."
         },
         {
           "date": "2006-02-01",
-          "text": "If two Vertigo Spawns block the same creature, both abilities trigger, but each only affects the creature during its controller’s next untap step. The creature can untap during its controller’s untap step following that one."
+          "text": "If two Vertigo Spawns block the same creature, both abilities trigger, but each only affects the creature during its controller's next untap step. The creature can untap during its controller's untap step following that one."
         }
       ],
       "subtypes": [
@@ -4382,7 +4382,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If your opponent discards any cards during his or her cleanup step to get down to the maximum hand size, the ability will trigger and players will receive priority. After that cleanup step ends, a new one will begin and Abyssal Nocturnus’s effect will end. It won’t carry over into the next turn."
+          "text": "If your opponent discards any cards during his or her cleanup step to get down to the maximum hand size, the ability will trigger and players will receive priority. After that cleanup step ends, a new one will begin and Abyssal Nocturnus's effect will end. It won't carry over into the next turn."
         },
         {
           "date": "2006-02-01",
@@ -4598,7 +4598,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If the target card is no longer in the graveyard when Cremate tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the target card is no longer in the graveyard when Cremate tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "text": "Exile target card from a graveyard.\nDraw a card.",
@@ -5287,23 +5287,23 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Leyline of the Void affects cards that would be put into opponents’ graveyards from anywhere, not just from the battlefield."
+          "text": "Leyline of the Void affects cards that would be put into opponents' graveyards from anywhere, not just from the battlefield."
         },
         {
           "date": "2010-08-15",
-          "text": "Leyline of the Void’s second ability prevents cards from ever reaching your opponents’ graveyards. Abilities that would trigger when those cards are put into an opponent’s graveyard (such as Hoarding Dragon’s last ability) won’t trigger."
+          "text": "Leyline of the Void's second ability prevents cards from ever reaching your opponents' graveyards. Abilities that would trigger when those cards are put into an opponent's graveyard (such as Hoarding Dragon's last ability) won't trigger."
         },
         {
           "date": "2010-08-15",
-          "text": "Leyline of the Void’s second ability doesn’t affect token permanents that would be put into an opponent’s graveyard from the battlefield. They’ll be put into that graveyard as normal (causing any applicable triggered abilities to trigger), then they’ll cease to exist."
+          "text": "Leyline of the Void's second ability doesn't affect token permanents that would be put into an opponent's graveyard from the battlefield. They'll be put into that graveyard as normal (causing any applicable triggered abilities to trigger), then they'll cease to exist."
         },
         {
           "date": "2010-08-15",
-          "text": "If your opponent discards a card while you control Leyline of the Void, abilities that function when that card is discarded (such as Liliana’s Caress’s ability, or a madness ability of the discarded card) still work, even though that card never reaches that player’s graveyard. In addition, spells or abilities that check the characteristics of the discarded card (such as Chandra Ablaze’s first ability) can find that card in exile."
+          "text": "If your opponent discards a card while you control Leyline of the Void, abilities that function when that card is discarded (such as Liliana's Caress's ability, or a madness ability of the discarded card) still work, even though that card never reaches that player's graveyard. In addition, spells or abilities that check the characteristics of the discarded card (such as Chandra Ablaze's first ability) can find that card in exile."
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
@@ -5402,11 +5402,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Necromancer’s Magemark returns only the creatures. The Auras attached to those creatures fall off and are put in their owner’s graveyard."
+          "text": "Necromancer's Magemark returns only the creatures. The Auras attached to those creatures fall off and are put in their owner's graveyard."
         },
         {
           "date": "2006-02-01",
-          "text": "Necromancer’s Magemark’s effect prevents the creature from ever reaching a graveyard, so abilities such as Haunt never trigger."
+          "text": "Necromancer's Magemark's effect prevents the creature from ever reaching a graveyard, so abilities such as Haunt never trigger."
         }
       ],
       "subtypes": [
@@ -5813,7 +5813,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "The controller of the creature that entered the battlefield loses the life. This may or may not be the same player as Poisonbelly Ogre’s controller."
+          "text": "The controller of the creature that entered the battlefield loses the life. This may or may not be the same player as Poisonbelly Ogre's controller."
         }
       ],
       "subtypes": [
@@ -6218,11 +6218,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "A “nonwhite nonblack” creature is a creature that’s neither white nor black. It can be any other color or combination of colors, or it can be colorless."
+          "text": "A \"nonwhite nonblack\" creature is a creature that's neither white nor black. It can be any other color or combination of colors, or it can be colorless."
         },
         {
           "date": "2006-02-01",
-          "text": "If you can’t choose a nonwhite nonblack creature to target when the haunted creature is put into a graveyard, or if the target becomes illegal, you don’t get a token."
+          "text": "If you can't choose a nonwhite nonblack creature to target when the haunted creature is put into a graveyard, or if the target becomes illegal, you don't get a token."
         }
       ],
       "text": "Destroy target nonwhite, nonblack creature. Create a 1/1 white Spirit creature token with flying.\nHaunt (When this spell card is put into a graveyard after resolving, exile it haunting target creature.)\nWhen the creature Seize the Soul haunts dies, destroy target nonwhite, nonblack creature. Create a 1/1 white Spirit creature token with flying.",
@@ -6326,7 +6326,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You may pay the cost of Skeletal Vampire’s activated abilities by sacrificing any Bat, not just a Bat token it created."
+          "text": "You may pay the cost of Skeletal Vampire's activated abilities by sacrificing any Bat, not just a Bat token it created."
         }
       ],
       "subtypes": [
@@ -6436,7 +6436,7 @@
         },
         {
           "date": "2006-02-01",
-          "text": "Smogsteed Rider doesn’t give itself fear, but if two are attacking, each will give the other one fear."
+          "text": "Smogsteed Rider doesn't give itself fear, but if two are attacking, each will give the other one fear."
         }
       ],
       "subtypes": [
@@ -6642,7 +6642,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Each Magemark gives its bonus to the creature it’s attached to, as long as the same player controls both the creature and the Aura."
+          "text": "Each Magemark gives its bonus to the creature it's attached to, as long as the same player controls both the creature and the Aura."
         }
       ],
       "subtypes": [
@@ -6747,7 +6747,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -6956,11 +6956,11 @@
         },
         {
           "date": "2006-02-01",
-          "text": "If you cast a creature with bloodthirst while Leyline of Lightning is on the battlefield, you may use the Leyline’s ability to deal damage to an opponent. If you do, that damage is dealt before the creature spell resolves, and the creature will enter the battlefield with counters from its bloodthirst ability."
+          "text": "If you cast a creature with bloodthirst while Leyline of Lightning is on the battlefield, you may use the Leyline's ability to deal damage to an opponent. If you do, that damage is dealt before the creature spell resolves, and the creature will enter the battlefield with counters from its bloodthirst ability."
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of Lightning is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you cast a spell, you may pay {1}. If you do, Leyline of Lightning deals 1 damage to target player.",
@@ -7060,11 +7060,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You divide the damage among the target creatures as you activate Living Inferno’s ability. Each target must be assigned at least 1 damage."
+          "text": "You divide the damage among the target creatures as you activate Living Inferno's ability. Each target must be assigned at least 1 damage."
         },
         {
           "date": "2006-02-01",
-          "text": "The amount of damage Living Inferno will deal is locked in as you activate its ability, since you’re dividing damage. If Living Inferno’s power changes after its ability is activated but before it resolves (via Giant Growth, for example), the amount of damage Living Inferno deals won’t change. The same is *not* true for the amount of damage dealt to Living Inferno by the other creatures, which is determined when the ability resolves."
+          "text": "The amount of damage Living Inferno will deal is locked in as you activate its ability, since you're dividing damage. If Living Inferno's power changes after its ability is activated but before it resolves (via Giant Growth, for example), the amount of damage Living Inferno deals won't change. The same is *not* true for the amount of damage dealt to Living Inferno by the other creatures, which is determined when the ability resolves."
         }
       ],
       "subtypes": [
@@ -7765,11 +7765,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "The Mountain will remain a creature for the rest of the game. It doesn’t have a creature type."
+          "text": "The Mountain will remain a creature for the rest of the game. It doesn't have a creature type."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Replicate {1}{R} (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nTarget Mountain becomes a 3/1 creature. It's still a land.",
@@ -7873,7 +7873,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You can activate Skarrgan Firebird’s last ability if an opponent was dealt damage by any source, even if you didn’t control that source."
+          "text": "You can activate Skarrgan Firebird's last ability if an opponent was dealt damage by any source, even if you didn't control that source."
         }
       ],
       "subtypes": [
@@ -8080,7 +8080,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Battering Wurm compares each blocker’s power against its own as blockers are being declared."
+          "text": "Battering Wurm compares each blocker's power against its own as blockers are being declared."
         }
       ],
       "subtypes": [
@@ -8281,7 +8281,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The reminder text printed on Bioplasm is no longer correct. Abilities that define a creature’s power (and toughness) apply in every zone. The value of * is defined by such an ability."
+          "text": "The reminder text printed on Bioplasm is no longer correct. Abilities that define a creature's power (and toughness) apply in every zone. The value of * is defined by such an ability."
         }
       ],
       "subtypes": [
@@ -8385,7 +8385,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Crash Landing can’t target a creature without flying just to deal damage to it."
+          "text": "Crash Landing can't target a creature without flying just to deal damage to it."
         }
       ],
       "text": "Target creature with flying loses flying until end of turn. Crash Landing deals damage to that creature equal to the number of Forests you control.",
@@ -8486,7 +8486,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "“Nonbasic landwalk” means “This creature can’t be blocked as long as defending player controls a nonbasic land.” A nonbasic land is any land that lacks the basic supertype, whether or not it has a basic land type (such as Island)."
+          "text": "\"Nonbasic landwalk\" means \"This creature can't be blocked as long as defending player controls a nonbasic land.\" A nonbasic land is any land that lacks the basic supertype, whether or not it has a basic land type (such as Island)."
         }
       ],
       "subtypes": [
@@ -8590,7 +8590,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Earth Surge gives the bonus to each permanent that has both the “land” and “creature” types. It doesn’t turn lands into creatures."
+          "text": "Earth Surge gives the bonus to each permanent that has both the \"land\" and \"creature\" types. It doesn't turn lands into creatures."
         }
       ],
       "text": "Each land gets +2/+2 as long as it's a creature.",
@@ -8691,11 +8691,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "The Aura you sacrifice doesn’t have to be attached to Gatherer of Graces."
+          "text": "The Aura you sacrifice doesn't have to be attached to Gatherer of Graces."
         },
         {
           "date": "2006-02-01",
-          "text": "If Gatherer of Graces already has damage on it equal to its toughness minus 1, then sacrificing an Aura attached to it results in Gatherer of Graces being put into its owner’s graveyard before the ability that would regenerate it resolves."
+          "text": "If Gatherer of Graces already has damage on it equal to its toughness minus 1, then sacrificing an Aura attached to it results in Gatherer of Graces being put into its owner's graveyard before the ability that would regenerate it resolves."
         }
       ],
       "subtypes": [
@@ -9005,11 +9005,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Activating Gruul Nodorog’s ability a second time in the same turn has no further effect."
+          "text": "Activating Gruul Nodorog's ability a second time in the same turn has no further effect."
         },
         {
           "date": "2006-02-01",
-          "text": "Activating Gruul Nodorog’s ability after blockers have been declared has no effect on the creatures already blocking it."
+          "text": "Activating Gruul Nodorog's ability after blockers have been declared has no effect on the creatures already blocking it."
         }
       ],
       "subtypes": [
@@ -9216,7 +9216,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of Lifeforce is in your opening hand, you may begin the game with it on the battlefield.\nCreature spells can't be countered.",
@@ -9316,11 +9316,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "“Protection from instants” means instant spells can’t target it, damage that would be dealt to it by instant sources is prevented, and it can’t be the target of abilities of instants (such as Haunt)."
+          "text": "\"Protection from instants\" means instant spells can't target it, damage that would be dealt to it by instant sources is prevented, and it can't be the target of abilities of instants (such as Haunt)."
         },
         {
           "date": "2006-02-01",
-          "text": "Protection from instants works only while Petrified Wood-Kin is on the battlefield. It can be targeted by instant spells or abilities of instant cards while it’s on the stack or in any other zone but on the battlefield."
+          "text": "Protection from instants works only while Petrified Wood-Kin is on the battlefield. It can be targeted by instant spells or abilities of instant cards while it's on the stack or in any other zone but on the battlefield."
         }
       ],
       "subtypes": [
@@ -9430,11 +9430,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If a creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If a creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When Predatory Focus resolves, you choose whether to use its effect or not. If you choose to use it, all your creatures will deal their combat damage to the planeswalker or defending player this turn whether or not they become blocked. You can’t have any of them deal combat damage to creatures that block them. If you choose not to use its effect, nothing happens."
+          "text": "When Predatory Focus resolves, you choose whether to use its effect or not. If you choose to use it, all your creatures will deal their combat damage to the planeswalker or defending player this turn whether or not they become blocked. You can't have any of them deal combat damage to creatures that block them. If you choose not to use its effect, nothing happens."
         }
       ],
       "text": "You may have creatures you control assign their combat damage this turn as though they weren't blocked.",
@@ -9631,7 +9631,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -9838,7 +9838,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Skarrgan Pit-Skulk compares each blocker’s power against its own as blockers are being declared."
+          "text": "Skarrgan Pit-Skulk compares each blocker's power against its own as blockers are being declared."
         }
       ],
       "subtypes": [
@@ -10139,7 +10139,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Wurmweaver Coil can enchant only a green creature. It can’t enter the battlefield attached to a nongreen creature, it can’t be moved onto a nongreen creature, and if the creature it’s attached to stops being green, the Aura is put into its owner’s graveyard."
+          "text": "Wurmweaver Coil can enchant only a green creature. It can't enter the battlefield attached to a nongreen creature, it can't be moved onto a nongreen creature, and if the creature it's attached to stops being green, the Aura is put into its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -10471,7 +10471,7 @@
         "Red",
         "Green"
       ],
-      "flavor": "\"It's easy to see why those Gruul dirtbags follow him—the only orders he gives are ‘Crush them!' and ‘We eat!'\"\n—Teysa",
+      "flavor": "\"It's easy to see why those Gruul dirtbags follow him—the only orders he gives are 'Crush them!' and 'We eat!'\"\n—Teysa",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -10554,7 +10554,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Borborygmos’s ability won’t save your creatures that were dealt lethal damage in combat. Those creatures will be sent to your graveyard before they would get a counter."
+          "text": "Borborygmos's ability won't save your creatures that were dealt lethal damage in combat. Those creatures will be sent to your graveyard before they would get a counter."
         }
       ],
       "subtypes": [
@@ -10664,7 +10664,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If both abilities are used on the same creature, it can’t block Burning-Tree Bloodscale."
+          "text": "If both abilities are used on the same creature, it can't block Burning-Tree Bloodscale."
         }
       ],
       "subtypes": [
@@ -10777,7 +10777,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "subtypes": [
@@ -11080,7 +11080,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Players may cast spells while Conjurer’s Ban is on the stack. Only after all players pass priority does Conjurer’s Ban resolve, and that’s when you name a card. Once you name a card, that card can’t be played in response."
+          "text": "Players may cast spells while Conjurer's Ban is on the stack. Only after all players pass priority does Conjurer's Ban resolve, and that's when you name a card. Once you name a card, that card can't be played in response."
         },
         {
           "date": "2006-02-01",
@@ -11088,11 +11088,11 @@
         },
         {
           "date": "2006-02-01",
-          "text": "Conjurer’s Ban only affects cards. A copy of a card (for example, one created by Eye of the Storm isn’t a card, so it can be played."
+          "text": "Conjurer's Ban only affects cards. A copy of a card (for example, one created by Eye of the Storm isn't a card, so it can be played."
         },
         {
           "date": "2008-08-01",
-          "text": "This can’t be used as a counterspell. It will have no effect on spells which were on the stack when it was cast, nor on those cast in response to it."
+          "text": "This can't be used as a counterspell. It will have no effect on spells which were on the stack when it was cast, nor on those cast in response to it."
         }
       ],
       "text": "Choose a card name. Until your next turn, spells with the chosen name can't be cast and lands with the chosen name can't be played.\nDraw a card.",
@@ -11402,7 +11402,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If all chosen targets are illegal as Electrolyze tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt and you won’t draw a card."
+          "text": "If all chosen targets are illegal as Electrolyze tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt and you won't draw a card."
         }
       ],
       "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
@@ -11511,11 +11511,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You don’t choose the value of X. The bonus Feral Animist gets is based on its power when the ability resolves. For example, if you activate the ability twice, the first ability will give it +2/+0 and the second one will give it +4/+0."
+          "text": "You don't choose the value of X. The bonus Feral Animist gets is based on its power when the ability resolves. For example, if you activate the ability twice, the first ability will give it +2/+0 and the second one will give it +4/+0."
         },
         {
-          "date": "2013-04-15",
-          "text": "If Feral Animist’s power is negative when its ability resolves, it will lose power. For example, if it’s somehow -3/1 when the ability resolves, it will become -6/1."
+          "date": "2017-06-27",
+          "text": "If this creature's power is negative as its ability resolves, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -11735,7 +11735,7 @@
         },
         {
           "date": "2006-02-01",
-          "text": "Normally, Ghost Council of Orzhova will return to the battlefield at the end of the same turn it’s exiled. But if it’s exiled during the End step, it’s too late to return it this turn. It has to wait to return to the battlefield until the next End step."
+          "text": "Normally, Ghost Council of Orzhova will return to the battlefield at the end of the same turn it's exiled. But if it's exiled during the End step, it's too late to return it this turn. It has to wait to return to the battlefield until the next End step."
         }
       ],
       "subtypes": [
@@ -11956,11 +11956,11 @@
         },
         {
           "date": "2006-02-01",
-          "text": "If the spell has multiple targets, you may either change all the targets or none of them. Each target is treated individually, and must be changed to a different legal target. For example, Seeds of Strength targeting Atog (target #1), the same Atog (target #2), and Scryb Sprites (target #3) can be changed so it targets the same Scryb Sprites (target #1), Eager Cadet (target #2), and Alpha Myr (target #3). If changing one of the targets would be impossible, then you can’t change any of the others."
+          "text": "If the spell has multiple targets, you may either change all the targets or none of them. Each target is treated individually, and must be changed to a different legal target. For example, Seeds of Strength targeting Atog (target #1), the same Atog (target #2), and Scryb Sprites (target #3) can be changed so it targets the same Scryb Sprites (target #1), Eager Cadet (target #2), and Alpha Myr (target #3). If changing one of the targets would be impossible, then you can't change any of the others."
         },
         {
           "date": "2006-02-01",
-          "text": "If a spell has a variable number of targets (such as Electrolyze), the number of targets chosen can’t be changed."
+          "text": "If a spell has a variable number of targets (such as Electrolyze), the number of targets chosen can't be changed."
         }
       ],
       "subtypes": [
@@ -12073,15 +12073,15 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Ink-Treader Nephilim’s ability is mandatory and will create a copy targeting each possible creature whether you want it to or not. You control all the copies of the spell (even if you didn’t control the original spell), so you choose the order to put them on the stack."
+          "text": "Ink-Treader Nephilim's ability is mandatory and will create a copy targeting each possible creature whether you want it to or not. You control all the copies of the spell (even if you didn't control the original spell), so you choose the order to put them on the stack."
         },
         {
           "date": "2006-02-01",
-          "text": "Even though you control the copies, the ability cares about who cast the original spell when determining which other creatures that spell could target. If the original spell has a targeting restriction that refers to “an opponent,” the copies will see that from the perspective of the original spell’s controller. For example, if your opponent casts a spell that says “Destroy target creature an opponent controls” targeting your Ink-Treader Nephilim, its ability will create a copy for each other creature the original spell could target: the rest of your creatures. However, since you control the copies, all the copies will be countered for having illegal targets."
+          "text": "Even though you control the copies, the ability cares about who cast the original spell when determining which other creatures that spell could target. If the original spell has a targeting restriction that refers to \"an opponent,\" the copies will see that from the perspective of the original spell's controller. For example, if your opponent casts a spell that says \"Destroy target creature an opponent controls\" targeting your Ink-Treader Nephilim, its ability will create a copy for each other creature the original spell could target: the rest of your creatures. However, since you control the copies, all the copies will be countered for having illegal targets."
         },
         {
           "date": "2006-02-01",
-          "text": "Ink-Treader Nephilim’s ability will trigger off a spell with multiple targets if all of those targets are Ink-Treader Nephilim. For example, Seeds of Strength cast with Ink-Treader Nephilim as each of the three targets will cause the ability to trigger."
+          "text": "Ink-Treader Nephilim's ability will trigger off a spell with multiple targets if all of those targets are Ink-Treader Nephilim. For example, Seeds of Strength cast with Ink-Treader Nephilim as each of the three targets will cause the ability to trigger."
         }
       ],
       "subtypes": [
@@ -12396,7 +12396,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If the top card of your library isn’t a creature card, it remains on top of your library. You won’t have to sacrifice it at end of turn."
+          "text": "If the top card of your library isn't a creature card, it remains on top of your library. You won't have to sacrifice it at end of turn."
         }
       ],
       "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a creature card, put it onto the battlefield. That creature gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
@@ -12601,7 +12601,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an enchantment, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target creature or enchantment.",
@@ -13548,7 +13548,7 @@
         },
         {
           "date": "2006-02-01",
-          "text": "If Souls of the Faultless is dealt combat damage in a Two-Headed Giant game, you may choose either member of the attacking team as the player who will lose life. The player you choose doesn’t have to be the controller of a creature that dealt damage to Souls of the Faultless."
+          "text": "If Souls of the Faultless is dealt combat damage in a Two-Headed Giant game, you may choose either member of the attacking team as the player who will lose life. The player you choose doesn't have to be the controller of a creature that dealt damage to Souls of the Faultless."
         }
       ],
       "subtypes": [
@@ -13852,7 +13852,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You may sacrifice Teysa itself to help pay for its first ability, but unlike other white and black creatures, it won’t cause its second ability to trigger. Any other white and black creatures you sacrifice to pay for the first ability will cause the second ability to trigger."
+          "text": "You may sacrifice Teysa itself to help pay for its first ability, but unlike other white and black creatures, it won't cause its second ability to trigger. Any other white and black creatures you sacrifice to pay for the first ability will cause the second ability to trigger."
         }
       ],
       "subtypes": [
@@ -13964,7 +13964,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "A spell you cast that’s blue and red will trigger both abilities. You can put them on the stack in either order."
+          "text": "A spell you cast that's blue and red will trigger both abilities. You can put them on the stack in either order."
         }
       ],
       "subtypes": [
@@ -14190,7 +14190,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Wee Dragonauts’s triggered ability will resolve before the spell that caused it to trigger."
+          "text": "Wee Dragonauts's triggered ability will resolve before the spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -14505,15 +14505,15 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "The creature you put onto the battlefield from your graveyard is attacking, even if the attack couldn’t legally be declared (for example, if that creature has defender or an effect says that no more than one creature can attack)."
+          "text": "The creature you put onto the battlefield from your graveyard is attacking, even if the attack couldn't legally be declared (for example, if that creature has defender or an effect says that no more than one creature can attack)."
         },
         {
           "date": "2006-02-01",
-          "text": "Putting an attacking creature onto the battlefield doesn’t trigger “When this creature attacks” abilities. It also won’t check attacking restrictions, costs, or requirements."
+          "text": "Putting an attacking creature onto the battlefield doesn't trigger \"When this creature attacks\" abilities. It also won't check attacking restrictions, costs, or requirements."
         },
         {
           "date": "2006-02-01",
-          "text": "In a multiplayer game in which you’re allowed to attack only one player each combat, the new creature will be attacking the same player as Yore-Tiller Nephilim. In a multiplayer game in which you may attack multiple players, you choose the player the new creature is attacking. It must be a player you’re allowed to attack."
+          "text": "In a multiplayer game in which you're allowed to attack only one player each combat, the new creature will be attacking the same player as Yore-Tiller Nephilim. In a multiplayer game in which you may attack multiple players, you choose the player the new creature is attacking. It must be a player you're allowed to attack."
         }
       ],
       "subtypes": [
@@ -14722,7 +14722,7 @@
         },
         {
           "date": "2006-02-01",
-          "text": "If you cast an instant or sorcery spell that has {X} in its mana cost, the value of X in the spell’s replicate cost will be the same as the value of X you chose for its mana cost."
+          "text": "If you cast an instant or sorcery spell that has {X} in its mana cost, the value of X in the spell's replicate cost will be the same as the value of X you chose for its mana cost."
         }
       ],
       "subtypes": [
@@ -15345,7 +15345,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Petrahydrox will return to its owner’s hand before the spell or ability targeting it can resolve."
+          "text": "Petrahydrox will return to its owner's hand before the spell or ability targeting it can resolve."
         }
       ],
       "subtypes": [
@@ -15453,7 +15453,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "While casting a spell with convoke, if you sacrifice Wild Cantor to add mana to your mana pool, Wild Cantor won’t be on the battlefield when you pay that spell’s costs. It can’t be tapped to help cast that spell using convoke."
+          "text": "While casting a spell with convoke, if you sacrifice Wild Cantor to add mana to your mana pool, Wild Cantor won't be on the battlefield when you pay that spell's costs. It can't be tapped to help cast that spell using convoke."
         }
       ],
       "subtypes": [
@@ -15654,15 +15654,15 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "While it’s a creature, Gruul War Plow gives itself trample."
+          "text": "While it's a creature, Gruul War Plow gives itself trample."
         },
         {
           "date": "2006-02-01",
-          "text": "While it’s a creature, Gruul War Plow has creature type Juggernaut. It doesn’t have any abilities associated with the card named Juggernaut."
+          "text": "While it's a creature, Gruul War Plow has creature type Juggernaut. It doesn't have any abilities associated with the card named Juggernaut."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Creatures you control have trample.\n{1}{R}{G}: Gruul War Plow becomes a 4/4 Juggernaut artifact creature until end of turn.",
@@ -15862,19 +15862,19 @@
         },
         {
           "date": "2006-02-01",
-          "text": "The second ability doesn’t wear off. If you use it, Mizzium Transreliquat becomes a copy of target artifact permanently and gains the {1}{U}{R} ability. It no longer has the {3} ability (unless it copied itself or another Mizzium Transreliquat)."
+          "text": "The second ability doesn't wear off. If you use it, Mizzium Transreliquat becomes a copy of target artifact permanently and gains the {1}{U}{R} ability. It no longer has the {3} ability (unless it copied itself or another Mizzium Transreliquat)."
         },
         {
           "date": "2006-02-01",
-          "text": "An artifact’s “copiable values” are those printed on it, as modified by other copy effects, plus any values set by “enters the battlefield as” abilities. Counters and other effects aren’t copied. For example, if you copy a Gruul War Plow that’s been turned into an artifact creature, the result will be just an artifact."
+          "text": "An artifact's \"copiable values\" are those printed on it, as modified by other copy effects, plus any values set by \"enters the battlefield as\" abilities. Counters and other effects aren't copied. For example, if you copy a Gruul War Plow that's been turned into an artifact creature, the result will be just an artifact."
         },
         {
           "date": "2006-02-01",
-          "text": "The results of all copy effects are copied. If Mizzium Transreliquat is copied, the copy will be a Mizzium Transreliquat after applying all copy effects currently affecting the original. For example, Copy Artifact copying a Transreliquat that’s using its first ability to copy an Izzet Signet will be an Izzet Signet. The effect won’t wear off at the end of the turn; rather, the Copy Artifact will remain an Izzet Signet for the rest of the game."
+          "text": "The results of all copy effects are copied. If Mizzium Transreliquat is copied, the copy will be a Mizzium Transreliquat after applying all copy effects currently affecting the original. For example, Copy Artifact copying a Transreliquat that's using its first ability to copy an Izzet Signet will be an Izzet Signet. The effect won't wear off at the end of the turn; rather, the Copy Artifact will remain an Izzet Signet for the rest of the game."
         },
         {
           "date": "2006-02-01",
-          "text": "If you use Mizzium Transreliquat’s abilities multiple times in a turn in response to one another, then each time one of those abilities resolves, it will overwrite whatever the permanent was copying. The Transreliquat will wind up as a copy of the artifact targeted by the last ability to resolve. When the turn ends, all instances of its first ability will wear off at the same time. If one of those was the last copy ability to resolve, the Transreliquat will become what it was before those abilities resolved. This will likely be either the original Mizzium Transreliquat or whatever it copied with the last instance of its second ability to resolve."
+          "text": "If you use Mizzium Transreliquat's abilities multiple times in a turn in response to one another, then each time one of those abilities resolves, it will overwrite whatever the permanent was copying. The Transreliquat will wind up as a copy of the artifact targeted by the last ability to resolve. When the turn ends, all instances of its first ability will wear off at the same time. If one of those was the last copy ability to resolve, the Transreliquat will become what it was before those abilities resolved. This will likely be either the original Mizzium Transreliquat or whatever it copied with the last instance of its second ability to resolve."
         }
       ],
       "text": "{3}: Mizzium Transreliquat becomes a copy of target artifact until end of turn.\n{1}{U}{R}: Mizzium Transreliquat becomes a copy of target artifact and gains this ability.",
@@ -16258,15 +16258,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -16572,15 +16572,15 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "“Until your next turn” means the effect wears off as soon as your next turn starts, even before you untap. It’s basically the same as “until the end of the turn of the player who immediately precedes you.”"
+          "text": "\"Until your next turn\" means the effect wears off as soon as your next turn starts, even before you untap. It's basically the same as \"until the end of the turn of the player who immediately precedes you.\""
         },
         {
           "date": "2006-02-01",
-          "text": "The card is cast using all normal rules and restrictions for casting spells. Casting it means you’ll have to pay its mana cost, and it will go to the graveyard after it resolves or is countered. The only thing that’s different is you’re casting it from the Exile zone."
+          "text": "The card is cast using all normal rules and restrictions for casting spells. Casting it means you'll have to pay its mana cost, and it will go to the graveyard after it resolves or is countered. The only thing that's different is you're casting it from the Exile zone."
         },
         {
           "date": "2006-02-01",
-          "text": "If you don’t cast the card, it stays exiled."
+          "text": "If you don't cast the card, it stays exiled."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{2}{U}{R}, {T}: Exile the top card of your library. Until your next turn, you may cast that card if it's an instant or sorcery card.",
@@ -16969,15 +16969,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -17083,15 +17083,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [

--- a/json/GTC.json
+++ b/json/GTC.json
@@ -353,7 +353,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You choose which ability creatures you control will gain when Angelic Skirmisher’s ability resolves. This happens before attacking creatures are declared."
+          "text": "You choose which ability creatures you control will gain when Angelic Skirmisher's ability resolves. This happens before attacking creatures are declared."
         },
         {
           "date": "2013-01-24",
@@ -587,11 +587,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -712,11 +712,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "text": "Extort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\nArtifacts and creatures your opponents control enter the battlefield tapped.",
@@ -828,11 +828,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -1064,11 +1064,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -1406,11 +1406,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -1418,7 +1418,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Creatures that come under your control after Frontline Medic’s battalion ability resolves will not be granted indestructible by this effect."
+          "text": "Creatures that come under your control after Frontline Medic's battalion ability resolves will not be granted indestructible by this effect."
         }
       ],
       "subtypes": [
@@ -1538,31 +1538,31 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If the first ability is countered (perhaps because the target opponent is an illegal target when the ability tries to resolve), you won’t put any additional loyalty counters on Gideon, although the loyalty counter you put on him to activate the ability will remain."
+          "text": "If the first ability is countered (perhaps because the target opponent is an illegal target when the ability tries to resolve), you won't put any additional loyalty counters on Gideon, although the loyalty counter you put on him to activate the ability will remain."
         },
         {
           "date": "2013-01-24",
-          "text": "If Gideon, Champion of Justice becomes a creature due to his second ability, that doesn’t count as having a creature enter the battlefield. Gideon was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "If Gideon, Champion of Justice becomes a creature due to his second ability, that doesn't count as having a creature enter the battlefield. Gideon was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2013-01-24",
-          "text": "Gideon, Champion of Justice’s power and toughness are set to the number of loyalty counters on him when his second ability resolves. They won’t change later in the turn if the number of loyalty counters on him changes."
+          "text": "Gideon, Champion of Justice's power and toughness are set to the number of loyalty counters on him when his second ability resolves. They won't change later in the turn if the number of loyalty counters on him changes."
         },
         {
           "date": "2013-01-24",
-          "text": "If Gideon, Champion of Justice becomes a creature the same turn he enters the battlefield, you can’t attack with him or use any of his {T} abilities (if he gains any)."
+          "text": "If Gideon, Champion of Justice becomes a creature the same turn he enters the battlefield, you can't attack with him or use any of his {T} abilities (if he gains any)."
         },
         {
           "date": "2013-01-24",
-          "text": "Gideon, Champion of Justice’s second ability causes him to become a creature with the creature types Human and Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
+          "text": "Gideon, Champion of Justice's second ability causes him to become a creature with the creature types Human and Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
         },
         {
           "date": "2013-01-24",
-          "text": "Say you activate Gideon, Champion of Justice’s second ability, and then an opponent gains control of him before combat. You may have any of your creatures attack Gideon, Champion of Justice (since he’s still a planeswalker). Then Gideon, Champion of Justice may block (since he’s a creature). He may block any eligible attacking creature, including one that’s attacking him! During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he’s blocking, but he doesn’t deal combat damage to any unblocked creatures that are attacking him."
+          "text": "Say you activate Gideon, Champion of Justice's second ability, and then an opponent gains control of him before combat. You may have any of your creatures attack Gideon, Champion of Justice (since he's still a planeswalker). Then Gideon, Champion of Justice may block (since he's a creature). He may block any eligible attacking creature, including one that's attacking him! During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he's blocking, but he doesn't deal combat damage to any unblocked creatures that are attacking him."
         },
         {
           "date": "2013-07-01",
-          "text": "If damage that can’t be prevented is dealt to Gideon, Champion of Justice after his second ability has resolved, that damage will have all applicable results: specifically, the damage is marked on Gideon (since he’s a creature) and that damage causes that many loyalty counters to be removed from him (since he’s a planeswalker). Even though he has indestructible, if Gideon, Champion of Justice has no loyalty counters on him, he’s put into his owner’s graveyard as a state-based action."
+          "text": "If damage that can't be prevented is dealt to Gideon, Champion of Justice after his second ability has resolved, that damage will have all applicable results: specifically, the damage is marked on Gideon (since he's a creature) and that damage causes that many loyalty counters to be removed from him (since he's a planeswalker). Even though he has indestructible, if Gideon, Champion of Justice has no loyalty counters on him, he's put into his owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -1676,7 +1676,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Guardian of the Gateless’s last ability triggers only once when it’s declared as a blocker no matter how many creatures it’s blocking."
+          "text": "Guardian of the Gateless's last ability triggers only once when it's declared as a blocker no matter how many creatures it's blocking."
         }
       ],
       "subtypes": [
@@ -1790,7 +1790,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The enchanted creature can’t be enchanted or equipped by multicolored Auras and Equipment, it can’t be blocked by multicolored creatures, it can’t be targeted by multicolored spells or abilities from multicolored sources, and all damage dealt to it by multicolored sources is prevented."
+          "text": "The enchanted creature can't be enchanted or equipped by multicolored Auras and Equipment, it can't be blocked by multicolored creatures, it can't be targeted by multicolored spells or abilities from multicolored sources, and all damage dealt to it by multicolored sources is prevented."
         },
         {
           "date": "2013-01-24",
@@ -2017,7 +2017,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The enchanted creature can’t be blocked, it can’t be targeted by abilities of creatures or creature cards (like, notably, the scavenge ability), and all damage dealt to it by creatures or creature cards is prevented."
+          "text": "The enchanted creature can't be blocked, it can't be targeted by abilities of creatures or creature cards (like, notably, the scavenge ability), and all damage dealt to it by creatures or creature cards is prevented."
         }
       ],
       "subtypes": [
@@ -2135,11 +2135,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -2486,7 +2486,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If another player gains control of either Murder Investigation or the enchanted creature (but not both), Murder Investigation will be enchanting an illegal permanent. The Aura will be put into its owner’s graveyard as a state-based action."
+          "text": "If another player gains control of either Murder Investigation or the enchanted creature (but not both), Murder Investigation will be enchanting an illegal permanent. The Aura will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -2600,11 +2600,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -2952,7 +2952,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "A “blocked creature” is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocked creature\" is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
         }
       ],
       "text": "Destroy target blocked creature.",
@@ -3067,11 +3067,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -3408,7 +3408,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat. There’s no such thing as an attacking creature outside of the combat phase."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat. There's no such thing as an attacking creature outside of the combat phase."
         }
       ],
       "text": "Return all attacking creatures to their owner's hand.",
@@ -3519,15 +3519,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Only Agoraphobia’s controller can activate its last ability, no matter who controls the creature Agoraphobia’s attached to."
+          "text": "Only Agoraphobia's controller can activate its last ability, no matter who controls the creature Agoraphobia's attached to."
         },
         {
           "date": "2013-01-24",
-          "text": "Agoraphobia’s last ability can be activated only while it’s on the battlefield."
+          "text": "Agoraphobia's last ability can be activated only while it's on the battlefield."
         },
         {
           "date": "2013-01-24",
-          "text": "Players don’t have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Agoraphobia to its owner’s hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get -5/-0)."
+          "text": "Players don't have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Agoraphobia to its owner's hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get -5/-0)."
         }
       ],
       "subtypes": [
@@ -3644,7 +3644,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -3660,7 +3660,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -3779,7 +3779,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -3795,7 +3795,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -3919,15 +3919,15 @@
         },
         {
           "date": "2013-01-24",
-          "text": "When casting an instant or sorcery card this way, ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "When casting an instant or sorcery card this way, ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2013-01-24",
-          "text": "If you can’t cast one of the target instant or sorcery cards, perhaps because there are no legal targets available, or if you choose not to cast one, it will remain in its owner’s graveyard."
+          "text": "If you can't cast one of the target instant or sorcery cards, perhaps because there are no legal targets available, or if you choose not to cast one, it will remain in its owner's graveyard."
         },
         {
           "date": "2013-01-24",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2013-01-24",
@@ -3939,11 +3939,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If you cast an instant or sorcery spell with cipher this way, you may exile the card encoded on a creature you control. If you can’t, or if you choose not to, the card will end up exiled but not encoded on a creature."
+          "text": "If you cast an instant or sorcery spell with cipher this way, you may exile the card encoded on a creature you control. If you can't, or if you choose not to, the card will end up exiled but not encoded on a creature."
         },
         {
           "date": "2013-01-24",
-          "text": "If an instant or sorcery card you cast this way goes to a zone other than exile or a graveyard, perhaps because one of its abilities says to put it into its owner’s hand, it won’t be exiled. This is true even if the card would be put into a graveyard later that turn."
+          "text": "If an instant or sorcery card you cast this way goes to a zone other than exile or a graveyard, perhaps because one of its abilities says to put it into its owner's hand, it won't be exiled. This is true even if the card would be put into a graveyard later that turn."
         }
       ],
       "subtypes": [
@@ -4057,11 +4057,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You won’t have to discard any card during the cleanup step of the turn you cast Enter the Infinite. You will have to discard down to your maximum hand size during the cleanup step of your next turn."
+          "text": "You won't have to discard any card during the cleanup step of the turn you cast Enter the Infinite. You will have to discard down to your maximum hand size during the cleanup step of your next turn."
         },
         {
           "date": "2013-01-24",
-          "text": "If you are playing with the top card of your library revealed (due to Garruk’s Horde, for example), you’ll reveal each card before you draw it."
+          "text": "If you are playing with the top card of your library revealed (due to Garruk's Horde, for example), you'll reveal each card before you draw it."
         }
       ],
       "text": "Draw cards equal to the number of cards in your library, then put a card from your hand on top of your library. You have no maximum hand size until your next turn.",
@@ -4385,23 +4385,23 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If the creature that was tapped by Hands of Binding is untapped during its controller’s next untap step (perhaps because a spell untapped it), Hands of Binding has no effect at that time. It won’t apply at some later time when the creature is tapped."
+          "text": "If the creature that was tapped by Hands of Binding is untapped during its controller's next untap step (perhaps because a spell untapped it), Hands of Binding has no effect at that time. It won't apply at some later time when the creature is tapped."
         },
         {
           "date": "2013-01-24",
-          "text": "If a different player gains control of the creature that was tapped by Hands of Binding, Hands of Binding will stop that creature from untapping during its new controller’s next untap step."
+          "text": "If a different player gains control of the creature that was tapped by Hands of Binding, Hands of Binding will stop that creature from untapping during its new controller's next untap step."
         },
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -4417,15 +4417,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -4437,7 +4437,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "This spell can target tapped creatures. If a targeted creature is already tapped when the spell resolves, that creature just remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "This spell can target tapped creatures. If a targeted creature is already tapped when the spell resolves, that creature just remains tapped and doesn't untap during its controller's next untap step."
         }
       ],
       "text": "Tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
@@ -4549,7 +4549,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Incursion Specialist’s ability can trigger only once each turn. The ability will resolve before the second spell resolves. It doesn’t matter if the first spell you cast that turn has resolved, was countered, or is still on the stack."
+          "text": "Incursion Specialist's ability can trigger only once each turn. The ability will resolve before the second spell resolves. It doesn't matter if the first spell you cast that turn has resolved, was countered, or is still on the stack."
         }
       ],
       "subtypes": [
@@ -4665,7 +4665,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Keymaster Rogue’s last ability isn’t optional. If Keymaster Rogue is the only creature you control when the ability resolves, you’ll have to return it to its owner’s hand."
+          "text": "Keymaster Rogue's last ability isn't optional. If Keymaster Rogue is the only creature you control when the ability resolves, you'll have to return it to its owner's hand."
         }
       ],
       "subtypes": [
@@ -4779,15 +4779,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -4803,15 +4803,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -5264,7 +5264,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Rapid Hybridization resolves and the creature isn’t destroyed (perhaps because it has indestructible), its controller will still get the Frog Lizard token."
+          "text": "If Rapid Hybridization resolves and the creature isn't destroyed (perhaps because it has indestructible), its controller will still get the Frog Lizard token."
         }
       ],
       "text": "Destroy target creature. It can't be regenerated. That creature's controller creates a 3/3 green Frog Lizard creature token.",
@@ -5375,11 +5375,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The basic land types are Plains, Island, Swamp, Mountain, and Forest. Other land types, like Gate, aren’t basic lands types."
+          "text": "The basic land types are Plains, Island, Swamp, Mountain, and Forest. Other land types, like Gate, aren't basic lands types."
         },
         {
           "date": "2013-01-24",
-          "text": "Lands you control will have the ability to tap for the color of mana corresponding to the chosen type. They’ll also retain any other abilities they have."
+          "text": "Lands you control will have the ability to tap for the color of mana corresponding to the chosen type. They'll also retain any other abilities they have."
         }
       ],
       "subtypes": [
@@ -5821,7 +5821,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If the creature is an illegal target when Simic Fluxmage’s ability tries to resolve, it will be countered and none of its effects will happen. No counters will be removed from Simic Fluxmage."
+          "text": "If the creature is an illegal target when Simic Fluxmage's ability tries to resolve, it will be countered and none of its effects will happen. No counters will be removed from Simic Fluxmage."
         },
         {
           "date": "2013-04-15",
@@ -5829,7 +5829,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -5845,7 +5845,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -5961,7 +5961,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The power of the target creature is checked both as you target it and as the ability resolves. If the power of the target creature when the ability resolves is greater than the number of +1/+1 counters removed from Simic Manipulator, the ability will be countered and none of its effects will happen. You won’t gain control of any creature, but the counters removed as a cost remain removed."
+          "text": "The power of the target creature is checked both as you target it and as the ability resolves. If the power of the target creature when the ability resolves is greater than the number of +1/+1 counters removed from Simic Manipulator, the ability will be countered and none of its effects will happen. You won't gain control of any creature, but the counters removed as a cost remain removed."
         },
         {
           "date": "2013-04-15",
@@ -5969,7 +5969,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -5985,7 +5985,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -6208,7 +6208,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The value of X is the greatest power among creatures you control when Spell Rupture resolves. If you control no creatures at that time, X will be 0. The target spell’s controller can choose to pay {0} (simply by indicating he or she wishes to do so). That player can also choose to not pay {0} and the spell will be countered."
+          "text": "The value of X is the greatest power among creatures you control when Spell Rupture resolves. If you control no creatures at that time, X will be 0. The target spell's controller can choose to pay {0} (simply by indicating he or she wishes to do so). That player can also choose to not pay {0} and the spell will be countered."
         }
       ],
       "text": "Counter target spell unless its controller pays {X}, where X is the greatest power among creatures you control.",
@@ -6321,7 +6321,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The token copies exactly what was printed on the original artifact or creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether it is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "The token copies exactly what was printed on the original artifact or creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether it is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2013-01-24",
@@ -6333,23 +6333,23 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If the copied permanent is a token, the token that’s created copies the original characteristics of that token as stated by the effect that put the token onto the battlefield."
+          "text": "If the copied permanent is a token, the token that's created copies the original characteristics of that token as stated by the effect that put the token onto the battlefield."
         },
         {
           "date": "2013-01-24",
-          "text": "Any enters-the-battlefield abilities of the copied permanent will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the chosen permanent will also work."
+          "text": "Any enters-the-battlefield abilities of the copied permanent will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the chosen permanent will also work."
         },
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -6365,15 +6365,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -6595,15 +6595,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -6619,15 +6619,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -6973,11 +6973,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -7097,19 +7097,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability to tap to add {B} to its controller’s mana pool. Contaminated Ground doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability to tap to add {B} to its controller's mana pool. Contaminated Ground doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         },
         {
           "date": "2010-06-15",
-          "text": "Contaminated Ground’s last ability triggers whenever the enchanted land becomes tapped for any reason, not just when it’s tapped for mana."
+          "text": "Contaminated Ground's last ability triggers whenever the enchanted land becomes tapped for any reason, not just when it's tapped for mana."
         },
         {
           "date": "2010-06-15",
-          "text": "If, while casting a spell or activating an ability, the enchanted land’s controller taps the land for mana to pay for it, Contaminated Ground’s ability triggers and goes on the stack on top of that spell or ability. Contaminated Ground’s ability will resolve first."
+          "text": "If, while casting a spell or activating an ability, the enchanted land's controller taps the land for mana to pay for it, Contaminated Ground's ability triggers and goes on the stack on top of that spell or ability. Contaminated Ground's ability will resolve first."
         },
         {
           "date": "2010-06-15",
-          "text": "On the other hand, the enchanted land’s controller may tap the land for mana, let Contaminated Ground’s ability trigger and go on the stack, then spend that mana to cast an instant or activate an ability in response. In that case, that instant or ability will resolve first."
+          "text": "On the other hand, the enchanted land's controller may tap the land for mana, let Contaminated Ground's ability trigger and go on the stack, then spend that mana to cast an instant or activate an ability in response. In that case, that instant or ability will resolve first."
         }
       ],
       "subtypes": [
@@ -7336,11 +7336,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -7455,7 +7455,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The value of X will change as the number of creature cards in the enchanted creature’s controller’s graveyard changes. Any time state-based actions are performed, if that creature’s toughness is 0 or less, or damage marked on it is equal to or greater than its toughness, the creature will be put into its owner’s graveyard."
+          "text": "The value of X will change as the number of creature cards in the enchanted creature's controller's graveyard changes. Any time state-based actions are performed, if that creature's toughness is 0 or less, or damage marked on it is equal to or greater than its toughness, the creature will be put into its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -7568,11 +7568,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Devour Flesh targets only a player. It doesn’t target any creatures. The target player chooses which creature to sacrifice when the spell resolves. That player can sacrifice only a creature he or she controls."
+          "text": "Devour Flesh targets only a player. It doesn't target any creatures. The target player chooses which creature to sacrifice when the spell resolves. That player can sacrifice only a creature he or she controls."
         },
         {
           "date": "2013-01-24",
-          "text": "The amount of life gained is equal to the creature’s toughness as it last existed on the battlefield."
+          "text": "The amount of life gained is equal to the creature's toughness as it last existed on the battlefield."
         }
       ],
       "text": "Target player sacrifices a creature, then gains life equal to that creature's toughness.",
@@ -7682,11 +7682,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Use the creature’s power the last time it was on the battlefield to determine how much life the target player loses and how much life you gain."
+          "text": "Use the creature's power the last time it was on the battlefield to determine how much life the target player loses and how much life you gain."
         },
         {
           "date": "2013-01-24",
-          "text": "If another player gains control of either Dying Wish or the enchanted creature (but not both), Dying Wish will be enchanting an illegal permanent. The Aura will be put into its owner’s graveyard as a state-based action."
+          "text": "If another player gains control of either Dying Wish or the enchanted creature (but not both), Dying Wish will be enchanting an illegal permanent. The Aura will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -7800,7 +7800,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You can’t tap an untapped Gate you control for mana and tap it to activate Gateway Shade’s ability at the same time. You must choose one or the other."
+          "text": "You can't tap an untapped Gate you control for mana and tap it to activate Gateway Shade's ability at the same time. You must choose one or the other."
         }
       ],
       "subtypes": [
@@ -7916,11 +7916,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Use the creature’s power the last time it was on the battlefield to determine how many cards its controller puts into his or her graveyard."
+          "text": "Use the creature's power the last time it was on the battlefield to determine how many cards its controller puts into his or her graveyard."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature is an illegal target when Grisly Spectacle tries to resolve, it will be countered and none of its effects will happen. The creature’s controller won’t put any cards into his or her graveyard."
+          "text": "If the creature is an illegal target when Grisly Spectacle tries to resolve, it will be countered and none of its effects will happen. The creature's controller won't put any cards into his or her graveyard."
         }
       ],
       "text": "Destroy target nonartifact creature. Its controller puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
@@ -8249,7 +8249,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If an effect creates a creature token that normally has toughness 1, it will enter the battlefield with toughness 0, be put into its owner’s graveyard as a state-based action, and then cease to exist. Any abilities that trigger when a creature enters the battlefield or dies will trigger."
+          "text": "If an effect creates a creature token that normally has toughness 1, it will enter the battlefield with toughness 0, be put into its owner's graveyard as a state-based action, and then cease to exist. Any abilities that trigger when a creature enters the battlefield or dies will trigger."
         }
       ],
       "text": "Creature tokens get -1/-1.",
@@ -8417,7 +8417,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Lord of the Void’s ability isn’t optional. If there is a creature card among the seven cards you exiled, you must put one onto the battlefield under your control."
+          "text": "Lord of the Void's ability isn't optional. If there is a creature card among the seven cards you exiled, you must put one onto the battlefield under your control."
         }
       ],
       "subtypes": [
@@ -8530,15 +8530,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -8554,15 +8554,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -8680,15 +8680,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -8704,15 +8704,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -9066,7 +9066,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The black creature that entered the battlefield can be chosen as the target of Shadow Alley Denizen’s ability, but it won’t be able to attack that turn unless it also has haste."
+          "text": "The black creature that entered the battlefield can be chosen as the target of Shadow Alley Denizen's ability, but it won't be able to attack that turn unless it also has haste."
         },
         {
           "date": "2013-01-24",
@@ -9184,15 +9184,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -9208,15 +9208,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -9560,11 +9560,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -9681,11 +9681,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The nonland permanent you choose as the target doesn’t have to have any counters on it. If it has more than one kind of counter, you’ll choose one of those counters when the ability resolves."
+          "text": "The nonland permanent you choose as the target doesn't have to have any counters on it. If it has more than one kind of counter, you'll choose one of those counters when the ability resolves."
         },
         {
           "date": "2013-01-24",
-          "text": "You can’t activate Thrull Parasite’s last ability to stop a player from paying the cost of a spell or an ability that requires removing a counter from a permanent (such as a planeswalker’s loyalty ability)."
+          "text": "You can't activate Thrull Parasite's last ability to stop a player from paying the cost of a spell or an ability that requires removing a counter from a permanent (such as a planeswalker's loyalty ability)."
         },
         {
           "date": "2013-04-15",
@@ -9693,11 +9693,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -9927,15 +9927,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -9951,15 +9951,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -10082,7 +10082,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Wight of Precinct Six’s ability applies only if Wight of Precinct Six is on the battlefield."
+          "text": "Wight of Precinct Six's ability applies only if Wight of Precinct Six is on the battlefield."
         }
       ],
       "subtypes": [
@@ -10208,15 +10208,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Act of Treason can target any creature, even one that’s untapped or one you already control."
+          "text": "Act of Treason can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2013-07-01",
-          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you’ll choose one to remain on the battlefield and put the other into its owner’s graveyard."
+          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you'll choose one to remain on the battlefield and put the other into its owner's graveyard."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
@@ -10327,11 +10327,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -10566,7 +10566,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You can’t tap an untapped Gate you control for mana and tap it to activate Crackling Perimeter’s ability at the same time. You must choose one or the other."
+          "text": "You can't tap an untapped Gate you control for mana and tap it to activate Crackling Perimeter's ability at the same time. You must choose one or the other."
         }
       ],
       "text": "Tap an untapped Gate you control: Crackling Perimeter deals 1 damage to each opponent.",
@@ -10683,15 +10683,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Ember Beast can’t attack or block unless another creature is also assigned to attack or block at the same time. Notably, two Ember Beasts can attack or block together."
+          "text": "Ember Beast can't attack or block unless another creature is also assigned to attack or block at the same time. Notably, two Ember Beasts can attack or block together."
         },
         {
           "date": "2013-01-24",
-          "text": "Once Ember Beast has been declared as an attacker or blocker, it doesn’t matter what happens to the other creature(s)."
+          "text": "Once Ember Beast has been declared as an attacker or blocker, it doesn't matter what happens to the other creature(s)."
         },
         {
           "date": "2013-01-24",
-          "text": "Other creatures assigned to attack alongside Ember Beast don’t have to attack the same player or planeswalker. Other creatures assigned to block alongside Ember Beast don’t have to block the same creature as Ember Beast."
+          "text": "Other creatures assigned to attack alongside Ember Beast don't have to attack the same player or planeswalker. Other creatures assigned to block alongside Ember Beast don't have to block the same creature as Ember Beast."
         }
       ],
       "subtypes": [
@@ -10806,11 +10806,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -10929,7 +10929,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Five-Alarm Fire’s first ability triggers once for each time a creature you control deals combat damage, even if it deals combat damage to more than one creature, planeswalker, or player. For example, an attacking creature with trample that deals combat damage to a blocking creature and the defending player will cause Five-Alarm Fire’s ability to trigger once. A creature with double strike, however, may cause Five-Alarm Fire’s ability to trigger twice during a single combat."
+          "text": "Five-Alarm Fire's first ability triggers once for each time a creature you control deals combat damage, even if it deals combat damage to more than one creature, planeswalker, or player. For example, an attacking creature with trample that deals combat damage to a blocking creature and the defending player will cause Five-Alarm Fire's ability to trigger once. A creature with double strike, however, may cause Five-Alarm Fire's ability to trigger twice during a single combat."
         }
       ],
       "text": "Whenever a creature you control deals combat damage, put a blaze counter on Five-Alarm Fire.\nRemove five blaze counters from Five-Alarm Fire: Five-Alarm Fire deals 5 damage to target creature or player.",
@@ -11255,7 +11255,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If you don’t control twenty or more artifacts at the beginning of your upkeep, Hellkite Tyrant’s last ability won’t trigger. If it does trigger, it will check again when it tries to resolve. If you don’t control twenty or more artifacts at that time, the ability will do nothing."
+          "text": "If you don't control twenty or more artifacts at the beginning of your upkeep, Hellkite Tyrant's last ability won't trigger. If it does trigger, it will check again when it tries to resolve. If you don't control twenty or more artifacts at that time, the ability will do nothing."
         }
       ],
       "subtypes": [
@@ -11371,15 +11371,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Hellraiser Goblin’s ability also affects itself. If it enters the battlefield before combat, it will have to attack that combat if able."
+          "text": "Hellraiser Goblin's ability also affects itself. If it enters the battlefield before combat, it will have to attack that combat if able."
         },
         {
           "date": "2013-01-24",
-          "text": "If, during your declare attackers step, a creature you control is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having a creature attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, a creature you control is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having a creature attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2013-01-24",
-          "text": "Unlike many other effects that force a creature to attack if able, Hellraiser Goblin’s ability applies during each combat. If a turn has multiple combat phases, creatures you control must attack in each of them if able."
+          "text": "Unlike many other effects that force a creature to attack if able, Hellraiser Goblin's ability applies during each combat. If a turn has multiple combat phases, creatures you control must attack in each of them if able."
         }
       ],
       "subtypes": [
@@ -11498,7 +11498,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The name of a creature token is the same as its creature types unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 1/1 Soldier creature token is named “Soldier.”"
+          "text": "The name of a creature token is the same as its creature types unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 1/1 Soldier creature token is named \"Soldier.\""
         }
       ],
       "text": "Homing Lightning deals 4 damage to target creature and each other creature with the same name as that creature.",
@@ -11608,11 +11608,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -11840,15 +11840,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "That creature’s controller still decides which attacking creature it blocks."
+          "text": "That creature's controller still decides which attacking creature it blocks."
         },
         {
           "date": "2013-01-24",
-          "text": "If the creature can’t block (perhaps because it has become tapped or it doesn’t have flying and all attacking creatures do), then the requirement to block does nothing."
+          "text": "If the creature can't block (perhaps because it has become tapped or it doesn't have flying and all attacking creatures do), then the requirement to block does nothing."
         },
         {
           "date": "2013-01-24",
-          "text": "If there are any costs required for that creature to block (such as the one imposed by War Cadence), the creature’s controller isn’t required to pay those costs. In that case, the requirement to block would do nothing."
+          "text": "If there are any costs required for that creature to block (such as the one imposed by War Cadence), the creature's controller isn't required to pay those costs. In that case, the requirement to block would do nothing."
         }
       ],
       "text": "Target creature an opponent controls blocks this turn if able. Untap that creature. Other creatures that player controls can't block this turn.",
@@ -12072,7 +12072,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "Molten Primordial’s triggered ability can target a creature that’s already untapped."
+          "text": "Molten Primordial's triggered ability can target a creature that's already untapped."
         }
       ],
       "subtypes": [
@@ -12628,11 +12628,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "Effects that would replace gaining life with another effect won’t apply because it’s impossible for players to gain life."
+          "text": "Effects that would replace gaining life with another effect won't apply because it's impossible for players to gain life."
         },
         {
           "date": "2013-01-24",
-          "text": "If an effect says to set a player’s life total to a certain number and that number is higher than the player’s current life total, that part of the effect won’t do anything. (If the number is lower than the player’s current life total, the effect will work as normal.)"
+          "text": "If an effect says to set a player's life total to a certain number and that number is higher than the player's current life total, that part of the effect won't do anything. (If the number is lower than the player's current life total, the effect will work as normal.)"
         }
       ],
       "text": "Players can't gain life this turn. Damage can't be prevented this turn. Skullcrack deals 3 damage to target player.",
@@ -12746,11 +12746,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The target player needn’t control an artifact or a land. Structural Collapse will still deal 2 damage to that player."
+          "text": "The target player needn't control an artifact or a land. Structural Collapse will still deal 2 damage to that player."
         },
         {
           "date": "2013-01-24",
-          "text": "If the player controls an artifact land, he or she can’t choose to sacrifice that permanent for both the artifact and the land. If that’s the only artifact the player controls, he or she must sacrifice another land. If it’s the only land the player controls, he or she must sacrifice another artifact. If it’s the only artifact and the only land the player controls, he or she sacrifices just that permanent."
+          "text": "If the player controls an artifact land, he or she can't choose to sacrifice that permanent for both the artifact and the land. If that's the only artifact the player controls, he or she must sacrifice another land. If it's the only land the player controls, he or she must sacrifice another artifact. If it's the only artifact and the only land the player controls, he or she sacrifices just that permanent."
         }
       ],
       "text": "Target player sacrifices an artifact and a land. Structural Collapse deals 2 damage to that player.",
@@ -12969,7 +12969,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You must activate Towering Thunderfist’s ability before you declare attackers (at the latest, during the beginning of combat step) in order to have it attack without becoming tapped."
+          "text": "You must activate Towering Thunderfist's ability before you declare attackers (at the latest, during the beginning of combat step) in order to have it attack without becoming tapped."
         }
       ],
       "subtypes": [
@@ -13197,11 +13197,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -13437,7 +13437,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -13453,7 +13453,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -13676,7 +13676,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Burst of Strength can target and put a +1/+1 counter on a creature that’s already untapped."
+          "text": "Burst of Strength can target and put a +1/+1 counter on a creature that's already untapped."
         }
       ],
       "text": "Put a +1/+1 counter on target creature and untap it.",
@@ -13790,7 +13790,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -13806,7 +13806,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -14146,7 +14146,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If removing two +1/+1 counters from Experiment One causes the amount of damage already marked on Experiment One to be equal to or greater than its toughness, it will be put into its owner’s graveyard as a state-based action before the regeneration shield is created."
+          "text": "If removing two +1/+1 counters from Experiment One causes the amount of damage already marked on Experiment One to be equal to or greater than its toughness, it will be put into its owner's graveyard as a state-based action before the regeneration shield is created."
         },
         {
           "date": "2013-04-15",
@@ -14154,7 +14154,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -14170,7 +14170,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -14290,7 +14290,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If Forced Adaptation’s ability triggers but Forced Adaptation isn’t on the battlefield when the ability resolves, put a +1/+1 counter on the creature it was enchanting when it left the battlefield."
+          "text": "If Forced Adaptation's ability triggers but Forced Adaptation isn't on the battlefield when the ability resolves, put a +1/+1 counter on the creature it was enchanting when it left the battlefield."
         }
       ],
       "subtypes": [
@@ -14404,7 +14404,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "As the token is created, it checks the printed values of the Giant Adephage it’s copying—or, if the Giant Adephage whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield—as well as any copy effects that have been applied to it. It won’t copy counters on the Giant Adephage, nor will it copy other effects that have changed Giant Adephage’s power, toughness, types, color, or so on. Normally, this means the token will simply be a Giant Adephage. But if any copy effects have affected that Giant Adephage, they’re taken into account."
+          "text": "As the token is created, it checks the printed values of the Giant Adephage it's copying—or, if the Giant Adephage whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield—as well as any copy effects that have been applied to it. It won't copy counters on the Giant Adephage, nor will it copy other effects that have changed Giant Adephage's power, toughness, types, color, or so on. Normally, this means the token will simply be a Giant Adephage. But if any copy effects have affected that Giant Adephage, they're taken into account."
         }
       ],
       "subtypes": [
@@ -14519,7 +14519,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Greenside Watcher’s ability is not a mana ability. It uses the stack and can be responded to."
+          "text": "Greenside Watcher's ability is not a mana ability. It uses the stack and can be responded to."
         }
       ],
       "subtypes": [
@@ -14634,7 +14634,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Gyre Sage’s last ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Gyre Sage's last ability is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-04-15",
@@ -14642,7 +14642,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -14658,7 +14658,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -14774,7 +14774,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Hindervines checks whether a creature has a +1/+1 counter on it at the moment it deals damage. It doesn’t matter whether a creature had a +1/+1 counter, or was even on the battlefield, when Hindervines resolved."
+          "text": "Hindervines checks whether a creature has a +1/+1 counter on it at the moment it deals damage. It doesn't matter whether a creature had a +1/+1 counter, or was even on the battlefield, when Hindervines resolved."
         }
       ],
       "text": "Prevent all combat damage that would be dealt this turn by creatures with no +1/+1 counters on them.",
@@ -14885,7 +14885,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The green creature that entered the battlefield can be chosen as the target of Ivy Lane Denizen’s ability."
+          "text": "The green creature that entered the battlefield can be chosen as the target of Ivy Lane Denizen's ability."
         },
         {
           "date": "2013-01-24",
@@ -15008,7 +15008,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The power and toughness of the Ooze token is determined when Miming Slime resolves. It won’t change as the greatest power among creatures you control changes."
+          "text": "The power and toughness of the Ooze token is determined when Miming Slime resolves. It won't change as the greatest power among creatures you control changes."
         }
       ],
       "text": "Create an X/X green Ooze creature token, where X is the greatest power among creatures you control.",
@@ -15361,7 +15361,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Use the creature’s power and toughness when Predator’s Rapport resolves to determine how much life you gain."
+          "text": "Use the creature's power and toughness when Predator's Rapport resolves to determine how much life you gain."
         }
       ],
       "text": "Choose target creature you control. You gain life equal to that creature's power plus its toughness.",
@@ -15472,7 +15472,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Rust Scarab’s ability normally triggers only once per combat, no matter how many creatures are assigned to block it."
+          "text": "Rust Scarab's ability normally triggers only once per combat, no matter how many creatures are assigned to block it."
         },
         {
           "date": "2013-01-24",
@@ -15701,15 +15701,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You may choose zero targets when you cast Serene Remembrance. If you do, you’ll shuffle Serene Remembrance into its owner’s library when it resolves."
+          "text": "You may choose zero targets when you cast Serene Remembrance. If you do, you'll shuffle Serene Remembrance into its owner's library when it resolves."
         },
         {
           "date": "2013-01-24",
-          "text": "If you choose at least one target for Serene Remembrance, and all of its targets are illegal when Serene Remembrance tries to resolve, it will be countered and none of its effects will happen. You won’t shuffle any library and Serene Remembrance will be put into its owner’s graveyard."
+          "text": "If you choose at least one target for Serene Remembrance, and all of its targets are illegal when Serene Remembrance tries to resolve, it will be countered and none of its effects will happen. You won't shuffle any library and Serene Remembrance will be put into its owner's graveyard."
         },
         {
           "date": "2013-01-24",
-          "text": "If you give Serene Remembrance the flashback ability and cast it from your graveyard, it will be exiled instead of being shuffled into your library. Any other targets will still be shuffled into their owners’ library, however."
+          "text": "If you give Serene Remembrance the flashback ability and cast it from your graveyard, it will be exiled instead of being shuffled into your library. Any other targets will still be shuffled into their owners' library, however."
         }
       ],
       "text": "Shuffle Serene Remembrance and up to three target cards from a single graveyard into their owners' libraries.",
@@ -16155,7 +16155,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Sylvan Primordial’s enters-the-battlefield ability resolves but one of the target noncreature permanents isn’t destroyed (perhaps because it has indestructible or it regenerated), it won’t count toward the number of Forest cards you can put onto the battlefield."
+          "text": "If Sylvan Primordial's enters-the-battlefield ability resolves but one of the target noncreature permanents isn't destroyed (perhaps because it has indestructible or it regenerated), it won't count toward the number of Forest cards you can put onto the battlefield."
         },
         {
           "date": "2014-02-01",
@@ -16384,7 +16384,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If the land targeted by Verdant Haven is an illegal target when Verdan Haven tries to resolve, Verdant Haven will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the land targeted by Verdant Haven is an illegal target when Verdan Haven tries to resolve, Verdant Haven will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -16714,7 +16714,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Multiple instances of lifelink are redundant. If a creature that had lifelink already is blocking or blocked by Alms Beast, the controller of that creature won’t gain extra life."
+          "text": "multiple instances of lifelink on the same creature are redundant. If a creature that had lifelink already is blocking or blocked by Alms Beast, the controller of that creature won't gain extra life."
         }
       ],
       "subtypes": [
@@ -16830,7 +16830,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If Assemble the Legion isn’t on the battlefield when its ability resolves, use the number of muster counters it had when it was last on the battlefield to determine how many Soldier tokens to put onto the battlefield."
+          "text": "If Assemble the Legion isn't on the battlefield when its ability resolves, use the number of muster counters it had when it was last on the battlefield to determine how many Soldier tokens to put onto the battlefield."
         }
       ],
       "text": "At the beginning of your upkeep, put a muster counter on Assemble the Legion. Then create a 1/1 red and white Soldier creature token with haste for each muster counter on Assemble the Legion.",
@@ -16945,15 +16945,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You untap all creatures you control, including ones that aren’t attacking."
+          "text": "You untap all creatures you control, including ones that aren't attacking."
         },
         {
           "date": "2013-01-24",
-          "text": "You don’t have to attack with any creatures during the additional combat phase."
+          "text": "You don't have to attack with any creatures during the additional combat phase."
         },
         {
           "date": "2013-01-24",
-          "text": "If Aurelia is put onto the battlefield attacking, the triggered ability won’t trigger."
+          "text": "If Aurelia is put onto the battlefield attacking, the triggered ability won't trigger."
         }
       ],
       "subtypes": [
@@ -17072,19 +17072,19 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You announce the value of X and how the damage will be divided as part of casting Aurelia’s Fury. Each chosen target must receive at least 1 damage."
+          "text": "You announce the value of X and how the damage will be divided as part of casting Aurelia's Fury. Each chosen target must receive at least 1 damage."
         },
         {
           "date": "2013-01-24",
-          "text": "Aurelia’s Fury can’t deal damage to both a planeswalker and that planeswalker’s controller. If damage dealt by Aurelia’s Fury is redirected from a player to a planeswalker he or she controls, that player will be able to cast noncreature spells that turn. If you want to stop a player from casting noncreature spells this turn, you can’t choose to redirect the damage to a planeswalker he or she controls."
+          "text": "Aurelia's Fury can't deal damage to both a planeswalker and that planeswalker's controller. If damage dealt by Aurelia's Fury is redirected from a player to a planeswalker he or she controls, that player will be able to cast noncreature spells that turn. If you want to stop a player from casting noncreature spells this turn, you can't choose to redirect the damage to a planeswalker he or she controls."
         },
         {
           "date": "2013-01-24",
-          "text": "If Aurelia’s Fury has multiple targets, and some but not all of them are illegal targets when Aurelia’s Fury resolves, Aurelia’s Fury will still deal damage to the remaining legal targets according to the original damage division."
+          "text": "If Aurelia's Fury has multiple targets, and some but not all of them are illegal targets when Aurelia's Fury resolves, Aurelia's Fury will still deal damage to the remaining legal targets according to the original damage division."
         },
         {
           "date": "2013-01-24",
-          "text": "If all of the targets are illegal when Aurelia’s Fury tries to resolve, it will be countered and none of its effects will happen. No creature or player will be dealt damage."
+          "text": "If all of the targets are illegal when Aurelia's Fury tries to resolve, it will be countered and none of its effects will happen. No creature or player will be dealt damage."
         }
       ],
       "text": "Aurelia's Fury deals X damage divided as you choose among any number of target creatures and/or players. Tap each creature dealt damage this way. Players dealt damage this way can't cast noncreature spells this turn.",
@@ -17197,23 +17197,23 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If Bane Alley Broker’s first ability resolves when you have no cards in your hand, you’ll draw a card and then exile it. You won’t have the opportunity to cast that card (or do anything else with it) before exiling it."
+          "text": "If Bane Alley Broker's first ability resolves when you have no cards in your hand, you'll draw a card and then exile it. You won't have the opportunity to cast that card (or do anything else with it) before exiling it."
         },
         {
           "date": "2013-01-24",
-          "text": "Once you are allowed to look at a face-down card in exile, you are allowed to look at that card as long as it’s exiled. If you no longer control Bane Alley Broker when its last ability resolves, you can continue to look at the relevant cards in exile to choose one to return."
+          "text": "Once you are allowed to look at a face-down card in exile, you are allowed to look at that card as long as it's exiled. If you no longer control Bane Alley Broker when its last ability resolves, you can continue to look at the relevant cards in exile to choose one to return."
         },
         {
           "date": "2013-01-24",
-          "text": "Bane Alley Broker’s second and third abilities apply to cards exiled with that specific Bane Alley Broker, not any other creature named Bane Alley Broker. You should keep cards exiled by different Bane Alley Brokers separate."
+          "text": "Bane Alley Broker's second and third abilities apply to cards exiled with that specific Bane Alley Broker, not any other creature named Bane Alley Broker. You should keep cards exiled by different Bane Alley Brokers separate."
         },
         {
           "date": "2013-01-24",
-          "text": "If Bane Alley Broker leaves the battlefield, the cards exiled with it will be exiled indefinitely. If it later returns to the battlefield, it will be a new object with no connection to the cards exiled with it in its previous existence. You won’t be able to use the “new” Bane Alley Broker to return cards exiled with the “old” one."
+          "text": "If Bane Alley Broker leaves the battlefield, the cards exiled with it will be exiled indefinitely. If it later returns to the battlefield, it will be a new object with no connection to the cards exiled with it in its previous existence. You won't be able to use the \"new\" Bane Alley Broker to return cards exiled with the \"old\" one."
         },
         {
           "date": "2013-01-24",
-          "text": "Even if not all players can look at the exiled cards, each card’s owner is still known. It is advisable to keep cards owned by different players in distinct piles in case another player gains control of Bane Alley Broker and exiles one or more cards with it."
+          "text": "Even if not all players can look at the exiled cards, each card's owner is still known. It is advisable to keep cards owned by different players in distinct piles in case another player gains control of Bane Alley Broker and exiles one or more cards with it."
         }
       ],
       "subtypes": [
@@ -17336,11 +17336,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If you don’t control four or more creatures named Biovisionary at the beginning of the end step, the ability won’t trigger."
+          "text": "If you don't control four or more creatures named Biovisionary at the beginning of the end step, the ability won't trigger."
         },
         {
           "date": "2013-01-24",
-          "text": "If the ability does trigger, but you don’t control four or more creatures named Biovisionary when the ability tries to resolve, the ability will do nothing."
+          "text": "If the ability does trigger, but you don't control four or more creatures named Biovisionary when the ability tries to resolve, the ability will do nothing."
         }
       ],
       "subtypes": [
@@ -17578,7 +17578,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Planeswalkers with indestructible will still have loyalty counters removed from them as they are dealt damage. If planeswalker with indestructible has no loyalty counters, it will still be put into its owner’s graveyard, as the rule that does this doesn’t destroy the planeswalker."
+          "text": "Planeswalkers with indestructible will still have loyalty counters removed from them as they are dealt damage. If planeswalker with indestructible has no loyalty counters, it will still be put into its owner's graveyard, as the rule that does this doesn't destroy the planeswalker."
         }
       ],
       "text": "Choose one —\n• Boros Charm deals 4 damage to target player.\n• Permanents you control gain indestructible until end of turn.\n• Target creature gains double strike until end of turn.",
@@ -17694,15 +17694,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -17718,15 +17718,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -18089,7 +18089,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The cards will be put into graveyards before the spell you cast to cause the ability to trigger resolves. However, none of those cards will be in a graveyard as you cast that spell, so they can’t be chosen as a target of that spell."
+          "text": "The cards will be put into graveyards before the spell you cast to cause the ability to trigger resolves. However, none of those cards will be in a graveyard as you cast that spell, so they can't be chosen as a target of that spell."
         }
       ],
       "subtypes": [
@@ -18206,15 +18206,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The card named Deathpact Angel that you return to the battlefield doesn’t necessarily have to be the same one that created the token you sacrificed."
+          "text": "The card named Deathpact Angel that you return to the battlefield doesn't necessarily have to be the same one that created the token you sacrificed."
         },
         {
           "date": "2013-01-24",
-          "text": "The activated ability is part of the Cleric token’s copiable values. Any copy of that creature token will also have that ability."
+          "text": "The activated ability is part of the Cleric token's copiable values. Any copy of that creature token will also have that ability."
         },
         {
           "date": "2013-01-24",
-          "text": "The activated ability of the token doesn’t target any card in your graveyard. You choose the card named Deathpact Angel, if any, when the ability resolves."
+          "text": "The activated ability of the token doesn't target any card in your graveyard. You choose the card named Deathpact Angel, if any, when the ability resolves."
         }
       ],
       "subtypes": [
@@ -18441,15 +18441,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target permanent is an illegal target when Dinrova Horror’s ability tries to resolve, the ability will be countered and none of its effects will happen. No player will discard a card."
+          "text": "If the target permanent is an illegal target when Dinrova Horror's ability tries to resolve, the ability will be countered and none of its effects will happen. No player will discard a card."
         },
         {
           "date": "2017-03-14",
-          "text": "If a player has no cards in his or her hand and Dinrova Horror returns a card to that player’s hand, the player must discard that card. He or she won’t have the opportunity to cast that card (or do anything else with it) before discarding it."
+          "text": "If a player has no cards in his or her hand and Dinrova Horror returns a card to that player's hand, the player must discard that card. He or she won't have the opportunity to cast that card (or do anything else with it) before discarding it."
         },
         {
           "date": "2017-03-14",
-          "text": "A token permanent returned to a player’s hand isn’t a card and can’t be discarded. It will cease to exist when state-based actions are performed after the ability finishes resolving."
+          "text": "A token permanent returned to a player's hand isn't a card and can't be discarded. It will cease to exist when state-based actions are performed after the ability finishes resolving."
         }
       ],
       "subtypes": [
@@ -18567,15 +18567,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "When resolving Domri’s first ability, if the card you look at isn’t a creature card, or if it’s a creature card you don’t want to put into your hand, you simply put it back on top of your library. You don’t reveal it or say why you’re putting it back."
+          "text": "When resolving Domri's first ability, if the card you look at isn't a creature card, or if it's a creature card you don't want to put into your hand, you simply put it back on top of your library. You don't reveal it or say why you're putting it back."
         },
         {
           "date": "2017-03-14",
-          "text": "The second target of Domri’s second ability can be another creature you control, but it can’t be the same creature as the first target."
+          "text": "The second target of Domri's second ability can be another creature you control, but it can't be the same creature as the first target."
         },
         {
           "date": "2017-03-14",
-          "text": "If either target of Domri’s second ability is an illegal target when the ability tries to resolve, neither creature will deal or be dealt damage."
+          "text": "If either target of Domri's second ability is an illegal target when the ability tries to resolve, neither creature will deal or be dealt damage."
         },
         {
           "date": "2017-03-14",
@@ -18807,15 +18807,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The first ability considers each of your opponents. You don’t choose just one of them."
+          "text": "The first ability considers each of your opponents. You don't choose just one of them."
         },
         {
           "date": "2013-01-24",
-          "text": "Each time the first ability resolves, a delayed triggered ability is created. Whenever a card is put into an opponent’s graveyard that turn, each of those abilities will trigger. For example, if you activate the first ability twice (and let those abilities resolve) and then activate the second ability targeting an opponent, that player will lose a total of 4 life. Each card put into that player’s graveyard will cause two abilities to trigger, each causing that player to lose 1 life."
+          "text": "Each time the first ability resolves, a delayed triggered ability is created. Whenever a card is put into an opponent's graveyard that turn, each of those abilities will trigger. For example, if you activate the first ability twice (and let those abilities resolve) and then activate the second ability targeting an opponent, that player will lose a total of 4 life. Each card put into that player's graveyard will cause two abilities to trigger, each causing that player to lose 1 life."
         },
         {
           "date": "2013-01-24",
-          "text": "The delayed triggered ability created won’t trigger if a token permanent is put into an opponent’s graveyard."
+          "text": "The delayed triggered ability created won't trigger if a token permanent is put into an opponent's graveyard."
         }
       ],
       "subtypes": [
@@ -18938,7 +18938,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The cards put into hands this way are not “drawn.” For example, you couldn’t reveal a card with miracle put into your hand this way (but it also won’t count as the first card you’ve drawn this turn either)."
+          "text": "The cards put into hands this way are not \"drawn.\" For example, you couldn't reveal a card with miracle put into your hand this way (but it also won't count as the first card you've drawn this turn either)."
         }
       ],
       "subtypes": [
@@ -19060,7 +19060,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -19076,7 +19076,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -19194,11 +19194,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You can’t choose a creature that hasn’t yet dealt damage during the turn as the target of Executioner’s Swing, so in most cases it’s not possible for Executioner’s Swing to reduce the amount of combat damage a creature deals. (If a creature has double strike, you could cast Executioner’s Swing after it deals first-strike damage but before it deals regular combat damage.)"
+          "text": "You can't choose a creature that hasn't yet dealt damage during the turn as the target of Executioner's Swing, so in most cases it's not possible for Executioner's Swing to reduce the amount of combat damage a creature deals. (If a creature has double strike, you could cast Executioner's Swing after it deals first-strike damage but before it deals regular combat damage.)"
         },
         {
           "date": "2013-01-24",
-          "text": "It doesn’t matter what the creature dealt damage to or if that damage was combat damage."
+          "text": "It doesn't matter what the creature dealt damage to or if that damage was combat damage."
         }
       ],
       "text": "Target creature that dealt damage this turn gets -5/-5 until end of turn.",
@@ -19313,7 +19313,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Fathom Mage’s last ability will trigger whenever any +1/+1 counter is placed on it, not just ones due to the evolve ability."
+          "text": "Fathom Mage's last ability will trigger whenever any +1/+1 counter is placed on it, not just ones due to the evolve ability."
         },
         {
           "date": "2013-01-24",
@@ -19329,7 +19329,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -19345,7 +19345,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -19465,19 +19465,19 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If the target creature or player is an illegal target when Firemane Avenger’s battalion ability tries to resolve, the ability will be countered and none of its effects will happen. You won’t gain life."
+          "text": "If the target creature or player is an illegal target when Firemane Avenger's battalion ability tries to resolve, the ability will be countered and none of its effects will happen. You won't gain life."
         },
         {
           "date": "2013-01-24",
-          "text": "If Firemane Avenger’s battalion ability resolves but some or all of the damage is prevented, you’ll still gain 3 life."
+          "text": "If Firemane Avenger's battalion ability resolves but some or all of the damage is prevented, you'll still gain 3 life."
         },
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -19712,7 +19712,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The number of creatures you control is counted when Foundry Champion’s triggered ability resolves. Foundry Champion will count itself if it’s still on the battlefield under your control at that time."
+          "text": "The number of creatures you control is counted when Foundry Champion's triggered ability resolves. Foundry Champion will count itself if it's still on the battlefield under your control at that time."
         }
       ],
       "subtypes": [
@@ -19835,11 +19835,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2013-01-24",
-          "text": "If the target land is an illegal target when Frenzied Tilling tries to resolve, the spell will be countered and none of its effects will happen. You won’t search your library for a basic land card."
+          "text": "If the target land is an illegal target when Frenzied Tilling tries to resolve, the spell will be countered and none of its effects will happen. You won't search your library for a basic land card."
         }
       ],
       "text": "Destroy target land. Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -20178,7 +20178,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If you choose the second mode, Gruul Charm’s effect will override any other control-changing effects on those permanents."
+          "text": "If you choose the second mode, Gruul Charm's effect will override any other control-changing effects on those permanents."
         },
         {
           "date": "2013-01-24",
@@ -20296,11 +20296,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Gruul Ragebeast’s triggered ability isn’t optional. However, if no opponent controls a creature when a creature enters the battlefield under your control, the ability will be removed from the stack."
+          "text": "Gruul Ragebeast's triggered ability isn't optional. However, if no opponent controls a creature when a creature enters the battlefield under your control, the ability will be removed from the stack."
         },
         {
           "date": "2013-01-24",
-          "text": "If one or both of the creatures that are supposed to fight are no longer on the battlefield when the ability resolves, the fight won’t happen. Neither creature will deal or be dealt damage."
+          "text": "If one or both of the creatures that are supposed to fight are no longer on the battlefield when the ability resolves, the fight won't happen. Neither creature will deal or be dealt damage."
         },
         {
           "date": "2013-01-24",
@@ -20422,7 +20422,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "High Priest of Penance’s ability triggers once for each instance of damage dealt to it, not once for each 1 damage. The ability will trigger even if High Priest of Penance is dealt lethal damage."
+          "text": "High Priest of Penance's ability triggers once for each instance of damage dealt to it, not once for each 1 damage. The ability will trigger even if High Priest of Penance is dealt lethal damage."
         }
       ],
       "subtypes": [
@@ -20540,15 +20540,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If the target land hasn’t been under its controller’s control continuously since the beginning of his or her most recent turn, that land won’t be able to attack and its {T} abilities won’t be able to be activated. In most cases, that means it will no longer be able to be tapped for mana that turn."
+          "text": "If the target land hasn't been under its controller's control continuously since the beginning of his or her most recent turn, that land won't be able to attack and its {T} abilities won't be able to be activated. In most cases, that means it will no longer be able to be tapped for mana that turn."
         },
         {
           "date": "2013-01-24",
-          "text": "Hydroform doesn’t affect the land’s name or any other types, subtypes, or supertypes (such as basic or legendary) the land may have. The land will also keep any abilities it had."
+          "text": "Hydroform doesn't affect the land's name or any other types, subtypes, or supertypes (such as basic or legendary) the land may have. The land will also keep any abilities it had."
         },
         {
           "date": "2013-01-24",
-          "text": "Effects that modify power and/or toughness but don’t set them to a specific value (like the one created by Giant Growth), power/toughness changes from counters, and effects that switch a creature’s power and toughness will continue to apply. This may happen if the land was already a creature when Hydroform resolved."
+          "text": "Effects that modify power and/or toughness but don't set them to a specific value (like the one created by Giant Growth), power/toughness changes from counters, and effects that switch a creature's power and toughness will continue to apply. This may happen if the land was already a creature when Hydroform resolved."
         }
       ],
       "text": "Target land becomes a 3/3 Elemental creature with flying until end of turn. It's still a land.",
@@ -20666,11 +20666,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -20787,19 +20787,19 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Lazav, Dimir Mastermind becomes a copy of the creature card in the graveyard. If that card is no longer in the graveyard when Lazav’s ability resolves, use the characteristics of that card as it last existed in the graveyard. Notably, copy effects that applied to the creature card when it was on the battlefield won’t be copied by Lazav. For example, if a Clone is put into an opponent’s graveyard from the battlefield and you use Lazav’s ability, it will become 0/0. It won’t become a copy of whatever Clone was copying."
+          "text": "Lazav, Dimir Mastermind becomes a copy of the creature card in the graveyard. If that card is no longer in the graveyard when Lazav's ability resolves, use the characteristics of that card as it last existed in the graveyard. Notably, copy effects that applied to the creature card when it was on the battlefield won't be copied by Lazav. For example, if a Clone is put into an opponent's graveyard from the battlefield and you use Lazav's ability, it will become 0/0. It won't become a copy of whatever Clone was copying."
         },
         {
           "date": "2013-01-24",
-          "text": "If multiple creature cards are put into an opponent’s graveyard at the same time, you choose the order that Lazav’s triggered abilities go on the stack."
+          "text": "If multiple creature cards are put into an opponent's graveyard at the same time, you choose the order that Lazav's triggered abilities go on the stack."
         },
         {
           "date": "2013-01-24",
-          "text": "Enters-the-battlefield abilities of the creature card Lazav is copying won’t trigger as Lazav is already on the battlefield when it becomes a copy of that creature card."
+          "text": "Enters-the-battlefield abilities of the creature card Lazav is copying won't trigger as Lazav is already on the battlefield when it becomes a copy of that creature card."
         },
         {
           "date": "2013-01-24",
-          "text": "Token creatures dying won’t cause Lazav’s triggered ability to trigger."
+          "text": "Token creatures dying won't cause Lazav's triggered ability to trigger."
         }
       ],
       "subtypes": [
@@ -20919,7 +20919,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You may choose the same creature for both targets since the card says “target creature” multiple times. You may also choose two different creatures."
+          "text": "You may choose the same creature for both targets since the card says \"target creature\" multiple times. You may also choose two different creatures."
         }
       ],
       "text": "Target creature gets +3/+0 until end of turn.\nTarget creature gets +0/+3 until end of turn.",
@@ -21034,7 +21034,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "To determine how many additional +1/+1 counters a creature enters the battlefield with, use Master Biomancer’s power as that creature is entering the battlefield."
+          "text": "To determine how many additional +1/+1 counters a creature enters the battlefield with, use Master Biomancer's power as that creature is entering the battlefield."
         }
       ],
       "subtypes": [
@@ -21265,11 +21265,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If an opponent’s library contains fewer than X land cards, all cards from that library are revealed and put into his or her graveyard."
+          "text": "If an opponent's library contains fewer than X land cards, all cards from that library are revealed and put into his or her graveyard."
         },
         {
           "date": "2013-01-24",
-          "text": "If another spell or ability instructs you to cast Mind Grind “without paying its mana cost,” you won’t be able to. You must pick 0 as the value of X in the mana cost of a spell being cast “without paying its mana cost,” but the X in Mind Grind’s mana cost can’t be 0."
+          "text": "If another spell or ability instructs you to cast Mind Grind \"without paying its mana cost,\" you won't be able to. You must pick 0 as the value of X in the mana cost of a spell being cast \"without paying its mana cost,\" but the X in Mind Grind's mana cost can't be 0."
         }
       ],
       "text": "Each opponent reveals cards from the top of his or her library until he or she reveals X land cards, then puts all cards revealed this way into his or her graveyard. X can't be 0.",
@@ -21383,7 +21383,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Mortis Strider will return to its owner’s hand only if it is still in the graveyard when its ability resolves."
+          "text": "Mortis Strider will return to its owner's hand only if it is still in the graveyard when its ability resolves."
         }
       ],
       "subtypes": [
@@ -21501,11 +21501,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target spell is an illegal target when Mystic Genesis tries to resolve, Mystic Genesis will be countered and none of its effects will happen. You won’t get an Ooze token."
+          "text": "If the target spell is an illegal target when Mystic Genesis tries to resolve, Mystic Genesis will be countered and none of its effects will happen. You won't get an Ooze token."
         },
         {
           "date": "2017-03-14",
-          "text": "You may target a spell that can’t be countered. When Mystic Genesis resolves, the target spell will be unaffected, but you’ll still get an Ooze token."
+          "text": "You may target a spell that can't be countered. When Mystic Genesis resolves, the target spell will be unaffected, but you'll still get an Ooze token."
         }
       ],
       "text": "Counter target spell. Create an X/X green Ooze creature token, where X is that spell's converted mana cost.",
@@ -21732,11 +21732,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Once Obzedat’s ability has returned it to the battlefield, it has haste for as long as it remains on the battlefield. If an opponent gains control of it (perhaps with Olivia Voldaren or Soul Ransom), it can attack that turn."
+          "text": "Once Obzedat's ability has returned it to the battlefield, it has haste for as long as it remains on the battlefield. If an opponent gains control of it (perhaps with Olivia Voldaren or Soul Ransom), it can attack that turn."
         },
         {
           "date": "2017-03-14",
-          "text": "If you gain control of Obzedat “until end of turn,” you’ll control it during your end step and you choose whether to exile it. If you do, it returns to the battlefield under its owner’s control at the beginning of your next upkeep, not its owner’s next upkeep."
+          "text": "If you gain control of Obzedat \"until end of turn,\" you'll control it during your end step and you choose whether to exile it. If you do, it returns to the battlefield under its owner's control at the beginning of your next upkeep, not its owner's next upkeep."
         }
       ],
       "subtypes": [
@@ -21856,7 +21856,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -21973,11 +21973,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -22098,15 +22098,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Orzhov Charm’s first mode doesn’t target any of the Auras attached to the target creature."
+          "text": "Orzhov Charm's first mode doesn't target any of the Auras attached to the target creature."
         },
         {
           "date": "2013-01-24",
-          "text": "If you choose the first mode, any Aura controlled by another player attached to the creature will be put into its owner’s graveyard as a state-based action after the creature leaves the battlefield."
+          "text": "If you choose the first mode, any Aura controlled by another player attached to the creature will be put into its owner's graveyard as a state-based action after the creature leaves the battlefield."
         },
         {
           "date": "2013-01-24",
-          "text": "If you choose the second mode, you’ll lose life equal to the creature’s toughness when it was last on the battlefield."
+          "text": "If you choose the second mode, you'll lose life equal to the creature's toughness when it was last on the battlefield."
         },
         {
           "date": "2013-01-24",
@@ -22114,7 +22114,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If you choose the second mode, and Orzhov Charm resolves but the creature isn’t destroyed (perhaps because it has indestructible or it regenerates), you’ll still lose life equal to the creature’s toughness."
+          "text": "If you choose the second mode, and Orzhov Charm resolves but the creature isn't destroyed (perhaps because it has indestructible or it regenerates), you'll still lose life equal to the creature's toughness."
         }
       ],
       "text": "Choose one —\n• Return target creature you control and all Auras you control attached to it to their owner's hand.\n• Destroy target creature and you lose life equal to its toughness.\n• Return target creature card with converted mana cost 1 or less from your graveyard to the battlefield.",
@@ -22226,15 +22226,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -22250,15 +22250,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -22494,11 +22494,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "The number of cards you draw equals Prime Speaker Zegana’s power when the last ability resolves."
+          "text": "The number of cards you draw equals Prime Speaker Zegana's power when the last ability resolves."
         },
         {
           "date": "2013-01-24",
-          "text": "If Prime Speaker Zegana enters the battlefield at the same time as another creature you control, you won’t consider that creature when determining the greatest power among creatures you control."
+          "text": "If Prime Speaker Zegana enters the battlefield at the same time as another creature you control, you won't consider that creature when determining the greatest power among creatures you control."
         }
       ],
       "subtypes": [
@@ -22619,11 +22619,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If the target spell is an illegal target when Psychic Strike tries to resolve, Psychic Strike will be countered and none of its effects will happen. The target’s controller won’t put any cards from the top of his or her library into his or her graveyard."
+          "text": "If the target spell is an illegal target when Psychic Strike tries to resolve, Psychic Strike will be countered and none of its effects will happen. The target's controller won't put any cards from the top of his or her library into his or her graveyard."
         },
         {
           "date": "2013-01-24",
-          "text": "You may target a spell that can’t be countered. When Psychic Strike resolves, the target spell will be unaffected, but its controller will still put the top two cards of his or her library into his or her graveyard."
+          "text": "You may target a spell that can't be countered. When Psychic Strike resolves, the target spell will be unaffected, but its controller will still put the top two cards of his or her library into his or her graveyard."
         }
       ],
       "text": "Counter target spell. Its controller puts the top two cards of his or her library into his or her graveyard.",
@@ -22736,7 +22736,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If the opponent has fewer than two cards in his or her hand, he or she will discard them. You’ll still gain 2 life, no matter how many cards were discarded."
+          "text": "If the opponent has fewer than two cards in his or her hand, he or she will discard them. You'll still gain 2 life, no matter how many cards were discarded."
         }
       ],
       "text": "Target opponent discards two cards and you gain 2 life.",
@@ -22851,11 +22851,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The ability that defines Rubblehulk’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Rubblehulk's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2013-01-24",
-          "text": "If you activate Rubblehulk’s bloodrush ability, the value of X is the number of lands you control when that ability resolves."
+          "text": "If you activate Rubblehulk's bloodrush ability, the value of X is the number of lands you control when that ability resolves."
         }
       ],
       "subtypes": [
@@ -23086,7 +23086,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won’t trigger at all."
+          "text": "Whenever a creature enters the battlefield under your control, check its power and toughness against the power and toughness of the creature with evolve. If neither stat of the new creature is greater, evolve won't trigger at all."
         },
         {
           "date": "2013-04-15",
@@ -23102,7 +23102,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "When comparing the stats as the evolve ability resolves, it’s possible that the stat that’s greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you’ll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You’ll put a +1/+1 counter on the creature with evolve."
+          "text": "When comparing the stats as the evolve ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on the creature with evolve. For example, if you control a 2/2 creature with evolve and a 1/3 creature enters the battlefield under your control, it toughness is greater so evolve will trigger. In response, the 1/3 creature gets +2/-2. When the evolve trigger tries to resolve, its power is greater. You'll put a +1/+1 counter on the creature with evolve."
         }
       ],
       "subtypes": [
@@ -23220,7 +23220,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If you don’t reveal three creature cards with different names, you’ll simply shuffle your library (including any cards you revealed)."
+          "text": "If you don't reveal three creature cards with different names, you'll simply shuffle your library (including any cards you revealed)."
         },
         {
           "date": "2013-01-24",
@@ -23450,11 +23450,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Only creatures you control when the first ability resolves will gain trample. Creatures that come under your control later in the turn won’t have trample. Lands you control that aren’t creatures also won’t gain trample, even if you use the second ability to turn them into creatures later in the turn."
+          "text": "Only creatures you control when the first ability resolves will gain trample. Creatures that come under your control later in the turn won't have trample. Lands you control that aren't creatures also won't gain trample, even if you use the second ability to turn them into creatures later in the turn."
         },
         {
           "date": "2013-01-24",
-          "text": "Skarrg Guildmage’s second ability doesn’t affect the land’s name or any other types, subtypes, or supertypes (such as basic or legendary) the land may have. The land will also keep any abilities it had."
+          "text": "Skarrg Guildmage's second ability doesn't affect the land's name or any other types, subtypes, or supertypes (such as basic or legendary) the land may have. The land will also keep any abilities it had."
         }
       ],
       "subtypes": [
@@ -23693,11 +23693,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "In most cases, you’ll enchant a creature controlled by an opponent, which will cause you to gain control of that creature. Any of your opponents can activate the last ability of Soul Ransom by discarding two cards. When that ability resolves, you’ll sacrifice Soul Ransom and draw two cards."
+          "text": "In most cases, you'll enchant a creature controlled by an opponent, which will cause you to gain control of that creature. Any of your opponents can activate the last ability of Soul Ransom by discarding two cards. When that ability resolves, you'll sacrifice Soul Ransom and draw two cards."
         },
         {
           "date": "2017-03-14",
-          "text": "You’ll draw two cards even if you can’t sacrifice Soul Ransom, perhaps because it left the battlefield in response to Soul Ransom’s ability."
+          "text": "You'll draw two cards even if you can't sacrifice Soul Ransom, perhaps because it left the battlefield in response to Soul Ransom's ability."
         }
       ],
       "subtypes": [
@@ -23927,7 +23927,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Only creatures you control when Sunhome Guildmage’s first ability resolves will get +1/+0. Creatures that come under your control later in the turn will not."
+          "text": "Only creatures you control when Sunhome Guildmage's first ability resolves will get +1/+0. Creatures that come under your control later in the turn will not."
         }
       ],
       "subtypes": [
@@ -24051,11 +24051,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -24284,15 +24284,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "If you reveal a nonland card, you may cast it during the resolution of Unexpected Results. Ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "If you reveal a nonland card, you may cast it during the resolution of Unexpected Results. Ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2013-01-24",
-          "text": "If you can’t cast the card (perhaps because there are no legal targets), or if you choose not to, the card will remain on top of the library."
+          "text": "If you can't cast the card (perhaps because there are no legal targets), or if you choose not to, the card will remain on top of the library."
         },
         {
           "date": "2013-01-24",
-          "text": "If you cast a spell “without paying its mana cost,” you can’t pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a spell \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2013-01-24",
@@ -24300,11 +24300,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If you reveal a land card, Unexpected Results will be returned to your hand only if you put that land card onto the battlefield. If you don’t, Unexpected Results will be put into its owner’s graveyard."
+          "text": "If you reveal a land card, Unexpected Results will be returned to your hand only if you put that land card onto the battlefield. If you don't, Unexpected Results will be put into its owner's graveyard."
         },
         {
           "date": "2013-01-24",
-          "text": "If you reveal a land card and put that card onto the battlefield, Unexpected Results will be put into its owner’s hand directly from the stack. It won’t be put into any graveyard."
+          "text": "If you reveal a land card and put that card onto the battlefield, Unexpected Results will be put into its owner's hand directly from the stack. It won't be put into any graveyard."
         }
       ],
       "text": "Shuffle your library, then reveal the top card. If it's a nonland card, you may cast it without paying its mana cost. If it's a land card, you may put it onto the battlefield and return Unexpected Results to its owner's hand.",
@@ -24419,15 +24419,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Urban Evolution’s effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don’t get to play a land as Urban Evolution resolves; Urban Evolution fully resolves first and draws three cards, perhaps including a land you’ll play later."
+          "text": "Urban Evolution's effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don't get to play a land as Urban Evolution resolves; Urban Evolution fully resolves first and draws three cards, perhaps including a land you'll play later."
         },
         {
           "date": "2017-03-14",
-          "text": "The effects of multiple Urban Evolutions in the same turn are cumulative. They’re also cumulative with other effects that let you play additional lands, such as the one from Explore."
+          "text": "The effects of multiple Urban Evolutions in the same turn are cumulative. They're also cumulative with other effects that let you play additional lands, such as the one from Explore."
         },
         {
           "date": "2017-03-14",
-          "text": "If you somehow manage to cast Urban Evolution when it’s not your turn, you’ll draw three cards when it resolves, but you won’t be able to play a land that turn."
+          "text": "If you somehow manage to cast Urban Evolution when it's not your turn, you'll draw three cards when it resolves, but you won't be able to play a land that turn."
         }
       ],
       "text": "Draw three cards. You may play an additional land this turn.",
@@ -24540,15 +24540,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You may pay 0 life when Vizkopa Confessor’s enters-the-battlefield ability resolves. If you do, no cards are revealed or exiled."
+          "text": "You may pay 0 life when Vizkopa Confessor's enters-the-battlefield ability resolves. If you do, no cards are revealed or exiled."
         },
         {
           "date": "2013-01-24",
-          "text": "The amount of life you pay is chosen when Vizkopa Confessor’s last ability resolves."
+          "text": "The amount of life you pay is chosen when Vizkopa Confessor's last ability resolves."
         },
         {
           "date": "2013-01-24",
-          "text": "If the target opponent is an illegal target when Vizkopa Confessor’s last ability tries to resolve, it will be countered and none of its effects will happen. You won’t pay life and no player will reveal any cards."
+          "text": "If the target opponent is an illegal target when Vizkopa Confessor's last ability tries to resolve, it will be countered and none of its effects will happen. You won't pay life and no player will reveal any cards."
         },
         {
           "date": "2013-04-15",
@@ -24556,11 +24556,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent’s life total can’t change (perhaps because that player controls Platinum Emperion), you won’t gain any life."
+          "text": "The amount of life you gain from extort is based on the total amount of life lost, not necessarily the number of opponents you have. For example, if your opponent's life total can't change (perhaps because that player controls Platinum Emperion), you won't gain any life."
         },
         {
           "date": "2013-04-15",
-          "text": "The extort ability doesn’t target any player."
+          "text": "The extort ability doesn't target any player."
         }
       ],
       "subtypes": [
@@ -24679,7 +24679,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Multiple instances of lifelink are redundant. Giving the same creature lifelink more than once won’t cause you to gain additional life."
+          "text": "multiple instances of lifelink on the same creature are redundant. Giving the same creature lifelink more than once won't cause you to gain additional life."
         },
         {
           "date": "2013-01-24",
@@ -24805,19 +24805,19 @@
         },
         {
           "date": "2013-01-24",
-          "text": "You’ll draw cards before deciding which creature (if any) Whispering Madness will be encoded on."
+          "text": "You'll draw cards before deciding which creature (if any) Whispering Madness will be encoded on."
         },
         {
           "date": "2013-04-15",
-          "text": "The spell with cipher is encoded on the creature as part of that spell’s resolution, just after the spell’s other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
+          "text": "The spell with cipher is encoded on the creature as part of that spell's resolution, just after the spell's other effects. That card goes directly from the stack to exile. It never goes to the graveyard."
         },
         {
           "date": "2013-04-15",
-          "text": "You choose the creature as the spell resolves. The cipher ability doesn’t target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
+          "text": "You choose the creature as the spell resolves. The cipher ability doesn't target that creature, although the spell with cipher may target that creature (or a different creature) because of its other abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner’s graveyard and won’t be encoded on a creature."
+          "text": "If the spell with cipher is countered, none of its effects will happen, including cipher. The card will go to its owner's graveyard and won't be encoded on a creature."
         },
         {
           "date": "2013-04-15",
@@ -24833,15 +24833,15 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card’s type."
+          "text": "You cast the copy of the card with cipher during the resolution of the triggered ability. Ignore timing restrictions based on the card's type."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose not to cast the copy, or you can’t cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won’t get a chance to cast the copy at a later time."
+          "text": "If you choose not to cast the copy, or you can't cast it (perhaps because there are no legal targets available), the copy will cease to exist the next time state-based actions are performed. You won't get a chance to cast the copy at a later time."
         },
         {
           "date": "2013-04-15",
-          "text": "The exiled card with cipher grants a triggered ability to the creature it’s encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won’t trigger. However, the exiled card will continue to be encoded on that creature."
+          "text": "The exiled card with cipher grants a triggered ability to the creature it's encoded on. If that creature loses that ability and subsequently deals combat damage to a player, the triggered ability won't trigger. However, the exiled card will continue to be encoded on that creature."
         },
         {
           "date": "2013-04-15",
@@ -24963,11 +24963,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The three attacking creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The three attacking creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2013-04-15",
-          "text": "Once a battalion ability has triggered, it doesn’t matter how many creatures are still attacking when that ability resolves."
+          "text": "Once a battalion ability has triggered, it doesn't matter how many creatures are still attacking when that ability resolves."
         },
         {
           "date": "2013-04-15",
@@ -25090,11 +25090,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Zameck Guildmage’s first ability is cumulative. For example, if it resolves twice in a turn, each creature that enters the battlefield under your control that turn will do so with two +1/+1 additional counters on it."
+          "text": "Zameck Guildmage's first ability is cumulative. For example, if it resolves twice in a turn, each creature that enters the battlefield under your control that turn will do so with two +1/+1 additional counters on it."
         },
         {
           "date": "2013-01-24",
-          "text": "Zameck Guildmage’s first ability has no effect on creatures already on the battlefield when it resolves."
+          "text": "Zameck Guildmage's first ability has no effect on creatures already on the battlefield when it resolves."
         }
       ],
       "subtypes": [
@@ -25324,7 +25324,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "An “attacking creature” or “blocking creature” is one that has been declared as an attacker or blocker this combat, or one that was put onto the battlefield attacking or blocking this combat. Unless that creature leaves combat, it continues to be an attacking or blocking creature through the end of combat step, even if the player it was attacking has left the game, the planeswalker it was attacking has left combat, or the creature or creatures it was blocking have left combat, as appropriate."
+          "text": "An \"attacking creature\" or \"blocking creature\" is one that has been declared as an attacker or blocker this combat, or one that was put onto the battlefield attacking or blocking this combat. Unless that creature leaves combat, it continues to be an attacking or blocking creature through the end of combat step, even if the player it was attacking has left the game, the planeswalker it was attacking has left combat, or the creature or creatures it was blocking have left combat, as appropriate."
         },
         {
           "date": "2013-01-24",
@@ -25450,11 +25450,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "Beckon Apparition will be on the stack when you choose its target. It can’t target itself."
+          "text": "Beckon Apparition will be on the stack when you choose its target. It can't target itself."
         },
         {
           "date": "2013-01-24",
-          "text": "If the target card is an illegal target when Beckon Apparition tries to resolve (if it’s no longer in the graveyard, for instance), the spell will be countered and none of its effects will happen. You won’t get a Spirit token."
+          "text": "If the target card is an illegal target when Beckon Apparition tries to resolve (if it's no longer in the graveyard, for instance), the spell will be countered and none of its effects will happen. You won't get a Spirit token."
         }
       ],
       "text": "Exile target card from a graveyard. Create a 1/1 white and black Spirit creature token with flying.",
@@ -25571,7 +25571,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "Biomass Mutation overwrites any effects that set the power and/or toughness of a creature you control to a specific value. Effects that modify power and/or toughness but don’t set them to a specific value (like the one created by Giant Growth), power/toughness changes from counters, and effects that switch a creature’s power and toughness will continue to apply. For example, say you control a 1/1 creature that’s getting +4/+2 from an Aura, has a +1/+1 counter on it, and is affected by an effect that switches its power and toughness. This creature is 4/6. If you cast Biomass Mutation with X equal to 4, the creature would become 7/9 (4/4, +4/+2 from the Aura, +1/+1 from the counter, then switch power and toughness)."
+          "text": "Biomass Mutation overwrites any effects that set the power and/or toughness of a creature you control to a specific value. Effects that modify power and/or toughness but don't set them to a specific value (like the one created by Giant Growth), power/toughness changes from counters, and effects that switch a creature's power and toughness will continue to apply. For example, say you control a 1/1 creature that's getting +4/+2 from an Aura, has a +1/+1 counter on it, and is affected by an effect that switches its power and toughness. This creature is 4/6. If you cast Biomass Mutation with X equal to 4, the creature would become 7/9 (4/4, +4/+2 from the Aura, +1/+1 from the counter, then switch power and toughness)."
         }
       ],
       "text": "Creatures you control have base power and toughness X/X until end of turn.",
@@ -25807,11 +25807,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Boros Reckoner’s first ability will trigger even if it is dealt lethal damage. For example, if it blocks a 7/7 creature, its ability will trigger and Boros Reckoner will deal 7 damage to the target creature or player."
+          "text": "Boros Reckoner's first ability will trigger even if it is dealt lethal damage. For example, if it blocks a 7/7 creature, its ability will trigger and Boros Reckoner will deal 7 damage to the target creature or player."
         },
         {
           "date": "2017-03-14",
-          "text": "Damage dealt by Boros Reckoner due to its first ability isn’t combat damage, even if it was combat damage that caused that ability to trigger."
+          "text": "Damage dealt by Boros Reckoner due to its first ability isn't combat damage, even if it was combat damage that caused that ability to trigger."
         },
         {
           "date": "2017-03-14",
@@ -25936,7 +25936,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Burning-Tree Emissary’s ability isn’t a mana ability. It uses the stack and can be responded to."
+          "text": "Burning-Tree Emissary's ability isn't a mana ability. It uses the stack and can be responded to."
         }
       ],
       "subtypes": [
@@ -26626,7 +26626,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "Nightveil Specter’s last ability applies to cards exiled with that specific Nightveil Specter, not any other creature named Nightveil Specter. You should keep cards exiled by different Nightveil Specters separate."
+          "text": "Nightveil Specter's last ability applies to cards exiled with that specific Nightveil Specter, not any other creature named Nightveil Specter. You should keep cards exiled by different Nightveil Specters separate."
         }
       ],
       "subtypes": [
@@ -26743,7 +26743,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The second target of Pit Fight can be another creature you control, but it can’t be the same creature as the first target."
+          "text": "The second target of Pit Fight can be another creature you control, but it can't be the same creature as the first target."
         },
         {
           "date": "2013-01-24",
@@ -26862,7 +26862,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Count the number of attacking creatures you control when Rubblebelt Raiders’s ability resolves, including Rubblebelt Raiders itself, to determine how many +1/+1 counters to put on it."
+          "text": "Count the number of attacking creatures you control when Rubblebelt Raiders's ability resolves, including Rubblebelt Raiders itself, to determine how many +1/+1 counters to put on it."
         }
       ],
       "subtypes": [
@@ -27190,7 +27190,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {R} or {W} to your mana pool.\n{R}{W}: Boros Keyrune becomes a 1/1 red and white Soldier artifact creature with double strike until end of turn. (It deals both first-strike and regular combat damage.)",
@@ -27303,7 +27303,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {U} or {B} to your mana pool.\n{U}{B}: Dimir Keyrune becomes a 2/2 blue and black Horror artifact creature until end of turn and can't be blocked this turn.",
@@ -27407,11 +27407,11 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Creatures your opponents control don’t actually lose hexproof, although you will ignore hexproof for purposes of choosing targets of spells and abilities you control."
+          "text": "Creatures your opponents control don't actually lose hexproof, although you will ignore hexproof for purposes of choosing targets of spells and abilities you control."
         },
         {
           "date": "2013-01-24",
-          "text": "Creatures that come under your control after Glaring Spotlight’s last ability resolves won’t have hexproof but they can’t be blocked that turn."
+          "text": "Creatures that come under your control after Glaring Spotlight's last ability resolves won't have hexproof but they can't be blocked that turn."
         }
       ],
       "text": "Creatures your opponents control with hexproof can be the targets of spells and abilities you control as though they didn't have hexproof.\n{3}, Sacrifice Glaring Spotlight: Creatures you control gain hexproof until end of turn and can't be blocked this turn.",
@@ -27523,7 +27523,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {R} or {G} to your mana pool.\n{R}{G}: Gruul Keyrune becomes a 3/2 red and green Beast artifact creature with trample until end of turn.",
@@ -27628,15 +27628,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "An activated ability is written in the form “Cost: Effect.”"
+          "text": "An activated ability is written in the form \"Cost: Effect.\""
         },
         {
           "date": "2013-01-24",
-          "text": "The copy will have the same targets as the ability it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the ability it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2013-01-24",
-          "text": "If the ability is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the ability is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2013-01-24",
@@ -27644,15 +27644,15 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If the cost of an activated ability requires Illusionist’s Bracers or the equipped creature to be sacrificed, the ability won’t be copied. At the time the ability is considered activated (after all costs are paid), Illusionist’s Bracers is no longer equipped to that creature."
+          "text": "If the cost of an activated ability requires Illusionist's Bracers or the equipped creature to be sacrificed, the ability won't be copied. At the time the ability is considered activated (after all costs are paid), Illusionist's Bracers is no longer equipped to that creature."
         },
         {
           "date": "2013-01-24",
-          "text": "If Illusionist’s Bracers somehow becomes equipped to a creature an opponent controls, and an activated ability (that isn’t a mana ability) of that creature is activated, you will control the copy of that ability."
+          "text": "If Illusionist's Bracers somehow becomes equipped to a creature an opponent controls, and an activated ability (that isn't a mana ability) of that creature is activated, you will control the copy of that ability."
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "subtypes": [
@@ -27867,7 +27867,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Multiple instances of lifelink are redundant. Activating the last ability multiple times won’t cause you to gain more life."
+          "text": "multiple instances of lifelink on the same creature are redundant. Activating the last ability multiple times won't cause you to gain more life."
         },
         {
           "date": "2013-04-15",
@@ -27875,7 +27875,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {W} or {B} to your mana pool.\n{W}{B}: Orzhov Keyrune becomes a 1/4 white and black Thrull artifact creature with lifelink until end of turn.",
@@ -28300,7 +28300,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {G} or {U} to your mana pool.\n{G}{U}: Simic Keyrune becomes a 2/3 green and blue Crab artifact creature with hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
@@ -28643,15 +28643,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -28885,15 +28885,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -29245,15 +29245,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -29489,15 +29489,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -29604,15 +29604,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "The copy effect created by the last activated ability doesn’t have a duration. It will last until Thespian’s Stage leaves the battlefield or another copy effect overwrites it. The permanent will no longer have the first ability of Thespian’s Stage."
+          "text": "The copy effect created by the last activated ability doesn't have a duration. It will last until Thespian's Stage leaves the battlefield or another copy effect overwrites it. The permanent will no longer have the first ability of Thespian's Stage."
         },
         {
           "date": "2013-01-24",
-          "text": "A land’s copiable values are those printed on it, as modified by other copy effects. Counters and other effects aren’t copied. Notably, if you copy a land that is also a creature because of a temporary effect (such as Celestial Colonnade), Thespian’s Stage will become just the “unanimated” land."
+          "text": "A land's copiable values are those printed on it, as modified by other copy effects. Counters and other effects aren't copied. Notably, if you copy a land that is also a creature because of a temporary effect (such as Celestial Colonnade), Thespian's Stage will become just the \"unanimated\" land."
         },
         {
           "date": "2013-01-24",
-          "text": "No enters-the-battlefield abilities of the land Thespian’s Stage is copying will trigger. Thespian’s Stage was already on the battlefield."
+          "text": "No enters-the-battlefield abilities of the land Thespian's Stage is copying will trigger. Thespian's Stage was already on the battlefield."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{2}, {T}: Thespian's Stage becomes a copy of target land and gains this ability.",
@@ -29724,15 +29724,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [

--- a/json/H09.json
+++ b/json/H09.json
@@ -49,11 +49,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -116,11 +116,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -248,11 +248,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -313,11 +313,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -381,15 +381,15 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -449,11 +449,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -517,11 +517,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -587,11 +587,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -655,11 +655,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -727,11 +727,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -794,11 +794,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -861,11 +861,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -941,11 +941,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1008,11 +1008,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1073,11 +1073,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1137,11 +1137,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1203,11 +1203,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1270,7 +1270,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Slivercycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Sliver card. After you find a Sliver card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Slivercycling doesn't allow you to draw a card. Instead, it lets you search your library for a Sliver card. After you find a Sliver card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -1282,15 +1282,15 @@
         },
         {
           "date": "2009-02-01",
-          "text": "You can choose to find any card with the Sliver creature type, even if it isn’t a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Sliver card in your library."
+          "text": "You can choose to find any card with the Sliver creature type, even if it isn't a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Sliver card in your library."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1356,11 +1356,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1424,11 +1424,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1489,15 +1489,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card’s controller controls the triggered ability, but the controller of the Sliver that deals damage to a player decides whether or not to put the token onto the battlefield under their control."
+          "text": "This card's controller controls the triggered ability, but the controller of the Sliver that deals damage to a player decides whether or not to put the token onto the battlefield under their control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1561,11 +1561,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1695,11 +1695,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1764,11 +1764,11 @@
         },
         {
           "date": "2006-07-15",
-          "text": "Can’t reduce Snow mana costs."
+          "text": "Can't reduce Snow mana costs."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Activated abilities of creatures cost {1} less to activate. This effect can't reduce the amount of mana an ability costs to activate to less than one mana.",
@@ -1951,7 +1951,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Coat of Arms counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Coat of Arms counts creatures, not creature types."
         }
       ],
       "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
@@ -2014,7 +2014,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "The game checks the power and toughness of the creature that just entered the battlefield as it exists on the battlefield. That might mean it’s impossible to get another copy of that same card. For example, a Triskelion on the battlefield is 4/4, but a Triskelion in your library is 1/1. The power and toughness might also have been affected while the triggered ability was on the stack (such as with Giant Growth, Sudden Death, or Ovinize)."
+          "text": "The game checks the power and toughness of the creature that just entered the battlefield as it exists on the battlefield. That might mean it's impossible to get another copy of that same card. For example, a Triskelion on the battlefield is 4/4, but a Triskelion in your library is 1/1. The power and toughness might also have been affected while the triggered ability was on the stack (such as with Giant Growth, Sudden Death, or Ovinize)."
         },
         {
           "date": "2007-02-01",
@@ -2074,11 +2074,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Mana produced by Ancient Ziggurat can be spent on any part of a creature spell’s total cost. This includes additional costs (such as kicker) and alternative costs (such as evoke or Worldheart Phoenix’s alternative cost)."
+          "text": "Mana produced by Ancient Ziggurat can be spent on any part of a creature spell's total cost. This includes additional costs (such as kicker) and alternative costs (such as evoke or Worldheart Phoenix's alternative cost)."
         },
         {
           "date": "2009-02-01",
-          "text": "Mana produced by Ancient Ziggurat can’t be spent on activated abilities that put a creature card directly onto the battlefield, such as unearth or ninjutsu."
+          "text": "Mana produced by Ancient Ziggurat can't be spent on activated abilities that put a creature card directly onto the battlefield, such as unearth or ninjutsu."
         }
       ],
       "text": "{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell.",
@@ -2132,11 +2132,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don’t have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don't have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",

--- a/json/HML.json
+++ b/json/HML.json
@@ -229,7 +229,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Affects any spell with the type creature, including those with other types such as artifact or enchantment. This includes older cards with “summon” on their type line."
+          "text": "Affects any spell with the type creature, including those with other types such as artifact or enchantment. This includes older cards with \"summon\" on their type line."
         }
       ],
       "text": "Creature spells can't be cast.\nPay 4 life: Destroy Aether Storm. It can't be regenerated. Any player may activate this ability.",
@@ -976,7 +976,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Anaba Spirit Crafter’s ability affects all Minotaurs, including Anaba Spirit Crafter itself."
+          "text": "Anaba Spirit Crafter's ability affects all Minotaurs, including Anaba Spirit Crafter itself."
         }
       ],
       "subtypes": [
@@ -1288,7 +1288,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Aysen Crusader’s ability counts the number of permanents you control that are Soldiers and/or Warriors. A permanent with both creature types is counted only once."
+          "text": "Aysen Crusader's ability counts the number of permanents you control that are Soldiers and/or Warriors. A permanent with both creature types is counted only once."
         }
       ],
       "subtypes": [
@@ -1433,11 +1433,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The Baron’s ability will only regenerate creatures with type “Vampire,” regardless of whether the creature has “Vampire” in its name."
+          "text": "The Baron's ability will only regenerate creatures with type \"Vampire,\" regardless of whether the creature has \"Vampire\" in its name."
         },
         {
           "date": "2007-09-16",
-          "text": "Although Baron Sengir is now a Vampire, it still can’t regenerate itself."
+          "text": "Although Baron Sengir is now a Vampire, it still can't regenerate itself."
         }
       ],
       "subtypes": [
@@ -1496,7 +1496,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1673,7 +1673,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won’t be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
+          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won't be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
         }
       ],
       "subtypes": [
@@ -1729,7 +1729,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won’t be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
+          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won't be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
         }
       ],
       "subtypes": [
@@ -2090,7 +2090,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "When Clockwork Steed’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "When Clockwork Steed's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         },
         {
           "date": "2008-10-01",
@@ -2701,11 +2701,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "You can’t target a creature if its controller doesn’t control an Island as you are activating the ability, and the ability will be countered if the creature’s controller doesn’t control an Island as the ability resolves."
+          "text": "You can't target a creature if its controller doesn't control an Island as you are activating the ability, and the ability will be countered if the creature's controller doesn't control an Island as the ability resolves."
         },
         {
           "date": "2008-08-01",
-          "text": "If control of the targeted creature changes between the activating and resolution of the ability (ie, while it’s on the stack), then the player who must control an Island as the ability resolves is the creature’s new controller."
+          "text": "If control of the targeted creature changes between the activating and resolution of the ability (ie, while it's on the stack), then the player who must control an Island as the ability resolves is the creature's new controller."
         }
       ],
       "subtypes": [
@@ -2727,7 +2727,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Their definition of ‘fair profit' is certainly novel.\"\n—Reveka, Wizard Savant",
+      "flavor": "\"Their definition of 'fair profit' is certainly novel.\"\n—Reveka, Wizard Savant",
       "id": "9f39d55b3716876dc14f0110a8bc28146086d8e2",
       "imageName": "dwarven trader1",
       "layout": "normal",
@@ -2977,7 +2977,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"Faeries talk all in riddles and tricky bits, ‘cept the Nobles. Now, there's some straight talkers.\"\n—Joskun, An-Havva Constable",
+      "flavor": "\"Faeries talk all in riddles and tricky bits, 'cept the Nobles. Now, there's some straight talkers.\"\n—Joskun, An-Havva Constable",
       "id": "5714a53c6786a797d9a36f8b9c423447f6a3a3ef",
       "imageName": "faerie noble",
       "layout": "normal",
@@ -3154,7 +3154,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Creature spells cost {2} more to cast.",
@@ -3586,11 +3586,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Activating the ability creates a continuous effect that works only as long as Giant Oyster remains tapped, a repeating delayed triggered ability that’s in effect only as long as Giant Oyster remains tapped, and a delayed triggered ability that triggers when Giant Oyster untaps or when it leaves the battlefield."
+          "text": "Activating the ability creates a continuous effect that works only as long as Giant Oyster remains tapped, a repeating delayed triggered ability that's in effect only as long as Giant Oyster remains tapped, and a delayed triggered ability that triggers when Giant Oyster untaps or when it leaves the battlefield."
         },
         {
           "date": "2006-09-25",
-          "text": "Giant Oyster’s ability can be activated during your upkeep, and the creature will get a -1/-1 counter during the draw step that follows it."
+          "text": "Giant Oyster's ability can be activated during your upkeep, and the creature will get a -1/-1 counter during the draw step that follows it."
         }
       ],
       "subtypes": [
@@ -4242,15 +4242,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The second ability will trigger only if Joven’s Ferrets is still on the battlefield at end of combat. If it’s been dealt lethal combat damage and destroyed during that combat (or has left the battlefield during that combat by any other means), its ability won’t trigger and the creatures that blocked it won’t be affected."
+          "text": "The second ability will trigger only if Joven's Ferrets is still on the battlefield at end of combat. If it's been dealt lethal combat damage and destroyed during that combat (or has left the battlefield during that combat by any other means), its ability won't trigger and the creatures that blocked it won't be affected."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature affected by the second ability is untapped at the time its controller’s next untap step begins, the “doesn’t untap” effect doesn’t do anything. It won’t apply at some later time when that creature is tapped."
+          "text": "If a creature affected by the second ability is untapped at the time its controller's next untap step begins, the \"doesn't untap\" effect doesn't do anything. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "The second ability doesn’t track the creatures’ controllers. If an affected creature changes controllers before its old controller’s next untap step, Joven’s Ferrets will prevent it from being untapped during its new controller’s next untap step."
+          "text": "The second ability doesn't track the creatures' controllers. If an affected creature changes controllers before its old controller's next untap step, Joven's Ferrets will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -4345,11 +4345,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "supertypes": [
@@ -4443,11 +4443,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the creature Labyrinth Minotaur blocked is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when that creature is tapped."
+          "text": "If the creature Labyrinth Minotaur blocked is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Labyrinth Minotaur doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Labyrinth Minotaur doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -4505,11 +4505,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the creature Labyrinth Minotaur blocked is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when that creature is tapped."
+          "text": "If the creature Labyrinth Minotaur blocked is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Labyrinth Minotaur doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Labyrinth Minotaur doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -4770,7 +4770,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell’s destination from its owner’s library to exile."
+          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell's destination from its owner's library to exile."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
@@ -4832,7 +4832,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell’s destination from its owner’s library to exile."
+          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell's destination from its owner's library to exile."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
@@ -4889,7 +4889,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a blue instant card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -5044,7 +5044,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -5449,7 +5449,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Renewal, sacrifice a land.\nSearch your library for a basic land card and put that card onto the battlefield. Then shuffle your library.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -5550,7 +5550,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Reveka’s effect causes it not to untap during _your_ next untap step. If another player gains control of it, it will untap during that player’s next untap step."
+          "text": "Reveka's effect causes it not to untap during _your_ next untap step. If another player gains control of it, it will untap during that player's next untap step."
         }
       ],
       "subtypes": [
@@ -5748,7 +5748,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6014,7 +6014,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sengir Autocrat’s last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
+          "text": "Sengir Autocrat's last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
         },
         {
           "date": "2016-06-08",
@@ -6173,7 +6173,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -6230,7 +6230,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -6386,7 +6386,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you’ve somehow manage to get a new arrowhead counter on the Arrows."
+          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you've somehow manage to get a new arrowhead counter on the Arrows."
         }
       ],
       "text": "Serrated Arrows enters the battlefield with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
@@ -6531,7 +6531,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -6602,7 +6602,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The checks for black cards is made both at the time you declare attackers and as the ability resolves. If there are any at the time attackers are declared, it won’t trigger at all. If there are any at the time it resolves, the ability will do nothing."
+          "text": "The checks for black cards is made both at the time you declare attackers and as the ability resolves. If there are any at the time attackers are declared, it won't trigger at all. If there are any at the time it resolves, the ability will do nothing."
         }
       ],
       "subtypes": [

--- a/json/HOP.json
+++ b/json/HOP.json
@@ -54,27 +54,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Academy at Tolaria West’s first ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you have no cards in hand as your end step begins, and (2) the ability will do nothing unless you have no cards in hand by the time it resolves."
+          "text": "Academy at Tolaria West's first ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you have no cards in hand as your end step begins, and (2) the ability will do nothing unless you have no cards in hand by the time it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "If you discard your hand as a result of rolling {CHAOS}, Academy at Tolaria West’s first ability will then trigger at the beginning of your end step (unless you planeswalk or somehow put a card in your hand before then)."
+          "text": "If you discard your hand as a result of rolling {CHAOS}, Academy at Tolaria West's first ability will then trigger at the beginning of your end step (unless you planeswalk or somehow put a card in your hand before then)."
         }
       ],
       "subtypes": [
@@ -189,27 +189,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The first ability of The Aether Flues doesn’t target a creature. You don’t choose a creature to sacrifice until the ability resolves. Once you choose a creature to sacrifice, it’s too late for players to respond."
+          "text": "The first ability of The Aether Flues doesn't target a creature. You don't choose a creature to sacrifice until the ability resolves. Once you choose a creature to sacrifice, it's too late for players to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the first ability of The Aether Flues but there are no creatures in your library, you’ll reveal your entire library then shuffle it."
+          "text": "If you use the first ability of The Aether Flues but there are no creatures in your library, you'll reveal your entire library then shuffle it."
         }
       ],
       "subtypes": [
@@ -329,27 +329,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Agyrem’s first and second abilities each set up a delayed triggered ability. These abilities will trigger at the beginning of the next end step even if Agyrem is no longer the face-up plane card."
+          "text": "Agyrem's first and second abilities each set up a delayed triggered ability. These abilities will trigger at the beginning of the next end step even if Agyrem is no longer the face-up plane card."
         },
         {
           "date": "2009-10-01",
-          "text": "Agyrem’s first ability will return a card to the battlefield only if it’s still in the graveyard by the time the delayed triggered ability resolves. Similarly, Agyrem’s second ability will return a card to its owner’s hand only if it’s still in the graveyard by the time the delayed triggered ability resolves."
+          "text": "Agyrem's first ability will return a card to the battlefield only if it's still in the graveyard by the time the delayed triggered ability resolves. Similarly, Agyrem's second ability will return a card to its owner's hand only if it's still in the graveyard by the time the delayed triggered ability resolves."
         },
         {
           "date": "2009-10-01",
@@ -357,19 +357,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A creature that caused either of Agyrem’s first two abilities to trigger will be returned at the beginning of the next end step even if it’s not a creature card. (For example, if it’s a Treetop Village.)"
+          "text": "A creature that caused either of Agyrem's first two abilities to trigger will be returned at the beginning of the next end step even if it's not a creature card. (For example, if it's a Treetop Village.)"
         },
         {
           "date": "2009-10-01",
-          "text": "If a token creature is put into a graveyard from the battlefield, one of Agyrem’s first two abilities will trigger, but the token will cease to exist long before it would be returned somewhere."
+          "text": "If a token creature is put into a graveyard from the battlefield, one of Agyrem's first two abilities will trigger, but the token will cease to exist long before it would be returned somewhere."
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple creatures are put into their owners’ graveyards at the same time (due to combat damage or Planar Cleansing, for example), Agyrem’s first two abilities trigger that many times. At the beginning of the next end step, the player whose turn it is at that time puts all of his or her Agyrem delayed triggered abilities on the stack in any order, then each other player in turn order does the same. The last ability put on the stack is the first one that resolves. The creatures are returned one at a time."
+          "text": "If multiple creatures are put into their owners' graveyards at the same time (due to combat damage or Planar Cleansing, for example), Agyrem's first two abilities trigger that many times. At the beginning of the next end step, the player whose turn it is at that time puts all of his or her Agyrem delayed triggered abilities on the stack in any order, then each other player in turn order does the same. The last ability put on the stack is the first one that resolves. The creatures are returned one at a time."
         },
         {
           "date": "2009-10-01",
-          "text": "If you’re affected by the chaos ability, creatures will still be able to attack planeswalkers you control."
+          "text": "If you're affected by the chaos ability, creatures will still be able to attack planeswalkers you control."
         }
       ],
       "subtypes": [
@@ -487,19 +487,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -507,7 +507,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2009-10-01",
@@ -515,7 +515,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2009-10-01",
@@ -523,7 +523,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         },
         {
           "date": "2013-07-01",
@@ -531,7 +531,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If all divinity counters on a creature are moved to a different creature, the indestructible ability doesn’t move along with them. The first creature no longer has indestructible because it no longer has a divinity counter on it. The second creature doesn’t have indestructible because the chaos ability didn’t target it."
+          "text": "If all divinity counters on a creature are moved to a different creature, the indestructible ability doesn't move along with them. The first creature no longer has indestructible because it no longer has a divinity counter on it. The second creature doesn't have indestructible because the chaos ability didn't target it."
         }
       ],
       "subtypes": [
@@ -613,11 +613,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -671,23 +671,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "For two players to exchange life totals, what actually happens is that each player gains or loses the amount of life necessary to equal the other player’s previous life total. For example, if Player A has 5 life and Player B has 3 life before the exchange, Player A will lose 2 life and Player B will gain 2 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For two players to exchange life totals, what actually happens is that each player gains or loses the amount of life necessary to equal the other player's previous life total. For example, if Player A has 5 life and Player B has 3 life before the exchange, Player A will lose 2 life and Player B will gain 2 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2009-10-01",
@@ -703,7 +703,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If either permanent targeted by the chaos ability is an illegal target by the time the ability resolves, the exchange doesn’t happen. If both targets become illegal, the ability is countered."
+          "text": "If either permanent targeted by the chaos ability is an illegal target by the time the ability resolves, the exchange doesn't happen. If both targets become illegal, the ability is countered."
         }
       ],
       "subtypes": [
@@ -812,23 +812,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The Dark Barony’s first ability doesn’t behave like a leaves-the-battlefield triggered ability, since the card put into a graveyard may come from anywhere. If a card is put into a graveyard from the battlefield, its color is checked in the graveyard, not as it last existed on the battlefield."
+          "text": "The Dark Barony's first ability doesn't behave like a leaves-the-battlefield triggered ability, since the card put into a graveyard may come from anywhere. If a card is put into a graveyard from the battlefield, its color is checked in the graveyard, not as it last existed on the battlefield."
         }
       ],
       "subtypes": [
@@ -890,11 +890,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The last ability works only if Prison Term is already on the battlefield. You may move it from the creature it’s currently enchanting onto the new creature."
+          "text": "The last ability works only if Prison Term is already on the battlefield. You may move it from the creature it's currently enchanting onto the new creature."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -951,27 +951,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "You’re “tapping a permanent for mana” only if you’re activating an activated ability of that permanent that includes the {T} symbol in its cost and produces mana as part of its effect."
+          "text": "You're \"tapping a permanent for mana\" only if you're activating an activated ability of that permanent that includes the {T} symbol in its cost and produces mana as part of its effect."
         },
         {
           "date": "2009-10-01",
-          "text": "Eloren Wilds’s first ability affects any permanent players tap for mana, not just lands they tap for mana."
+          "text": "Eloren Wilds's first ability affects any permanent players tap for mana, not just lands they tap for mana."
         },
         {
           "date": "2009-10-01",
@@ -979,7 +979,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability prevents the affected player from casting permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It doesn’t stop the player from playing lands or activating abilities (such as cycling or unearth)."
+          "text": "The chaos ability prevents the affected player from casting permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It doesn't stop the player from playing lands or activating abilities (such as cycling or unearth)."
         }
       ],
       "subtypes": [
@@ -1056,7 +1056,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other’s ability to trigger."
+          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other's ability to trigger."
         },
         {
           "date": "2005-08-01",
@@ -1119,19 +1119,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -1245,19 +1245,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -1372,19 +1372,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -1490,19 +1490,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -1575,7 +1575,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Since Master of Etherium is an artifact itself, while it’s on the battlefield you will usually control at least one artifact."
+          "text": "Since Master of Etherium is an artifact itself, while it's on the battlefield you will usually control at least one artifact."
         }
       ],
       "subtypes": [
@@ -1635,59 +1635,59 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell targets multiple things, it won’t cause Glimmervoid Basin’s first ability to trigger, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, it won't cause Glimmervoid Basin's first ability to trigger, even if all but one of those targets has become illegal."
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell targets the same player or object multiple times, it won’t cause Glimmervoid Basin’s first ability to trigger."
+          "text": "If a spell targets the same player or object multiple times, it won't cause Glimmervoid Basin's first ability to trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "Other than choices involving modes or additional costs, the copies are created based on what they could target if the spell were cast anew. For example, if a player casts Naturalize (“Destroy target artifact or enchantment”) targeting an artifact, Glimmervoid Basin’s first ability will copy it for each artifact and enchantment it could target (and each copy will target a different one of those), not just for each artifact it could target."
+          "text": "Other than choices involving modes or additional costs, the copies are created based on what they could target if the spell were cast anew. For example, if a player casts Naturalize (\"Destroy target artifact or enchantment\") targeting an artifact, Glimmervoid Basin's first ability will copy it for each artifact and enchantment it could target (and each copy will target a different one of those), not just for each artifact it could target."
         },
         {
           "date": "2009-10-01",
-          "text": "Anything that couldn’t be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Glimmervoid Basin’s first ability."
+          "text": "Anything that couldn't be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Glimmervoid Basin's first ability."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of the spell that caused Glimmervoid Basin’s first ability to trigger also controls all the copies. That player chooses the order the copies are put onto the stack. The original spell will be on the stack beneath those copies and resolves last."
+          "text": "The controller of the spell that caused Glimmervoid Basin's first ability to trigger also controls all the copies. That player chooses the order the copies are put onto the stack. The original spell will be on the stack beneath those copies and resolves last."
         },
         {
           "date": "2009-10-01",
-          "text": "The copies that Glimmervoid Basin’s first ability creates are created on the stack, so they’re not “cast.” Abilities that trigger when a player casts a spell (like Glimmervoid Basin’s first ability itself) won’t trigger."
+          "text": "The copies that Glimmervoid Basin's first ability creates are created on the stack, so they're not \"cast.\" Abilities that trigger when a player casts a spell (like Glimmervoid Basin's first ability itself) won't trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. Its controller can’t choose a different one."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. Its controller can't choose a different one."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a copy can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
+          "text": "The controller of a copy can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
         },
         {
           "date": "2009-10-01",
-          "text": "As a token is created by the chaos ability, it checks the printed values of the creature it’s copying, as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, and so on."
+          "text": "As a token is created by the chaos ability, it checks the printed values of the creature it's copying, as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, and so on."
         }
       ],
       "subtypes": [
@@ -1804,19 +1804,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -1938,27 +1938,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The Great Forest’s first ability means, for example, that a 2/3 creature will assign 3 damage in combat instead of 2."
+          "text": "The Great Forest's first ability means, for example, that a 2/3 creature will assign 3 damage in combat instead of 2."
         },
         {
           "date": "2009-10-01",
-          "text": "The Great Forest’s first ability doesn’t actually change creatures’ power; it changes only the value of the combat damage they assign. All other rules and effects that check power or toughness use the real values."
+          "text": "The Great Forest's first ability doesn't actually change creatures' power; it changes only the value of the combat damage they assign. All other rules and effects that check power or toughness use the real values."
         }
       ],
       "subtypes": [
@@ -2077,27 +2077,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Despite the appearance of the reminder text, the unearth abilities that Grixis grants are activated abilities of each individual blue, black, and/or red creature card in a graveyard. They’re not activated abilities of Grixis."
+          "text": "Despite the appearance of the reminder text, the unearth abilities that Grixis grants are activated abilities of each individual blue, black, and/or red creature card in a graveyard. They're not activated abilities of Grixis."
         },
         {
           "date": "2009-10-01",
-          "text": "A card’s mana cost includes its color."
+          "text": "A card's mana cost includes its color."
         },
         {
           "date": "2009-10-01",
@@ -2105,23 +2105,23 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you activate a creature card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a creature card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Essence Scatter) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Essence Scatter) will not."
         },
         {
           "date": "2009-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the ability won’t trigger again. However, the replacement effect will still exile the creature if it would eventually leave the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the ability won't trigger again. However, the replacement effect will still exile the creature if it would eventually leave the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the exile abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the exile abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new permanent with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new permanent with no relation to its previous existence. The unearth effect will no longer apply to it."
         },
         {
           "date": "2009-10-01",
@@ -2242,19 +2242,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -2262,11 +2262,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A creature that would assign 0 or less combat damage (due to having power 0 or less) doesn’t assign combat damage at all."
+          "text": "A creature that would assign 0 or less combat damage (due to having power 0 or less) doesn't assign combat damage at all."
         },
         {
           "date": "2009-10-01",
-          "text": "You may target any creature with The Hippodrome’s chaos ability. Whether its power is 0 or less isn’t checked until the ability resolves."
+          "text": "You may target any creature with The Hippodrome's chaos ability. Whether its power is 0 or less isn't checked until the ability resolves."
         }
       ],
       "subtypes": [
@@ -2328,11 +2328,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -2340,7 +2340,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You must target two creatures as you cast Whiplash Trap. If you can’t (because just one creature is on the battlefield, perhaps), you can’t cast the spell."
+          "text": "You must target two creatures as you cast Whiplash Trap. If you can't (because just one creature is on the battlefield, perhaps), you can't cast the spell."
         },
         {
           "date": "2009-10-01",
@@ -2401,23 +2401,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature controlled by a player other than the planar controller enters the battlefield, the planar controller (not the creature’s controller) controls Immersturm’s triggered ability. That means that if multiple creatures enter the battlefield at the same time, that player controls all of Immersturm’s triggered abilities and may put them on the stack in whichever order he or she likes. The last one put on the stack is the first one to resolve."
+          "text": "If a creature controlled by a player other than the planar controller enters the battlefield, the planar controller (not the creature's controller) controls Immersturm's triggered ability. That means that if multiple creatures enter the battlefield at the same time, that player controls all of Immersturm's triggered abilities and may put them on the stack in whichever order he or she likes. The last one put on the stack is the first one to resolve."
         },
         {
           "date": "2009-10-01",
@@ -2425,11 +2425,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Any “as [this permanent] enters the battlefield” choices for the card returned by the chaos ability are made by that card’s owner, not its old controller or the controller of the chaos ability."
+          "text": "Any \"as [this permanent] enters the battlefield\" choices for the card returned by the chaos ability are made by that card's owner, not its old controller or the controller of the chaos ability."
         },
         {
           "date": "2009-10-01",
-          "text": "A token that has left the battlefield can’t come back onto the battlefield. If the chaos ability exiles a token, that token remains in exile until state-based actions are checked, then it ceases to exist."
+          "text": "A token that has left the battlefield can't come back onto the battlefield. If the chaos ability exiles a token, that token remains in exile until state-based actions are checked, then it ceases to exist."
         }
       ],
       "subtypes": [
@@ -2555,31 +2555,31 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "As a token is created by Isle of Vesuva’s first ability, it checks the printed values of the creature it’s copying, as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, and so on."
+          "text": "As a token is created by Isle of Vesuva's first ability, it checks the printed values of the creature it's copying, as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, and so on."
         },
         {
           "date": "2009-10-01",
-          "text": "If the creature that caused Isle of Vesuva’s first ability to trigger has already left the battlefield by the time the ability resolves, the ability still creates a token. It will have the copiable values of the characteristics of that nontoken creature as it last existed on the battlefield."
+          "text": "If the creature that caused Isle of Vesuva's first ability to trigger has already left the battlefield by the time the ability resolves, the ability still creates a token. It will have the copiable values of the characteristics of that nontoken creature as it last existed on the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability will destroy all creatures with the same name as the target creature, not just tokens created by Isle of Vesuva’s first ability. It doesn’t matter who controls them."
+          "text": "The chaos ability will destroy all creatures with the same name as the target creature, not just tokens created by Isle of Vesuva's first ability. It doesn't matter who controls them."
         },
         {
           "date": "2009-10-01",
@@ -2587,15 +2587,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s name is the same as the creature types listed by the effect that created it, unless the token copies a permanent or that effect specifically gives that token a name. For example, the effect of The Fourth Sphere’s chaos ability creates a token with the name “Zombie.”"
+          "text": "A token's name is the same as the creature types listed by the effect that created it, unless the token copies a permanent or that effect specifically gives that token a name. For example, the effect of The Fourth Sphere's chaos ability creates a token with the name \"Zombie.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-down creature has no name, so it doesn’t have the same name as anything else."
+          "text": "A face-down creature has no name, so it doesn't have the same name as anything else."
         },
         {
           "date": "2013-07-01",
-          "text": "If the permanent targeted by the chaos ability isn’t destroyed (because it regenerates, or because it has indestructible), all other permanents with the same name as it will still be destroyed."
+          "text": "If the permanent targeted by the chaos ability isn't destroyed (because it regenerates, or because it has indestructible), all other permanents with the same name as it will still be destroyed."
         }
       ],
       "subtypes": [
@@ -2660,7 +2660,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If a Beacon is countered, it’s put into its owner’s graveyard, not shuffled into the library."
+          "text": "If a Beacon is countered, it's put into its owner's graveyard, not shuffled into the library."
         }
       ],
       "text": "Put target artifact or creature card from a graveyard onto the battlefield under your control. Shuffle Beacon of Unrest into its owner's library.",
@@ -2714,55 +2714,55 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect of Izzet Steam Maze’s first ability is mandatory. You must copy the spell whether you want to or not."
+          "text": "The effect of Izzet Steam Maze's first ability is mandatory. You must copy the spell whether you want to or not."
         },
         {
           "date": "2009-10-01",
-          "text": "Izzet Steam Maze’s first ability will copy any instant or sorcery spell, not just one with targets."
+          "text": "Izzet Steam Maze's first ability will copy any instant or sorcery spell, not just one with targets."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of the spell that caused Izzet Steam Maze’s first ability to trigger also controls the copy. The copy resolves before the original spell."
+          "text": "The controller of the spell that caused Izzet Steam Maze's first ability to trigger also controls the copy. The copy resolves before the original spell."
         },
         {
           "date": "2009-10-01",
-          "text": "A copy is created even if the spell that caused Izzet Steam Maze’s first ability to trigger has been countered by the time that ability resolves."
+          "text": "A copy is created even if the spell that caused Izzet Steam Maze's first ability to trigger has been countered by the time that ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. The new targets must be legal."
+          "text": "The copy will have the same targets as the spell it's copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. The new targets must be legal."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. Its controller can’t choose a different one."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. Its controller can't choose a different one."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of the copy can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
+          "text": "The controller of the copy can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
         },
         {
           "date": "2009-10-01",
-          "text": "The copy that Izzet Steam Maze’s first ability creates is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell (like Izzet Steam Maze’s first ability itself) won’t trigger."
+          "text": "The copy that Izzet Steam Maze's first ability creates is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell (like Izzet Steam Maze's first ability itself) won't trigger."
         }
       ],
       "subtypes": [
@@ -2825,7 +2825,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -2898,19 +2898,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -3022,23 +3022,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If you don’t have ten cards in your library, you’ll put all the cards in your library into your graveyard. The same is true if the targeted player doesn’t have ten cards in his or her library."
+          "text": "If you don't have ten cards in your library, you'll put all the cards in your library into your graveyard. The same is true if the targeted player doesn't have ten cards in his or her library."
         }
       ],
       "subtypes": [
@@ -3111,7 +3111,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
@@ -3168,19 +3168,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -3297,19 +3297,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -3317,11 +3317,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "As The Maelstrom’s first ability resolves, you choose whether or not to reveal the top card of your library. If you reveal it and it’s a permanent card, you have two choices: Put it onto the battlefield, or put it on the bottom of your library. It can’t remain on top of your library. On the other hand, if you reveal it and it’s an instant or sorcery card, it must be put on the bottom of your library. There is no way you can leave a card revealed this way on top of your library."
+          "text": "As The Maelstrom's first ability resolves, you choose whether or not to reveal the top card of your library. If you reveal it and it's a permanent card, you have two choices: Put it onto the battlefield, or put it on the bottom of your library. It can't remain on top of your library. On the other hand, if you reveal it and it's an instant or sorcery card, it must be put on the bottom of your library. There is no way you can leave a card revealed this way on top of your library."
         },
         {
           "date": "2009-10-01",
-          "text": "If you reveal a permanent card that can’t enter the battlefield (because it’s an Aura and there’s nothing it can enchant, for example), then you must put it on the bottom of your library."
+          "text": "If you reveal a permanent card that can't enter the battlefield (because it's an Aura and there's nothing it can enchant, for example), then you must put it on the bottom of your library."
         }
       ],
       "subtypes": [
@@ -3432,33 +3432,33 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Minamo’s first ability resolves before the spell that caused it to trigger."
+          "text": "Minamo's first ability resolves before the spell that caused it to trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability doesn’t target the cards it will return, so they’re not chosen until resolution. As the ability resolves, first the active player may choose a blue card in his or her graveyard, then each other player in turn order does the same, then all cards chosen this way are returned to their owners’ hands. Once a card is chosen, it’s too late for players to respond."
+          "text": "The chaos ability doesn't target the cards it will return, so they're not chosen until resolution. As the ability resolves, first the active player may choose a blue card in his or her graveyard, then each other player in turn order does the same, then all cards chosen this way are returned to their owners' hands. Once a card is chosen, it's too late for players to respond."
         }
       ],
       "subtypes": [
         "Kamigawa"
       ],
-      "text": "Whenever a player casts a spell, that player may draw a card. \nWhenever you roll {CHAOS}, each player may return a blue card from his or her graveyard to his or her hand.",
+      "text": "Whenever a player casts a spell, that player may draw a card.\nWhenever you roll {CHAOS}, each player may return a blue card from his or her graveyard to his or her hand.",
       "type": "Plane — Kamigawa",
       "types": [
         "Plane"
@@ -3601,23 +3601,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect of the chaos ability has no duration. The affected land will remain a creature until the end of the game, it leaves the battlefield, or some other effect changes its card types, whichever comes first. It doesn’t matter whether Murasa remains the face-up plane card."
+          "text": "The effect of the chaos ability has no duration. The affected land will remain a creature until the end of the game, it leaves the battlefield, or some other effect changes its card types, whichever comes first. It doesn't matter whether Murasa remains the face-up plane card."
         }
       ],
       "subtypes": [
@@ -3680,11 +3680,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "A creature that’s both a Skeleton and a Zombie will get the bonus only once."
+          "text": "A creature that's both a Skeleton and a Zombie will get the bonus only once."
         },
         {
           "date": "2008-10-01",
-          "text": "Death Baron doesn’t normally affect itself. If you manage to turn it into a Skeleton, however, then it will give itself +1/+1 and deathtouch."
+          "text": "Death Baron doesn't normally affect itself. If you manage to turn it into a Skeleton, however, then it will give itself +1/+1 and deathtouch."
         }
       ],
       "subtypes": [
@@ -3743,19 +3743,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -3821,23 +3821,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -3895,27 +3895,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If you play lands using Naya’s first ability, and then you planeswalk away from Naya, the lands you played still count as additional land plays for the turn. If you haven’t already, you can still play a land using your standard land play."
+          "text": "If you play lands using Naya's first ability, and then you planeswalk away from Naya, the lands you played still count as additional land plays for the turn. If you haven't already, you can still play a land using your standard land play."
         },
         {
           "date": "2009-10-01",
-          "text": "The bonus granted by the chaos ability is determined at the time it resolves. It won’t change if the number of lands you control changes later in the turn."
+          "text": "The bonus granted by the chaos ability is determined at the time it resolves. It won't change if the number of lands you control changes later in the turn."
         }
       ],
       "subtypes": [
@@ -4035,43 +4035,43 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use a card’s flashback ability, you’re actually casting that card. It moves from your graveyard to the stack. Abilities that trigger when you cast a spell will trigger. That spell can be countered."
+          "text": "If you use a card's flashback ability, you're actually casting that card. It moves from your graveyard to the stack. Abilities that trigger when you cast a spell will trigger. That spell can be countered."
         },
         {
           "date": "2009-10-01",
-          "text": "If you cast a card by using flashback, you cast that card from your graveyard rather than your hand, and you pay an alternative cost rather than its mana cost, but everything else about casting that spell works normally. You must follow timing restrictions based on the card’s type (if it’s a sorcery), as well as other restrictions (such as “Cast [this card] only before blockers are declared”). You may pay additional costs (such as kicker). Effects that cause you to pay more or less for a spell will apply."
+          "text": "If you cast a card by using flashback, you cast that card from your graveyard rather than your hand, and you pay an alternative cost rather than its mana cost, but everything else about casting that spell works normally. You must follow timing restrictions based on the card's type (if it's a sorcery), as well as other restrictions (such as \"Cast [this card] only before blockers are declared\"). You may pay additional costs (such as kicker). Effects that cause you to pay more or less for a spell will apply."
         },
         {
           "date": "2009-10-01",
-          "text": "As a spell cast with flashback resolves, it never goes to its owner’s graveyard, so abilities that trigger on cards being put in a graveyard won’t trigger. The card is exiled instead."
+          "text": "As a spell cast with flashback resolves, it never goes to its owner's graveyard, so abilities that trigger on cards being put in a graveyard won't trigger. The card is exiled instead."
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell cast by using flashback is countered, it’s still exiled rather than being put into its owner’s graveyard."
+          "text": "If a spell cast by using flashback is countered, it's still exiled rather than being put into its owner's graveyard."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the flashback ability granted by Otaria to cast a split card from your graveyard, the flashback cost you pay is equal to the mana cost of the half that you’re casting."
+          "text": "If you use the flashback ability granted by Otaria to cast a split card from your graveyard, the flashback cost you pay is equal to the mana cost of the half that you're casting."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the flashback ability granted by Otaria to cast a card with X in its mana cost from your graveyard, you choose the value of X as you cast it. You’ll still have to pay that X."
+          "text": "If you use the flashback ability granted by Otaria to cast a card with X in its mana cost from your graveyard, you choose the value of X as you cast it. You'll still have to pay that X."
         },
         {
           "date": "2009-10-01",
@@ -4079,7 +4079,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you roll {CHAOS} multiple times in the same turn, you’ll take that many extra turns after this one."
+          "text": "If you roll {CHAOS} multiple times in the same turn, you'll take that many extra turns after this one."
         }
       ],
       "subtypes": [
@@ -4199,19 +4199,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -4258,6 +4258,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -4300,7 +4304,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -4358,23 +4362,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The face-up plane card isn’t currently part of its owner’s planar deck. If the chaos ability is rolled by the owner of Pools of Becoming, Pools of Becoming is not one of the three cards that are revealed."
+          "text": "The face-up plane card isn't currently part of its owner's planar deck. If the chaos ability is rolled by the owner of Pools of Becoming, Pools of Becoming is not one of the three cards that are revealed."
         },
         {
           "date": "2009-10-01",
@@ -4382,7 +4386,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If one of the revealed plane cards is another Pools of Becoming, its chaos ability triggers. When it resolves, you’ll reveal three more cards from the top of your planar deck, their chaos abilities will trigger, and you’ll put them on the stack in any order on top of any remaining chaos abilities from the first Pools of Becoming’s effect."
+          "text": "If one of the revealed plane cards is another Pools of Becoming, its chaos ability triggers. When it resolves, you'll reveal three more cards from the top of your planar deck, their chaos abilities will trigger, and you'll put them on the stack in any order on top of any remaining chaos abilities from the first Pools of Becoming's effect."
         }
       ],
       "subtypes": [
@@ -4498,19 +4502,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -4518,11 +4522,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The -1/-1 counters that result from wither remain on the damaged creature indefinitely. They won’t be removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters that result from wither remain on the damaged creature indefinitely. They won't be removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2009-10-01",
-          "text": "Since damage from a creature with wither is real damage, it follows all the other rules for damage. It can be prevented or redirected. When it’s dealt, it will cause “Whenever [this creature] deals damage” and “Whenever [this creature] is dealt damage” abilities to trigger."
+          "text": "Since damage from a creature with wither is real damage, it follows all the other rules for damage. It can be prevented or redirected. When it's dealt, it will cause \"Whenever [this creature] deals damage\" and \"Whenever [this creature] is dealt damage\" abilities to trigger."
         },
         {
           "date": "2009-10-01",
@@ -4538,7 +4542,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You must target three different creatures when the chaos ability triggers, even if that means you have to target creatures you control. If you can’t target three creatures (because there are just two creatures on the battlefield, perhaps), the ability is removed from the stack and does nothing."
+          "text": "You must target three different creatures when the chaos ability triggers, even if that means you have to target creatures you control. If you can't target three creatures (because there are just two creatures on the battlefield, perhaps), the ability is removed from the stack and does nothing."
         }
       ],
       "subtypes": [
@@ -4658,19 +4662,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -4678,7 +4682,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "For a player’s life total to become 20, what actually happens is that the player gains or loses the appropriate amount of life. For example, if your life total is 14 when this ability resolves, it will cause you to gain 6 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For a player's life total to become 20, what actually happens is that the player gains or loses the appropriate amount of life. For example, if your life total is 14 when this ability resolves, it will cause you to gain 6 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         }
       ],
       "subtypes": [
@@ -4741,7 +4745,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You must target three different creatures. If you can’t, you can’t cast Incremental Blight."
+          "text": "You must target three different creatures. If you can't, you can't cast Incremental Blight."
         }
       ],
       "text": "Put a -1/-1 counter on target creature, two -1/-1 counters on another target creature, and three -1/-1 counters on a third target creature.",
@@ -4795,19 +4799,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -4924,19 +4928,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -5048,19 +5052,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -5068,11 +5072,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, the new top card won’t be revealed until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
+          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, the new top card won't be revealed until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
         },
         {
           "date": "2009-10-01",
-          "text": "Skybreen’s second ability prevents each player from casting spells that share a card type with a card on top of any library, not just the one on top of that player’s own library. This includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It doesn’t stop players from playing lands or activating abilities (such as cycling or unearth)."
+          "text": "Skybreen's second ability prevents each player from casting spells that share a card type with a card on top of any library, not just the one on top of that player's own library. This includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It doesn't stop players from playing lands or activating abilities (such as cycling or unearth)."
         }
       ],
       "subtypes": [
@@ -5183,19 +5187,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -5314,35 +5318,35 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Stronghold Furnace’s first ability interacts with all damage, not just combat damage. Notably, it doubles the damage from its own chaos ability."
+          "text": "Stronghold Furnace's first ability interacts with all damage, not just combat damage. Notably, it doubles the damage from its own chaos ability."
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn.” Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Stronghold Furnace’s effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn.\" Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Stronghold Furnace's effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         },
         {
           "date": "2009-10-01",
-          "text": "Combat damage that a source would deal to a planeswalker is not doubled. However, if a source a player controls would deal noncombat damage to an opponent who controls a planeswalker, and that opponent chooses to apply Stronghold Furnace’s replacement effect before applying the planeswalker redirection effect, the damage will be doubled before the source’s controller chooses whether to deal it to a planeswalker that opponent controls. (If players always apply the planeswalker redirection effect first, Stronghold Furnace’s effect will never double damage that a source would deal to a planeswalker.)"
+          "text": "Combat damage that a source would deal to a planeswalker is not doubled. However, if a source a player controls would deal noncombat damage to an opponent who controls a planeswalker, and that opponent chooses to apply Stronghold Furnace's replacement effect before applying the planeswalker redirection effect, the damage will be doubled before the source's controller chooses whether to deal it to a planeswalker that opponent controls. (If players always apply the planeswalker redirection effect first, Stronghold Furnace's effect will never double damage that a source would deal to a planeswalker.)"
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell or ability divides damage among multiple recipients (such as Pyrotechnics does), the damage is divided before Stronghold Furnace’s effect doubles it. The same is true for combat damage."
+          "text": "If a spell or ability divides damage among multiple recipients (such as Pyrotechnics does), the damage is divided before Stronghold Furnace's effect doubles it. The same is true for combat damage."
         }
       ],
       "subtypes": [
@@ -5455,27 +5459,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Turri Island’s first ability can’t reduce the cost to cast a creature spell to less than {0}."
+          "text": "Turri Island's first ability can't reduce the cost to cast a creature spell to less than {0}."
         },
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than three cards in your library as the chaos ability resolves, you’ll reveal all the cards in your library."
+          "text": "If there are fewer than three cards in your library as the chaos ability resolves, you'll reveal all the cards in your library."
         }
       ],
       "subtypes": [
@@ -5539,10 +5543,10 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The value chosen for X applies to each X in the spell’s effect. You pay {X} only once."
+          "text": "The value chosen for X applies to each X in the spell's effect. You pay {X} only once."
         }
       ],
-      "text": "Choose two —\n• Target player loses X life. \n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
+      "text": "Choose two —\n• Target player loses X life.\n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -5593,19 +5597,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -5617,11 +5621,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability’s effect continues to apply even after Undercity Reaches stops being the face-up plane card."
+          "text": "The chaos ability's effect continues to apply even after Undercity Reaches stops being the face-up plane card."
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then roll {CHAOS} while Undercity Reaches is the face-up plane card, you’ll have no maximum hand size. However, if those events had happened in the opposite order, your maximum hand size would be two for as long as Null Profusion is on the battlefield."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then roll {CHAOS} while Undercity Reaches is the face-up plane card, you'll have no maximum hand size. However, if those events had happened in the opposite order, your maximum hand size would be two for as long as Null Profusion is on the battlefield."
         }
       ],
       "subtypes": [
@@ -5683,7 +5687,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "When Rotting Rats’s enters-the-battlefield ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order does the same, then all cards are discarded at the same time. No one sees what the other players are discarding before deciding which card to discard."
+          "text": "When Rotting Rats's enters-the-battlefield ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order does the same, then all cards are discarded at the same time. No one sees what the other players are discarding before deciding which card to discard."
         }
       ],
       "subtypes": [
@@ -5742,27 +5746,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Velis Vel’s first ability counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Velis Vel's first ability counts creatures, not creature types."
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability doesn’t give a creature changeling."
+          "text": "The chaos ability doesn't give a creature changeling."
         }
       ],
       "subtypes": [
@@ -5874,19 +5878,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -6623,11 +6627,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of the three targets must be different. If there aren’t three different legal targets available, you can’t cast the spell."
+          "text": "Each of the three targets must be different. If there aren't three different legal targets available, you can't cast the spell."
         },
         {
           "date": "2014-07-18",
-          "text": "If one or two of Cone of Flame’s targets are illegal when it resolves, you can’t change how much damage will be dealt to the remaining legal targets."
+          "text": "If one or two of Cone of Flame's targets are illegal when it resolves, you can't change how much damage will be dealt to the remaining legal targets."
         }
       ],
       "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
@@ -6815,7 +6819,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can’t normally end up with an odd amount of damage on something."
+          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can't normally end up with an odd amount of damage on something."
         },
         {
           "date": "2004-10-04",
@@ -6831,7 +6835,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn.” Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn.\" Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         }
       ],
       "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
@@ -6887,7 +6891,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The tokens are named “Goblin” and are of creature type “Goblin”."
+          "text": "The tokens are named \"Goblin\" and are of creature type \"Goblin\"."
         }
       ],
       "text": "Create X 1/1 red Goblin creature tokens.",
@@ -7130,15 +7134,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If some but not all of Pyrotechnics’s targets become illegal, you can’t change the division of damage. Damage that would have been dealt to illegal targets simply isn’t dealt."
+          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can’t deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
         },
         {
           "date": "2014-11-24",
-          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can’t be changed. The effect that creates the copy may allow you to change the targets, however."
+          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
         }
       ],
       "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
@@ -7255,7 +7259,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -7395,7 +7399,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If X is greater than 0, you can’t choose zero targets. You must choose between one and X targets. If X is 0, you can’t choose any targets."
+          "text": "If X is greater than 0, you can't choose zero targets. You must choose between one and X targets. If X is 0, you can't choose any targets."
         },
         {
           "date": "2015-08-25",
@@ -7407,7 +7411,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can’t change the way damage is divided."
+          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can't change the way damage is divided."
         }
       ],
       "text": "Rolling Thunder deals X damage divided as you choose among any number of target creatures and/or players.",
@@ -7527,15 +7531,15 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The mana can be two mana of the same color, or one mana of each of two different colors. The mana can’t be colorless."
+          "text": "The mana can be two mana of the same color, or one mana of each of two different colors. The mana can't be colorless."
         },
         {
           "date": "2007-10-01",
-          "text": "You can use this mana to pay an alternative cost (such as evoke) or additional cost incurred while casting an Elemental spell. It’s not limited to just that spell’s mana cost."
+          "text": "You can use this mana to pay an alternative cost (such as evoke) or additional cost incurred while casting an Elemental spell. It's not limited to just that spell's mana cost."
         },
         {
           "date": "2007-10-01",
-          "text": "The mana can’t be spent to activate activated abilities of Elemental sources that aren’t on the battlefield."
+          "text": "The mana can't be spent to activate activated abilities of Elemental sources that aren't on the battlefield."
         }
       ],
       "subtypes": [
@@ -7660,7 +7664,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are three or fewer cards in your library, you’ll reveal all of them."
+          "text": "If there are three or fewer cards in your library, you'll reveal all of them."
         }
       ],
       "text": "Reveal the top three cards of your library. Put all creature cards revealed this way into your hand and the rest into your graveyard.",
@@ -7917,7 +7921,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Although the targeted player doesn’t need to find a basic land card if he or she doesn’t want to, that player must shuffle his or her library."
+          "text": "Although the targeted player doesn't need to find a basic land card if he or she doesn't want to, that player must shuffle his or her library."
         }
       ],
       "subtypes": [
@@ -8194,7 +8198,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -8253,39 +8257,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -8344,7 +8348,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -8409,11 +8413,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -8421,7 +8425,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -8541,7 +8545,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Verdant Force’s controller gets the tokens. That is the controller at the beginning of upkeep."
+          "text": "Verdant Force's controller gets the tokens. That is the controller at the beginning of upkeep."
         },
         {
           "date": "2005-08-01",
@@ -8677,7 +8681,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may choose just the first mode (targeting a creature with flying), just the second mode (targeting a creature without flying), or both modes (targeting a creature with flying and a creature without flying). You can’t choose a mode unless there’s a legal target for it."
+          "text": "You may choose just the first mode (targeting a creature with flying), just the second mode (targeting a creature without flying), or both modes (targeting a creature with flying and a creature without flying). You can't choose a mode unless there's a legal target for it."
         }
       ],
       "text": "Choose one or both —\n• Branching Bolt deals 3 damage to target creature with flying.\n• Branching Bolt deals 3 damage to target creature without flying.",
@@ -8798,7 +8802,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the first target is no longer on the battlefield, then the damage will not be dealt at all, so it can’t be redirected by this ability."
+          "text": "If the first target is no longer on the battlefield, then the damage will not be dealt at all, so it can't be redirected by this ability."
         }
       ],
       "text": "The next X damage that would be dealt to target creature or player this turn is dealt to another target creature or player instead.",
@@ -8976,7 +8980,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "There is never a point at which Glory of Warfare will give a creature you control +2/+2 or +0/+0. A creature that’s normally 1/1, for example, will change from being 3/1 to being 1/3 when your turn ends and another player’s turn begins. At no time will it be 3/3 or 1/1."
+          "text": "There is never a point at which Glory of Warfare will give a creature you control +2/+2 or +0/+0. A creature that's normally 1/1, for example, will change from being 3/1 to being 1/3 when your turn ends and another player's turn begins. At no time will it be 3/3 or 1/1."
         }
       ],
       "text": "As long as it's your turn, creatures you control get +2/+0.\nAs long as it's not your turn, creatures you control get +0/+2.",
@@ -9094,7 +9098,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
@@ -9224,11 +9228,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The 3 damage doesn’t have to be from the same source, and it doesn’t have to be all dealt at once. If only 2 damage is redirected, the next 1 damage will also be redirected."
+          "text": "The 3 damage doesn't have to be from the same source, and it doesn't have to be all dealt at once. If only 2 damage is redirected, the next 1 damage will also be redirected."
         },
         {
           "date": "2005-10-01",
-          "text": "If either target creature leaves the battlefield before damage is dealt, that damage won’t be redirected. It doesn’t matter if Razia leaves the battlefield."
+          "text": "If either target creature leaves the battlefield before damage is dealt, that damage won't be redirected. It doesn't matter if Razia leaves the battlefield."
         }
       ],
       "subtypes": [
@@ -9423,11 +9427,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If Sludge Strider and another artifact enter the battlefield under your control at the same time, Sludge Strider’s triggered ability will trigger. Similarly, if Sludge Strider and another artifact you control leave the battlefield at the same time, Sludge Strider’s triggered ability will trigger."
+          "text": "If Sludge Strider and another artifact enter the battlefield under your control at the same time, Sludge Strider's triggered ability will trigger. Similarly, if Sludge Strider and another artifact you control leave the battlefield at the same time, Sludge Strider's triggered ability will trigger."
         },
         {
           "date": "2009-02-01",
-          "text": "If an artifact creature with 0 toughness enters the battlefield under your control, Sludge Strider’s ability will trigger a total of twice: Once when that creature enters the battlefield, and once when it’s put into a graveyard. Both abilities will be put on the stack after the state-based action check that puts the 0-toughness creature into the graveyard is finished."
+          "text": "If an artifact creature with 0 toughness enters the battlefield under your control, Sludge Strider's ability will trigger a total of twice: Once when that creature enters the battlefield, and once when it's put into a graveyard. Both abilities will be put on the stack after the state-based action check that puts the 0-toughness creature into the graveyard is finished."
         }
       ],
       "subtypes": [
@@ -9632,11 +9636,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers whenever you cast a spell that’s both of its listed colors. It doesn’t matter whether that spell also happens to be any other colors."
+          "text": "The ability triggers whenever you cast a spell that's both of its listed colors. It doesn't matter whether that spell also happens to be any other colors."
         },
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
+          "text": "If you cast a spell that's the two appropriate colors for the second time in a turn, the ability triggers again. The Mimic will once again become the power and toughness stated in its ability, which could overwrite power- and toughness-setting effects that have been applied to it in the meantime."
         },
         {
           "date": "2008-08-01",
@@ -9644,7 +9648,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -9829,7 +9833,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Each of the triggered abilities has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don’t control two or more lands of the appropriate land type by the time it resolves."
+          "text": "Each of the triggered abilities has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control two or more lands of the appropriate land type when the Hedge-Mage enters the battlefield, and (2) the ability will do nothing if you don't control two or more lands of the appropriate land type by the time it resolves."
         },
         {
           "date": "2008-08-01",
@@ -9841,7 +9845,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don’t plan to use the ability."
+          "text": "Both abilities are optional; you choose whether to use them when they resolve. If an ability has a target, you must choose a target even if you don't plan to use the ability."
         }
       ],
       "subtypes": [
@@ -11188,11 +11192,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus's other abilities."
         },
         {
           "date": "2011-09-22",
-          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus’s second activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus's second activated ability, not just ones created by Pentavus's other abilities."
         }
       ],
       "subtypes": [
@@ -11253,11 +11257,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If you activate Relic of Progenitus’s first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
+          "text": "If you activate Relic of Progenitus's first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "You can activate Relic of Progenitus’s second ability even if no players have any cards in their graveyards. You’ll still draw a card."
+          "text": "You can activate Relic of Progenitus's second ability even if no players have any cards in their graveyards. You'll still draw a card."
         }
       ],
       "text": "{T}: Target player exiles a card from his or her graveyard.\n{1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.",
@@ -12005,7 +12009,7 @@
         },
         {
           "date": "2005-10-01",
-          "text": "If you give double strike to a creature after either first-strike or normal combat damage has been dealt, it won’t help that creature deal any additional combat damage."
+          "text": "If you give double strike to a creature after either first-strike or normal combat damage has been dealt, it won't help that creature deal any additional combat damage."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{2}{R}{W}, {T}: Target creature gains double strike until end of turn.",

--- a/json/HOU.json
+++ b/json/HOU.json
@@ -94,7 +94,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -111,11 +131,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You can cast Act of Heroism even if the target creature won’t be able to block right away, perhaps because you’re the attacking player."
+          "text": "You can cast Act of Heroism even if the target creature won't be able to block right away, perhaps because you're the attacking player."
         },
         {
           "date": "2017-06-27",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         },
         {
           "date": "2017-06-27",
@@ -198,7 +218,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -220,15 +260,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you’ll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you'll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an eternalize ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've activated an eternalize ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -311,7 +351,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -329,23 +389,23 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-06-27",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature token is exiled this way, it will cease to exist and won’t return to the battlefield."
+          "text": "If a creature token is exiled this way, it will cease to exist and won't return to the battlefield."
         },
         {
           "date": "2017-06-27",
@@ -353,19 +413,19 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If Angel of Condemnation leaves the battlefield before its last ability resolves, the target creature won’t be exiled."
+          "text": "If Angel of Condemnation leaves the battlefield before its last ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2017-06-27",
-          "text": "The card exiled with Angel of Condemnation’s last ability returns to the battlefield immediately after Angel of Condemnation leaves the battlefield. Nothing happens between the two events, including state-based actions."
+          "text": "The card exiled with Angel of Condemnation's last ability returns to the battlefield immediately after Angel of Condemnation leaves the battlefield. Nothing happens between the two events, including state-based actions."
         },
         {
           "date": "2017-06-27",
-          "text": "Tapping Angel of Condemnation to activate either of its abilities while it’s attacking doesn’t remove it from combat."
+          "text": "Tapping Angel of Condemnation to activate either of its abilities while it's attacking doesn't remove it from combat."
         },
         {
           "date": "2017-06-27",
-          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you’ve already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
+          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you've already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
         }
       ],
       "subtypes": [
@@ -445,7 +505,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -537,7 +617,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -630,7 +730,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -652,11 +772,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Crested Sunmare’s triggered ability won’t trigger unless you’ve gained life in the turn before the end step began. It can’t be satisfied by another triggered ability causing you to gain life during that end step."
+          "text": "Crested Sunmare's triggered ability won't trigger unless you've gained life in the turn before the end step began. It can't be satisfied by another triggered ability causing you to gain life during that end step."
         },
         {
           "date": "2017-06-27",
-          "text": "Crested Sunmare’s triggered ability cares only whether you gained life in the turn, even if Crested Sunmare wasn’t on the battlefield when that happened. It doesn’t care how much you gained, whether you also lost life, or even whether you lost more life than you gained."
+          "text": "Crested Sunmare's triggered ability cares only whether you gained life in the turn, even if Crested Sunmare wasn't on the battlefield when that happened. It doesn't care how much you gained, whether you also lost life, or even whether you lost more life than you gained."
         }
       ],
       "subtypes": [
@@ -736,7 +856,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -754,11 +894,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         },
         {
           "date": "2017-06-27",
-          "text": "All attackers are chosen at once. You can’t attack with Dauntless Aven, untap a tapped creature, and then attack with that creature."
+          "text": "All attackers are chosen at once. You can't attack with Dauntless Aven, untap a tapped creature, and then attack with that creature."
         }
       ],
       "subtypes": [
@@ -838,7 +978,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -855,15 +1015,15 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keyword abilities are activated abilities and will have colons in their reminder text. Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected by the last ability of Desert’s Hold."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keyword abilities are activated abilities and will have colons in their reminder text. Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected by the last ability of Desert's Hold."
         },
         {
           "date": "2017-06-27",
-          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn’t matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
+          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn't matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don’t have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
+          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don't have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
         }
       ],
       "subtypes": [
@@ -942,7 +1102,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1034,7 +1214,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1136,7 +1336,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1223,7 +1443,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1313,7 +1553,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1400,7 +1660,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1418,11 +1698,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If you cast a spell that’s two or more of these colors, you gain only 1 life."
+          "text": "If you cast a spell that's two or more of these colors, you gain only 1 life."
         },
         {
           "date": "2017-06-27",
-          "text": "The triggered ability of God-Pharaoh’s Faithful will resolve before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "The triggered ability of God-Pharaoh's Faithful will resolve before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         }
       ],
       "subtypes": [
@@ -1503,7 +1783,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1520,11 +1820,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You determine the cost to cast Hour of Revelation before you pay any of that cost. For example, if the only nonland permanents on the battlefield are Tezzeret the Schemer and nine Etherium Cells he’s given you, Hour of Revelation costs {W}{W}{W} to cast. You may sacrifice three Etherium Cells to pay this cost, even though there are no longer ten or more nonland permanents after you produce {W}{W}{W}."
+          "text": "You determine the cost to cast Hour of Revelation before you pay any of that cost. For example, if the only nonland permanents on the battlefield are Tezzeret the Schemer and nine Etherium Cells he's given you, Hour of Revelation costs {W}{W}{W} to cast. You may sacrifice three Etherium Cells to pay this cost, even though there are no longer ten or more nonland permanents after you produce {W}{W}{W}."
         },
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Hour of Revelation costs {3} less to cast if there are ten or more nonland permanents on the battlefield.\nDestroy all nonland permanents.",
@@ -1600,7 +1900,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1692,7 +2012,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1710,19 +2050,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -1803,7 +2143,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1820,19 +2180,19 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "For your life total to become your starting life total (normally 20), you gain or lose the appropriate amount of life. For example, if your life total is 4 when Oketra’s Last Mercy resolves, it will cause you to gain 16 life; alternatively, if your life total is 25 when it resolves, it will cause you to lose 5 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For your life total to become your starting life total (normally 20), you gain or lose the appropriate amount of life. For example, if your life total is 4 when Oketra's Last Mercy resolves, it will cause you to gain 16 life; alternatively, if your life total is 25 when it resolves, it will cause you to lose 5 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2017-06-27",
-          "text": "In a Two-Headed Giant game, Oketra’s Last Mercy causes the team’s life total to become the team’s starting life total (normally 30), but only you actually gain or lose life."
+          "text": "In a Two-Headed Giant game, Oketra's Last Mercy causes the team's life total to become the team's starting life total (normally 30), but only you actually gain or lose life."
         },
         {
           "date": "2017-06-27",
-          "text": "No lands that you control will untap during your next untap step, even lands that aren’t tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
+          "text": "No lands that you control will untap during your next untap step, even lands that aren't tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
         },
         {
           "date": "2017-06-27",
-          "text": "If more than one spell says that lands you control don’t untap during your next untap step, the effects will all wear off during that untap step. You’ll untap lands you control during your untap step after that one."
+          "text": "If more than one spell says that lands you control don't untap during your next untap step, the effects will all wear off during that untap step. You'll untap lands you control during your untap step after that one."
         }
       ],
       "text": "Your life total becomes equal to your starting life total. Lands you control don't untap during your next untap step.",
@@ -1907,7 +2267,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -1924,31 +2304,31 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Overwhelming Splendor overwrites all previous effects that set a creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply to a creature after Overwhelming Splendor becomes attached to its controller will overwrite this effect. For example, the enchanted player’s Riddleform will become a 3/3 creature if player casts a noncreature spell."
+          "text": "Overwhelming Splendor overwrites all previous effects that set a creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply to a creature after Overwhelming Splendor becomes attached to its controller will overwrite this effect. For example, the enchanted player's Riddleform will become a 3/3 creature if player casts a noncreature spell."
         },
         {
           "date": "2017-06-27",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the effect of Titanic Growth, will apply to the creatures no matter when they started to take effect. The same is true for any counters that change their power and/or toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the effect of Titanic Growth, will apply to the creatures no matter when they started to take effect. The same is true for any counters that change their power and/or toughness."
         },
         {
           "date": "2017-06-27",
-          "text": "If an effect grants a creature an ability after Overwhelming Splendor has become attached to its controller, that creature won’t lose that ability."
+          "text": "If an effect grants a creature an ability after Overwhelming Splendor has become attached to its controller, that creature won't lose that ability."
         },
         {
           "date": "2017-06-27",
-          "text": "If a noncreature permanent becomes a creature, it will lose all abilities it has. However, if the effect that makes that permanent a creature grants it an ability, it will continue to have that ability. For example, the enchanted player’s Riddleform will have flying once it becomes a creature."
+          "text": "If a noncreature permanent becomes a creature, it will lose all abilities it has. However, if the effect that makes that permanent a creature grants it an ability, it will continue to have that ability. For example, the enchanted player's Riddleform will have flying once it becomes a creature."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature enters the battlefield under enchanted player’s control, any “when [this creature] enters the battlefield” abilities of that creature won’t trigger. However, any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities will be applied."
+          "text": "If a creature enters the battlefield under enchanted player's control, any \"when [this creature] enters the battlefield\" abilities of that creature won't trigger. However, any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities will be applied."
         },
         {
           "date": "2017-06-27",
-          "text": "If Overwhelming Splendor leaves the battlefield at the same time as a creature enchanted player controls, any “when [this creature] [dies or leaves the battlefield]” abilities of that creature won’t trigger."
+          "text": "If Overwhelming Splendor leaves the battlefield at the same time as a creature enchanted player controls, any \"when [this creature] [dies or leaves the battlefield]\" abilities of that creature won't trigger."
         },
         {
           "date": "2017-06-27",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keyword abilities (such as equip and eternalize) are activated abilities and will have colons in their reminder text. Triggered abilities (starting with “when,” “whenever,” or “at”) of noncreature permanents are unaffected by the last ability of Overwhelming Splendor."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keyword abilities (such as equip and eternalize) are activated abilities and will have colons in their reminder text. Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") of noncreature permanents are unaffected by the last ability of Overwhelming Splendor."
         },
         {
           "date": "2017-06-27",
@@ -1956,7 +2336,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "While the enchanted player can still activate mana abilities and loyalty abilities, creatures that player controls won’t normally have any of those abilities to be activated."
+          "text": "While the enchanted player can still activate mana abilities and loyalty abilities, creatures that player controls won't normally have any of those abilities to be activated."
         }
       ],
       "subtypes": [
@@ -2035,6 +2415,10 @@
       "imageName": "sandblast",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -2143,7 +2527,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -2160,11 +2564,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Saving Grace’s ability has no effect on damage already dealt earlier in the turn."
+          "text": "Saving Grace's ability has no effect on damage already dealt earlier in the turn."
         },
         {
           "date": "2017-06-27",
-          "text": "If Saving Grace leaves the battlefield during the turn its triggered ability resolved, damage will continue to be redirected to the creature it enchanted before it left the battlefield. If the creature Saving Grace was last attached to isn’t on the battlefield or isn’t a creature at the time damage would be dealt, it won’t be redirected."
+          "text": "If Saving Grace leaves the battlefield during the turn its triggered ability resolved, damage will continue to be redirected to the creature it enchanted before it left the battlefield. If the creature Saving Grace was last attached to isn't on the battlefield or isn't a creature at the time damage would be dealt, it won't be redirected."
         },
         {
           "date": "2017-06-27",
@@ -2172,15 +2576,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Saving Grace’s redirection effect doesn’t change the source of the damage or whether the damage is combat damage."
+          "text": "Saving Grace's redirection effect doesn't change the source of the damage or whether the damage is combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If you have more than one Saving Grace enter the battlefield in one turn, all damage that would be dealt at once to you and/or permanents you control is dealt to one of the enchanted creatures of your choice. It’s not dealt to all of them, and you can’t split the damage between them."
+          "text": "If you have more than one Saving Grace enter the battlefield in one turn, all damage that would be dealt at once to you and/or permanents you control is dealt to one of the enchanted creatures of your choice. It's not dealt to all of them, and you can't split the damage between them."
         },
         {
           "date": "2017-06-27",
-          "text": "If noncombat damage would be dealt to a planeswalker you control, the planeswalker redirection effect and Saving Grace’s redirection effect apply in whichever order you choose. However, no matter which order you choose to apply them in, that damage will be dealt to the enchanted creature instead."
+          "text": "If noncombat damage would be dealt to a planeswalker you control, the planeswalker redirection effect and Saving Grace's redirection effect apply in whichever order you choose. However, no matter which order you choose to apply them in, that damage will be dealt to the enchanted creature instead."
         }
       ],
       "subtypes": [
@@ -2259,7 +2663,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -2276,7 +2700,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Solemnity doesn’t remove any counters players or permanents already have."
+          "text": "Solemnity doesn't remove any counters players or permanents already have."
         },
         {
           "date": "2017-06-27",
@@ -2284,19 +2708,19 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If the cost of an ability or an additional cost of a spell requires putting counters on an artifact, creature, enchantment, or land, that cost can’t be paid. If a resolving spell or ability says that a player may put counters on one of those objects, that player can’t choose to do so."
+          "text": "If the cost of an ability or an additional cost of a spell requires putting counters on an artifact, creature, enchantment, or land, that cost can't be paid. If a resolving spell or ability says that a player may put counters on one of those objects, that player can't choose to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "If a replacement effect allows a player to modify or replace an event by putting counters on an artifact, creature, enchantment, or land, that player may apply that replacement effect. Counters won’t be put on the object, but if the original event is entirely replaced (such as by applying Soul-Scar Mage’s replacement effect), the original event won’t happen."
+          "text": "If a replacement effect allows a player to modify or replace an event by putting counters on an artifact, creature, enchantment, or land, that player may apply that replacement effect. Counters won't be put on the object, but if the original event is entirely replaced (such as by applying Soul-Scar Mage's replacement effect), the original event won't happen."
         },
         {
           "date": "2017-06-27",
-          "text": "If an artifact, creature, enchantment, or land would enter the battlefield with counters on it at the same time that Solemnity enters the battlefield, Solemnity doesn’t stop it from getting those counters."
+          "text": "If an artifact, creature, enchantment, or land would enter the battlefield with counters on it at the same time that Solemnity enters the battlefield, Solemnity doesn't stop it from getting those counters."
         },
         {
           "date": "2017-06-27",
-          "text": "Damage from a source with wither or infect has no effect on creatures or players. No -1/-1 counters are placed on creatures, and no damage is marked on them. Players don’t get poison counters and they don’t lose life. The damage is still dealt for purposes of effects that care about damage, such as lifelink."
+          "text": "Damage from a source with wither or infect has no effect on creatures or players. No -1/-1 counters are placed on creatures, and no damage is marked on them. Players don't get poison counters and they don't lose life. The damage is still dealt for purposes of effects that care about damage, such as lifelink."
         },
         {
           "date": "2017-06-27",
@@ -2304,11 +2728,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature with tribute is entering the battlefield, the chosen opponent can’t pay tribute even if he or she wants to."
+          "text": "If a creature with tribute is entering the battlefield, the chosen opponent can't pay tribute even if he or she wants to."
         },
         {
           "date": "2017-06-27",
-          "text": "While resolving a cumulative upkeep trigger of a permanent, you’ll fail to put a counter on that permanent, then you may pay for the age counters already on it. If it has no age counters on it, you may pay {0}."
+          "text": "While resolving a cumulative upkeep trigger of a permanent, you'll fail to put a counter on that permanent, then you may pay for the age counters already on it. If it has no age counters on it, you may pay {0}."
         }
       ],
       "text": "Players can't get counters.\nCounters can't be put on artifacts, creatures, enchantments, or lands.",
@@ -2384,7 +2808,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -2402,7 +2846,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn’t matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
+          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn't matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
         }
       ],
       "subtypes": [
@@ -2481,7 +2925,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -2503,15 +2967,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you’ll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you'll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an eternalize ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've activated an eternalize ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -2596,7 +3060,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -2614,19 +3098,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-06-27",
-          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you’ve already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
+          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you've already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
         }
       ],
       "subtypes": [
@@ -2706,7 +3190,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -2724,11 +3228,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "The amount of life you gain is determined as Sunscourge Champion’s triggered ability resolves. Players may respond to the ability by attempting to change its power."
+          "text": "The amount of life you gain is determined as Sunscourge Champion's triggered ability resolves. Players may respond to the ability by attempting to change its power."
         },
         {
           "date": "2017-06-27",
-          "text": "If Sunscourge Champion leaves the battlefield before its triggered ability resolves, use its power as it last existed on the battlefield to determine how much life to gain. If that number is negative, you don’t gain any life and you don’t lose any life."
+          "text": "If Sunscourge Champion leaves the battlefield before its triggered ability resolves, use its power as it last existed on the battlefield to determine how much life to gain. If that number is negative, you don't gain any life and you don't lose any life."
         },
         {
           "date": "2017-06-27",
@@ -2736,15 +3240,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you’ll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you'll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an eternalize ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've activated an eternalize ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -2752,11 +3256,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         },
         {
           "date": "2017-06-27",
-          "text": "Several cards have an eternalize cost that includes “Discard a card.” You can’t discard the card with eternalize to pay its own cost because the card has to be in your graveyard to begin activating its eternalize ability."
+          "text": "Several cards have an eternalize cost that includes \"Discard a card.\" You can't discard the card with eternalize to pay its own cost because the card has to be in your graveyard to begin activating its eternalize ability."
         }
       ],
       "subtypes": [
@@ -2836,7 +3340,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -2923,7 +3447,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -2941,19 +3485,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "If a creature has a targeted triggered ability that triggers when you exert it, you can exert it even if there isn’t a legal target for that triggered ability."
+          "text": "If a creature has a targeted triggered ability that triggers when you exert it, you can exert it even if there isn't a legal target for that triggered ability."
         },
         {
           "date": "2017-04-18",
@@ -2961,7 +3505,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -3042,7 +3586,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3134,7 +3698,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3226,7 +3810,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3244,7 +3848,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Use Champion of Wits’s power as the first ability resolves to determine if you want to use the ability and how many cards you draw if you do. If you use the ability, you discard two cards regardless of how many cards you draw. If Champion of Wits leaves the battlefield before that ability resolves, use its last known power."
+          "text": "Use Champion of Wits's power as the first ability resolves to determine if you want to use the ability and how many cards you draw if you do. If you use the ability, you discard two cards regardless of how many cards you draw. If Champion of Wits leaves the battlefield before that ability resolves, use its last known power."
         },
         {
           "date": "2017-06-27",
@@ -3252,15 +3856,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you’ll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you'll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an eternalize ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've activated an eternalize ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -3268,7 +3872,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         }
       ],
       "subtypes": [
@@ -3349,7 +3953,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3366,7 +3990,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Count the number of cards in your graveyard as Countervailing Winds resolves to determine how much mana the controller of the target spell must pay to avoid the spell being countered. Countervailing Winds is still on the stack at this time and won’t count toward this number."
+          "text": "Count the number of cards in your graveyard as Countervailing Winds resolves to determine how much mana the controller of the target spell must pay to avoid the spell being countered. Countervailing Winds is still on the stack at this time and won't count toward this number."
         }
       ],
       "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nCycling {2} ({2}, Discard this card: Draw a card.)",
@@ -3442,7 +4066,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3464,11 +4108,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -3553,7 +4197,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3571,7 +4235,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         },
         {
           "date": "2017-06-27",
@@ -3579,15 +4243,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -3668,7 +4332,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3685,11 +4369,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Fraying Sanity’s triggered ability counts the number of cards that were put into the enchanted player’s graveyard during the turn, even if Fraying Sanity wasn’t on the battlefield at the time those cards were put there, and even if those cards have left that graveyard."
+          "text": "Fraying Sanity's triggered ability counts the number of cards that were put into the enchanted player's graveyard during the turn, even if Fraying Sanity wasn't on the battlefield at the time those cards were put there, and even if those cards have left that graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "The value of X is determined only as Fraying Sanity’s triggered ability resolves. For example, if three Fraying Sanity Auras are attached to one player who had four cards put into his or her graveyard this turn, X will be four for the first ability to resolve, eight for the second, and sixteen for the third."
+          "text": "The value of X is determined only as Fraying Sanity's triggered ability resolves. For example, if three Fraying Sanity Auras are attached to one player who had four cards put into his or her graveyard this turn, X will be four for the first ability to resolve, eight for the second, and sixteen for the third."
         }
       ],
       "subtypes": [
@@ -3769,7 +4453,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3786,7 +4490,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Each token copies exactly what was printed on the original card and nothing else, except the characteristics it specifically modifies. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "Each token copies exactly what was printed on the original card and nothing else, except the characteristics it specifically modifies. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -3794,15 +4498,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Unlike the tokens created by an eternalize ability, the tokens have the mana cost and thus converted mana cost of the cards they’re copying."
+          "text": "Unlike the tokens created by an eternalize ability, the tokens have the mana cost and thus converted mana cost of the cards they're copying."
         },
         {
           "date": "2017-06-27",
-          "text": "If a card copied by one of the tokens had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If a card copied by one of the tokens had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         },
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Exile X target creature cards from your graveyard. For each card exiled this way, create a token that's a copy of that card, except it's a 4/4 black Zombie.",
@@ -3878,7 +4582,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3895,15 +4619,15 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "No creatures that player controls will untap during his or her next untap step, even creatures that don’t attack. This includes creatures that enter the battlefield or become tapped after this spell resolves."
+          "text": "No creatures that player controls will untap during his or her next untap step, even creatures that don't attack. This includes creatures that enter the battlefield or become tapped after this spell resolves."
         },
         {
           "date": "2017-06-27",
-          "text": "If the opponent exerts any creatures he or she controls, exert and the effect from Imaginary Threats stopping them from untapping both apply in the same untap step. Those creatures will untap as normal in the player’s subsequent untap step."
+          "text": "If the opponent exerts any creatures he or she controls, exert and the effect from Imaginary Threats stopping them from untapping both apply in the same untap step. Those creatures will untap as normal in the player's subsequent untap step."
         },
         {
           "date": "2017-06-27",
-          "text": "If, during that player’s declare attackers step, a creature that player controls is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having a creature attack, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during that player's declare attackers step, a creature that player controls is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having a creature attack, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "text": "Creatures target opponent controls attack this turn if able. During that player's next untap step, creatures he or she controls don't untap.\nCycling {2} ({2}, Discard this card: Draw a card.)",
@@ -3979,7 +4703,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -4066,7 +4810,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -4083,15 +4847,15 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "The control-change effect of Kefnet’s Last Word lasts indefinitely. It doesn’t wear off during the cleanup step."
+          "text": "The control-change effect of Kefnet's Last Word lasts indefinitely. It doesn't wear off during the cleanup step."
         },
         {
           "date": "2017-06-27",
-          "text": "If the target permanent is an illegal target by the time Kefnet’s Last Word resolves, the entire spell is countered. Your lands will untap during your next untap step as normal."
+          "text": "If the target permanent is an illegal target by the time Kefnet's Last Word resolves, the entire spell is countered. Your lands will untap during your next untap step as normal."
         },
         {
           "date": "2017-06-27",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it. They’ll remain attached, but an Aura’s effect that affects “you” still affects its controller rather than you, the controller of an Equipment can move it during his or her next main phase, and so on."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it. They'll remain attached, but an Aura's effect that affects \"you\" still affects its controller rather than you, the controller of an Equipment can move it during his or her next main phase, and so on."
         },
         {
           "date": "2017-06-27",
@@ -4099,11 +4863,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "No lands that you control will untap during your next untap step, even lands that aren’t tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
+          "text": "No lands that you control will untap during your next untap step, even lands that aren't tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
         },
         {
           "date": "2017-06-27",
-          "text": "If more than one spell says that lands you control don’t untap during your next untap step, the effects will all wear off during that untap step. You’ll untap lands you control during your untap step after that one."
+          "text": "If more than one spell says that lands you control don't untap during your next untap step, the effects will all wear off during that untap step. You'll untap lands you control during your untap step after that one."
         }
       ],
       "text": "Gain control of target artifact, creature, or enchantment. Lands you control don't untap during your next untap step.",
@@ -4178,7 +4942,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -4200,31 +4984,31 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Triggered abilities from cycling a card and the cycling ability itself aren’t spells. Effects that interact with spells (such as that of Cancel) won’t affect them."
+          "text": "Triggered abilities from cycling a card and the cycling ability itself aren't spells. Effects that interact with spells (such as that of Cancel) won't affect them."
         },
         {
           "date": "2017-04-18",
-          "text": "You can cycle a card even if it has a triggered ability from cycling that won’t have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability’s targets have become illegal), the other ability will still resolve."
+          "text": "You can cycle a card even if it has a triggered ability from cycling that won't have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability's targets have become illegal), the other ability will still resolve."
         },
         {
           "date": "2017-06-27",
-          "text": "Activated abilities are written in the form “Cost: Effect.” Some keyword abilities, such as equip and eternalize, are activated abilities and will have colons in their reminder texts."
+          "text": "Activated abilities are written in the form \"Cost: Effect.\" Some keyword abilities, such as equip and eternalize, are activated abilities and will have colons in their reminder texts."
         },
         {
           "date": "2017-06-27",
-          "text": "Triggered abilities use the word “when,” “whenever,” or “at.” They’re often written as “[Trigger condition], [effect].” Some keyword abilities, such as prowess and afflict, are triggered abilities and will have “when,” “whenever,” or “at” in their reminder text."
+          "text": "Triggered abilities use the word \"when,\" \"whenever,\" or \"at.\" They're often written as \"[Trigger condition], [effect].\" Some keyword abilities, such as prowess and afflict, are triggered abilities and will have \"when,\" \"whenever,\" or \"at\" in their reminder text."
         },
         {
           "date": "2017-06-27",
-          "text": "If you counter a delayed triggered ability that triggers at the beginning of the “next” occurrence of a specified step or phase, that ability won’t trigger again the following time that phase or step occurs."
+          "text": "If you counter a delayed triggered ability that triggers at the beginning of the \"next\" occurrence of a specified step or phase, that ability won't trigger again the following time that phase or step occurs."
         },
         {
           "date": "2017-06-27",
-          "text": "Mana abilities can’t be targeted. An activated mana ability is one that adds mana to a player’s mana pool as it resolves, doesn’t have a target, and isn’t a loyalty ability. A triggered mana ability is one that adds mana to a player’s mana pool and triggers on an activated mana ability."
+          "text": "Mana abilities can't be targeted. An activated mana ability is one that adds mana to a player's mana pool as it resolves, doesn't have a target, and isn't a loyalty ability. A triggered mana ability is one that adds mana to a player's mana pool and triggers on an activated mana ability."
         },
         {
           "date": "2017-06-27",
-          "text": "Abilities that create replacement effects, such as a permanent entering the battlefield tapped or with counters on it, can’t be targeted. Abilities that apply “as [this creature] enters the battlefield” are also replacement effects and can’t be targeted."
+          "text": "Abilities that create replacement effects, such as a permanent entering the battlefield tapped or with counters on it, can't be targeted. Abilities that apply \"as [this creature] enters the battlefield\" are also replacement effects and can't be targeted."
         }
       ],
       "subtypes": [
@@ -4305,7 +5089,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -4327,11 +5131,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -4415,7 +5219,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -4437,15 +5261,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you’ll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you'll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an eternalize ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've activated an eternalize ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -4529,7 +5353,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -4546,11 +5390,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Riddleform’s first ability resolves before the spell that caused it to trigger, but after targets for that spell are chosen. It will resolve even if that spell is countered. This means that if a spell affects each creature or each creature you control, it will affect Riddleform if you choose for Riddleform to become a creature, but a spell can’t target Riddleform if that spell requires a “target creature.”"
+          "text": "Riddleform's first ability resolves before the spell that caused it to trigger, but after targets for that spell are chosen. It will resolve even if that spell is countered. This means that if a spell affects each creature or each creature you control, it will affect Riddleform if you choose for Riddleform to become a creature, but a spell can't target Riddleform if that spell requires a \"target creature.\""
         },
         {
           "date": "2017-06-27",
-          "text": "If Riddleform becomes a creature the same turn it enters the battlefield, you can’t attack with it or use any of its {T} abilities (if it gains any)."
+          "text": "If Riddleform becomes a creature the same turn it enters the battlefield, you can't attack with it or use any of its {T} abilities (if it gains any)."
         }
       ],
       "text": "Whenever you cast a noncreature spell, you may have Riddleform become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.\n{2}{U}: Scry 1.",
@@ -4626,7 +5470,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -4718,7 +5582,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -4740,15 +5624,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you’ll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you'll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an eternalize ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've activated an eternalize ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -4756,7 +5640,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Several cards have an eternalize cost that includes “Discard a card.” You can’t discard the card with eternalize to pay its own cost because the card has to be in your graveyard to begin activating its eternalize ability."
+          "text": "Several cards have an eternalize cost that includes \"Discard a card.\" You can't discard the card with eternalize to pay its own cost because the card has to be in your graveyard to begin activating its eternalize ability."
         }
       ],
       "subtypes": [
@@ -4837,7 +5721,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -4859,15 +5763,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -4949,11 +5853,19 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
           "legality": "Legal"
         },
         {
@@ -5057,7 +5969,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -5148,7 +6080,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -5235,7 +6187,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -5256,31 +6228,31 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Swarm Intelligence can copy the spell even if it’s countered before Swarm Intelligence’s triggered ability resolves."
+          "text": "Swarm Intelligence can copy the spell even if it's countered before Swarm Intelligence's triggered ability resolves."
         },
         {
           "date": "2017-06-27",
-          "text": "The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell (such as Swarm Intelligence’s own ability) won’t trigger."
+          "text": "The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell (such as Swarm Intelligence's own ability) won't trigger."
         },
         {
           "date": "2017-06-27",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2017-06-27",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. A different mode can’t be chosen."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. A different mode can't be chosen."
         },
         {
           "date": "2017-06-27",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Torment of Hailfire does), the copy will have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Torment of Hailfire does), the copy will have the same value of X."
         },
         {
           "date": "2017-06-27",
-          "text": "If the spell has damage divided as it was cast (like Chandra’s Pyrohelix), the division can’t be changed (although the targets receiving that damage still can)."
+          "text": "If the spell has damage divided as it was cast (like Chandra's Pyrohelix), the division can't be changed (although the targets receiving that damage still can)."
         },
         {
           "date": "2017-06-27",
-          "text": "The controller of a copy can’t choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
+          "text": "The controller of a copy can't choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell, you may copy that spell. You may choose new targets for the copy.",
@@ -5356,7 +6328,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -5373,7 +6365,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You don’t choose which land to return to its owner’s hand or whether to discard a card instead until you see the two cards you draw."
+          "text": "You don't choose which land to return to its owner's hand or whether to discard a card instead until you see the two cards you draw."
         }
       ],
       "text": "Draw two cards. Then discard a card unless you return a land you control to its owner's hand.",
@@ -5448,7 +6440,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -5466,11 +6478,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "To determine the total cost of a Sphinx spell, start with the mana cost or alternative cost you’re paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
+          "text": "To determine the total cost of a Sphinx spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions. The converted mana cost of the creature remains unchanged, no matter what the total cost to cast it was."
         },
         {
           "date": "2017-06-27",
-          "text": "Unesh’s cost-reduction ability doesn’t reduce the cost to cast itself."
+          "text": "Unesh's cost-reduction ability doesn't reduce the cost to cast itself."
         },
         {
           "date": "2017-06-27",
@@ -5478,11 +6490,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "A pile can have no cards in it. In this case, you’ll choose whether to put all the revealed cards into your hand or into your graveyard."
+          "text": "A pile can have no cards in it. In this case, you'll choose whether to put all the revealed cards into your hand or into your graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn’t target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
+          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn't target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
         }
       ],
       "subtypes": [
@@ -5564,7 +6576,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -5581,11 +6613,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn’t matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
+          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn't matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don’t have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
+          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don't have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
         }
       ],
       "subtypes": [
@@ -5663,6 +6695,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -5790,7 +6826,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -5808,7 +6864,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If you activate an eternalize or embalm ability, you’ll draw a card before that ability resolves, but after you’ve paid all of the costs for that ability. If an eternalize ability requires a discard to activate, you’ll need to have another card available to discard."
+          "text": "If you activate an eternalize or embalm ability, you'll draw a card before that ability resolves, but after you've paid all of the costs for that ability. If an eternalize ability requires a discard to activate, you'll need to have another card available to discard."
         }
       ],
       "subtypes": [
@@ -5888,7 +6944,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -5906,7 +6982,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Accursed Horde’s ability can target itself while it’s attacking."
+          "text": "Accursed Horde's ability can target itself while it's attacking."
         },
         {
           "date": "2017-06-27",
@@ -5989,7 +7065,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6007,7 +7103,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Ammit Eternal’s middle ability will resolve before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Ammit Eternal's middle ability will resolve before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         },
         {
           "date": "2017-06-27",
@@ -6015,15 +7111,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -6104,7 +7200,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6122,7 +7238,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "The ability that defines Apocalypse Demon’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Apocalypse Demon's power and toughness works in all zones, not just the battlefield."
         }
       ],
       "subtypes": [
@@ -6202,7 +7318,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6295,7 +7431,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6312,11 +7468,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "No lands that you control will untap during your next untap step, even lands that aren’t tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
+          "text": "No lands that you control will untap during your next untap step, even lands that aren't tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
         },
         {
           "date": "2017-06-27",
-          "text": "If more than one spell says that lands you control don’t untap during your next untap step, the effects will all wear off during that untap step. You’ll untap lands you control during your untap step after that one."
+          "text": "If more than one spell says that lands you control don't untap during your next untap step, the effects will all wear off during that untap step. You'll untap lands you control during your untap step after that one."
         }
       ],
       "text": "Destroy all creatures. Lands you control don't untap during your next untap step.",
@@ -6392,7 +7548,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6485,7 +7661,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6502,11 +7698,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If you choose Doomfall’s first mode, the target opponent chooses which creature to exile. That creature isn’t targeted, so a creature with hexproof can be exiled this way."
+          "text": "If you choose Doomfall's first mode, the target opponent chooses which creature to exile. That creature isn't targeted, so a creature with hexproof can be exiled this way."
         },
         {
           "date": "2017-06-27",
-          "text": "If you choose Doomfall’s second mode, you must exile a nonland card from that player’s hand if able. If you can’t, most likely because that player’s hand contains only land cards, nothing happens. That player won’t exile a creature he or she controls instead."
+          "text": "If you choose Doomfall's second mode, you must exile a nonland card from that player's hand if able. If you can't, most likely because that player's hand contains only land cards, nothing happens. That player won't exile a creature he or she controls instead."
         }
       ],
       "text": "Choose one —\n• Target opponent exiles a creature he or she controls.\n• Target opponent reveals his or her hand. You choose a nonland card from it. Exile that card.",
@@ -6581,7 +7777,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6603,15 +7819,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you’ll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you'll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an eternalize ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've activated an eternalize ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -6619,7 +7835,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         }
       ],
       "subtypes": [
@@ -6700,7 +7916,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6722,11 +7958,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you discard a card doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "An ability that triggers whenever you discard a card doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         },
         {
           "date": "2017-04-18",
-          "text": "An ability that triggers whenever you “cycle or discard” a card triggers only once if you cycle a card. The ability “Whenever you discard a card” is functionally identical to this ability; cycling is mentioned for clarity."
+          "text": "An ability that triggers whenever you \"cycle or discard\" a card triggers only once if you cycle a card. The ability \"Whenever you discard a card\" is functionally identical to this ability; cycling is mentioned for clarity."
         },
         {
           "date": "2017-04-18",
@@ -6811,7 +8047,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6832,7 +8088,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Exile target creature. If that creature was a God, its controller reveals his or her hand and exiles all cards from it with the same name as that creature.",
@@ -6908,7 +8164,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -6930,15 +8206,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -7020,7 +8296,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7037,7 +8333,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If you don’t control any creatures or can’t put any -1/-1 counters on any creature you control, you can’t cast Lethal Sting."
+          "text": "If you don't control any creatures or can't put any -1/-1 counters on any creature you control, you can't cast Lethal Sting."
         }
       ],
       "text": "As an additional cost to cast Lethal Sting, put a -1/-1 counter on a creature you control.\nDestroy target creature.",
@@ -7113,7 +8409,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7200,7 +8516,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7293,7 +8629,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7311,11 +8667,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Whether you control another Zombie is checked only as you declare blockers. Marauding Boneslasher won’t stop blocking if you don’t control one later."
+          "text": "Whether you control another Zombie is checked only as you declare blockers. Marauding Boneslasher won't stop blocking if you don't control one later."
         },
         {
           "date": "2017-06-27",
-          "text": "The other Zombie doesn’t have to block."
+          "text": "The other Zombie doesn't have to block."
         }
       ],
       "subtypes": [
@@ -7396,7 +8752,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7418,15 +8794,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -7507,7 +8883,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7600,7 +8996,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7695,7 +9111,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7782,7 +9218,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7880,7 +9336,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7972,7 +9448,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -7993,7 +9489,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "While resolving Torment of Hailfire, your opponent chooses a card to be discarded without revealing it, chooses a nonland permanent to be sacrificed, or chooses to do neither. Then that player discards that card, sacrifices that permanent, or loses 3 life, then repeats this process if it hasn’t been done X times yet. Your opponent can always choose to lose 3 life, even if he or she has cards to discard or nonland permanents to sacrifice."
+          "text": "While resolving Torment of Hailfire, your opponent chooses a card to be discarded without revealing it, chooses a nonland permanent to be sacrificed, or chooses to do neither. Then that player discards that card, sacrifices that permanent, or loses 3 life, then repeats this process if it hasn't been done X times yet. Your opponent can always choose to lose 3 life, even if he or she has cards to discard or nonland permanents to sacrifice."
         },
         {
           "date": "2017-06-27",
@@ -8001,11 +9497,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "State-based actions aren’t checked in between repetitions of this process, so the game state may be a little unusual while making the choice. For example, a player may sacrifice a creature and then later sacrifice an Aura that was attached to that creature."
+          "text": "State-based actions aren't checked in between repetitions of this process, so the game state may be a little unusual while making the choice. For example, a player may sacrifice a creature and then later sacrifice an Aura that was attached to that creature."
         },
         {
           "date": "2017-06-27",
-          "text": "In a multiplayer game, each opponent in turn order makes his or her choice once, then all of the actions occur simultaneously, then they repeat this process if it hasn’t been done X times yet. Opponents will know choices made by earlier opponents when making their choices, although a card chosen to be discarded this way isn’t revealed until it’s discarded."
+          "text": "In a multiplayer game, each opponent in turn order makes his or her choice once, then all of the actions occur simultaneously, then they repeat this process if it hasn't been done X times yet. Opponents will know choices made by earlier opponents when making their choices, although a card chosen to be discarded this way isn't revealed until it's discarded."
         },
         {
           "date": "2017-06-27",
@@ -8085,7 +9581,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -8182,7 +9698,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -8199,15 +9735,15 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If the target creature is an illegal target by the time Torment of Venom resolves, the entire spell is countered. The creature’s controller won’t be tormented."
+          "text": "If the target creature is an illegal target by the time Torment of Venom resolves, the entire spell is countered. The creature's controller won't be tormented."
         },
         {
           "date": "2017-06-27",
-          "text": "Because state-based actions aren’t performed while Torment of Venom is resolving, the target creature is still on the battlefield while its controller is tormented. If that creature has an Aura attached to it, that Aura can be sacrificed."
+          "text": "Because state-based actions aren't performed while Torment of Venom is resolving, the target creature is still on the battlefield while its controller is tormented. If that creature has an Aura attached to it, that Aura can be sacrificed."
         },
         {
           "date": "2017-06-27",
-          "text": "While resolving Torment of Venom, the creature’s controller chooses a card to be discarded without revealing it, chooses a nonland permanent to be sacrificed, or chooses to do neither. Then that player discards that card, sacrifices that permanent, or loses 3 life. That player can always choose to lose 3 life, even if he or she has cards to discard or nonland permanents to sacrifice."
+          "text": "While resolving Torment of Venom, the creature's controller chooses a card to be discarded without revealing it, chooses a nonland permanent to be sacrificed, or chooses to do neither. Then that player discards that card, sacrifices that permanent, or loses 3 life. That player can always choose to lose 3 life, even if he or she has cards to discard or nonland permanents to sacrifice."
         }
       ],
       "text": "Put three -1/-1 counters on target creature. Its controller loses 3 life unless he or she sacrifices another nonland permanent or discards a card.",
@@ -8283,7 +9819,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -8301,15 +9857,15 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Vile Manifestation’s first ability counts only the cards with cycling abilities in your graveyard. It doesn’t care whether or not they were cycled to get there."
+          "text": "Vile Manifestation's first ability counts only the cards with cycling abilities in your graveyard. It doesn't care whether or not they were cycled to get there."
         },
         {
           "date": "2017-06-27",
-          "text": "Vile Manifestation’s first ability applies only while it’s on the battlefield. In all other zones, its power is 0."
+          "text": "Vile Manifestation's first ability applies only while it's on the battlefield. In all other zones, its power is 0."
         },
         {
           "date": "2017-06-27",
-          "text": "Certain older cards have variants of cycling, such as basic landcycling or Wizardcycling. Vile Manifestation’s effect counts these cards."
+          "text": "Certain older cards have variants of cycling, such as basic landcycling or Wizardcycling. Vile Manifestation's effect counts these cards."
         }
       ],
       "subtypes": [
@@ -8388,7 +9944,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -8475,7 +10051,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -8493,11 +10089,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn’t matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
+          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn't matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don’t have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
+          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don't have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
         }
       ],
       "subtypes": [
@@ -8578,7 +10174,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -8665,7 +10281,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -8682,7 +10318,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If the targeted creature is an illegal target by the time Blur of Blades resolves, it will be countered and none of its effects will happen. Blur of Blades won’t deal damage to any player."
+          "text": "If the targeted creature is an illegal target by the time Blur of Blades resolves, it will be countered and none of its effects will happen. Blur of Blades won't deal damage to any player."
         }
       ],
       "text": "Put a -1/-1 counter on target creature. Blur of Blades deals 2 damage to that creature's controller.",
@@ -8758,7 +10394,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -8851,7 +10507,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -8938,7 +10614,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9030,7 +10726,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9047,7 +10763,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Crash Through affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn won’t gain trample."
+          "text": "Crash Through affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn won't gain trample."
         }
       ],
       "text": "Creatures you control gain trample until end of turn.\nDraw a card.",
@@ -9123,7 +10839,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9213,7 +10949,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9231,11 +10987,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "The target creature’s power is checked when you target it with Earthshaker Khenra’s ability and when that ability resolves. Once the ability resolves, if the creature’s power increases or Earthshaker Khenra’s power decreases, the target creature will still be unable to block."
+          "text": "The target creature's power is checked when you target it with Earthshaker Khenra's ability and when that ability resolves. Once the ability resolves, if the creature's power increases or Earthshaker Khenra's power decreases, the target creature will still be unable to block."
         },
         {
           "date": "2017-06-27",
-          "text": "Spells, activated abilities, and triggered abilities can’t raise Earthshaker Khenra’s power before you have to choose a target for its ability. Static abilities, such as that of Lord of the Accursed, will raise its power in time to let you target a larger creature."
+          "text": "Spells, activated abilities, and triggered abilities can't raise Earthshaker Khenra's power before you have to choose a target for its ability. Static abilities, such as that of Lord of the Accursed, will raise its power in time to let you target a larger creature."
         },
         {
           "date": "2017-06-27",
@@ -9243,15 +10999,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you’ll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you'll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an eternalize ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've activated an eternalize ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -9259,7 +11015,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         }
       ],
       "subtypes": [
@@ -9340,7 +11096,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9358,19 +11134,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-06-27",
-          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you’ve already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
+          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you've already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
         }
       ],
       "subtypes": [
@@ -9451,7 +11227,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9469,11 +11265,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Firebrand Archer’s ability will resolve before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Firebrand Archer's ability will resolve before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         },
         {
           "date": "2017-06-27",
-          "text": "In a Two-Headed Giant game, Firebrand Archer’s ability causes it to deal a total of 2 damage to the opposing team."
+          "text": "In a Two-Headed Giant game, Firebrand Archer's ability causes it to deal a total of 2 damage to the opposing team."
         }
       ],
       "subtypes": [
@@ -9554,7 +11350,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9576,15 +11392,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -9666,7 +11482,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9684,11 +11520,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn’t matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
+          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn't matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don’t have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
+          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don't have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
         }
       ],
       "subtypes": [
@@ -9768,7 +11604,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9859,7 +11715,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -9884,7 +11760,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
         },
         {
           "date": "2017-06-27",
@@ -9892,23 +11768,23 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If any abilities trigger as you cast any of those cards, they won’t be put on the stack until after you’re done casting them. They’ll resolve before any of those spells."
+          "text": "If any abilities trigger as you cast any of those cards, they won't be put on the stack until after you're done casting them. They'll resolve before any of those spells."
         },
         {
           "date": "2017-06-27",
-          "text": "If you cast any of those cards, you do so as part of the resolution of Hazoret’s Undying Fury. You can’t wait to cast them later in the turn."
+          "text": "If you cast any of those cards, you do so as part of the resolution of Hazoret's Undying Fury. You can't wait to cast them later in the turn."
         },
         {
           "date": "2017-06-27",
-          "text": "If a spell you cast this way targets another spell, it may target a spell you cast earlier during the resolution of Hazoret’s Undying Fury. It may target Hazoret’s Undying Fury as well, but Hazoret’s Undying Fury will be put into your graveyard soon afterwards and the spell’s target will become illegal."
+          "text": "If a spell you cast this way targets another spell, it may target a spell you cast earlier during the resolution of Hazoret's Undying Fury. It may target Hazoret's Undying Fury as well, but Hazoret's Undying Fury will be put into your graveyard soon afterwards and the spell's target will become illegal."
         },
         {
           "date": "2017-06-27",
-          "text": "No lands that you control will untap during your next untap step, even lands that aren’t tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
+          "text": "No lands that you control will untap during your next untap step, even lands that aren't tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
         },
         {
           "date": "2017-06-27",
-          "text": "If more than one spell says that lands you control don’t untap during your next untap step, the effects will all wear off during that untap step. You’ll untap lands you control during your untap step after that one."
+          "text": "If more than one spell says that lands you control don't untap during your next untap step, the effects will all wear off during that untap step. You'll untap lands you control during your untap step after that one."
         }
       ],
       "text": "Shuffle your library, then exile the top four cards. You may cast any number of nonland cards with converted mana cost 5 or less from among them without paying their mana costs. Lands you control don't untap during your next untap step.",
@@ -9984,7 +11860,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -10005,11 +11901,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Once Hour of Devastation begins to resolve, no player may take actions until it’s done. Notably, players can’t try to give a creature indestructible again to save it from the damage."
+          "text": "Once Hour of Devastation begins to resolve, no player may take actions until it's done. Notably, players can't try to give a creature indestructible again to save it from the damage."
         },
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "All creatures lose indestructible until end of turn. Hour of Devastation deals 5 damage to each creature and each non-Bolas planeswalker.",
@@ -10084,7 +11980,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -10101,7 +12017,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Imminent Doom’s triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Imminent Doom's triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         },
         {
           "date": "2017-06-27",
@@ -10109,7 +12025,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "The amount of damage Imminent Doom’s triggered ability deals is the number of counters it had on it as the ability triggered. For example, if you cast Shock and then respond to Imminent Doom’s triggered ability with a second Shock, both abilities cause Imminent Doom to deal 1 damage and Imminent Doom will end up with three doom counters on it."
+          "text": "The amount of damage Imminent Doom's triggered ability deals is the number of counters it had on it as the ability triggered. For example, if you cast Shock and then respond to Imminent Doom's triggered ability with a second Shock, both abilities cause Imminent Doom to deal 1 damage and Imminent Doom will end up with three doom counters on it."
         }
       ],
       "text": "Imminent Doom enters the battlefield with a doom counter on it.\nWhenever you cast a spell with converted mana cost equal to the number of doom counters on Imminent Doom, Imminent Doom deals that much damage to target creature or player. Then put a doom counter on Imminent Doom.",
@@ -10185,7 +12101,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -10272,7 +12208,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -10290,19 +12246,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         }
       ],
       "subtypes": [
@@ -10383,6 +12339,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -10428,7 +12388,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn’t prevent that creature from dealing combat damage."
+          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn't prevent that creature from dealing combat damage."
         }
       ],
       "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
@@ -10504,7 +12464,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -10522,7 +12502,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Magmaroth’s second ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Magmaroth's second ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         }
       ],
       "subtypes": [
@@ -10602,7 +12582,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -10620,7 +12620,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If, during your declare attackers step, Manticore Eternal is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having it attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Manticore Eternal is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having it attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2017-06-27",
@@ -10628,15 +12628,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -10717,7 +12717,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -10739,27 +12759,27 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Because it triggers at the beginning of a phase, Neheb’s last ability isn’t a mana ability. It uses the stack and can be countered by effects that interact with triggered abilities, such as that of Nimble Obstructionist."
+          "text": "Because it triggers at the beginning of a phase, Neheb's last ability isn't a mana ability. It uses the stack and can be countered by effects that interact with triggered abilities, such as that of Nimble Obstructionist."
         },
         {
           "date": "2017-06-27",
-          "text": "You get a postcombat main phase even if no creatures attacked during a turn. Neheb’s last ability will trigger."
+          "text": "You get a postcombat main phase even if no creatures attacked during a turn. Neheb's last ability will trigger."
         },
         {
           "date": "2017-06-27",
-          "text": "If an opponent loses life but Neheb leaves the battlefield before your postcombat main phase begins, its last ability doesn’t trigger."
+          "text": "If an opponent loses life but Neheb leaves the battlefield before your postcombat main phase begins, its last ability doesn't trigger."
         },
         {
           "date": "2017-06-27",
-          "text": "Neheb’s ability checks only how much life opponents lost during the turn, not by how much their life total decreased compared to the start of the turn. For example, if an opponent lost 2 life and then gained 8 life before your postcombat main phase, you’ll add {R}{R} to your mana pool."
+          "text": "Neheb's ability checks only how much life opponents lost during the turn, not by how much their life total decreased compared to the start of the turn. For example, if an opponent lost 2 life and then gained 8 life before your postcombat main phase, you'll add {R}{R} to your mana pool."
         },
         {
           "date": "2017-06-27",
-          "text": "If an opponent loses life and subsequently loses the game before your postcombat main phase, Neheb’s last ability counts that loss of life."
+          "text": "If an opponent loses life and subsequently loses the game before your postcombat main phase, Neheb's last ability counts that loss of life."
         },
         {
           "date": "2017-06-27",
-          "text": "If you somehow have more than two main phases in a turn, each main phase after your first one is a postcombat main phase, and Neheb’s last ability triggers at the beginning of each of them."
+          "text": "If you somehow have more than two main phases in a turn, each main phase after your first one is a postcombat main phase, and Neheb's last ability triggers at the beginning of each of them."
         },
         {
           "date": "2017-06-27",
@@ -10767,15 +12787,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -10860,7 +12880,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -10947,7 +12987,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -10964,7 +13024,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Puncturing Blow’s replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Puncturing Blow deals no damage to it (due to a prevention effect) or Puncturing Blow deals damage to a different creature (due to a redirection effect)."
+          "text": "Puncturing Blow's replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Puncturing Blow deals no damage to it (due to a prevention effect) or Puncturing Blow deals damage to a different creature (due to a redirection effect)."
         }
       ],
       "text": "Puncturing Blow deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
@@ -11040,7 +13100,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -11058,11 +13138,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn’t matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
+          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn't matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don’t have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
+          "text": "For abilities that trigger only if you control a Desert or there is a Desert card in your graveyard, one condition must be true as the ability triggers and one must be true as the ability resolves. They don't have to be the same condition, though. For example, you could sacrifice your only Desert after the ability triggers but before it has resolved."
         }
       ],
       "subtypes": [
@@ -11142,7 +13222,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -11233,7 +13333,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -11251,15 +13371,15 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         },
         {
           "date": "2017-06-27",
-          "text": "Wildfire Eternal’s second ability resolves before combat damage is dealt, and you must cast a spell at that time if you wish to cast one without paying its mana cost. You can cast a sorcery during the declare blockers step this way."
+          "text": "Wildfire Eternal's second ability resolves before combat damage is dealt, and you must cast a spell at that time if you wish to cast one without paying its mana cost. You can cast a sorcery during the declare blockers step this way."
         },
         {
           "date": "2017-06-27",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, those must be paid to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, those must be paid to cast the card."
         },
         {
           "date": "2017-06-27",
@@ -11271,15 +13391,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -11361,7 +13481,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -11378,7 +13518,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If the creature you control leaves the battlefield before Ambuscade resolves, Ambuscade has no effect and no damage is dealt. If the creature an opponent controls leaves the battlefield instead, the creature you control gets +1/+0 even though it won’t deal any damage."
+          "text": "If the creature you control leaves the battlefield before Ambuscade resolves, Ambuscade has no effect and no damage is dealt. If the creature an opponent controls leaves the battlefield instead, the creature you control gets +1/+0 even though it won't deal any damage."
         }
       ],
       "text": "Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature an opponent controls.",
@@ -11454,7 +13594,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -11541,7 +13701,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -11634,7 +13814,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -11727,7 +13927,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -11745,7 +13965,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You can’t tap a single untapped Desert both to pay {1} and also to pay “Tap an untapped Desert you control.”"
+          "text": "You can't tap a single untapped Desert both to pay {1} and also to pay \"Tap an untapped Desert you control.\""
         }
       ],
       "subtypes": [
@@ -11826,7 +14046,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -11918,7 +14158,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12010,7 +14270,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12097,7 +14377,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12188,7 +14488,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12206,19 +14526,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-06-27",
-          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you’ve already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
+          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you've already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
         }
       ],
       "subtypes": [
@@ -12299,7 +14619,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12320,7 +14660,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library. Then if you control three or more Deserts, create two 2/2 black Zombie creature tokens.",
@@ -12396,7 +14736,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12413,7 +14773,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You won’t gain more than 8 life if more than one creature died this turn."
+          "text": "You won't gain more than 8 life if more than one creature died this turn."
         },
         {
           "date": "2017-06-27",
@@ -12492,7 +14852,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12514,19 +14894,19 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Majestic Myriarch’s first ability applies in all zones. While it’s on the battlefield, it counts itself, so it’ll be at least 2/2."
+          "text": "Majestic Myriarch's first ability applies in all zones. While it's on the battlefield, it counts itself, so it'll be at least 2/2."
         },
         {
           "date": "2017-06-27",
-          "text": "Majestic Myriarch’s second ability triggers at the beginning of each combat, not just combat on your turn, whether or not any creatures you control have any of the listed abilities."
+          "text": "Majestic Myriarch's second ability triggers at the beginning of each combat, not just combat on your turn, whether or not any creatures you control have any of the listed abilities."
         },
         {
           "date": "2017-06-27",
-          "text": "Which abilities Majestic Myriarch gains is determined as the ability resolves. They won’t change even if every other creature that has the abilities leaves the battlefield or if creatures enter the battlefield or gain abilities."
+          "text": "Which abilities Majestic Myriarch gains is determined as the ability resolves. They won't change even if every other creature that has the abilities leaves the battlefield or if creatures enter the battlefield or gain abilities."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature gains one of the listed abilities before Majestic Mryiarch’s triggered ability resolves, perhaps due to another ability that triggered at the beginning of combat, Majestic Myriarch will gain that ability."
+          "text": "If a creature gains one of the listed abilities before Majestic Mryiarch's triggered ability resolves, perhaps due to another ability that triggered at the beginning of combat, Majestic Myriarch will gain that ability."
         },
         {
           "date": "2017-06-27",
@@ -12610,7 +14990,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12627,7 +15027,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Most nonbasic lands that produce green mana aren’t Forests. For example, Desert of the Indomitable isn’t a Forest. Some nonbasic lands (such as Sheltered Thicket from the Amonkhet set) do have basic land types printed on the type line and may be Forests."
+          "text": "Most nonbasic lands that produce green mana aren't Forests. For example, Desert of the Indomitable isn't a Forest. Some nonbasic lands (such as Sheltered Thicket from the Amonkhet set) do have basic land types printed on the type line and may be Forests."
         }
       ],
       "text": "Destroy target Forest, green enchantment, or green planeswalker. If that permanent was a Nissa planeswalker, draw a card.",
@@ -12703,7 +15103,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12721,19 +15141,19 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-06-27",
-          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you’ve already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
+          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you've already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
         }
       ],
       "subtypes": [
@@ -12814,7 +15234,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12901,7 +15341,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -12919,23 +15379,23 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-06-27",
-          "text": "Because damage remains marked on a creature until it’s removed as the turn ends, the damage Pride Sovereign takes during combat may become lethal if other Cats you control leave the battlefield later in the turn."
+          "text": "Because damage remains marked on a creature until it's removed as the turn ends, the damage Pride Sovereign takes during combat may become lethal if other Cats you control leave the battlefield later in the turn."
         },
         {
           "date": "2017-06-27",
-          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you’ve already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
+          "text": "Some cards in the Hour of Devastation set let you exert a creature as a cost to activate one of its abilities. You can exert it to pay that cost even if you've already exerted it earlier in the turn. Exerting it multiple times will keep it tapped only during your next untap step."
         }
       ],
       "subtypes": [
@@ -13015,7 +15475,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13033,7 +15513,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Quarry Beetle’s ability doesn’t count as playing a land. It can return a land card to the battlefield even if you’ve already played as many lands as able this turn."
+          "text": "Quarry Beetle's ability doesn't count as playing a land. It can return a land card to the battlefield even if you've already played as many lands as able this turn."
         }
       ],
       "subtypes": [
@@ -13113,7 +15593,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13205,7 +15705,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13223,11 +15743,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Ramunap Excavator doesn’t change the times when you can play those land cards. You can still play only one land per turn, and only during your main phase when you have priority and the stack is empty."
+          "text": "Ramunap Excavator doesn't change the times when you can play those land cards. You can still play only one land per turn, and only during your main phase when you have priority and the stack is empty."
         },
         {
           "date": "2017-06-27",
-          "text": "Ramunap Excavator doesn’t allow you to activate activated abilities (such as cycling) of land cards in your graveyard."
+          "text": "Ramunap Excavator doesn't allow you to activate activated abilities (such as cycling) of land cards in your graveyard."
         }
       ],
       "subtypes": [
@@ -13307,7 +15827,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13325,7 +15865,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Unlike other cards in this set that care only whether you control a Desert or there is a Desert card in your graveyard, Ramunap Hydra’s abilities reward you for meeting both conditions. If you control one or more Deserts and have one or more Desert cards in your graveyard, it’ll get +2/+2."
+          "text": "Unlike other cards in this set that care only whether you control a Desert or there is a Desert card in your graveyard, Ramunap Hydra's abilities reward you for meeting both conditions. If you control one or more Deserts and have one or more Desert cards in your graveyard, it'll get +2/+2."
         }
       ],
       "subtypes": [
@@ -13405,7 +15945,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13423,7 +15983,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "The value of X is determined only as Resilient Khenra’s triggered ability resolves. Once that happens, the value of X won’t change later in the turn even if Resilient Khenra’s power changes."
+          "text": "The value of X is determined only as Resilient Khenra's triggered ability resolves. Once that happens, the value of X won't change later in the turn even if Resilient Khenra's power changes."
         },
         {
           "date": "2017-06-27",
@@ -13431,7 +15991,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If Resilient Khenra’s power is negative as its triggered ability resolves, X is considered to be 0. (This is a change from previous rules.)"
+          "text": "If Resilient Khenra's power is negative as its triggered ability resolves, X is considered to be 0. (This is a change from previous rules.)"
         },
         {
           "date": "2017-06-27",
@@ -13439,15 +15999,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you’ll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it’s legal for you to do so."
+          "text": "If a creature card with eternalize is put into your graveyard during your main phase, you'll have priority immediately afterward. You can activate its eternalize ability before any player can try to exile it, such as with Crook of Condemnation, if it's legal for you to do so."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve activated an eternalize ability, the card is immediately exiled. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've activated an eternalize ability, the card is immediately exiled. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics specifically modified by eternalize. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -13455,7 +16015,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         }
       ],
       "subtypes": [
@@ -13536,7 +16096,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13553,11 +16133,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "No lands that you control will untap during your next untap step, even lands that aren’t tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
+          "text": "No lands that you control will untap during your next untap step, even lands that aren't tapped as this spell resolves. This includes lands that enter the battlefield after this spell resolves."
         },
         {
           "date": "2017-06-27",
-          "text": "If more than one spell says that lands you control don’t untap during your next untap step, the effects will all wear off during that untap step. You’ll untap lands you control during your untap step after that one."
+          "text": "If more than one spell says that lands you control don't untap during your next untap step, the effects will all wear off during that untap step. You'll untap lands you control during your untap step after that one."
         }
       ],
       "text": "Create a 5/4 green Snake creature token. Lands you control don't untap during your next untap step.",
@@ -13633,7 +16213,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13651,23 +16251,23 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         },
         {
           "date": "2017-06-27",
-          "text": "Once a creature with power 3 or greater has blocked an exerted Rhonas’s Stalwart, changing the power of the blocking creature won’t cause Rhonas’s Stalwart to become unblocked."
+          "text": "Once a creature with power 3 or greater has blocked an exerted Rhonas's Stalwart, changing the power of the blocking creature won't cause Rhonas's Stalwart to become unblocked."
         }
       ],
       "subtypes": [
@@ -13748,7 +16348,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13766,7 +16386,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn’t matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
+          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn't matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
         }
       ],
       "subtypes": [
@@ -13847,7 +16467,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13865,7 +16505,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once Sifter Wurm’s triggered ability begins to resolve, no player may take other actions until it’s done. Notably, opponents can’t try to change your library after you scry but before you reveal the top card of your library."
+          "text": "Once Sifter Wurm's triggered ability begins to resolve, no player may take other actions until it's done. Notably, opponents can't try to change your library after you scry but before you reveal the top card of your library."
         },
         {
           "date": "2017-06-27",
@@ -13953,7 +16593,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -13971,7 +16631,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "A creature with a -1/-1 counter on it controlled by any player satisfies Tenacious Hunter’s ability."
+          "text": "A creature with a -1/-1 counter on it controlled by any player satisfies Tenacious Hunter's ability."
         },
         {
           "date": "2017-06-27",
@@ -14055,7 +16715,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -14072,7 +16752,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If you cast Uncage the Menagerie with X as 0, you’ll search your library and shuffle it, but you won’t be able to find any cards."
+          "text": "If you cast Uncage the Menagerie with X as 0, you'll search your library and shuffle it, but you won't be able to find any cards."
         },
         {
           "date": "2017-06-27",
@@ -14153,7 +16833,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -14246,7 +16946,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -14265,7 +16985,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If a spell or ability causes you to put cards into your hand without specifically using the word “draw,” The Locust God’s first triggered ability won’t trigger."
+          "text": "If a spell or ability causes you to put cards into your hand without specifically using the word \"draw,\" The Locust God's first triggered ability won't trigger."
         },
         {
           "date": "2017-06-27",
@@ -14273,7 +16993,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "The “next end step” refers to the next end step that occurs, not the end step of the next turn. If this creature dies before a turn’s end step (for example, during combat), it will be returned to its owner’s hand at the beginning of that turn’s end step."
+          "text": "The \"next end step\" refers to the next end step that occurs, not the end step of the next turn. If this creature dies before a turn's end step (for example, during combat), it will be returned to its owner's hand at the beginning of that turn's end step."
         }
       ],
       "subtypes": [
@@ -14359,7 +17079,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -14377,23 +17117,23 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "The cards exiled by Nicol Bolas’s first and second abilities are exiled face up."
+          "text": "The cards exiled by Nicol Bolas's first and second abilities are exiled face up."
         },
         {
           "date": "2017-06-27",
-          "text": "You may cast the nonland card exiled by Nicol Bolas’s first ability that turn even if Nicol Bolas is no longer on the battlefield or under your control."
+          "text": "You may cast the nonland card exiled by Nicol Bolas's first ability that turn even if Nicol Bolas is no longer on the battlefield or under your control."
         },
         {
           "date": "2017-06-27",
-          "text": "Casting the card exiled with Nicol Bolas’s first ability follows the normal timing rules for casting that card. For example, if the card is a creature card, you can cast that card only during your main phase while the stack is empty."
+          "text": "Casting the card exiled with Nicol Bolas's first ability follows the normal timing rules for casting that card. For example, if the card is a creature card, you can cast that card only during your main phase while the stack is empty."
         },
         {
           "date": "2017-06-27",
-          "text": "If you don’t cast the card exiled by Nicol Bolas’s first ability that turn, it will remain exiled."
+          "text": "If you don't cast the card exiled by Nicol Bolas's first ability that turn, it will remain exiled."
         },
         {
           "date": "2017-06-27",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, you must pay those to cast the card."
         },
         {
           "date": "2017-06-27",
@@ -14401,11 +17141,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "While resolving Nicol Bolas’s second ability, each opponent chooses which cards to exile from his or her hand. Any opponent with two or fewer cards exiles his or her entire hand."
+          "text": "While resolving Nicol Bolas's second ability, each opponent chooses which cards to exile from his or her hand. Any opponent with two or fewer cards exiles his or her entire hand."
         },
         {
           "date": "2017-06-27",
-          "text": "In a multiplayer game, if a player leaves the game, all cards that player owns leave as well. If you leave the game, any spell or permanent cards you control from Nicol Bolas’s first ability are exiled."
+          "text": "In a multiplayer game, if a player leaves the game, all cards that player owns leave as well. If you leave the game, any spell or permanent cards you control from Nicol Bolas's first ability are exiled."
         }
       ],
       "subtypes": [
@@ -14485,7 +17225,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -14507,27 +17267,27 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Obelisk Spider’s first triggered ability puts only one -1/-1 counter on the creature, no matter how much combat damage it dealt."
+          "text": "Obelisk Spider's first triggered ability puts only one -1/-1 counter on the creature, no matter how much combat damage it dealt."
         },
         {
           "date": "2017-06-27",
-          "text": "If Obelisk Spider deals combat damage to a creature but that creature isn’t on the battlefield as Obelisk Spider’s first triggered ability resolves, most likely because Obelisk Spider killed that creature already, that ability won’t put a -1/-1 counter on it."
+          "text": "If Obelisk Spider deals combat damage to a creature but that creature isn't on the battlefield as Obelisk Spider's first triggered ability resolves, most likely because Obelisk Spider killed that creature already, that ability won't put a -1/-1 counter on it."
         },
         {
           "date": "2017-06-27",
-          "text": "Because damage remains marked on a creature until it’s removed as the turn ends, the counter Obelisk Spider’s first triggered ability puts on a creature may cause previously marked damage to become lethal."
+          "text": "Because damage remains marked on a creature until it's removed as the turn ends, the counter Obelisk Spider's first triggered ability puts on a creature may cause previously marked damage to become lethal."
         },
         {
           "date": "2017-06-27",
-          "text": "If Obelisk Spider deals combat damage to a creature at the same time Obelisk Spider is dealt lethal damage, its first triggered ability will put a -1/-1 counter on the other creature. However, because Obelisk Spider has left the battlefield before that ability resolves, its last ability won’t trigger."
+          "text": "If Obelisk Spider deals combat damage to a creature at the same time Obelisk Spider is dealt lethal damage, its first triggered ability will put a -1/-1 counter on the other creature. However, because Obelisk Spider has left the battlefield before that ability resolves, its last ability won't trigger."
         },
         {
           "date": "2017-06-27",
-          "text": "If you put one or more -1/-1 counter on each of multiple creatures at the same time, Obelisk Spider’s last ability triggers once for each of those creatures."
+          "text": "If you put one or more -1/-1 counter on each of multiple creatures at the same time, Obelisk Spider's last ability triggers once for each of those creatures."
         },
         {
           "date": "2017-06-27",
-          "text": "In a Two-Headed Giant game, Obelisk Spider’s last ability causes the opposing team to lose 2 life and you gain 1 life."
+          "text": "In a Two-Headed Giant game, Obelisk Spider's last ability causes the opposing team to lose 2 life and you gain 1 life."
         }
       ],
       "subtypes": [
@@ -14609,7 +17369,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -14627,15 +17407,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "You can’t exert a creature unless an effect allows you to do so. Similar effects that “tap and freeze” a creature (such as that of Decision Paralysis) don’t exert that creature."
+          "text": "You can't exert a creature unless an effect allows you to do so. Similar effects that \"tap and freeze\" a creature (such as that of Decision Paralysis) don't exert that creature."
         },
         {
           "date": "2017-04-18",
-          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert’s effect preventing it from untapping expires without having done anything."
+          "text": "If an exerted creature is already untapped during your next untap step (most likely because it had vigilance or an effect untapped it), exert's effect preventing it from untapping expires without having done anything."
         },
         {
           "date": "2017-04-18",
-          "text": "If you gain control of another player’s creature until end of turn and exert it, it will untap during that player’s untap step."
+          "text": "If you gain control of another player's creature until end of turn and exert it, it will untap during that player's untap step."
         },
         {
           "date": "2017-04-18",
@@ -14643,11 +17423,11 @@
         },
         {
           "date": "2017-04-18",
-          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can’t do so later in combat, and creatures put onto the battlefield attacking can’t be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
+          "text": "All cards in the Amonkhet set that let you exert a creature let you do so as you declare it as an attacking creature, as do some of the cards in the Hour of Devastation set. You can't do so later in combat, and creatures put onto the battlefield attacking can't be exerted. Any abilities that trigger on exerting an attacking creature will resolve before blockers are declared."
         },
         {
           "date": "2017-06-27",
-          "text": "In a Two-Headed Giant game, Resolute Survivors’s last ability causes it to deal a total of 2 damage to the opposing team and you gain 1 life."
+          "text": "In a Two-Headed Giant game, Resolute Survivors's last ability causes it to deal a total of 2 damage to the opposing team and you gain 1 life."
         }
       ],
       "subtypes": [
@@ -14730,7 +17510,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -14823,7 +17623,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -14841,15 +17661,15 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You divide the damage as you activate Samut’s second ability, not as it resolves. Each target must be assigned at least 1 damage. In other words, as you activate the ability, you choose whether to have it deal 2 damage to a single target, or deal 1 damage to each of two targets."
+          "text": "You divide the damage as you activate Samut's second ability, not as it resolves. Each target must be assigned at least 1 damage. In other words, as you activate the ability, you choose whether to have it deal 2 damage to a single target, or deal 1 damage to each of two targets."
         },
         {
           "date": "2017-06-27",
-          "text": "If Samut’s second ability has two targets and one becomes an illegal target, the remaining target is dealt 1 damage, not 2."
+          "text": "If Samut's second ability has two targets and one becomes an illegal target, the remaining target is dealt 1 damage, not 2."
         },
         {
           "date": "2017-06-27",
-          "text": "While resolving Samut’s last ability, all of the creatures and planeswalkers put onto the battlefield this way enter at the same time. If any have triggered abilities that trigger on something else entering the battlefield, they’ll see each other."
+          "text": "While resolving Samut's last ability, all of the creatures and planeswalkers put onto the battlefield this way enter at the same time. If any have triggered abilities that trigger on something else entering the battlefield, they'll see each other."
         }
       ],
       "subtypes": [
@@ -14929,7 +17749,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -14948,11 +17788,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "The number of Zombies you control is counted as The Scarab God’s first ability resolves. Players can try to change that number in response to the ability (perhaps by activating its second ability)."
+          "text": "The number of Zombies you control is counted as The Scarab God's first ability resolves. Players can try to change that number in response to the ability (perhaps by activating its second ability)."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics it specifically modifies. It doesn’t copy any information about the object the card was before it was put into its owner’s graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics it specifically modifies. It doesn't copy any information about the object the card was before it was put into its owner's graveyard."
         },
         {
           "date": "2017-06-27",
@@ -14960,15 +17800,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Unlike the tokens created by an eternalize ability, this token has the mana cost and thus converted mana cost of the card it’s copying."
+          "text": "Unlike the tokens created by an eternalize ability, this token has the mana cost and thus converted mana cost of the card it's copying."
         },
         {
           "date": "2017-06-27",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         },
         {
           "date": "2017-06-27",
-          "text": "In a Two-Headed Giant game, The Scarab God’s first ability causes the opposing team to lose life equal to twice the number of Zombies you control, although you scry only equal to the number of Zombies you control."
+          "text": "In a Two-Headed Giant game, The Scarab God's first ability causes the opposing team to lose life equal to twice the number of Zombies you control, although you scry only equal to the number of Zombies you control."
         },
         {
           "date": "2017-06-27",
@@ -14976,7 +17816,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "The “next end step” refers to the next end step that occurs, not the end step of the next turn. If this creature dies before a turn’s end step (for example, during combat), it will be returned to its owner’s hand at the beginning of that turn’s end step."
+          "text": "The \"next end step\" refers to the next end step that occurs, not the end step of the next turn. If this creature dies before a turn's end step (for example, during combat), it will be returned to its owner's hand at the beginning of that turn's end step."
         }
       ],
       "subtypes": [
@@ -15060,7 +17900,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -15079,11 +17939,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You’ll draw only one card when a creature with more than one -1/-1 counter on it dies."
+          "text": "You'll draw only one card when a creature with more than one -1/-1 counter on it dies."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature with a -1/-1 counter on it dies at the same time as The Scorpion God does, you’ll draw a card. The same is true if The Scorpion God dies with a -1/-1 counter on it."
+          "text": "If a creature with a -1/-1 counter on it dies at the same time as The Scorpion God does, you'll draw a card. The same is true if The Scorpion God dies with a -1/-1 counter on it."
         },
         {
           "date": "2017-06-27",
@@ -15091,7 +17951,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "The “next end step” refers to the next end step that occurs, not the end step of the next turn. If this creature dies before a turn’s end step (for example, during combat), it will be returned to its owner’s hand at the beginning of that turn’s end step."
+          "text": "The \"next end step\" refers to the next end step that occurs, not the end step of the next turn. If this creature dies before a turn's end step (for example, during combat), it will be returned to its owner's hand at the beginning of that turn's end step."
         }
       ],
       "subtypes": [
@@ -15176,7 +18036,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -15194,7 +18074,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Unraveling Mummy’s abilities can target itself while it’s attacking."
+          "text": "Unraveling Mummy's abilities can target itself while it's attacking."
         },
         {
           "date": "2017-06-27",
@@ -15281,7 +18161,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -15302,15 +18202,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -15318,23 +18218,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Destroy target attacking or blocking creature.",
@@ -15409,7 +18309,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -15430,7 +18350,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw two cards, then discard two cards.",
@@ -15505,7 +18425,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -15526,15 +18466,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -15542,23 +18482,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Return target nonland permanent to its owner's hand.",
@@ -15633,7 +18573,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -15654,7 +18614,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget opponent discards two cards.",
@@ -15729,7 +18689,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -15750,15 +18730,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -15766,23 +18746,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
@@ -15857,7 +18837,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -15878,7 +18878,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature gets +2/+0 and gains haste until end of turn.",
@@ -15953,7 +18953,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -15974,15 +18994,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -15990,23 +19010,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Struggle deals damage to target creature equal to the number of lands you control.",
@@ -16081,7 +19101,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -16106,7 +19146,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach player shuffles his or her graveyard into his or her library.",
@@ -16181,7 +19221,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -16202,15 +19262,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -16218,27 +19278,27 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         },
         {
           "date": "2017-06-27",
-          "text": "The value of X is determined only as Appeal begins to resolve. It won’t change later in the turn if the number of creatures you control changes."
+          "text": "The value of X is determined only as Appeal begins to resolve. It won't change later in the turn if the number of creatures you control changes."
         }
       ],
       "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of creatures you control.",
@@ -16313,7 +19373,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -16334,11 +19414,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You may cast Authority without choosing any target creatures. Creatures you control will still gain vigilance until end of turn. However, if you choose any targets and each of those targets become illegal before Authority resolves, the spell will be countered and your creatures won’t gain vigilance."
+          "text": "You may cast Authority without choosing any target creatures. Creatures you control will still gain vigilance until end of turn. However, if you choose any targets and each of those targets become illegal before Authority resolves, the spell will be countered and your creatures won't gain vigilance."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTap up to two target creatures your opponents control. Creatures you control gain vigilance until end of turn.",
@@ -16413,7 +19493,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -16434,15 +19534,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -16450,27 +19550,27 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         },
         {
           "date": "2017-06-27",
-          "text": "You are a permanent’s owner if the card representing it began the game in your deck, or if it’s a token that entered the battlefield under your control. Leave can target a permanent you own but don’t control."
+          "text": "You are a permanent's owner if the card representing it began the game in your deck, or if it's a token that entered the battlefield under your control. Leave can target a permanent you own but don't control."
         }
       ],
       "text": "Return any number of target permanents you own to your hand.",
@@ -16545,7 +19645,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -16566,7 +19686,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDiscard any number of cards, then draw that many cards.",
@@ -16641,7 +19761,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -16662,15 +19802,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -16678,23 +19818,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         }
       ],
       "text": "Scry 3.",
@@ -16769,7 +19909,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -16790,15 +19950,15 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "For Believe, you put the top card of your library into your hand if you don’t put it onto the battlefield for any reason, whether it’s not a creature card or whether you just didn’t want to put it onto the battlefield."
+          "text": "For Believe, you put the top card of your library into your hand if you don't put it onto the battlefield for any reason, whether it's not a creature card or whether you just didn't want to put it onto the battlefield."
         },
         {
           "date": "2017-06-27",
-          "text": "If you don’t put the top card of your library onto the battlefield, you don’t reveal it before putting it into your hand."
+          "text": "If you don't put the top card of your library onto the battlefield, you don't reveal it before putting it into your hand."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nLook at the top card of your library. You may put it onto the battlefield if it's a creature card. If you don't, put it into your hand.",
@@ -16873,7 +20033,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -16894,15 +20074,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -16910,27 +20090,27 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         },
         {
           "date": "2017-06-27",
-          "text": "You can’t target the same creature twice with Grind to give it two -1/-1 counters."
+          "text": "You can't target the same creature twice with Grind to give it two -1/-1 counters."
         }
       ],
       "text": "Put a -1/-1 counter on each of up to two target creatures.",
@@ -17005,7 +20185,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -17026,11 +20226,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If one of Dust’s target creatures loses its -1/-1 counters, leaves the battlefield, or otherwise becomes an illegal target before the spell resolves, it won’t be exiled, but the remaining legal targets will be exiled."
+          "text": "If one of Dust's target creatures loses its -1/-1 counters, leaves the battlefield, or otherwise becomes an illegal target before the spell resolves, it won't be exiled, but the remaining legal targets will be exiled."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nExile any number of target creatures that have -1/-1 counters on them.",
@@ -17105,7 +20305,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -17126,15 +20346,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -17142,23 +20362,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         },
         {
           "date": "2017-06-27",
@@ -17237,7 +20457,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -17262,7 +20502,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger."
+          "text": "The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger."
         },
         {
           "date": "2017-06-27",
@@ -17270,27 +20510,27 @@
         },
         {
           "date": "2017-06-27",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2017-06-27",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. A different mode can’t be chosen."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. A different mode can't be chosen."
         },
         {
           "date": "2017-06-27",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Torment of Hailfire does), the copy will have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Torment of Hailfire does), the copy will have the same value of X."
         },
         {
           "date": "2017-06-27",
-          "text": "If the spell has damage divided as it was cast (like Chandra’s Pyrohelix), the division can’t be changed (although the targets receiving that damage still can)."
+          "text": "If the spell has damage divided as it was cast (like Chandra's Pyrohelix), the division can't be changed (although the targets receiving that damage still can)."
         },
         {
           "date": "2017-06-27",
-          "text": "The controller of a copy can’t choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
+          "text": "The controller of a copy can't choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
@@ -17365,7 +20605,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -17386,15 +20646,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you’d cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
+          "text": "Split cards with aftermath have a new frame treatment—the half you can cast from your hand is oriented the same as other cards you'd cast from your hand, while the half you can cast from your graveyard is a traditional split card half. This frame treatment is for your convenience and has no rules significance."
         },
         {
           "date": "2017-04-18",
-          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you’re casting. The characteristics of the half of the card you didn’t cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
+          "text": "All split cards have two card faces on a single card, and you put a split card onto the stack with only the half you're casting. The characteristics of the half of the card you didn't cast are ignored while the spell is on the stack. For example, if an effect prevents you from casting green spells, you can cast Destined of Destined // Lead, but not Lead."
         },
         {
           "date": "2017-04-18",
-          "text": "Each split card is a single card. For example, if you discard one, you’ve discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
+          "text": "Each split card is a single card. For example, if you discard one, you've discarded one card, not two. If an effect counts the number of instant and sorcery cards in your graveyard, Destined // Lead counts once, not twice."
         },
         {
           "date": "2017-04-18",
@@ -17402,23 +20662,23 @@
         },
         {
           "date": "2017-04-18",
-          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can’t cast Destined. This is a change from the previous rules for split cards."
+          "text": "While not on the stack, the characteristics of a split card are the combination of its two halves. For example, Destined // Lead is a green and black card, it is both an instant card and a sorcery card, and its converted mana cost is 6. This means that if an effect allows you to cast a card with converted mana cost 2 from your hand, you can't cast Destined. This is a change from the previous rules for split cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If you cast the first half of a split card with aftermath during your turn, you’ll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it’s legal for you to do so."
+          "text": "If you cast the first half of a split card with aftermath during your turn, you'll have priority immediately after it resolves. You can cast the half with aftermath from your graveyard before any player can take any other action if it's legal for you to do so."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can’t cast the half with aftermath."
+          "text": "If another effect allows you to cast a split card with aftermath from any zone other than a graveyard, you can't cast the half with aftermath."
         },
         {
           "date": "2017-04-18",
-          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you’ll exile the card if it would leave the stack."
+          "text": "If another effect allows you to cast a split card with aftermath from a graveyard, you may cast either half. If you cast the half that has aftermath, you'll exile the card if it would leave the stack."
         },
         {
           "date": "2017-04-18",
-          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it’s countered, or it leaves the stack in some other way."
+          "text": "A spell with aftermath cast from a graveyard will always be exiled afterward, whether it resolves, it's countered, or it leaves the stack in some other way."
         },
         {
           "date": "2017-06-27",
@@ -17430,7 +20690,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Driven and Despair each affect only creatures you control at the time it resolves. Creatures you begin to control later in the turn won’t gain the keyword ability or the triggered ability."
+          "text": "Driven and Despair each affect only creatures you control at the time it resolves. Creatures you begin to control later in the turn won't gain the keyword ability or the triggered ability."
         }
       ],
       "text": "Until end of turn, creatures you control gain trample and \"Whenever this creature deals combat damage to a player, draw a card.\"",
@@ -17505,7 +20765,27 @@
       "layout": "aftermath",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -17534,11 +20814,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Driven and Despair each affect only creatures you control at the time it resolves. Creatures you begin to control later in the turn won’t gain the keyword ability or the triggered ability."
+          "text": "Driven and Despair each affect only creatures you control at the time it resolves. Creatures you begin to control later in the turn won't gain the keyword ability or the triggered ability."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can’t try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
+          "text": "Once you've started to cast a spell with aftermath from your graveyard, the card is immediately moved to the stack. Opponents can't try to stop the ability by exiling the card with an effect such as that of Crook of Condemnation."
         }
       ],
       "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nUntil end of turn, creatures you control gain menace and \"Whenever this creature deals combat damage to a player, that player discards a card.\"",
@@ -17608,7 +20888,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -17625,19 +20925,19 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "A token permanent with cycling will go to your graveyard before ceasing to exist. It won’t be exiled. Similarly, a nontoken permanent that lost cycling while it was on the battlefield will also go to your graveyard."
+          "text": "A token permanent with cycling will go to your graveyard before ceasing to exist. It won't be exiled. Similarly, a nontoken permanent that lost cycling while it was on the battlefield will also go to your graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "If you cycle an instant card, you may cast it from your graveyard right away before any player may take any other action. If you do, that spell will resolve before the cycling ability. If you cycle a noninstant card without flash, you can’t cast it until after the cycling ability has resolved."
+          "text": "If you cycle an instant card, you may cast it from your graveyard right away before any player may take any other action. If you do, that spell will resolve before the cycling ability. If you cycle a noninstant card without flash, you can't cast it until after the cycling ability has resolved."
         },
         {
           "date": "2017-06-27",
-          "text": "Abandoned Sarcophagus doesn’t grant you permission to do anything with those cards except cast them. For example, you can’t cycle nonland cards with cycling from your graveyard."
+          "text": "Abandoned Sarcophagus doesn't grant you permission to do anything with those cards except cast them. For example, you can't cycle nonland cards with cycling from your graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "Certain older cards have variants of cycling, such as basic landcycling or Wizardcycling. Abandoned Sarcophagus’s effect lets you cast these cards and exiles them if they weren’t discarded for their cycling variant’s ability."
+          "text": "Certain older cards have variants of cycling, such as basic landcycling or Wizardcycling. Abandoned Sarcophagus's effect lets you cast these cards and exiles them if they weren't discarded for their cycling variant's ability."
         }
       ],
       "text": "You may cast nonland cards with cycling from your graveyard.\nIf a card with cycling would be put into your graveyard from anywhere and it wasn't cycled, exile it instead.",
@@ -17707,7 +21007,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -17787,7 +21107,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -17812,15 +21152,15 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict causes the defending player to lose life; it’s not damage or combat damage."
+          "text": "Afflict causes the defending player to lose life; it's not damage or combat damage."
         },
         {
           "date": "2017-06-27",
-          "text": "If a creature is attacking a planeswalker, that planeswalker’s controller is the defending player."
+          "text": "If a creature is attacking a planeswalker, that planeswalker's controller is the defending player."
         },
         {
           "date": "2017-06-27",
-          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won’t deal combat damage in time to save that player."
+          "text": "Afflict resolves before combat damage is dealt. If this loss of life brings a player to 0 life or less, that player loses the game immediately. A blocking creature with lifelink won't deal combat damage in time to save that player."
         }
       ],
       "subtypes": [
@@ -17892,7 +21232,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -17909,11 +21269,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "The ability of God-Pharaoh’s Gift doesn’t target the creature card you’ll exile. You choose one as the ability resolves. No player may take actions between the time you choose a creature card to exile and the time you create the token."
+          "text": "The ability of God-Pharaoh's Gift doesn't target the creature card you'll exile. You choose one as the ability resolves. No player may take actions between the time you choose a creature card to exile and the time you create the token."
         },
         {
           "date": "2017-06-27",
-          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics it specifically modifies. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else, except the characteristics it specifically modifies. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-06-27",
@@ -17921,11 +21281,11 @@
         },
         {
           "date": "2017-06-27",
-          "text": "Unlike the tokens created by an eternalize ability, this token has the mana cost and thus converted mana cost of the card it’s copying."
+          "text": "Unlike the tokens created by an eternalize ability, this token has the mana cost and thus converted mana cost of the card it's copying."
         },
         {
           "date": "2017-06-27",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         }
       ],
       "text": "At the beginning of combat on your turn, you may exile a creature card from your graveyard. If you do, create a token that's a copy of that card, except it's a 4/4 black Zombie. It gains haste until end of turn.",
@@ -17995,7 +21355,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -18082,7 +21462,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -18100,15 +21500,15 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Hollow One’s cost is reduced even if the cards you’ve cycled or discarded aren’t in your graveyard."
+          "text": "Hollow One's cost is reduced even if the cards you've cycled or discarded aren't in your graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "Once you’ve discarded three cards, Hollow One costs {0} to cast. It won’t stop at {1} or cost negative amounts of mana."
+          "text": "Once you've discarded three cards, Hollow One costs {0} to cast. It won't stop at {1} or cost negative amounts of mana."
         },
         {
           "date": "2017-06-27",
-          "text": "Hollow One’s first ability doesn’t give you permission to discard cards. You’ll need another effect that instructs or allows you to discard them."
+          "text": "Hollow One's first ability doesn't give you permission to discard cards. You'll need another effect that instructs or allows you to discard them."
         }
       ],
       "subtypes": [
@@ -18182,6 +21582,10 @@
       "imageName": "manalith",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -18281,7 +21685,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -18298,35 +21722,35 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "Once Mirage Mirror’s ability resolves, it no longer has that ability."
+          "text": "Once Mirage Mirror's ability resolves, it no longer has that ability."
         },
         {
           "date": "2017-06-27",
-          "text": "Mirage Mirror copies the printed values of the target permanent, plus any copy effects that have been applied to it. It won’t copy counters on that permanent or effects that have changed its power, toughness, types, color, or so on. Notably, it won’t copy effects that made the target permanent become a creature."
+          "text": "Mirage Mirror copies the printed values of the target permanent, plus any copy effects that have been applied to it. It won't copy counters on that permanent or effects that have changed its power, toughness, types, color, or so on. Notably, it won't copy effects that made the target permanent become a creature."
         },
         {
           "date": "2017-06-27",
-          "text": "If Mirage Mirror copies a permanent that’s copying something else, it will become whatever the target is copying."
+          "text": "If Mirage Mirror copies a permanent that's copying something else, it will become whatever the target is copying."
         },
         {
           "date": "2017-06-27",
-          "text": "If you activate Mirage Mirror’s ability multiple times in a turn in response to itself, then each time one of those abilities resolves, it will overwrite whatever Mirage Mirror is copying. Mirage Mirror will wind up as a copy of the permanent targeted by the last ability to resolve. When the turn ends, all instances of the ability will wear off at the same time."
+          "text": "If you activate Mirage Mirror's ability multiple times in a turn in response to itself, then each time one of those abilities resolves, it will overwrite whatever Mirage Mirror is copying. Mirage Mirror will wind up as a copy of the permanent targeted by the last ability to resolve. When the turn ends, all instances of the ability will wear off at the same time."
         },
         {
           "date": "2017-06-27",
-          "text": "If an effect begins to apply to Mirage Mirror before it becomes a copy of another permanent, that effect will continue to apply. For example, if Mirage Mirror is activated twice in response to itself targeting first Rampaging Hippo then Frilled Sandwalla, the ability it has while it’s a copy of Frilled Sandwalla can be activated and its effect will continue to apply while Mirage Mirror is a copy of Rampaging Hippo."
+          "text": "If an effect begins to apply to Mirage Mirror before it becomes a copy of another permanent, that effect will continue to apply. For example, if Mirage Mirror is activated twice in response to itself targeting first Rampaging Hippo then Frilled Sandwalla, the ability it has while it's a copy of Frilled Sandwalla can be activated and its effect will continue to apply while Mirage Mirror is a copy of Rampaging Hippo."
         },
         {
           "date": "2017-06-27",
-          "text": "If Mirage Mirror becomes a creature the same turn it enters the battlefield, you can’t attack with it or use any of its {T} abilities (if it gains any) unless it has haste."
+          "text": "If Mirage Mirror becomes a creature the same turn it enters the battlefield, you can't attack with it or use any of its {T} abilities (if it gains any) unless it has haste."
         },
         {
           "date": "2017-06-27",
-          "text": "If Mirage Mirror becomes a copy of a legendary permanent you control, you’ll put one of them into your graveyard. The same is true if it becomes a copy of a planeswalker creature you control (such as Gideon of the Trials that’s become a creature)."
+          "text": "If Mirage Mirror becomes a copy of a legendary permanent you control, you'll put one of them into your graveyard. The same is true if it becomes a copy of a planeswalker creature you control (such as Gideon of the Trials that's become a creature)."
         },
         {
           "date": "2017-06-27",
-          "text": "If Mirage Mirror becomes a copy of an Aura, it’s put into its owner’s graveyard unless it’s somehow attached to an appropriate object or player already. If it becomes a copy of an Equipment and is attached to a creature, it’ll become unattached when it becomes a non-Equipment artifact again."
+          "text": "If Mirage Mirror becomes a copy of an Aura, it's put into its owner's graveyard unless it's somehow attached to an appropriate object or player already. If it becomes a copy of an Equipment and is attached to a creature, it'll become unattached when it becomes a non-Equipment artifact again."
         }
       ],
       "text": "{2}: Mirage Mirror becomes a copy of target artifact, creature, enchantment, or land until end of turn.",
@@ -18396,7 +21820,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -18476,6 +21920,10 @@
       "imageName": "traveler's amulet",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -18583,7 +22031,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -18601,7 +22069,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn’t matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
+          "text": "If an ability checks whether you control a Desert or there is a Desert card in your graveyard, having more than one doesn't matter. Controlling one is the same as controlling five. There is also no extra bonus for both controlling one and having one in your graveyard."
         }
       ],
       "subtypes": [
@@ -18680,7 +22148,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -18761,7 +22249,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -18777,7 +22285,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -18851,7 +22359,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -18867,7 +22395,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -18941,7 +22469,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -18957,7 +22505,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -19031,7 +22579,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19047,7 +22615,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -19121,7 +22689,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19137,7 +22725,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -19209,7 +22797,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19225,15 +22833,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
-          "text": "Dunes of the Dead’s second ability doesn’t allow you to sacrifice it whenever you’d like. You must find another way to get Dunes of the Dead into the graveyard."
+          "text": "Dunes of the Dead's second ability doesn't allow you to sacrifice it whenever you'd like. You must find another way to get Dunes of the Dead into the graveyard."
         },
         {
           "date": "2017-06-27",
-          "text": "If you sacrifice Dunes of the Dead to pay the activation cost of an ability, you’ll create the Zombie token before that activated ability resolves."
+          "text": "If you sacrifice Dunes of the Dead to pay the activation cost of an ability, you'll create the Zombie token before that activated ability resolves."
         }
       ],
       "subtypes": [
@@ -19304,7 +22912,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19320,7 +22948,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
@@ -19328,7 +22956,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If you exile a creature that isn’t a creature card with the second ability of Endless Sands (such as a token creature or a land that has become a creature), the third ability won’t return that token or card from exile."
+          "text": "If you exile a creature that isn't a creature card with the second ability of Endless Sands (such as a token creature or a land that has become a creature), the third ability won't return that token or card from exile."
         }
       ],
       "subtypes": [
@@ -19402,7 +23030,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19418,11 +23066,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
-          "text": "If a Desert has an ability with a cost of “Sacrifice a Desert,” you can sacrifice that Desert to pay the cost for its own ability."
+          "text": "If a Desert has an ability with a cost of \"Sacrifice a Desert,\" you can sacrifice that Desert to pay the cost for its own ability."
         }
       ],
       "subtypes": [
@@ -19494,7 +23142,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19510,11 +23178,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
-          "text": "If Hostile Desert becomes a creature the same turn it enters the battlefield, you can’t attack with it or tap it for mana."
+          "text": "If Hostile Desert becomes a creature the same turn it enters the battlefield, you can't attack with it or tap it for mana."
         }
       ],
       "subtypes": [
@@ -19588,7 +23256,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19604,11 +23292,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
-          "text": "If a Desert has an ability with a cost of “Sacrifice a Desert,” you can sacrifice that Desert to pay the cost for its own ability."
+          "text": "If a Desert has an ability with a cost of \"Sacrifice a Desert,\" you can sacrifice that Desert to pay the cost for its own ability."
         }
       ],
       "subtypes": [
@@ -19682,7 +23370,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19698,11 +23406,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
-          "text": "If a Desert has an ability with a cost of “Sacrifice a Desert,” you can sacrifice that Desert to pay the cost for its own ability."
+          "text": "If a Desert has an ability with a cost of \"Sacrifice a Desert,\" you can sacrifice that Desert to pay the cost for its own ability."
         }
       ],
       "subtypes": [
@@ -19776,7 +23484,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19792,15 +23520,15 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
-          "text": "In a Two-Headed Giant game, Ramunap Ruins’s last ability causes it to deal a total of 4 damage to the opposing team."
+          "text": "In a Two-Headed Giant game, Ramunap Ruins's last ability causes it to deal a total of 4 damage to the opposing team."
         },
         {
           "date": "2017-06-27",
-          "text": "If a Desert has an ability with a cost of “Sacrifice a Desert,” you can sacrifice that Desert to pay the cost for its own ability."
+          "text": "If a Desert has an ability with a cost of \"Sacrifice a Desert,\" you can sacrifice that Desert to pay the cost for its own ability."
         }
       ],
       "subtypes": [
@@ -19872,7 +23600,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19888,7 +23636,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
@@ -19896,7 +23644,7 @@
         },
         {
           "date": "2017-06-27",
-          "text": "If a Desert has an ability with a cost of “Sacrifice a Desert,” you can sacrifice that Desert to pay the cost for its own ability."
+          "text": "If a Desert has an ability with a cost of \"Sacrifice a Desert,\" you can sacrifice that Desert to pay the cost for its own ability."
         }
       ],
       "subtypes": [
@@ -19970,7 +23718,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -19986,11 +23754,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
-          "text": "If a Desert has an ability with a cost of “Sacrifice a Desert,” you can sacrifice that Desert to pay the cost for its own ability."
+          "text": "If a Desert has an ability with a cost of \"Sacrifice a Desert,\" you can sacrifice that Desert to pay the cost for its own ability."
         }
       ],
       "subtypes": [
@@ -20062,7 +23830,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -20078,11 +23866,11 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         },
         {
           "date": "2017-06-27",
-          "text": "To activate the last ability, you may tap any untapped creature you control, including one you haven’t controlled continuously since the beginning of your most recent turn. (Note that tapping the creature doesn’t use {T} [the tap symbol].)"
+          "text": "To activate the last ability, you may tap any untapped creature you control, including one you haven't controlled continuously since the beginning of your most recent turn. (Note that tapping the creature doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -21347,24 +25135,24 @@
           "multiverseid": 432080
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 432270
-        },
-        {
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 432469
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 432477
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 431275
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 432478
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 431283
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 431284
         }
       ],
       "id": "5b68cb907fb7ece908f4f9f0dca255c881ebdd4e",
@@ -21626,11 +25414,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "树林",
-          "multiverseid": 432669
-        },
-        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 432868
@@ -21726,16 +25509,6 @@
           "multiverseid": 432271
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Floresta",
-          "multiverseid": 432280
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Floresta",
-          "multiverseid": 432281
-        },
-        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 432470
@@ -21749,6 +25522,21 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 432480
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 431276
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 431285
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 431286
         }
       ],
       "id": "abb25377c31556c18e059e9dede962484a9e99b8",
@@ -23634,19 +27422,19 @@
           "multiverseid": 432269
         },
         {
-          "language": "Spanish",
-          "name": "Pantano",
-          "multiverseid": 431274
+          "language": "Portuguese (Brazil)",
+          "name": "Pântano",
+          "multiverseid": 432276
         },
         {
-          "language": "Spanish",
-          "name": "Pantano",
-          "multiverseid": 431281
+          "language": "Portuguese (Brazil)",
+          "name": "Pântano",
+          "multiverseid": 432277
         },
         {
-          "language": "Spanish",
-          "name": "Pantano",
-          "multiverseid": 431282
+          "language": "Russian",
+          "name": "Болото",
+          "multiverseid": 432468
         }
       ],
       "id": "3cabcad77de60bb5b736716d1170c20ea574f51e",
@@ -24017,19 +27805,19 @@
           "multiverseid": 432269
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 432276
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 431274
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 432277
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 431281
         },
         {
-          "language": "Russian",
-          "name": "Болото",
-          "multiverseid": 432468
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 431282
         }
       ],
       "id": "a3f0b36e4ae22931b95c0f356e415e8051b2bd6f",
@@ -24779,24 +28567,24 @@
           "multiverseid": 432080
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 432270
-        },
-        {
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 432469
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 432477
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 431275
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 432478
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 431283
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 431284
         }
       ],
       "id": "6a3175628ed1d070c3312335a5c255c745f0577a",
@@ -25058,11 +28846,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "树林",
-          "multiverseid": 432669
-        },
-        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 432868
@@ -25158,16 +28941,6 @@
           "multiverseid": 432271
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Floresta",
-          "multiverseid": 432280
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Floresta",
-          "multiverseid": 432281
-        },
-        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 432470
@@ -25181,6 +28954,21 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 432480
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 431276
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 431285
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 431286
         }
       ],
       "id": "8f9397777cc66c1a2f16986668c939967909db04",
@@ -25881,7 +29669,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -25899,11 +29707,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You can activate Nissa’s first ability with fewer than four targets. For example, you could target one creature and two lands, or no creatures and two lands. You could even choose no targets at all."
+          "text": "You can activate Nissa's first ability with fewer than four targets. For example, you could target one creature and two lands, or no creatures and two lands. You could even choose no targets at all."
         },
         {
           "date": "2017-06-27",
-          "text": "While resolving Nissa’s last ability, all creatures and lands put onto the battlefield this way enter at the same time. If any have triggered abilities that trigger on something else entering the battlefield, they’ll see each other."
+          "text": "While resolving Nissa's last ability, all creatures and lands put onto the battlefield this way enter at the same time. If any have triggered abilities that trigger on something else entering the battlefield, they'll see each other."
         }
       ],
       "subtypes": [
@@ -25983,7 +29791,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -26001,11 +29829,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You can activate Avid Reclaimer’s ability even if you don’t have anything to spend that mana on. You’ll still gain 2 life if you control a Nissa planeswalker."
+          "text": "You can activate Avid Reclaimer's ability even if you don't have anything to spend that mana on. You'll still gain 2 life if you control a Nissa planeswalker."
         },
         {
           "date": "2017-06-27",
-          "text": "Avid Reclaimer’s ability is a mana ability. It doesn’t use the stack and can’t be responded to. You’ll immediately add mana to your mana pool and gain 2 life, if applicable."
+          "text": "Avid Reclaimer's ability is a mana ability. It doesn't use the stack and can't be responded to. You'll immediately add mana to your mana pool and gain 2 life, if applicable."
         }
       ],
       "subtypes": [
@@ -26086,7 +29914,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -26177,7 +30025,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -26194,11 +30062,11 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You can find any or all of the cards listed with Nissa’s Encouragement. You could even find none, but that wouldn’t be very encouraging."
+          "text": "You can find any or all of the cards listed with Nissa's Encouragement. You could even find none, but that wouldn't be very encouraging."
         },
         {
           "date": "2017-06-27",
-          "text": "Nissa’s Encouragement can’t be used to find a card with the land type Forest that isn’t also named Forest (such as Sheltered Thicket from the Amonkhet set)."
+          "text": "Nissa's Encouragement can't be used to find a card with the land type Forest that isn't also named Forest (such as Sheltered Thicket from the Amonkhet set)."
         }
       ],
       "text": "Search your library and graveyard for a card named Forest, a card named Brambleweft Behemoth, and a card named Nissa, Genesis Mage. Reveal those cards, put them into your hand, then shuffle your library.",
@@ -26391,7 +30259,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -26409,19 +30297,19 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "While resolving Nicol Bolas’s first ability, your opponent chooses a card to be discarded without revealing it, chooses a nonland permanent to be sacrificed, or chooses to do neither. Then that player discards that card, sacrifices that permanent, or loses 3 life. Your opponent can always choose to lose 3 life, even if he or she has cards to discard or nonland permanents to sacrifice."
+          "text": "While resolving Nicol Bolas's first ability, your opponent chooses a card to be discarded without revealing it, chooses a nonland permanent to be sacrificed, or chooses to do neither. Then that player discards that card, sacrifices that permanent, or loses 3 life. Your opponent can always choose to lose 3 life, even if he or she has cards to discard or nonland permanents to sacrifice."
         },
         {
           "date": "2017-06-27",
-          "text": "In a multiplayer game, each opponent in turn order makes his or her choice for Nicol Bolas’s first ability, then all of the actions occur simultaneously. Opponents will know choices made by earlier opponents when making their choices, although a card chosen to be discarded this way isn’t revealed until it’s discarded."
+          "text": "In a multiplayer game, each opponent in turn order makes his or her choice for Nicol Bolas's first ability, then all of the actions occur simultaneously. Opponents will know choices made by earlier opponents when making their choices, although a card chosen to be discarded this way isn't revealed until it's discarded."
         },
         {
           "date": "2017-06-27",
-          "text": "If the target of Nicol Bolas’s second ability becomes illegal, the ability is countered and you won’t draw a card. If that target is legal but can’t be destroyed, most likely because it has indestructible, you still draw a card."
+          "text": "If the target of Nicol Bolas's second ability becomes illegal, the ability is countered and you won't draw a card. If that target is legal but can't be destroyed, most likely because it has indestructible, you still draw a card."
         },
         {
           "date": "2017-06-27",
-          "text": "If Nicol Bolas’s third ability causes each opponent to have 0 or less life, but it also causes you to try to draw more cards than you have in your library, the game ends in a draw."
+          "text": "If Nicol Bolas's third ability causes each opponent to have 0 or less life, but it also causes you to try to draw more cards than you have in your library, the game ends in a draw."
         }
       ],
       "subtypes": [
@@ -26500,7 +30388,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -26518,7 +30426,7 @@
       "rulings": [
         {
           "date": "2017-06-27",
-          "text": "You choose a target for Wasp of the Bitter End’s triggered ability right after casting a Bolas planeswalker spell, but you don’t choose whether to sacrifice Wasp of the Bitter End or not until that ability resolves. If the creature becomes an illegal target, the entire ability is countered and you can’t sacrifice Wasp of the Bitter End."
+          "text": "You choose a target for Wasp of the Bitter End's triggered ability right after casting a Bolas planeswalker spell, but you don't choose whether to sacrifice Wasp of the Bitter End or not until that ability resolves. If the creature becomes an illegal target, the entire ability is countered and you can't sacrifice Wasp of the Bitter End."
         }
       ],
       "subtypes": [
@@ -26599,7 +30507,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -26690,7 +30618,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],

--- a/json/ICE.json
+++ b/json/ICE.json
@@ -396,11 +396,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2013-04-15",
@@ -637,11 +637,11 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "Adds the snow or removes the snow supertype to or from a land. Adding snow doesn’t overwrite other supertypes."
+          "text": "Adds the snow or removes the snow supertype to or from a land. Adding snow doesn't overwrite other supertypes."
         },
         {
           "date": "2006-10-15",
-          "text": "Can’t be used on a dual land to add the Snow Supertype even though it is a basic land subtype. You can use it on any land to remove the snow supertype."
+          "text": "Can't be used on a dual land to add the Snow Supertype even though it is a basic land subtype. You can use it on any land to remove the snow supertype."
         }
       ],
       "text": "{2}, {T}: Target snow land is no longer snow.\n{2}, {T}: Target nonsnow basic land becomes snow.",
@@ -890,7 +890,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "A card is “above” another card in your graveyard if it was put into that graveyard later."
+          "text": "A card is \"above\" another card in your graveyard if it was put into that graveyard later."
         },
         {
           "date": "2008-10-01",
@@ -902,11 +902,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -1040,7 +1040,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Barbarian raids were a concern to those living in the northwest provinces, but the Skyknights never dealt with the problem in a systematic way. They thought of the Balduvians as an ‘amusing model' of their forebears' culture.\"\n—Kjeldor: Ice Civilization",
+      "flavor": "\"Barbarian raids were a concern to those living in the northwest provinces, but the Skyknights never dealt with the problem in a systematic way. They thought of the Balduvians as an 'amusing model' of their forebears' culture.\"\n—Kjeldor: Ice Civilization",
       "id": "4079d8c24b881241766a971d90e445e850537854",
       "imageName": "balduvian barbarians",
       "layout": "normal",
@@ -1187,11 +1187,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2008-10-01",
-          "text": "If an affected land later loses the supertype snow, Balduvian Conjurer’s effect doesn’t end. The land will remain a creature until end of turn."
+          "text": "If an affected land later loses the supertype snow, Balduvian Conjurer's effect doesn't end. The land will remain a creature until end of turn."
         }
       ],
       "subtypes": [
@@ -1310,7 +1310,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -1377,7 +1377,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You choose a land subtype, and if the defending player controls any snow lands with that subtype, the targeted creature can’t be blocked."
+          "text": "You choose a land subtype, and if the defending player controls any snow lands with that subtype, the targeted creature can't be blocked."
         }
       ],
       "subtypes": [
@@ -1473,7 +1473,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -2061,7 +2061,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -2173,7 +2173,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -2242,7 +2242,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -2410,7 +2410,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose “colorless” as a color."
+          "text": "You can't choose \"colorless\" as a color."
         },
         {
           "date": "2009-10-01",
@@ -2418,15 +2418,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Call to Arms changes controllers, it will continue to check the nontoken permanents controlled by the player chosen as it entered the battlefield, even if that player isn’t an opponent of its current controller."
+          "text": "If Call to Arms changes controllers, it will continue to check the nontoken permanents controlled by the player chosen as it entered the battlefield, even if that player isn't an opponent of its current controller."
         },
         {
           "date": "2009-10-01",
-          "text": "The game continually counts the number of nontoken permanents of each color the chosen player controls. Multicolored ones are counted for each of their colors; colorless ones are ignored. The moment the number of nontoken permanents of the chosen color that player controls is less than or equal to the number of permanents of one of the other colors that player controls, Call to Arms’s second ability stops giving white creatures +1/+1 and its third ability triggers. Call to Arms will be sacrificed when the third ability resolves, even if those numbers have changed by then."
+          "text": "The game continually counts the number of nontoken permanents of each color the chosen player controls. Multicolored ones are counted for each of their colors; colorless ones are ignored. The moment the number of nontoken permanents of the chosen color that player controls is less than or equal to the number of permanents of one of the other colors that player controls, Call to Arms's second ability stops giving white creatures +1/+1 and its third ability triggers. Call to Arms will be sacrificed when the third ability resolves, even if those numbers have changed by then."
         },
         {
           "date": "2009-10-01",
-          "text": "Call to Arms’s third ability is a “state trigger.” Once a state trigger triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "Call to Arms's third ability is a \"state trigger.\" Once a state trigger triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         }
       ],
       "text": "As Call to Arms enters the battlefield, choose a color and an opponent.\nWhite creatures get +1/+1 as long as the chosen color is the most common color among nontoken permanents the chosen player controls but isn't tied for most common.\nWhen the chosen color isn't the most common color among nontoken permanents the chosen player controls or is tied for most common, sacrifice Call to Arms.",
@@ -2634,7 +2634,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This creature’s changing of controllers is a new effect each upkeep so it will take precedence over any other control effects. This means that using another control-changing effect won’t guarantee that you keep it."
+          "text": "This creature's changing of controllers is a new effect each upkeep so it will take precedence over any other control effects. This means that using another control-changing effect won't guarantee that you keep it."
         }
       ],
       "subtypes": [
@@ -2870,7 +2870,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2946,7 +2946,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3022,7 +3022,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3102,7 +3102,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3178,7 +3178,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -3283,7 +3283,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -3439,7 +3439,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -3583,7 +3583,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This only targets the Aura and not either creature. This means it can move Auras onto a creature which can’t normally be targeted by spells and abilities if the Aura is legal on that creature."
+          "text": "This only targets the Aura and not either creature. This means it can move Auras onto a creature which can't normally be targeted by spells and abilities if the Aura is legal on that creature."
         }
       ],
       "text": "{4}, {T}: Attach target Aura attached to a creature to another creature.",
@@ -3691,15 +3691,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Once the creature is returned to the battlefield, Dance of the Dead can’t be attached to anything other than it (unless Dance of the Dead somehow manages to put a different creature onto the battlefield). Attempting to move Dance of the Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Dance of the Dead can't be attached to anything other than it (unless Dance of the Dead somehow manages to put a different creature onto the battlefield). Attempting to move Dance of the Dead to another creature won't work."
         },
         {
           "date": "2008-04-01",
-          "text": "If the creature card put onto the battlefield has protection from black (or anything that prevents this from legally being attached), this won’t be able to attach to it. Then this will go to the graveyard as a state-based action, causing the creature to be sacrificed."
+          "text": "If the creature card put onto the battlefield has protection from black (or anything that prevents this from legally being attached), this won't be able to attach to it. Then this will go to the graveyard as a state-based action, causing the creature to be sacrificed."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -3992,7 +3992,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -4012,11 +4012,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Deflection, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Deflection, even if all but one of those targets has become illegal."
         },
         {
           "date": "2009-02-01",
-          "text": "If a spell targets the same player or object multiple times, you can’t target it with Deflection."
+          "text": "If a spell targets the same player or object multiple times, you can't target it with Deflection."
         }
       ],
       "text": "Change the target of target spell with a single target.",
@@ -4069,7 +4069,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "There is no way to make this card affect your opponent. It affects “you”, and “you” means the controller of the spell. It has no targets."
+          "text": "There is no way to make this card affect your opponent. It affects \"you\", and \"you\" means the controller of the spell. It has no targets."
         },
         {
           "date": "2004-10-04",
@@ -4077,11 +4077,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You don’t name a card until Demonic Consultation resolves."
+          "text": "You don't name a card until Demonic Consultation resolves."
         },
         {
           "date": "2008-10-01",
-          "text": "If you don’t reveal the named card (perhaps because it was in the top six cards of your library), you’ll end up exiling your entire library. You don’t lose the game at that point, but will lose the next time you’re instructed to draw a card."
+          "text": "If you don't reveal the named card (perhaps because it was in the top six cards of your library), you'll end up exiling your entire library. You don't lose the game at that point, but will lose the next time you're instructed to draw a card."
         }
       ],
       "text": "Choose a card name. Exile the top six cards of your library, then reveal cards from the top of your library until you reveal a card with the chosen name. Put that card into your hand and exile all other cards revealed this way.",
@@ -4129,11 +4129,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You own a nontoken permanent if it started the game in your deck. If it started the game in no one’s deck (for example, it was brought into the game by Living Wish), you own it if you brought it into the game."
+          "text": "You own a nontoken permanent if it started the game in your deck. If it started the game in no one's deck (for example, it was brought into the game by Living Wish), you own it if you brought it into the game."
         },
         {
           "date": "2012-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         }
       ],
       "text": "{T}: Destroy target permanent you own. It can't be regenerated.",
@@ -4238,7 +4238,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -4466,11 +4466,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with Dreams of the Dead would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence."
+          "text": "If a creature returned to the battlefield with Dreams of the Dead would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence."
         },
         {
           "date": "2013-04-15",
@@ -4580,7 +4580,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You have to sacrifice a Swamp for each black mana in the activation cost. If you use Pestilence with {B}{B}{B}{B}, that’s 4 activations with {B} each so you sacrifice 4 Swamps."
+          "text": "You have to sacrifice a Swamp for each black mana in the activation cost. If you use Pestilence with {B}{B}{B}{B}, that's 4 activations with {B} each so you sacrifice 4 Swamps."
         },
         {
           "date": "2008-08-01",
@@ -4588,7 +4588,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "At the beginning of your upkeep, sacrifice Drought unless you pay {W}{W}.\nSpells cost an additional \"Sacrifice a Swamp\" to cast for each black mana symbol in their mana costs.\nActivated abilities cost an additional \"Sacrifice a Swamp\" to activate for each black mana symbol in their activation costs.",
@@ -4641,7 +4641,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be activated during your opponent’s upkeep as well as your own. The upkeep restriction is there to avoid its use during combat."
+          "text": "The ability can be activated during your opponent's upkeep as well as your own. The upkeep restriction is there to avoid its use during combat."
         }
       ],
       "text": "{2}, Sacrifice a land: Put a +2/+2 counter on target creature. Activate this ability only during any upkeep step.",
@@ -4911,15 +4911,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the Bottle leaves the battlefield or your control, the cards remain waiting until played or until the beginning of your next upkeep. The card is in the “Exile” zone."
+          "text": "If the Bottle leaves the battlefield or your control, the cards remain waiting until played or until the beginning of your next upkeep. The card is in the \"Exile\" zone."
         },
         {
           "date": "2004-10-04",
-          "text": "The card is not part of your hand in any way. You can’t be forced to discard it due to a discard from hand effect, and you can’t discard it to pay a cost."
+          "text": "The card is not part of your hand in any way. You can't be forced to discard it due to a discard from hand effect, and you can't discard it to pay a cost."
         },
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2008-08-01",
@@ -4927,7 +4927,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The exiled card is played using the normal timing rules for its card type, as well as any other applicable restrictions such as “Cast [this card] only during combat.” For example, you can’t play the card during an opponent’s turn unless it’s an instant or has flash. Similarly, if the exiled card is a land, you can’t play it if you’ve already played a land that turn. If it’s a nonland card, you’ll have to pay its mana cost. The only thing that’s different is you’re playing it from the Exile zone."
+          "text": "The exiled card is played using the normal timing rules for its card type, as well as any other applicable restrictions such as \"Cast [this card] only during combat.\" For example, you can't play the card during an opponent's turn unless it's an instant or has flash. Similarly, if the exiled card is a land, you can't play it if you've already played a land that turn. If it's a nonland card, you'll have to pay its mana cost. The only thing that's different is you're playing it from the Exile zone."
         }
       ],
       "text": "{3}, {T}: Exile the top card of your library. Until the beginning of your next upkeep, you may play that card.",
@@ -5048,7 +5048,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Enduring Renewal only affects creature cards that are “drawn”. It doesn’t affect cards that are put into your hand from your library, or from anywhere else."
+          "text": "Enduring Renewal only affects creature cards that are \"drawn\". It doesn't affect cards that are put into your hand from your library, or from anywhere else."
         },
         {
           "date": "2004-10-04",
@@ -5068,11 +5068,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If, after the last ability triggers, the creature card is removed from your graveyard in response, it won’t be returned to your hand."
+          "text": "If, after the last ability triggers, the creature card is removed from your graveyard in response, it won't be returned to your hand."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Play with your hand revealed.\nIf you would draw a card, reveal the top card of your library instead. If it's a creature card, put it into your graveyard. Otherwise, draw a card.\nWhenever a creature is put into your graveyard from the battlefield, return it to your hand.",
@@ -5274,11 +5274,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Can only attack alone” means the enchanted creature can’t be declared as an attacker during the declare attackers step unless no other creatures are declared as attackers at that time (either by you or your Two-Headed Giant teammate)."
+          "text": "\"Can only attack alone\" means the enchanted creature can't be declared as an attacker during the declare attackers step unless no other creatures are declared as attackers at that time (either by you or your Two-Headed Giant teammate)."
         },
         {
           "date": "2008-10-01",
-          "text": "If the enchanted creature attacks alone, then a spell or ability causes another creature to be put onto the battlefield attacking, that’s fine."
+          "text": "If the enchanted creature attacks alone, then a spell or ability causes another creature to be put onto the battlefield attacking, that's fine."
         }
       ],
       "subtypes": [
@@ -5626,7 +5626,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The target opponent for the life-gaining effect may also be a target for the damage-dealing effect. If this happens and the damage brings that player’s life total to 0 or less, the life-gaining effect will raise his or her life total above 0 again before the player would lose the game."
+          "text": "The target opponent for the life-gaining effect may also be a target for the damage-dealing effect. If this happens and the damage brings that player's life total to 0 or less, the life-gaining effect will raise his or her life total above 0 again before the player would lose the game."
         }
       ],
       "text": "Fiery Justice deals 5 damage divided as you choose among any number of target creatures and/or players. Target opponent gains 5 life.",
@@ -5685,7 +5685,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "You divide the damage as you cast the spell. You can’t redistribute the damage if any of the target creatures becomes illegal before the spell resolves."
+          "text": "You divide the damage as you cast the spell. You can't redistribute the damage if any of the target creatures becomes illegal before the spell resolves."
         }
       ],
       "text": "As an additional cost to cast Fire Covenant, pay X life.\nFire Covenant deals X damage divided as you choose among any number of target creatures.",
@@ -5899,7 +5899,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -6010,7 +6010,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Forbidden Lore grants an activated ability to the enchanted land. Only that land’s controller can activate the ability."
+          "text": "Forbidden Lore grants an activated ability to the enchanted land. Only that land's controller can activate the ability."
         }
       ],
       "subtypes": [
@@ -6873,7 +6873,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You target an opponent when you cast Forgotten Lore. The opponent chooses a card in your graveyard as Forgotten Lore resolves. After that choice is made, you’re given the option to pay {G}. If you do, the targeted opponent must choose a different card, if there is one. (If there isn’t one, this part is skipped.) Then you’re given the option to pay {G} again. As long as you keep paying {G}, the process continues. As soon as you decline to pay {G}, the last card that was chosen by the opponent is put into your hand."
+          "text": "You target an opponent when you cast Forgotten Lore. The opponent chooses a card in your graveyard as Forgotten Lore resolves. After that choice is made, you're given the option to pay {G}. If you do, the targeted opponent must choose a different card, if there is one. (If there isn't one, this part is skipped.) Then you're given the option to pay {G} again. As long as you keep paying {G}, the process continues. As soon as you decline to pay {G}, the last card that was chosen by the opponent is put into your hand."
         },
         {
           "date": "2008-10-01",
@@ -6931,7 +6931,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -7203,7 +7203,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "During your untap step, first you determine which of your permanents will untap, then you untap them. If you control a permanent that says “You may choose not to untap [this permanent] during your untap step” and you decide not to untap it, no wind counters will be removed from it because it wouldn’t untap. The same is true for a permanent you control that wouldn’t untap due to a spell or ability (such as the one from Barl’s Cage)."
+          "text": "During your untap step, first you determine which of your permanents will untap, then you untap them. If you control a permanent that says \"You may choose not to untap [this permanent] during your untap step\" and you decide not to untap it, no wind counters will be removed from it because it wouldn't untap. The same is true for a permanent you control that wouldn't untap due to a spell or ability (such as the one from Barl's Cage)."
         }
       ],
       "text": "Whenever a permanent becomes tapped, put a wind counter on it.\nIf a permanent with a wind counter on it would untap during its controller's untap step, remove all wind counters from it instead.",
@@ -7259,7 +7259,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Fumarole can’t be cast unless you can target both a creature and a land. If there’s a permanent on the battlefield that’s both a creature and a land, it can be both targets."
+          "text": "Fumarole can't be cast unless you can target both a creature and a land. If there's a permanent on the battlefield that's both a creature and a land, it can be both targets."
         }
       ],
       "text": "As an additional cost to cast Fumarole, pay 3 life.\nDestroy target creature and target land.",
@@ -7622,7 +7622,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "To “double the life stakes” means to double the amount of life lost or gained."
+          "text": "To \"double the life stakes\" means to double the amount of life lost or gained."
         }
       ],
       "text": "Flip a coin. If you win the flip, you gain 1 life and target opponent loses 1 life, and you decide whether to flip again. If you lose the flip, you lose 1 life and that opponent gains 1 life, and that player decides whether to flip again. Double the life stakes with each flip.",
@@ -7734,7 +7734,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "text": "Until end of turn, whenever a creature you control attacks and isn't blocked, you may choose to have it deal damage equal to its power to a target creature. If you do, it assigns no combat damage this turn.",
@@ -7859,7 +7859,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Does not make red and black spells and permanents colorless. They still have color. A red spell can’t target a creature with Protection from Red due to this. The spells just act like colorless sources when dealing damage."
+          "text": "Does not make red and black spells and permanents colorless. They still have color. A red spell can't target a creature with Protection from Red due to this. The spells just act like colorless sources when dealing damage."
         },
         {
           "date": "2004-10-04",
@@ -8068,7 +8068,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "When Glacial Chasm’s enters-the-battlefield ability resolves, if you don’t control any other lands, you must sacrifice Glacial Chasm itself."
+          "text": "When Glacial Chasm's enters-the-battlefield ability resolves, if you don't control any other lands, you must sacrifice Glacial Chasm itself."
         }
       ],
       "text": "Cumulative upkeep—Pay 2 life. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Glacial Chasm enters the battlefield, sacrifice a land.\nCreatures you control can't attack.\nPrevent all damage that would be dealt to you.",
@@ -8429,7 +8429,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Goblin Ski Patrol’s ability may be activated only once in the entire game. If its ability is activated and then it changes controllers, its ability may not be activated again, and its new controller will still have to sacrifice it at the beginning of the End step."
+          "text": "Goblin Ski Patrol's ability may be activated only once in the entire game. If its ability is activated and then it changes controllers, its ability may not be activated again, and its new controller will still have to sacrifice it at the beginning of the End step."
         }
       ],
       "subtypes": [
@@ -8845,7 +8845,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You draw a card at the beginning of the next turn’s upkeep after Heal resolves, regardless of whether 1 damage was actually prevented."
+          "text": "You draw a card at the beginning of the next turn's upkeep after Heal resolves, regardless of whether 1 damage was actually prevented."
         }
       ],
       "text": "Prevent the next 1 damage that would be dealt to target creature or player this turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -9344,7 +9344,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         },
         {
           "date": "2016-06-08",
@@ -9404,7 +9404,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control.",
@@ -9452,11 +9452,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The Cauldron counts only mana spent on it. It doesn’t see the value of X, so isn’t affected by cost reductions. Thus, if you spent {C}{C}{R}{R} on X, you get {C}{C}{R}{R} later even if X was 6."
+          "text": "The Cauldron counts only mana spent on it. It doesn't see the value of X, so isn't affected by cost reductions. Thus, if you spent {C}{C}{R}{R} on X, you get {C}{C}{R}{R} later even if X was 6."
         },
         {
           "date": "2004-10-04",
-          "text": "Cards which are not actually in your hand can’t be exiled by the Ice Cauldron."
+          "text": "Cards which are not actually in your hand can't be exiled by the Ice Cauldron."
         },
         {
           "date": "2004-10-04",
@@ -9468,7 +9468,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You do not have to use any mana from the Cauldron when casting the spell if you don’t want to. You don’t even have to tap the Cauldron and draw the mana, you can just cast the spell using mana from somewhere else."
+          "text": "You do not have to use any mana from the Cauldron when casting the spell if you don't want to. You don't even have to tap the Cauldron and draw the mana, you can just cast the spell using mana from somewhere else."
         },
         {
           "date": "2004-10-04",
@@ -9488,7 +9488,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can only cast the spell when you could legally cast it normally. So no casting a sorcery on your opponent’s turn."
+          "text": "You can only cast the spell when you could legally cast it normally. So no casting a sorcery on your opponent's turn."
         },
         {
           "date": "2004-10-04",
@@ -9550,7 +9550,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target a tapped creature with Ice Floe’s activated ability."
+          "text": "You may target a tapped creature with Ice Floe's activated ability."
         },
         {
           "date": "2008-10-01",
@@ -9558,19 +9558,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the ability resolves, then the creature gains flying later, Ice Floe’s effect will not end. (The ability checks whether the creature has flying only at the time you activate it and the time it resolves.)"
+          "text": "If the ability resolves, then the creature gains flying later, Ice Floe's effect will not end. (The ability checks whether the creature has flying only at the time you activate it and the time it resolves.)"
         },
         {
           "date": "2008-10-01",
-          "text": "If the affected creature is untapped by some other spell or ability, Ice Floe’s effect will not end. If you keep Ice Floe tapped, and that creature becomes tapped again, Ice Floe will continue to prevent it from being untapped during its controller’s untap step."
+          "text": "If the affected creature is untapped by some other spell or ability, Ice Floe's effect will not end. If you keep Ice Floe tapped, and that creature becomes tapped again, Ice Floe will continue to prevent it from being untapped during its controller's untap step."
         },
         {
           "date": "2008-10-01",
-          "text": "Ice Floe doesn’t track the creature’s controller. If the affected creature changes controllers, Ice Floe will prevent it from being untapped during its new controller’s untap step."
+          "text": "Ice Floe doesn't track the creature's controller. If the affected creature changes controllers, Ice Floe will prevent it from being untapped during its new controller's untap step."
         },
         {
           "date": "2008-10-01",
-          "text": "If Ice Floe untaps or leaves the battlefield, its effect will end. This has no immediate visible affect on the creature. (It doesn’t untap immediately, for example.) The creature will just untap as normal during its controller’s next untap step."
+          "text": "If Ice Floe untaps or leaves the battlefield, its effect will end. This has no immediate visible affect on the creature. (It doesn't untap immediately, for example.) The creature will just untap as normal during its controller's next untap step."
         }
       ],
       "text": "You may choose not to untap Ice Floe during your untap step.\n{T}: Tap target creature without flying that's attacking you. It doesn't untap during its controller's untap step for as long as Ice Floe remains tapped.",
@@ -9672,7 +9672,7 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "Checks only on resolution to see if the land has the supertype snow; it’s not part of the targeting condition."
+          "text": "Checks only on resolution to see if the land has the supertype snow; it's not part of the targeting condition."
         }
       ],
       "text": "Destroy target land. If that land was a snow land, Icequake deals 1 damage to that land's controller.",
@@ -9684,7 +9684,7 @@
     {
       "artist": "Amy Weber",
       "cmc": 4,
-      "flavor": "\"The scavengers who first found it called it the ‘Bone Crank.' Not a bad name, I'd say.\"\n—Arcum Dagsson, Soldevi Machinist",
+      "flavor": "\"The scavengers who first found it called it the 'Bone Crank.' Not a bad name, I'd say.\"\n—Arcum Dagsson, Soldevi Machinist",
       "id": "37aa71d42dfcce0910afd8bb108e3b6d16d51367",
       "imageName": "icy manipulator",
       "layout": "normal",
@@ -9739,19 +9739,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player’s pool."
+          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player's pool."
         },
         {
           "date": "2004-10-04",
-          "text": "Icy Manipulator can’t be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
+          "text": "Icy Manipulator can't be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger “if the card becomes tapped” effects."
+          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger \"if the card becomes tapped\" effects."
         },
         {
           "date": "2004-10-04",
-          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use the Icy Manipulator."
+          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use the Icy Manipulator."
         },
         {
           "date": "2004-10-04",
@@ -9863,7 +9863,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -9922,15 +9922,15 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Can only give landwalk of land sub-types that exist (so you can no longer give “Island of Wak-Wak walk”)."
+          "text": "Can only give landwalk of land sub-types that exist (so you can no longer give \"Island of Wak-Wak walk\")."
         },
         {
           "date": "2005-11-01",
-          "text": "Can’t give Snow landwalk, because Snow is supertype, not a subtype."
+          "text": "Can't give Snow landwalk, because Snow is supertype, not a subtype."
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -10113,7 +10113,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"I can't believe they expect me to fight with this rabble. A Goblin in a big mask sends ‘em running for cover.\"\n—Avram Garrisson, Leader of the Knights of Stromgald",
+      "flavor": "\"I can't believe they expect me to fight with this rabble. A Goblin in a big mask sends 'em running for cover.\"\n—Avram Garrisson, Leader of the Knights of Stromgald",
       "id": "c576ad50042d0d9bd0581a49f37b3707b9590a23",
       "imageName": "imposing visage",
       "layout": "normal",
@@ -10164,7 +10164,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Yes, I think ‘toast' is an appropriate description.\"\n—Jaya Ballard, Task Mage",
+      "flavor": "\"Yes, I think 'toast' is an appropriate description.\"\n—Jaya Ballard, Task Mage",
       "id": "9c4db2b4131b916a5d22df6152b81955d278edad",
       "imageName": "incinerate",
       "layout": "normal",
@@ -10219,7 +10219,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Regeneration abilities that would affect that creature can still be activated; they just won’t do anything. The creature can’t be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
+          "text": "Regeneration abilities that would affect that creature can still be activated; they just won't do anything. The creature can't be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
         }
       ],
       "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
@@ -10273,7 +10273,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This effect changes the type of mana produced, but not the amount. For example, if a land that’s tapped for mana would add {W}{W} to its controller’s mana pool, it adds {B}{B} to that player’s mana pool instead."
+          "text": "This effect changes the type of mana produced, but not the amount. For example, if a land that's tapped for mana would add {W}{W} to its controller's mana pool, it adds {B}{B} to that player's mana pool instead."
         }
       ],
       "text": "Cumulative upkeep—Pay {B} and 1 life. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nIf a land is tapped for mana, it produces {B} instead of any other type.",
@@ -10327,11 +10327,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You must sacrifice the Swamps if you can. You can’t choose not to pay if you have them."
+          "text": "You must sacrifice the Swamps if you can. You can't choose not to pay if you have them."
         },
         {
           "date": "2004-10-04",
-          "text": "You should always have one creature for your opponent to take (i.e. the Denizen). If by chance you have no creature for your opponent to take, then they don’t get one. Remember that taking a creature is optional so your opponent is not forced to take the Denizen."
+          "text": "You should always have one creature for your opponent to take (i.e. the Denizen). If by chance you have no creature for your opponent to take, then they don't get one. Remember that taking a creature is optional so your opponent is not forced to take the Denizen."
         }
       ],
       "subtypes": [
@@ -10430,7 +10430,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target any artifact, creature, or land, not just a tapped one. If the targeted permanent is already untapped as Infuse resolves, Infuse won’t affect it, but you’ll still draw a card at the beginning of the next turn’s upkeep."
+          "text": "You may target any artifact, creature, or land, not just a tapped one. If the targeted permanent is already untapped as Infuse resolves, Infuse won't affect it, but you'll still draw a card at the beginning of the next turn's upkeep."
         }
       ],
       "text": "Untap target artifact, creature, or land.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -11324,7 +11324,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Charge counters are indistinguishable from one another. If some other spell or ability (such as Power Conduit’s ability) puts a charge counter on Jeweled Amulet, activating Jeweled Amulet’s second ability will still check the type of mana last noted by its first ability. If there is no type of mana noted by its first ability (because it hasn’t been activated by that point), the second ability will produce no mana."
+          "text": "Charge counters are indistinguishable from one another. If some other spell or ability (such as Power Conduit's ability) puts a charge counter on Jeweled Amulet, activating Jeweled Amulet's second ability will still check the type of mana last noted by its first ability. If there is no type of mana noted by its first ability (because it hasn't been activated by that point), the second ability will produce no mana."
         }
       ],
       "text": "{1}, {T}: Put a charge counter on Jeweled Amulet. Note the type of mana spent to pay this activation cost. Activate this ability only if there are no charge counters on Jeweled Amulet.\n{T}, Remove a charge counter from Jeweled Amulet: Add one mana of Jeweled Amulet's last noted type to your mana pool.",
@@ -11536,7 +11536,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a single source does damage to multiple targets at once, Justice will add up all the damage done and deal damage to the source’s controller at one time (not multiple separate damagings)."
+          "text": "If a single source does damage to multiple targets at once, Justice will add up all the damage done and deal damage to the source's controller at one time (not multiple separate damagings)."
         },
         {
           "date": "2004-10-04",
@@ -11827,7 +11827,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "When Kjeldoran Dead’s enters-the-battlefield ability resolves, if you don’t control any other creatures, you must sacrifice Kjeldoran Dead itself."
+          "text": "When Kjeldoran Dead's enters-the-battlefield ability resolves, if you don't control any other creatures, you must sacrifice Kjeldoran Dead itself."
         }
       ],
       "subtypes": [
@@ -11943,11 +11943,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Kjeldoran Frostbeast’s ability triggers only if it’s still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it blocks a 7/7 creature and is destroyed, its ability won’t trigger at all. The 7/7 will remain on the battlefield."
+          "text": "Kjeldoran Frostbeast's ability triggers only if it's still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it blocks a 7/7 creature and is destroyed, its ability won't trigger at all. The 7/7 will remain on the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "Its ability will destroy all creatures it’s currently blocking or blocked by, not necessarily the creatures it had blocked or become blocked by during that combat phase. For example, if Kjeldoran Frostbeast is dealt lethal combat damage and regenerates, it’s removed from combat. Its ability will trigger at end of combat, but since it’s no longer blocking or blocked by any creatures, the ability won’t do anything."
+          "text": "Its ability will destroy all creatures it's currently blocking or blocked by, not necessarily the creatures it had blocked or become blocked by during that combat phase. For example, if Kjeldoran Frostbeast is dealt lethal combat damage and regenerates, it's removed from combat. Its ability will trigger at end of combat, but since it's no longer blocking or blocked by any creatures, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -12059,7 +12059,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -12131,7 +12131,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -12210,7 +12210,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won’t be redirected. It will be dealt to you as normal."
+          "text": "If you activate the ability but Kjeldoran Royal Guard leaves the battlefield before combat damage is dealt, the combat damage from unblocked creatures won't be redirected. It will be dealt to you as normal."
         }
       ],
       "subtypes": [
@@ -12271,7 +12271,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -12342,7 +12342,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -12413,7 +12413,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -12713,19 +12713,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "At the beginning of each end step, the game checks all creatures that died that turn to see if Krovikan Vampire had dealt damage to them during the turn. It doesn’t matter whether the damage was combat damage, and it doesn’t matter whether the damage was what caused the creatures to die."
+          "text": "At the beginning of each end step, the game checks all creatures that died that turn to see if Krovikan Vampire had dealt damage to them during the turn. It doesn't matter whether the damage was combat damage, and it doesn't matter whether the damage was what caused the creatures to die."
         },
         {
           "date": "2004-10-04",
-          "text": "If a creature Krovikan Vampire dealt damage to dies, then leaves the graveyard by some means, the game loses track of it. Krovikan Vampire’s ability won’t be able to return it to the battlefield, even if it’s put back into the graveyard before the end step."
+          "text": "If a creature Krovikan Vampire dealt damage to dies, then leaves the graveyard by some means, the game loses track of it. Krovikan Vampire's ability won't be able to return it to the battlefield, even if it's put back into the graveyard before the end step."
         },
         {
           "date": "2008-08-01",
-          "text": "Whoever controls Krovikan Vampire when the ability triggers will return the applicable cards to the battlefield under his or her control. It doesn’t matter who controlled it at the time the damage was dealt."
+          "text": "Whoever controls Krovikan Vampire when the ability triggers will return the applicable cards to the battlefield under his or her control. It doesn't matter who controlled it at the time the damage was dealt."
         },
         {
           "date": "2008-08-01",
-          "text": "If Krovikan Vampire isn’t on the battlefield at the beginning of the end step, its ability won’t trigger. No cards will be returned to the battlefield, even if Krovikan Vampire dealt damage to some creatures that died that turn."
+          "text": "If Krovikan Vampire isn't on the battlefield at the beginning of the end step, its ability won't trigger. No cards will be returned to the battlefield, even if Krovikan Vampire dealt damage to some creatures that died that turn."
         },
         {
           "date": "2008-10-01",
@@ -13133,7 +13133,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -13192,11 +13192,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target any creature, not just one that doesn’t have first strike. If the targeted creature already has first strike as Lightning Blow resolves, Lightning Blow won’t affect it (since multiple instances of first strike are redundant), but you’ll still draw a card at the beginning of the next turn’s upkeep."
+          "text": "You may target any creature, not just one that doesn't have first strike. If the targeted creature already has first strike as Lightning Blow resolves, Lightning Blow won't affect it (since multiple instances of first strike are redundant), but you'll still draw a card at the beginning of the next turn's upkeep."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature doesn’t have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won’t prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
+          "text": "If the targeted creature doesn't have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won't prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
         }
       ],
       "text": "Target creature gains first strike until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -13553,11 +13553,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the artifact when you lose control of it for any reason — because Magus of the Unseen’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the artifact when you lose control of it for any reason — because Magus of the Unseen's effect ends, or because a spell or ability causes another player to gain control of it."
         },
         {
           "date": "2008-10-01",
-          "text": "The artifact will gain haste whether or not it’s a creature. Of course, if it’s not a creature, haste will have no particular effect."
+          "text": "The artifact will gain haste whether or not it's a creature. Of course, if it's not a creature, haste will have no particular effect."
         }
       ],
       "subtypes": [
@@ -13711,11 +13711,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Melee only during your turn and only during combat before blockers are declared.\nYou choose which creatures block this combat and how those creatures block.\nWhenever a creature attacks and isn't blocked this combat, untap it and remove it from combat.",
@@ -13882,15 +13882,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Merieke becomes untapped, its “destroy” ability will trigger, but you won’t lose control of the creature you took before it’s destroyed."
+          "text": "If Merieke becomes untapped, its \"destroy\" ability will trigger, but you won't lose control of the creature you took before it's destroyed."
         },
         {
           "date": "2006-09-25",
-          "text": "If another player takes control of Merieke, you will immediately lose control of the creature you took, but Merieke’s “destroy” ability won’t trigger. The affected creature will go back under the control of the appropriate player."
+          "text": "If another player takes control of Merieke, you will immediately lose control of the creature you took, but Merieke's \"destroy\" ability won't trigger. The affected creature will go back under the control of the appropriate player."
         },
         {
           "date": "2006-09-25",
-          "text": "If Merieke leaves the battlefield, you will immediately lose control of the creature you took and Merieke’s “destroy” ability will trigger. The affected creature will go back under the control of the appropriate player, then it will be destroyed."
+          "text": "If Merieke leaves the battlefield, you will immediately lose control of the creature you took and Merieke's \"destroy\" ability will trigger. The affected creature will go back under the control of the appropriate player, then it will be destroyed."
         }
       ],
       "subtypes": [
@@ -14000,7 +14000,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose to do fractional damage to a target."
+          "text": "You can't choose to do fractional damage to a target."
         },
         {
           "date": "2008-10-01",
@@ -14221,11 +14221,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you don’t sacrifice a creature at the beginning of your upkeep (either by choice or because you can’t), but you somehow prevent all the damage Minion of Leshrac would deal to you, then you don’t tap Minion of Leshrac."
+          "text": "If you don't sacrifice a creature at the beginning of your upkeep (either by choice or because you can't), but you somehow prevent all the damage Minion of Leshrac would deal to you, then you don't tap Minion of Leshrac."
         },
         {
           "date": "2008-10-01",
-          "text": "Minion of Leshrac can’t target itself with its activated ability because it has protection from black."
+          "text": "Minion of Leshrac can't target itself with its activated ability because it has protection from black."
         }
       ],
       "subtypes": [
@@ -15420,7 +15420,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "First the player chooses all the tapped creatures he or she would like to untap this way. Then the entire payment is made at once, then all of those creatures untap at the same time. If the entire payment can’t be paid (because the player chose too many creatures, for example), none of it is paid and none of those creatures untap."
+          "text": "First the player chooses all the tapped creatures he or she would like to untap this way. Then the entire payment is made at once, then all of those creatures untap at the same time. If the entire payment can't be paid (because the player chose too many creatures, for example), none of it is paid and none of those creatures untap."
         }
       ],
       "text": "Creatures without flying don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, that player may choose any number of tapped creatures without flying he or she controls and pay {2} for each creature chosen this way. If the player does, untap those creatures.",
@@ -15475,11 +15475,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         },
         {
           "date": "2008-10-01",
-          "text": "This ability has no duration. An affected creature will retain the triggered ability until the game ends, it leaves the battlefield, or some other effect causes it to lose its abilities. It doesn’t matter if Musician is still on the battlefield or not."
+          "text": "This ability has no duration. An affected creature will retain the triggered ability until the game ends, it leaves the battlefield, or some other effect causes it to lose its abilities. It doesn't matter if Musician is still on the battlefield or not."
         },
         {
           "date": "2008-10-01",
@@ -15487,7 +15487,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If a music counter is put on a creature by some other means (Fate Transfer, for example), but that creature has never been affected by Musician’s ability, that creature won’t have the triggered ability and its controller won’t have to pay mana. The music counters will stay on that creature but won’t do anything."
+          "text": "If a music counter is put on a creature by some other means (Fate Transfer, for example), but that creature has never been affected by Musician's ability, that creature won't have the triggered ability and its controller won't have to pay mana. The music counters will stay on that creature but won't do anything."
         }
       ],
       "subtypes": [
@@ -15595,11 +15595,11 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "First the opponent chooses whether or not to pay {4}. Then, if he or she doesn’t pay, you choose whether or not to draw a card."
+          "text": "First the opponent chooses whether or not to pay {4}. Then, if he or she doesn't pay, you choose whether or not to draw a card."
         },
         {
           "date": "2008-04-01",
-          "text": "A “noncreature spell” is any spell that doesn’t have the type Creature. Artifact Creatures, Enchantment Creatures, and older cards of type Summon are all creature spells."
+          "text": "A \"noncreature spell\" is any spell that doesn't have the type Creature. Artifact Creatures, Enchantment Creatures, and older cards of type Summon are all creature spells."
         }
       ],
       "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever an opponent casts a noncreature spell, you may draw a card unless that player pays {4}.",
@@ -15762,7 +15762,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -15824,11 +15824,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Necropotence’s last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
+          "text": "Necropotence's last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
         },
         {
           "date": "2016-06-08",
-          "text": "If the discarded card isn’t put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won’t be exiled."
+          "text": "If the discarded card isn't put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won't be exiled."
         }
       ],
       "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
@@ -15881,7 +15881,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2013-09-20",
@@ -16139,7 +16139,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This ability changes the targeted land’s land types. It doesn’t affect its name, its supertypes (such as whether or not it’s legendary, snow, or basic), or its other types (if it’s also a creature, for example). The ability will cause the land to lose all of its printed abilities and gain the ability “{T}: Add {B} to your mana pool.”"
+          "text": "This ability changes the targeted land's land types. It doesn't affect its name, its supertypes (such as whether or not it's legendary, snow, or basic), or its other types (if it's also a creature, for example). The ability will cause the land to lose all of its printed abilities and gain the ability \"{T}: Add {B} to your mana pool.\""
         }
       ],
       "subtypes": [
@@ -16381,11 +16381,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you lose control of Orcish Squatters before its ability resolves, you won’t gain control of the targeted land at all."
+          "text": "If you lose control of Orcish Squatters before its ability resolves, you won't gain control of the targeted land at all."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -16607,7 +16607,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Panic only during combat before blockers are declared.\nTarget creature can't block this turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -16762,7 +16762,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the ability resolves, then the targeted creature’s toughness becomes greater than 2 later, Phantasmal Mount’s effect will not end. (The ability checks whether the creature has toughness 2 or less only at the time you activate it and the time it resolves.)"
+          "text": "If the ability resolves, then the targeted creature's toughness becomes greater than 2 later, Phantasmal Mount's effect will not end. (The ability checks whether the creature has toughness 2 or less only at the time you activate it and the time it resolves.)"
         }
       ],
       "subtypes": [
@@ -17623,7 +17623,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -17766,7 +17766,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -17824,15 +17824,15 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "The losses, discards, and sacrifices are rounded up. For example, if you have 5 life, you’ll lose 2 life, leaving you at 3 life. (Five divided by three is one and two-thirds. Rounding that up to the nearest whole number gives you two.)"
+          "text": "The losses, discards, and sacrifices are rounded up. For example, if you have 5 life, you'll lose 2 life, leaving you at 3 life. (Five divided by three is one and two-thirds. Rounding that up to the nearest whole number gives you two.)"
         },
         {
           "date": "2007-09-16",
-          "text": "Each part of Pox’s effect is processed separately. For each part, first the player whose turn it is makes all necessary choices (such as which cards to discard), then each other player in turn order chooses, then the actions happen at the same time. Then Pox’s effect moves to the next stage."
+          "text": "Each part of Pox's effect is processed separately. For each part, first the player whose turn it is makes all necessary choices (such as which cards to discard), then each other player in turn order chooses, then the actions happen at the same time. Then Pox's effect moves to the next stage."
         },
         {
           "date": "2007-09-16",
-          "text": "The number you need to lose, discard, or sacrifice isn’t calculated until it’s time to perform that part of the effect. For example, if your opponent casts Pox and you discard Dodecapod as part of Pox’s discard effect, Dodecapod will be put onto the battlefield instead of into your graveyard. Then, when determining how many creatures you need to sacrifice, the Dodecapod is taken into account."
+          "text": "The number you need to lose, discard, or sacrifice isn't calculated until it's time to perform that part of the effect. For example, if your opponent casts Pox and you discard Dodecapod as part of Pox's discard effect, Dodecapod will be put onto the battlefield instead of into your graveyard. Then, when determining how many creatures you need to sacrifice, the Dodecapod is taken into account."
         }
       ],
       "text": "Each player loses a third of his or her life, then discards a third of the cards in his or her hand, then sacrifices a third of the creatures he or she controls, then sacrifices a third of the lands he or she controls. Round up each time.",
@@ -18043,7 +18043,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         },
         {
           "date": "2016-06-08",
@@ -18223,11 +18223,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The creature returns to the opponent when the “until end of turn” effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
+          "text": "The creature returns to the opponent when the \"until end of turn\" effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command's effect ends, or because a spell or ability causes another player to gain control of it."
         }
       ],
       "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature gains haste until end of turn. When you lose control of the creature, tap it.",
@@ -18560,7 +18560,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t landwalk through a non-Snow Forest."
+          "text": "Can't landwalk through a non-Snow Forest."
         }
       ],
       "subtypes": [
@@ -18619,7 +18619,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This effect changes the type of mana produced, but not the amount. For example, if a land that’s tapped for mana would add {W}{W} to its controller’s mana pool, it adds {C}{C} to that player’s mana pool instead."
+          "text": "This effect changes the type of mana produced, but not the amount. For example, if a land that's tapped for mana would add {W}{W} to its controller's mana pool, it adds {C}{C} to that player's mana pool instead."
         }
       ],
       "text": "Cumulative upkeep {2} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nIf a land is tapped for mana, it produces colorless mana instead of any other type.",
@@ -19035,19 +19035,19 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If Seraph isn’t on the battlefield at the time the other creature is put into a graveyard, the ability won’t trigger. However, the ability does trigger if Seraph and the other creature are put into the graveyard at the same time."
+          "text": "If Seraph isn't on the battlefield at the time the other creature is put into a graveyard, the ability won't trigger. However, the ability does trigger if Seraph and the other creature are put into the graveyard at the same time."
         },
         {
           "date": "2007-09-16",
-          "text": "If the other creature is a token, it will cease to exist after being exiled. It won’t be returned to the battlefield."
+          "text": "If the other creature is a token, it will cease to exist after being exiled. It won't be returned to the battlefield."
         },
         {
           "date": "2007-09-16",
-          "text": "If the other creature ceases to be a creature card after it leaves the battlefield (it’s an animated Mishra’s Factory, for example), it will be returned to the battlefield by this ability and you will have to sacrifice it when you lose control of Seraph."
+          "text": "If the other creature ceases to be a creature card after it leaves the battlefield (it's an animated Mishra's Factory, for example), it will be returned to the battlefield by this ability and you will have to sacrifice it when you lose control of Seraph."
         },
         {
           "date": "2007-09-16",
-          "text": "Once the ability triggers, you’ll return the card to the battlefield under your control at the end of the turn even if you no longer control Seraph at that time. In fact, if Seraph leaves the battlefield before the card is returned to the battlefield, you’ll never have to sacrifice it as a result of this ability. If Seraph remains on the battlefield but changes controllers before the card is returned, you’ll still get the returned card. However, in that scenario, you’ll still have to sacrifice it if you later regain control Seraph and then lose control of it once more."
+          "text": "Once the ability triggers, you'll return the card to the battlefield under your control at the end of the turn even if you no longer control Seraph at that time. In fact, if Seraph leaves the battlefield before the card is returned to the battlefield, you'll never have to sacrifice it as a result of this ability. If Seraph remains on the battlefield but changes controllers before the card is returned, you'll still get the returned card. However, in that scenario, you'll still have to sacrifice it if you later regain control Seraph and then lose control of it once more."
         }
       ],
       "subtypes": [
@@ -19254,7 +19254,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -19368,11 +19368,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Shyft’s ability won’t let you make it colorless. Colorless is not a color."
+          "text": "Shyft's ability won't let you make it colorless. Colorless is not a color."
         },
         {
           "date": "2008-10-01",
-          "text": "The ability’s effect has no duration. Shyft will remain the chosen color or colors until the game ends, it leaves the battlefield, or some other effect (such as the next time its ability resolves) changes its colors."
+          "text": "The ability's effect has no duration. Shyft will remain the chosen color or colors until the game ends, it leaves the battlefield, or some other effect (such as the next time its ability resolves) changes its colors."
         }
       ],
       "subtypes": [
@@ -19433,7 +19433,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Your opponent does not have to draw a card if they don’t want to."
+          "text": "Your opponent does not have to draw a card if they don't want to."
         }
       ],
       "subtypes": [
@@ -19653,7 +19653,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t Sleight proper nouns (i.e. card names). This means that you can’t affect a “Black Vise”."
+          "text": "You can't Sleight proper nouns (i.e. card names). This means that you can't affect a \"Black Vise\"."
         },
         {
           "date": "2004-10-04",
@@ -19661,7 +19661,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Can’t change a color word to the same color word. It must be a different word."
+          "text": "Can't change a color word to the same color word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -19673,7 +19673,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -19892,7 +19892,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -19900,11 +19900,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -19963,7 +19963,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -19971,11 +19971,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -20034,7 +20034,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -20042,11 +20042,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -20105,7 +20105,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -20113,11 +20113,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -20176,7 +20176,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -20184,11 +20184,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -20406,7 +20406,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Mana from the ability can only be spent on activation costs for abilities from artifacts. It can’t be spent on artifact spells, or on costs resulting from triggered abilities."
+          "text": "Mana from the ability can only be spent on activation costs for abilities from artifacts. It can't be spent on artifact spells, or on costs resulting from triggered abilities."
         }
       ],
       "subtypes": [
@@ -20461,7 +20461,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -20520,7 +20520,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Add {B} to your mana pool for each creature card in your graveyard.",
@@ -20574,7 +20574,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Whenever an opponent casts a creature spell, Soul Barrier deals 2 damage to that player unless he or she pays {2}.",
@@ -20796,11 +20796,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The text “for each artifact or creature” means the sum of cards which are either creature and/or artifact. Artifact creatures are not double counted."
+          "text": "The text \"for each artifact or creature\" means the sum of cards which are either creature and/or artifact. Artifact creatures are not double counted."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "For each artifact or creature card in target opponent's graveyard, add {C} to your mana pool and you gain 1 life.",
@@ -20854,11 +20854,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-08-01",
-          "text": "X is set as you cast the spell to be exactly the number of appropriate cards in an opponent’s graveyard. You can’t choose a higher or lower value for X."
+          "text": "X is set as you cast the spell to be exactly the number of appropriate cards in an opponent's graveyard. You can't choose a higher or lower value for X."
         }
       ],
       "text": "X is the number of artifact and/or creature cards in an opponent's graveyard as you cast Spoils of War.\nDistribute X +1/+1 counters among any number of target creatures.",
@@ -21145,7 +21145,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don’t actually have Flying."
+          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don't actually have Flying."
         }
       ],
       "subtypes": [
@@ -21324,7 +21324,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since the discard is a cost, it can’t be used with Library of Leng."
+          "text": "Since the discard is a cost, it can't be used with Library of Leng."
         }
       ],
       "text": "{2}, Discard a card at random: Stormbind deals 2 damage to target creature or player.",
@@ -22359,7 +22359,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -24059,7 +24059,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Winter's Chill only during combat before blockers are declared.\nX can't be greater than the number of snow lands you control.\nChoose X target attacking creatures. For each of those creatures, its controller may pay {1} or {2}. If that player doesn't, destroy that creature at end of combat. If that player pays only {1}, prevent all combat damage that would be dealt to and dealt by that creature this combat.",
@@ -24112,15 +24112,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Withering Wisps’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless there are no creatures on the battlefield when a turn’s end step begins, and (2) the ability will do nothing if there are any creatures on the battlefield by the time the ability resolves."
+          "text": "Withering Wisps's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless there are no creatures on the battlefield when a turn's end step begins, and (2) the ability will do nothing if there are any creatures on the battlefield by the time the ability resolves."
         },
         {
           "date": "2008-10-01",
-          "text": "If all creatures leave the battlefield during a turn’s End step (after any “at the beginning of the end step” triggers would have triggered that turn), Withering Wisps will remain on the battlefield because the trigger condition has already passed."
+          "text": "If all creatures leave the battlefield during a turn's End step (after any \"at the beginning of the end step\" triggers would have triggered that turn), Withering Wisps will remain on the battlefield because the trigger condition has already passed."
         },
         {
           "date": "2008-10-01",
-          "text": "The number of snow Swamps you control and the number of times Withering Wisps’s ability has been activated so far that turn are checked each time you attempt to activate the ability."
+          "text": "The number of snow Swamps you control and the number of times Withering Wisps's ability has been activated so far that turn are checked each time you attempt to activate the ability."
         }
       ],
       "text": "At the beginning of the end step, if no creatures are on the battlefield, sacrifice Withering Wisps.\n{B}: Withering Wisps deals 1 damage to each creature and each player. Activate this ability no more times each turn than the number of snow Swamps you control.",
@@ -24401,7 +24401,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"It is our third day of travel on the Yavimaya River, and still these creatures plague us. Davin Lansson, our naturalist, has facetiously labeled them ‘gnats,' and the name has stuck.\"\n—Disa the Restless, journal entry",
+      "flavor": "\"It is our third day of travel on the Yavimaya River, and still these creatures plague us. Davin Lansson, our naturalist, has facetiously labeled them 'gnats,' and the name has stuck.\"\n—Disa the Restless, journal entry",
       "id": "08d80e30ff5918412a7c414d4f5a41e959b6308a",
       "imageName": "yavimaya gnats",
       "layout": "normal",
@@ -24507,7 +24507,7 @@
         },
         {
           "date": "2006-04-01",
-          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur’s Weirding’s replacement. If the latter, you first resolve Zur’s Weirding’s ability, then if you’re going to draw the card, decide whether or not to replace that draw with Dredge."
+          "text": "When using Dredge with this, you have two choices. You can immediately replace the draw with Dredge, or you can apply Zur's Weirding's replacement. If the latter, you first resolve Zur's Weirding's ability, then if you're going to draw the card, decide whether or not to replace that draw with Dredge."
         }
       ],
       "text": "Players play with their hands revealed.\nIf a player would draw a card, he or she reveals it instead. Then any other player may pay 2 life. If a player does, put that card into its owner's graveyard. Otherwise, that player draws a card.",

--- a/json/INV.json
+++ b/json/INV.json
@@ -847,7 +847,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It counts all opponents’ swamps."
+          "text": "It counts all opponents' swamps."
         }
       ],
       "subtypes": [
@@ -1043,7 +1043,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This is not preventing damage since it does not use the word “prevent”. It is a replacement."
+          "text": "This is not preventing damage since it does not use the word \"prevent\". It is a replacement."
         }
       ],
       "text": "If a source would deal 4 or more damage to a creature or player, that source deals 3 damage to that creature or player instead.",
@@ -1108,7 +1108,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Creatures which enter the battlefield (or cards which become creatures) after the beginning of combat ability resolves are not placed in either pile. Since they weren’t in the chosen pile, they won’t be able to attack."
+          "text": "Creatures which enter the battlefield (or cards which become creatures) after the beginning of combat ability resolves are not placed in either pile. Since they weren't in the chosen pile, they won't be able to attack."
         },
         {
           "date": "2008-08-01",
@@ -1116,7 +1116,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "The effect is best understood if you read it as “creatures not in the chosen pile can’t attack.”"
+          "text": "The effect is best understood if you read it as \"creatures not in the chosen pile can't attack.\""
         }
       ],
       "text": "At the beginning of combat on each opponent's turn, separate all creatures that player controls into two piles. Only creatures in the pile of his or her choice can attack this turn.",
@@ -1258,7 +1258,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "You sacrifice all lands other than the chosen ones. Since you can only choose lands with basic land types, any non-basic lands that don’t have a basic land type (even if they have some other land type, as in the case of Cloudpost) are necessarily going to be sacrificed."
+          "text": "You sacrifice all lands other than the chosen ones. Since you can only choose lands with basic land types, any non-basic lands that don't have a basic land type (even if they have some other land type, as in the case of Cloudpost) are necessarily going to be sacrificed."
         }
       ],
       "text": "Each player chooses from the lands he or she controls a land of each basic land type, then sacrifices the rest.",
@@ -1452,7 +1452,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature returns after “at the beginning of the end step” abilities trigger, so any such abilities on the creature will not trigger this turn."
+          "text": "The creature returns after \"at the beginning of the end step\" abilities trigger, so any such abilities on the creature will not trigger this turn."
         }
       ],
       "text": "Exile target creature you control. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
@@ -2699,7 +2699,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -2978,7 +2978,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -3312,11 +3312,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Domain — Creatures can't attack you unless their controller pays {X} for each creature he or she controls that's attacking you, where X is the number of basic land types among lands you control.",
@@ -3389,7 +3389,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -3401,7 +3401,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
@@ -3413,7 +3413,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target spell or permanent by replacing all instances of one color word with another or one basic land type with another until end of turn.\nDraw a card.",
@@ -3744,7 +3744,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It can enchant a permanent that is not red or green, but it doesn’t do anything in that case."
+          "text": "It can enchant a permanent that is not red or green, but it doesn't do anything in that case."
         }
       ],
       "subtypes": [
@@ -3886,7 +3886,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Each pile may contain from zero to five cards; they don’t have to be split “evenly.”"
+          "text": "Each pile may contain from zero to five cards; they don't have to be split \"evenly.\""
         }
       ],
       "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
@@ -4020,7 +4020,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If a spell’s color was changed while on the stack, use the color at the time it was when you started announcement, not as it currently is on the stack or as it was at the time it resolved."
+          "text": "If a spell's color was changed while on the stack, use the color at the time it was when you started announcement, not as it currently is on the stack or as it was at the time it resolved."
         }
       ],
       "text": "Players can't cast spells that share a color with the spell most recently cast this turn.",
@@ -4145,7 +4145,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can activate the ability in response to itself and get more than one creature card onto the battlefield before this returns to its owner’s hand."
+          "text": "You can activate the ability in response to itself and get more than one creature card onto the battlefield before this returns to its owner's hand."
         }
       ],
       "subtypes": [
@@ -4607,7 +4607,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change the number of targets, choose an illegal target, or make something get targeted more than once."
+          "text": "You can't change the number of targets, choose an illegal target, or make something get targeted more than once."
         },
         {
           "date": "2004-10-04",
@@ -5283,11 +5283,11 @@
       "rulings": [
         {
           "date": "2006-01-01",
-          "text": "Remember that a spell only targets something if it is an Aura or uses the phrase “target” in its text."
+          "text": "Remember that a spell only targets something if it is an Aura or uses the phrase \"target\" in its text."
         },
         {
           "date": "2006-01-01",
-          "text": "If none of the targeted spell’s targets is a land when Teferi’s Response would resolve, Teferi’s Response is countered on resolution due to having no legal targets."
+          "text": "If none of the targeted spell's targets is a land when Teferi's Response would resolve, Teferi's Response is countered on resolution due to having no legal targets."
         }
       ],
       "text": "Counter target spell or ability an opponent controls that targets a land you control. If a permanent's ability is countered this way, destroy that permanent.\nDraw two cards.",
@@ -6027,7 +6027,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
@@ -6347,7 +6347,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature is an illegal target when Annihilate tries to resolve, the entire spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target when Annihilate tries to resolve, the entire spell is countered. You won't draw a card."
         }
       ],
       "text": "Destroy target nonblack creature. It can't be regenerated.\nDraw a card.",
@@ -6497,7 +6497,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If the target card is no longer in the graveyard when Cremate tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the target card is no longer in the graveyard when Cremate tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "text": "Exile target card from a graveyard.\nDraw a card.",
@@ -7073,7 +7073,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -7475,7 +7475,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If attached to an opponent’s creature, only you can activate the ability to return it."
+          "text": "If attached to an opponent's creature, only you can activate the ability to return it."
         }
       ],
       "subtypes": [
@@ -7811,7 +7811,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is possible to activate this ability in response to itself and generate some odd combinations. For example, if you control this card and another creature, you can use this card’s ability and target the creature you control. You can then use this card’s ability again and target a creature your opponent controls. The second usage resolves first and you get your opponent’s creature in exchange for this one. The first usage then resolves and swaps your other creature for the Infiltrator so you get it back. The net effect is that you can swap any creature you have for any of theirs if you can pay this ability twice. Note that your opponent does get the chance to use the Infiltrator if they have the mana in between your two usages and can mess you up."
+          "text": "It is possible to activate this ability in response to itself and generate some odd combinations. For example, if you control this card and another creature, you can use this card's ability and target the creature you control. You can then use this card's ability again and target a creature your opponent controls. The second usage resolves first and you get your opponent's creature in exchange for this one. The first usage then resolves and swaps your other creature for the Infiltrator so you get it back. The net effect is that you can swap any creature you have for any of theirs if you can pay this ability twice. Note that your opponent does get the chance to use the Infiltrator if they have the mana in between your two usages and can mess you up."
         },
         {
           "date": "2004-10-04",
@@ -9077,7 +9077,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The cards in your graveyard are not considered to be in your hand for any reason. For example, you can’t discard them."
+          "text": "The cards in your graveyard are not considered to be in your hand for any reason. For example, you can't discard them."
         },
         {
           "date": "2004-10-04",
@@ -9408,7 +9408,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s after the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's after the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Chaotic Strike only during combat after blockers are declared.\nFlip a coin. If you win the flip, target creature gets +1/+1 until end of turn.\nDraw a card.",
@@ -9481,7 +9481,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — At the beginning of each player's upkeep, that player gains 1 life for each basic land type among lands he or she controls. Then Collapsing Borders deals 3 damage to him or her.",
@@ -9758,11 +9758,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -10175,7 +10175,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -10521,7 +10521,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Counterspells can be cast that target it, but when they resolve they simply don’t counter it since it can’t be countered."
+          "text": "Counterspells can be cast that target it, but when they resolve they simply don't counter it since it can't be countered."
         }
       ],
       "text": "Obliterate can't be countered.\nDestroy all artifacts, creatures, and lands. They can't be regenerated.",
@@ -10989,7 +10989,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It means “a black or green creature other than itself attacks”."
+          "text": "It means \"a black or green creature other than itself attacks\"."
         }
       ],
       "subtypes": [
@@ -11574,11 +11574,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Must be used before blockers are declared in order to affect blocking decisions. You can’t wait to see what your opponent declares and then try to stop them."
+          "text": "Must be used before blockers are declared in order to affect blocking decisions. You can't wait to see what your opponent declares and then try to stop them."
         },
         {
           "date": "2004-10-04",
-          "text": "You can use it after combat or even on a creature which can’t possibly block this turn because it’s that player’s turn to attack, but it generally has no effect other than to let you draw a card."
+          "text": "You can use it after combat or even on a creature which can't possibly block this turn because it's that player's turn to attack, but it generally has no effect other than to let you draw a card."
         }
       ],
       "text": "Target creature can't block this turn.\nDraw a card.",
@@ -11858,7 +11858,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
@@ -11991,11 +11991,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This spell has a self-replacement in it . This means that if Urza’s Rage is kicked, the 3 damage is replaced with 10 unpreventable damage before any other replacements can be applied. For example, you can’t use Healing Salve to prevent the 3 damage before it gets changed."
+          "text": "This spell has a self-replacement in it . This means that if Urza's Rage is kicked, the 3 damage is replaced with 10 unpreventable damage before any other replacements can be applied. For example, you can't use Healing Salve to prevent the 3 damage before it gets changed."
         },
         {
           "date": "2004-10-04",
-          "text": "You can target this spell with spells and abilities, so you can change its target. Those spells and abilities just can’t counter it."
+          "text": "You can target this spell with spells and abilities, so you can change its target. Those spells and abilities just can't counter it."
         },
         {
           "date": "2004-10-04",
@@ -12007,7 +12007,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Counterspells can be cast that target it, but when they resolve they simply don’t counter it since it can’t be countered."
+          "text": "Counterspells can be cast that target it, but when they resolve they simply don't counter it since it can't be countered."
         }
       ],
       "text": "Kicker {8}{R} (You may pay an additional {8}{R} as you cast this spell.)\nUrza's Rage can't be countered by spells or abilities.\nUrza's Rage deals 3 damage to target creature or player. If Urza's Rage was kicked, instead it deals 10 damage to that creature or player and the damage can't be prevented.",
@@ -12264,7 +12264,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Counter target activated ability. (Mana abilities can't be targeted.)\nDraw a card.",
@@ -12335,7 +12335,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Counterspells can be cast that target it, but when they resolve they simply don’t counter it since it can’t be countered."
+          "text": "Counterspells can be cast that target it, but when they resolve they simply don't counter it since it can't be countered."
         }
       ],
       "subtypes": [
@@ -12463,15 +12463,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have more than one of these on the battlefield, you get to use them all and you don’t skip multiple draw steps."
+          "text": "If you have more than one of these on the battlefield, you get to use them all and you don't skip multiple draw steps."
         },
         {
           "date": "2004-10-04",
-          "text": "The “if you do” means “if you search your library”. You get to skip your draw step and shuffle your deck even if you don’t find (or choose not to find) a basic land."
+          "text": "The \"if you do\" means \"if you search your library\". You get to skip your draw step and shuffle your deck even if you don't find (or choose not to find) a basic land."
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "At the beginning of your upkeep, you may search your library for a basic land card, reveal that card, and put it into your hand. If you do, you skip your draw step this turn and shuffle your library.",
@@ -12782,7 +12782,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can’t pay this cost more than once to get a multiple effect."
+          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can't pay this cost more than once to get a multiple effect."
         },
         {
           "date": "2004-10-04",
@@ -12790,7 +12790,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
@@ -12926,7 +12926,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Counterspells can be cast that target it, but when they resolve they simply don’t counter it since it can’t be countered."
+          "text": "Counterspells can be cast that target it, but when they resolve they simply don't counter it since it can't be countered."
         }
       ],
       "subtypes": [
@@ -13821,7 +13821,7 @@
         },
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -13897,7 +13897,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -14474,7 +14474,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “if you do” means “if you choose to reveal cards”. You still shuffle if you have no creature card in your library."
+          "text": "The \"if you do\" means \"if you choose to reveal cards\". You still shuffle if you have no creature card in your library."
         }
       ],
       "subtypes": [
@@ -14909,7 +14909,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Verdeloth won’t give himself +1/+1 unless he somehow becomes a Saproling."
+          "text": "Verdeloth won't give himself +1/+1 unless he somehow becomes a Saproling."
         }
       ],
       "subtypes": [
@@ -15177,7 +15177,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — You gain 2 life for each basic land type among lands you control.",
@@ -15308,7 +15308,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If cast targeting a spell that can’t be countered, the life gain still happens, but that spell is not countered."
+          "text": "If cast targeting a spell that can't be countered, the life gain still happens, but that spell is not countered."
         }
       ],
       "text": "Counter target spell. You gain 3 life.",
@@ -15520,11 +15520,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "While Armadillo Cloak’s last ability is similar to lifelink, it isn’t lifelink—it’s a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you’ll gain that much life for lifelink, and then Armadillo Cloak’s triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak’s triggered ability do trigger separately."
+          "text": "While Armadillo Cloak's last ability is similar to lifelink, it isn't lifelink—it's a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you'll gain that much life for lifelink, and then Armadillo Cloak's triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak's triggered ability do trigger separately."
         },
         {
           "date": "2016-06-08",
-          "text": "If Armadillo Cloak enchants a creature you don’t control, you’ll gain life when it deals damage, as long as that damage hasn’t already caused you to lose the game."
+          "text": "If Armadillo Cloak enchants a creature you don't control, you'll gain life when it deals damage, as long as that damage hasn't already caused you to lose the game."
         }
       ],
       "subtypes": [
@@ -16075,7 +16075,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -16822,11 +16822,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2013-01-24",
-          "text": "If the target land is an illegal target when Frenzied Tilling tries to resolve, the spell will be countered and none of its effects will happen. You won’t search your library for a basic land card."
+          "text": "If the target land is an illegal target when Frenzied Tilling tries to resolve, the spell will be countered and none of its effects will happen. You won't search your library for a basic land card."
         }
       ],
       "text": "Destroy target land. Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -17176,7 +17176,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Being “without flying” is a targeting restriction. The ability will be countered if the target gains flying before the ability resolves."
+          "text": "Being \"without flying\" is a targeting restriction. The ability will be countered if the target gains flying before the ability resolves."
         }
       ],
       "subtypes": [
@@ -17391,7 +17391,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You only get to pick one card from the player’s hand."
+          "text": "You only get to pick one card from the player's hand."
         },
         {
           "date": "2004-10-04",
@@ -17612,7 +17612,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Create a 1/1 blue Bird creature token with flying for each basic land type among lands you control.",
@@ -17683,7 +17683,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This card’s ability is a mana ability. There is no chance to respond to it in order to prevent the damage. If you want to prevent the damage, you need to use a prevention spell or ability prior to tapping the land for mana."
+          "text": "This card's ability is a mana ability. There is no chance to respond to it in order to prevent the damage. If you want to prevent the damage, you need to use a prevention spell or ability prior to tapping the land for mana."
         }
       ],
       "text": "Whenever a player taps a land for mana, that player adds one mana to his or her mana pool of any type that land produced, and Overabundance deals 1 damage to him or her.",
@@ -18744,7 +18744,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "text": "At the beginning of your upkeep, target player loses 1 life.\nSacrifice Smoldering Tar: Smoldering Tar deals 4 damage to target creature. Activate this ability only any time you could cast a sorcery.",
@@ -18812,7 +18812,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice is mandatory. The last “if you do” only fails if for some reason you could not sacrifice."
+          "text": "The sacrifice is mandatory. The last \"if you do\" only fails if for some reason you could not sacrifice."
         }
       ],
       "text": "Cast Spinal Embrace only during combat.\nUntap target creature you don't control and gain control of it. It gains haste until end of turn. At the beginning of the next end step, sacrifice it. If you do, you gain life equal to its toughness.",
@@ -18946,7 +18946,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Other enchantments you control have shroud. (They can't be the targets of spells or abilities.)\n{1}, Sacrifice Sterling Grove: Search your library for an enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -19580,7 +19580,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The target player is chosen as you announce Void, but the number isn’t chosen until it’s resolving. No player may choose to take actions between you choosing a number and the rest of Void’s effects."
+          "text": "The target player is chosen as you announce Void, but the number isn't chosen until it's resolving. No player may choose to take actions between you choosing a number and the rest of Void's effects."
         }
       ],
       "text": "Choose a number. Destroy all artifacts and creatures with converted mana cost equal to that number. Then target player reveals his or her hand and discards all nonland cards with converted mana cost equal to the number.",
@@ -20796,7 +20796,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a mana ability, which means it can be activated as part of the process of casting a spell or activating another ability. If that happens you get the mana right away, but you don’t get to look at the drawn card until you have finished casting that spell or activating that ability."
+          "text": "This is a mana ability, which means it can be activated as part of the process of casting a spell or activating another ability. If that happens you get the mana right away, but you don't get to look at the drawn card until you have finished casting that spell or activating that ability."
         }
       ],
       "text": "{1}, {T}, Sacrifice Chromatic Sphere: Add one mana of any color to your mana pool. Draw a card.",
@@ -20942,7 +20942,7 @@
         "U",
         "B"
       ],
-      "flavor": "\"A strange skull was turned up by an Ephran farmer's plow. I traded a copper ring for the ‘ox skull.' It resonates of the sea and danger.\"\n—Isel, master carver",
+      "flavor": "\"A strange skull was turned up by an Ephran farmer's plow. I traded a copper ring for the 'ox skull.' It resonates of the sea and danger.\"\n—Isel, master carver",
       "foreignNames": [
         {
           "language": "French",
@@ -21399,7 +21399,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — {3}, {T}: Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
@@ -21881,11 +21881,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "When Tsabo's Web enters the battlefield, draw a card.\nEach land with an activated ability that isn't a mana ability doesn't untap during its controller's untap step.",

--- a/json/ISD.json
+++ b/json/ISD.json
@@ -355,7 +355,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you control a Human, and an effect tries to destroy each Human you control and Angelic Overseer simultaneously, Angelic Overseer won’t be destroyed."
+          "text": "If you control a Human, and an effect tries to destroy each Human you control and Angelic Overseer simultaneously, Angelic Overseer won't be destroyed."
         },
         {
           "date": "2011-09-22",
@@ -575,7 +575,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Once the enchanted creature has been declared as an attacking or blocking creature, causing it to stop being a Human won’t remove it from combat. It will lose the +2/+2 bonus, however."
+          "text": "Once the enchanted creature has been declared as an attacking or blocking creature, causing it to stop being a Human won't remove it from combat. It will lose the +2/+2 bonus, however."
         }
       ],
       "subtypes": [
@@ -1127,7 +1127,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "However, you’ll ignore the continuous effects of static abilities that come from other sources. For example, if you control Xenograft with Human as the chosen creature type, a Vampire creature would not enter the battlefield with a +1/+1 counter."
+          "text": "However, you'll ignore the continuous effects of static abilities that come from other sources. For example, if you control Xenograft with Human as the chosen creature type, a Vampire creature would not enter the battlefield with a +1/+1 counter."
         }
       ],
       "subtypes": [
@@ -1988,7 +1988,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The ability that defines Geist-Honored Monk’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Geist-Honored Monk's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2011-09-22",
@@ -2421,7 +2421,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Apply power bonuses from counters the creature enters the battlefield with and continuous effects like Mayor of Avabruck’s when checking to see if Mentor of the Meek’s ability will trigger."
+          "text": "Apply power bonuses from counters the creature enters the battlefield with and continuous effects like Mayor of Avabruck's when checking to see if Mentor of the Meek's ability will trigger."
         },
         {
           "date": "2011-09-22",
@@ -2851,23 +2851,23 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "No one can cast spells or activate abilities between the time a card is named and the time that Nevermore’s ability starts to work."
+          "text": "No one can cast spells or activate abilities between the time a card is named and the time that Nevermore's ability starts to work."
         },
         {
           "date": "2011-09-22",
-          "text": "Spells with the chosen name that somehow happen to already be on the stack when Nevermore enters the battlefield are not affected by Nevermore’s ability."
+          "text": "Spells with the chosen name that somehow happen to already be on the stack when Nevermore enters the battlefield are not affected by Nevermore's ability."
         },
         {
           "date": "2011-09-22",
-          "text": "Although the named card can’t be cast, it can still be put onto the battlefield by a spell or ability (if it’s a permanent card)."
+          "text": "Although the named card can't be cast, it can still be put onto the battlefield by a spell or ability (if it's a permanent card)."
         },
         {
           "date": "2011-09-22",
-          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can’t be cast. The other half is unaffected."
+          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can't be cast. The other half is unaffected."
         },
         {
           "date": "2011-09-22",
-          "text": "If you want to name a double-faced card, remember to name the front face of that card. (The back face can’t be cast anyway.)"
+          "text": "If you want to name a double-faced card, remember to name the front face of that card. (The back face can't be cast anyway.)"
         },
         {
           "date": "2011-09-22",
@@ -3075,11 +3075,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Purify the Grave can’t be used in response to a spell being cast with flashback or a spell that requires cards to exiled from a graveyard as an additional cost to try and counter the spell or prevent it from being cast."
+          "text": "Purify the Grave can't be used in response to a spell being cast with flashback or a spell that requires cards to exiled from a graveyard as an additional cost to try and counter the spell or prevent it from being cast."
         },
         {
           "date": "2011-09-22",
-          "text": "If it’s your turn, and you cast a spell with flashback from your hand, you’ll have priority to cast that spell again using flashback before any other player has priority to cast Purify the Grave in order to remove that card from your graveyard."
+          "text": "If it's your turn, and you cast a spell with flashback from your hand, you'll have priority to cast that spell again using flashback before any other player has priority to cast Purify the Grave in order to remove that card from your graveyard."
         }
       ],
       "text": "Exile target card from a graveyard.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -3393,11 +3393,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can activate Selfless Cathar’s ability even if you control no other creatures."
+          "text": "You can activate Selfless Cathar's ability even if you control no other creatures."
         },
         {
           "date": "2011-09-22",
-          "text": "Only creatures you control when Selfless Cathar’s ability resolves will be affected. Creatures that enter the battlefield or that you gain control of later in the turn will not."
+          "text": "Only creatures you control when Selfless Cathar's ability resolves will be affected. Creatures that enter the battlefield or that you gain control of later in the turn will not."
         }
       ],
       "subtypes": [
@@ -3614,7 +3614,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you control the only Vampire, Werewolf, or Zombie, you must target it with Slayer of the Wicked’s ability. You choose whether or not to destroy the target when the ability resolves."
+          "text": "If you control the only Vampire, Werewolf, or Zombie, you must target it with Slayer of the Wicked's ability. You choose whether or not to destroy the target when the ability resolves."
         }
       ],
       "subtypes": [
@@ -3839,11 +3839,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Only creatures you control when Spare from Evil resolves will be affected. Creatures that enter the battlefield or that you gain control of later in the turn won’t be."
+          "text": "Only creatures you control when Spare from Evil resolves will be affected. Creatures that enter the battlefield or that you gain control of later in the turn won't be."
         },
         {
           "date": "2011-09-22",
-          "text": "A “non-Human creature” is any creature that doesn’t have the creature type Human. A creature that is a Human in addition to other creature types is not a non-Human creature."
+          "text": "A \"non-Human creature\" is any creature that doesn't have the creature type Human. A creature that is a Human in addition to other creature types is not a non-Human creature."
         }
       ],
       "text": "Creatures you control gain protection from non-Human creatures until end of turn.",
@@ -4054,7 +4054,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keyword abilities, such as equip, are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keyword abilities, such as equip, are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2017-03-14",
@@ -4062,7 +4062,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Stony Silence’s ability affects only artifacts on the battlefield. Activated abilities that work in other zones (such as cycling) can still be activated. Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected."
+          "text": "Stony Silence's ability affects only artifacts on the battlefield. Activated abilities that work in other zones (such as cycling) can still be activated. Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected."
         }
       ],
       "text": "Activated abilities of artifacts can't be activated.",
@@ -4274,7 +4274,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If multiple creatures you control die simultaneously, Thraben Sentry’s ability will trigger that many times. Only the first one to resolve will cause it to transform."
+          "text": "If multiple creatures you control die simultaneously, Thraben Sentry's ability will trigger that many times. Only the first one to resolve will cause it to transform."
         },
         {
           "date": "2016-07-13",
@@ -4506,7 +4506,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If Unruly Mob and another creature you control die simultaneously (perhaps because they were both attacking or blocking), Unruly Mob won’t be on the battlefield as its triggered ability resolves. It can’t be saved by the +1/+1 counter that would have been put on it."
+          "text": "If Unruly Mob and another creature you control die simultaneously (perhaps because they were both attacking or blocking), Unruly Mob won't be on the battlefield as its triggered ability resolves. It can't be saved by the +1/+1 counter that would have been put on it."
         }
       ],
       "subtypes": [
@@ -4716,7 +4716,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Untapping an attacking creature doesn’t remove it from combat."
+          "text": "Untapping an attacking creature doesn't remove it from combat."
         }
       ],
       "subtypes": [
@@ -4931,7 +4931,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you have fewer than four cards in your library when Armored Skaab enters the battlefield, you’ll put all of them into your graveyard."
+          "text": "If you have fewer than four cards in your library when Armored Skaab enters the battlefield, you'll put all of them into your graveyard."
         }
       ],
       "subtypes": [
@@ -5041,15 +5041,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Although you’re paying the card’s mana cost, you aren’t casting that card. Abilities that reduce the cost to cast a creature spell won’t apply, and additional costs to cast that creature can’t be paid. If the card has an ability that allows another cost to be paid “rather than its mana cost,” that alternative cost can be paid. Other alternative costs that affect what it costs to cast a creature spell, such as evoke, can’t."
+          "text": "Although you're paying the card's mana cost, you aren't casting that card. Abilities that reduce the cost to cast a creature spell won't apply, and additional costs to cast that creature can't be paid. If the card has an ability that allows another cost to be paid \"rather than its mana cost,\" that alternative cost can be paid. Other alternative costs that affect what it costs to cast a creature spell, such as evoke, can't."
         },
         {
           "date": "2011-09-22",
-          "text": "Any enters-the-battlefield abilities of the creature will trigger when the token enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the creature will also work."
+          "text": "Any enters-the-battlefield abilities of the creature will trigger when the token enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the creature will also work."
         },
         {
           "date": "2011-09-22",
-          "text": "If you exile a double-faced creature card this way, you’ll pay the mana cost of the front face. The token will be a copy of the front face and it won’t be able to transform."
+          "text": "If you exile a double-faced creature card this way, you'll pay the mana cost of the front face. The token will be a copy of the front face and it won't be able to transform."
         },
         {
           "date": "2011-09-22",
@@ -5263,7 +5263,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2017-03-14",
@@ -5271,7 +5271,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If the copied creature is a token, the token that’s created copies the original characteristics of that token as stated by the effect that created the token."
+          "text": "If the copied creature is a token, the token that's created copies the original characteristics of that token as stated by the effect that created the token."
         },
         {
           "date": "2017-03-14",
@@ -5279,7 +5279,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         }
       ],
       "text": "Create a token that's a copy of target creature you control.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -5390,11 +5390,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You don’t have priority between untapping Civilized Scholar and transforming it. You can’t activate the draw-and-discard ability again, for example."
+          "text": "You don't have priority between untapping Civilized Scholar and transforming it. You can't activate the draw-and-discard ability again, for example."
         },
         {
           "date": "2011-09-22",
-          "text": "If Civilized Scholar attacks, and later in the turn (but before the beginning of your end step), it transforms, Homicidal Brute’s last ability won’t trigger. This is because the creature attacked that turn, even if had its other face up at the time."
+          "text": "If Civilized Scholar attacks, and later in the turn (but before the beginning of your end step), it transforms, Homicidal Brute's last ability won't trigger. This is because the creature attacked that turn, even if had its other face up at the time."
         },
         {
           "date": "2016-07-13",
@@ -5513,7 +5513,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You’ll tap and transform Homicidal Brute even if it couldn’t attack."
+          "text": "You'll tap and transform Homicidal Brute even if it couldn't attack."
         }
       ],
       "subtypes": [
@@ -5630,7 +5630,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The enchanted creature can still be untapped in other ways. Claustrophobia will remain attached, and the creature will continue to not untap during its controller’s untap step."
+          "text": "The enchanted creature can still be untapped in other ways. Claustrophobia will remain attached, and the creature will continue to not untap during its controller's untap step."
         }
       ],
       "subtypes": [
@@ -5749,7 +5749,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If put on your opponent’s creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
+          "text": "If put on your opponent's creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
         },
         {
           "date": "2007-02-01",
@@ -5757,7 +5757,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "“You” refers to the controller of Curiosity, which may be different from the controller of the enchanted creature. “An opponent” refers to an opponent of Curiosity’s controller."
+          "text": "\"You\" refers to the controller of Curiosity, which may be different from the controller of the enchanted creature. \"An opponent\" refers to an opponent of Curiosity's controller."
         },
         {
           "date": "2011-09-22",
@@ -5765,7 +5765,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Curiosity doesn’t trigger if the enchanted creature deals damage to a planeswalker controlled by an opponent."
+          "text": "Curiosity doesn't trigger if the enchanted creature deals damage to a planeswalker controlled by an opponent."
         }
       ],
       "subtypes": [
@@ -5987,7 +5987,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You may reveal the card even if it’s not an instant or sorcery. Whether or not you reveal it, the card stays on top of your library."
+          "text": "You may reveal the card even if it's not an instant or sorcery. Whether or not you reveal it, the card stays on top of your library."
         },
         {
           "date": "2016-07-13",
@@ -6326,7 +6326,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then it does not get exiled."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then it does not get exiled."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
@@ -6533,7 +6533,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you have fewer than four cards in your library, you’ll look at all the cards there and put one into your hand and the rest into your graveyard."
+          "text": "If you have fewer than four cards in your library, you'll look at all the cards there and put one into your hand and the rest into your graveyard."
         }
       ],
       "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -6740,7 +6740,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You must target a spell in order to cast Frightful Delusion. You can’t cast it without a legal target just to make a player discard a card."
+          "text": "You must target a spell in order to cast Frightful Delusion. You can't cast it without a legal target just to make a player discard a card."
         },
         {
           "date": "2011-09-22",
@@ -6952,7 +6952,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Hysterical Blindness’s effect will continue to apply to a creature even if you (or a teammate) gains control of that creature later in the turn."
+          "text": "Hysterical Blindness's effect will continue to apply to a creature even if you (or a teammate) gains control of that creature later in the turn."
         }
       ],
       "text": "Creatures your opponents control get -4/-0 until end of turn.",
@@ -7163,11 +7163,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If for some reason you can’t win the game (because your opponent controls Platinum Angel, for example), you won’t lose for having tried to draw a card from a library with no cards in it, because the draw was still replaced."
+          "text": "If for some reason you can't win the game (because your opponent controls Platinum Angel, for example), you won't lose for having tried to draw a card from a library with no cards in it, because the draw was still replaced."
         },
         {
           "date": "2017-04-18",
-          "text": "If two or more players control a Laboratory Maniac and each player is instructed to draw a number of cards, first the player whose turn it is draws that many cards. If this causes that player to win the game instead, the game is immediately over. If the game isn’t over yet, repeat this process for each other player in turn order."
+          "text": "If two or more players control a Laboratory Maniac and each player is instructed to draw a number of cards, first the player whose turn it is draws that many cards. If this causes that player to win the game instead, the game is immediately over. If the game isn't over yet, repeat this process for each other player in turn order."
         }
       ],
       "subtypes": [
@@ -7278,7 +7278,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Only Lantern Spirit’s controller may activate its ability."
+          "text": "Only Lantern Spirit's controller may activate its ability."
         }
       ],
       "subtypes": [
@@ -7391,7 +7391,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If one of Lost in the Mist’s targets is illegal by the time it resolves, Lost in the Mist will still affect the remaining legal target. If both targets are illegal at this time, Lost in the Mist will be countered."
+          "text": "If one of Lost in the Mist's targets is illegal by the time it resolves, Lost in the Mist will still affect the remaining legal target. If both targets are illegal at this time, Lost in the Mist will be countered."
         }
       ],
       "text": "Counter target spell. Return target permanent to its owner's hand.",
@@ -7835,23 +7835,23 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You don’t have to target any cards when you cast Memory’s Journey, but you must target a player."
+          "text": "You don't have to target any cards when you cast Memory's Journey, but you must target a player."
         },
         {
           "date": "2011-09-22",
-          "text": "If the player is an illegal target by the time Memory’s Journey resolves, the spell will have no effect, even if the cards are still legal targets. This is because a spell can’t make an illegal target (the player) perform any actions (such as shuffling his or her library)."
+          "text": "If the player is an illegal target by the time Memory's Journey resolves, the spell will have no effect, even if the cards are still legal targets. This is because a spell can't make an illegal target (the player) perform any actions (such as shuffling his or her library)."
         },
         {
           "date": "2011-09-22",
-          "text": "Any of the targeted cards that are illegal targets by the time Memory’s Journey resolves aren’t shuffled into their owner’s library."
+          "text": "Any of the targeted cards that are illegal targets by the time Memory's Journey resolves aren't shuffled into their owner's library."
         },
         {
           "date": "2011-09-22",
-          "text": "If no cards were targeted by Memory’s Journey or if all the targeted cards are illegal targets by the time Memory’s Journey resolves, the targeted player will still shuffle his or her library."
+          "text": "If no cards were targeted by Memory's Journey or if all the targeted cards are illegal targets by the time Memory's Journey resolves, the targeted player will still shuffle his or her library."
         },
         {
           "date": "2011-09-22",
-          "text": "If you cast Memory’s Journey with flashback, it won’t be in the graveyard when you choose targets. It can’t target itself."
+          "text": "If you cast Memory's Journey with flashback, it won't be in the graveyard when you choose targets. It can't target itself."
         }
       ],
       "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -8060,15 +8060,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can only activate the ability if you control Mirror-Mad Phantasm, even if you don’t own it."
+          "text": "You can only activate the ability if you control Mirror-Mad Phantasm, even if you don't own it."
         },
         {
           "date": "2011-09-22",
-          "text": "If no card named Mirror-Mad Phantasm is revealed (possibly because it was a card copying Mirror-Mad Phantasm or it was a token), all cards from that library will be put into their owner’s graveyard."
+          "text": "If no card named Mirror-Mad Phantasm is revealed (possibly because it was a card copying Mirror-Mad Phantasm or it was a token), all cards from that library will be put into their owner's graveyard."
         },
         {
           "date": "2011-09-22",
-          "text": "If another creature (such as Necrotic Ooze) gains Mirror-Mad Phantasm’s activated ability, its owner reveals cards until he or she reveals a card named Mirror-Mad Phantasm."
+          "text": "If another creature (such as Necrotic Ooze) gains Mirror-Mad Phantasm's activated ability, its owner reveals cards until he or she reveals a card named Mirror-Mad Phantasm."
         }
       ],
       "subtypes": [
@@ -8283,11 +8283,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you choose to draw a card, and that draw is replaced by another action, you’ll still discard a card."
+          "text": "If you choose to draw a card, and that draw is replaced by another action, you'll still discard a card."
         },
         {
           "date": "2011-09-22",
-          "text": "You can’t do anything in between drawing a card and discarding a card, including casting the card you drew."
+          "text": "You can't do anything in between drawing a card and discarding a card, including casting the card you drew."
         }
       ],
       "subtypes": [
@@ -8509,11 +8509,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "An effect that gives flashback to an instant or sorcery card in your graveyard stops applying once that card has left the stack. The card won’t have flashback while exiled and can’t be the target of Runic Repetition (unless it naturally has flashback)."
+          "text": "An effect that gives flashback to an instant or sorcery card in your graveyard stops applying once that card has left the stack. The card won't have flashback while exiled and can't be the target of Runic Repetition (unless it naturally has flashback)."
         },
         {
           "date": "2011-09-22",
-          "text": "A card that’s exiled face down doesn’t have any characteristics or abilities, so it can’t be the target of Runic Repetition."
+          "text": "A card that's exiled face down doesn't have any characteristics or abilities, so it can't be the target of Runic Repetition."
         }
       ],
       "text": "Return target exiled card with flashback you own to your hand.",
@@ -9032,11 +9032,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Skaab Ruinator is on the stack when you pay its costs. It can’t be exiled to pay for itself."
+          "text": "Skaab Ruinator is on the stack when you pay its costs. It can't be exiled to pay for itself."
         },
         {
           "date": "2011-09-22",
-          "text": "You must exile three creature cards from your graveyard no matter what zone you’re casting Skaab Ruinator from."
+          "text": "You must exile three creature cards from your graveyard no matter what zone you're casting Skaab Ruinator from."
         }
       ],
       "subtypes": [
@@ -9141,14 +9141,11 @@
       "power": "2",
       "printings": [
         "ISD",
+        "pWCQ",
         "MM3"
       ],
       "rarity": "Rare",
       "rulings": [
-        {
-          "date": "2013-07-01",
-          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
-        },
         {
           "date": "2017-03-14",
           "text": "If you cast an instant or sorcery with {X} in its mana cost this way, you still choose the value of X as part of casting the spell and pay that cost."
@@ -9160,6 +9157,10 @@
         {
           "date": "2017-03-14",
           "text": "You may pay any optional additional costs the spell has, such as conspire costs. You must pay any mandatory additional costs the spell has, such as that of Bone Splinters."
+        },
+        {
+          "date": "2017-04-18",
+          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
         }
       ],
       "subtypes": [
@@ -9488,11 +9489,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can’t do anything in between the Homunculus token being created and having to sacrifice a creature."
+          "text": "You can't do anything in between the Homunculus token being created and having to sacrifice a creature."
         },
         {
           "date": "2011-09-22",
-          "text": "If you control no creatures when the ability resolves, you’ll put the Homunculus token onto the battlefield and immediately sacrifice it."
+          "text": "If you control no creatures when the ability resolves, you'll put the Homunculus token onto the battlefield and immediately sacrifice it."
         }
       ],
       "subtypes": [
@@ -9601,7 +9602,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The ability that defines Sturmgeist’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Sturmgeist's power and toughness works in all zones, not just the battlefield."
         }
       ],
       "subtypes": [
@@ -9814,11 +9815,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you control multiple Undead Alchemists, the multiple replacement abilities will have no added effect. Combat damage dealt to a player by a Zombie you control will be replaced only once with cards being put into that player’s graveyard."
+          "text": "If you control multiple Undead Alchemists, the multiple replacement abilities will have no added effect. Combat damage dealt to a player by a Zombie you control will be replaced only once with cards being put into that player's graveyard."
         },
         {
           "date": "2011-09-22",
-          "text": "Whenever a creature card is put into an opponent’s graveyard from his or her library, the triggered ability of each Undead Alchemist you control will trigger. The first such ability to resolve will exile that creature card and create a Zombie token. Subsequent abilities won’t exile the creature card, but each will create another Zombie token."
+          "text": "Whenever a creature card is put into an opponent's graveyard from his or her library, the triggered ability of each Undead Alchemist you control will trigger. The first such ability to resolve will exile that creature card and create a Zombie token. Subsequent abilities won't exile the creature card, but each will create another Zombie token."
         }
       ],
       "subtypes": [
@@ -9929,7 +9930,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You’ll gain life equal to the creature’s last known toughness before it died. For example, if Abattoir Ghoul deals 3 first-strike damage to a 7/7 creature and then you give the creature -5/-5 before the regular combat damage step, you’ll gain 2 life."
+          "text": "You'll gain life equal to the creature's last known toughness before it died. For example, if Abattoir Ghoul deals 3 first-strike damage to a 7/7 creature and then you give the creature -5/-5 before the regular combat damage step, you'll gain 2 life."
         }
       ],
       "subtypes": [
@@ -10263,7 +10264,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The Curse must be legally able to enchant the player. For example, if the player has protection from red, you couldn’t put a red Curse onto the battlefield this way."
+          "text": "The Curse must be legally able to enchant the player. For example, if the player has protection from red, you couldn't put a red Curse onto the battlefield this way."
         }
       ],
       "subtypes": [
@@ -10698,7 +10699,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -11557,7 +11558,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you control fewer than two Zombies, you won’t get any tokens."
+          "text": "If you control fewer than two Zombies, you won't get any tokens."
         },
         {
           "date": "2011-09-22",
@@ -11669,7 +11670,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Falkenrath Noble and another creature die at the same time, Falkenrath Noble’s triggered ability will trigger for each of them."
+          "text": "If Falkenrath Noble and another creature die at the same time, Falkenrath Noble's triggered ability will trigger for each of them."
         }
       ],
       "subtypes": [
@@ -12084,7 +12085,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The first ability doesn’t reduce any colored mana requirements of the creature spell."
+          "text": "The first ability doesn't reduce any colored mana requirements of the creature spell."
         }
       ],
       "text": "Creature spells you cast cost {2} less to cast.\nCreatures you control get -1/-1.",
@@ -12184,21 +12185,22 @@
       "originalType": "Planeswalker — Liliana",
       "printings": [
         "ISD",
+        "pWCQ",
         "MM3"
       ],
       "rarity": "Mythic Rare",
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "When Liliana’s first ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order chooses a card to discard, then those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
+          "text": "When Liliana's first ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order chooses a card to discard, then those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
         },
         {
           "date": "2017-03-14",
-          "text": "The player targeted by Liliana’s second ability chooses which creature to sacrifice when the ability resolves. This ability doesn’t target any creature."
+          "text": "The player targeted by Liliana's second ability chooses which creature to sacrifice when the ability resolves. This ability doesn't target any creature."
         },
         {
           "date": "2017-03-14",
-          "text": "When Liliana’s third ability resolves, you put each permanent the player controls into one of the two piles. For example, you could put a creature into one pile and an Aura enchanting that creature into the other pile."
+          "text": "When Liliana's third ability resolves, you put each permanent the player controls into one of the two piles. For example, you could put a creature into one pile and an Aura enchanting that creature into the other pile."
         },
         {
           "date": "2017-03-14",
@@ -12518,7 +12520,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the targeted land is an illegal target by the time Maw of the Mire resolves, it will be countered and none of its effects will occur. You won’t gain 4 life."
+          "text": "If the targeted land is an illegal target by the time Maw of the Mire resolves, it will be countered and none of its effects will occur. You won't gain 4 life."
         }
       ],
       "text": "Destroy target land. You gain 4 life.",
@@ -13379,7 +13381,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Only creatures on the battlefield will be exiled. In other zones, they’re “creature cards,” not “creatures.”"
+          "text": "Only creatures on the battlefield will be exiled. In other zones, they're \"creature cards,\" not \"creatures.\""
         },
         {
           "date": "2017-03-14",
@@ -13387,11 +13389,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named “Beast.”"
+          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named \"Beast.\""
         },
         {
           "date": "2017-03-14",
-          "text": "A double-faced creature only has the name of the face that’s up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn’t be exiled."
+          "text": "A double-faced creature only has the name of the face that's up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn't be exiled."
         }
       ],
       "text": "Exile target creature and all other creatures with the same name as that creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -13600,7 +13602,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Unlike Skirsdag High Priest itself, the two other creatures you tap to activate the ability aren’t required to have been under your control continuously since the beginning of your most recent turn."
+          "text": "Unlike Skirsdag High Priest itself, the two other creatures you tap to activate the ability aren't required to have been under your control continuously since the beginning of your most recent turn."
         }
       ],
       "subtypes": [
@@ -13817,7 +13819,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The amount of life you gain is equal to the creature’s toughness as it last existed on the battlefield."
+          "text": "The amount of life you gain is equal to the creature's toughness as it last existed on the battlefield."
         }
       ],
       "text": "Target opponent sacrifices a creature. You gain life equal to that creature's toughness.",
@@ -14779,7 +14781,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Ashmouth Hound’s ability triggers once for each creature it blocks or becomes blocked by."
+          "text": "Ashmouth Hound's ability triggers once for each creature it blocks or becomes blocked by."
         }
       ],
       "subtypes": [
@@ -14890,7 +14892,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The damage dealt by Balefire Dragon’s triggered ability isn’t combat damage."
+          "text": "The damage dealt by Balefire Dragon's triggered ability isn't combat damage."
         }
       ],
       "subtypes": [
@@ -15005,11 +15007,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Blasphemous Act’s ability can’t reduce the total cost to cast the spell below {R}."
+          "text": "Blasphemous Act's ability can't reduce the total cost to cast the spell below {R}."
         },
         {
           "date": "2011-09-22",
-          "text": "Although players may respond to Blasphemous Act once it’s been cast, once it’s announced, they can’t respond before the cost is calculated and paid."
+          "text": "Although players may respond to Blasphemous Act once it's been cast, once it's announced, they can't respond before the cost is calculated and paid."
         }
       ],
       "text": "Blasphemous Act costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
@@ -15323,11 +15325,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Burning Vengeance doesn’t trigger when you activate an ability of a card in your graveyard, such as unearth or the ability of Reassembling Skeleton."
+          "text": "Burning Vengeance doesn't trigger when you activate an ability of a card in your graveyard, such as unearth or the ability of Reassembling Skeleton."
         },
         {
           "date": "2016-06-08",
-          "text": "Burning Vengeance’s triggered ability will resolve before the spell you cast from your graveyard."
+          "text": "Burning Vengeance's triggered ability will resolve before the spell you cast from your graveyard."
         }
       ],
       "text": "Whenever you cast a spell from your graveyard, Burning Vengeance deals 2 damage to target creature or player.",
@@ -15435,11 +15437,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The instant or sorcery card returned to your hand is chosen at random as the triggered ability resolves. If any player responds to the ability, that player won’t yet know what card will be returned."
+          "text": "The instant or sorcery card returned to your hand is chosen at random as the triggered ability resolves. If any player responds to the ability, that player won't yet know what card will be returned."
         },
         {
           "date": "2011-09-22",
-          "text": "Because the first ability doesn’t target the instant or sorcery card, any instants or sorceries put into your graveyard in response to that ability may be returned to your hand."
+          "text": "Because the first ability doesn't target the instant or sorcery card, any instants or sorceries put into your graveyard in response to that ability may be returned to your hand."
         }
       ],
       "subtypes": [
@@ -15766,11 +15768,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If there are multiple combat phases in a turn, each creature must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, each creature must attack only in the first one in which it's able to."
         },
         {
           "date": "2011-09-22",
-          "text": "If, during the enchanted player’s declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having the creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during the enchanted player's declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having the creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -16400,15 +16402,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The enchanted creature’s controller still chooses which player or planeswalker that creature attacks."
+          "text": "The enchanted creature's controller still chooses which player or planeswalker that creature attacks."
         },
         {
           "date": "2011-09-22",
-          "text": "If there are multiple combat phases in a turn, the enchanted creature must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, the enchanted creature must attack only in the first one in which it's able to."
         },
         {
           "date": "2011-09-22",
-          "text": "If, during its controller’s declare attackers step, the enchanted creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having the creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during its controller's declare attackers step, the enchanted creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having the creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -16941,7 +16943,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If you have two or fewer cards in your library when the ability resolves, all of them will be put into your graveyard. Heretic’s Punishment will still deal damage equal to the highest converted mana cost among those cards."
+          "text": "If you have two or fewer cards in your library when the ability resolves, all of them will be put into your graveyard. Heretic's Punishment will still deal damage equal to the highest converted mana cost among those cards."
         },
         {
           "date": "2011-09-22",
@@ -17387,7 +17389,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If one of Into the Maw of Hell’s targets is illegal by the time it resolves, Into the Maw of Hell will still affect the remaining legal target. If both targets are illegal at this time, Into the Maw of Hell will be countered."
+          "text": "If one of Into the Maw of Hell's targets is illegal by the time it resolves, Into the Maw of Hell will still affect the remaining legal target. If both targets are illegal at this time, Into the Maw of Hell will be countered."
         }
       ],
       "text": "Destroy target land. Into the Maw of Hell deals 13 damage to target creature.",
@@ -18025,12 +18027,8 @@
       "rarity": "Mythic Rare",
       "rulings": [
         {
-          "date": "2013-07-01",
-          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
-        },
-        {
           "date": "2017-03-14",
-          "text": "Only instant and sorcery cards in your graveyard when Past in Flames resolves will gain flashback. Instant and sorcery cards that are put into your graveyard later in the turn, including the resolving Past in Flames, won’t gain flashback."
+          "text": "Only instant and sorcery cards in your graveyard when Past in Flames resolves will gain flashback. Instant and sorcery cards that are put into your graveyard later in the turn, including the resolving Past in Flames, won't gain flashback."
         },
         {
           "date": "2017-03-14",
@@ -18043,6 +18041,10 @@
         {
           "date": "2017-03-14",
           "text": "You may pay any optional additional costs the spell has, such as conspire costs. You must pay any mandatory additional costs the spell has, such as that of Bone Splinters."
+        },
+        {
+          "date": "2017-04-18",
+          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
         }
       ],
       "text": "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -19430,11 +19432,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Traitorous Blood can target any creature, even one that’s tapped or one you already control."
+          "text": "Traitorous Blood can target any creature, even one that's tapped or one you already control."
         },
         {
           "date": "2011-09-22",
-          "text": "Gaining control of a creature doesn’t cause you gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you gain control of any Auras or Equipment attached to it."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap it. It gains trample and haste until end of turn.",
@@ -19539,7 +19541,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Only Vampires you control when Vampiric Fury resolves will receive the bonus. Creatures that enter the battlefield, that you gain control of later in the turn, or that become Vampires later in the turn won’t be affected."
+          "text": "Only Vampires you control when Vampiric Fury resolves will receive the bonus. Creatures that enter the battlefield, that you gain control of later in the turn, or that become Vampires later in the turn won't be affected."
         }
       ],
       "text": "Vampire creatures you control get +2/+0 and gain first strike until end of turn.",
@@ -20081,7 +20083,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The ability that defines Boneyard Wurm’s power and toughness works in all zones, not just the battlefield. If Boneyard Wurm is in your graveyard, it will count itself."
+          "text": "The ability that defines Boneyard Wurm's power and toughness works in all zones, not just the battlefield. If Boneyard Wurm is in your graveyard, it will count itself."
         }
       ],
       "subtypes": [
@@ -20830,7 +20832,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Once the ability has resolved, the bonus won’t change if the number of creatures you control changes later in the turn."
+          "text": "Once the ability has resolved, the bonus won't change if the number of creatures you control changes later in the turn."
         }
       ],
       "subtypes": [
@@ -20941,11 +20943,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Creatures you control don’t copy whether Essence of the Wild is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Creatures you control don't copy whether Essence of the Wild is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2011-09-22",
-          "text": "Because creatures you control enter the battlefield as a copy of Essence of the Wild, any enters-the-battlefield triggered abilities printed on such creatures won’t trigger."
+          "text": "Because creatures you control enter the battlefield as a copy of Essence of the Wild, any enters-the-battlefield triggered abilities printed on such creatures won't trigger."
         },
         {
           "date": "2011-09-22",
@@ -20953,19 +20955,19 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If a creature such as Clone is entering the battlefield under your control, there will be two copy effects to apply: the creature’s own and Essence of the Wild’s. No matter what order these effects are applied, the creature will be a copy of Essence of the Wild when it enters the battlefield."
+          "text": "If a creature such as Clone is entering the battlefield under your control, there will be two copy effects to apply: the creature's own and Essence of the Wild's. No matter what order these effects are applied, the creature will be a copy of Essence of the Wild when it enters the battlefield."
         },
         {
           "date": "2011-09-22",
-          "text": "Other enters-the-battlefield replacement abilities printed on the creature entering the battlefield won’t be applied because the creature will already be Essence of the Wild at that point (and therefore it won’t have those abilities). For example, a creature that normally enters the battlefield tapped will enter the battlefield as an untapped Essence of the Wild, and a creature that would normally enter the battlefield with counters on it will enter the battlefield as an Essence of the Wild with no counters."
+          "text": "Other enters-the-battlefield replacement abilities printed on the creature entering the battlefield won't be applied because the creature will already be Essence of the Wild at that point (and therefore it won't have those abilities). For example, a creature that normally enters the battlefield tapped will enter the battlefield as an untapped Essence of the Wild, and a creature that would normally enter the battlefield with counters on it will enter the battlefield as an Essence of the Wild with no counters."
         },
         {
           "date": "2011-09-22",
-          "text": "External abilities may still affect how a creature enters the battlefield. For example, if your opponent controls Urabrask the Hidden, which reads, in part, “Creatures your opponents control enter the battlefield tapped,” a creature entering the battlefield under your control will be a tapped Essence of the Wild."
+          "text": "External abilities may still affect how a creature enters the battlefield. For example, if your opponent controls Urabrask the Hidden, which reads, in part, \"Creatures your opponents control enter the battlefield tapped,\" a creature entering the battlefield under your control will be a tapped Essence of the Wild."
         },
         {
           "date": "2011-09-22",
-          "text": "If a creature such as Cryptoplasm that’s already on the battlefield copies Essence of the Wild and modifies its own copy effect, that modification is also copied by creatures entering the battlefield under your control."
+          "text": "If a creature such as Cryptoplasm that's already on the battlefield copies Essence of the Wild and modifies its own copy effect, that modification is also copied by creatures entering the battlefield under your control."
         },
         {
           "date": "2011-09-22",
@@ -21183,7 +21185,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "In order to regenerate Werewolves involved in combat, you must sacrifice Full Moon’s Rise before combat damage is assigned. This means they will lose the +1/+0 and trample bonuses before combat damage assignment."
+          "text": "In order to regenerate Werewolves involved in combat, you must sacrifice Full Moon's Rise before combat damage is assigned. This means they will lose the +1/+0 and trample bonuses before combat damage assignment."
         }
       ],
       "text": "Werewolf creatures you control get +1/+0 and have trample.\nSacrifice Full Moon's Rise: Regenerate all Werewolf creatures you control.",
@@ -21293,15 +21295,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Garruk Relentless’s first ability is a state-triggered ability. It triggers once Garruk has two or fewer loyalty counters on him and it can’t retrigger while that ability is on the stack."
+          "text": "Garruk Relentless's first ability is a state-triggered ability. It triggers once Garruk has two or fewer loyalty counters on him and it can't retrigger while that ability is on the stack."
         },
         {
           "date": "2011-09-22",
-          "text": "You don’t add or remove loyalty counters from Garruk Relentless when he transforms into Garruk, the Veil-Cursed. In most cases, he’ll have one or two loyalty counters on him."
+          "text": "You don't add or remove loyalty counters from Garruk Relentless when he transforms into Garruk, the Veil-Cursed. In most cases, he'll have one or two loyalty counters on him."
         },
         {
           "date": "2011-09-22",
-          "text": "You can’t activate a loyalty ability of Garruk Relentless and later that turn after he transforms activate a loyalty ability of Garruk, the Veil-Cursed."
+          "text": "You can't activate a loyalty ability of Garruk Relentless and later that turn after he transforms activate a loyalty ability of Garruk, the Veil-Cursed."
         },
         {
           "date": "2016-07-13",
@@ -21417,15 +21419,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The second ability of Garruk, the Veil-Cursed doesn’t target a creature. However, when that ability resolves, you must sacrifice a creature if you control one."
+          "text": "The second ability of Garruk, the Veil-Cursed doesn't target a creature. However, when that ability resolves, you must sacrifice a creature if you control one."
         },
         {
           "date": "2011-09-22",
-          "text": "The number of creature cards in your graveyard is counted when the third ability of Garruk, the Veil-Cursed resolves. Once the ability resolves, the bonus doesn’t change if that number changes later in the turn."
+          "text": "The number of creature cards in your graveyard is counted when the third ability of Garruk, the Veil-Cursed resolves. Once the ability resolves, the bonus doesn't change if that number changes later in the turn."
         },
         {
           "date": "2011-09-22",
-          "text": "Only creatures you control when the third ability of Garruk, the Veil-Cursed resolves will receive the bonus. Creatures that enter the battlefield or that you gain control of later in the turn won’t be affected."
+          "text": "Only creatures you control when the third ability of Garruk, the Veil-Cursed resolves will receive the bonus. Creatures that enter the battlefield or that you gain control of later in the turn won't be affected."
         }
       ],
       "subtypes": [
@@ -22185,7 +22187,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If Gutter Grime leaves the battlefield, the power and toughness of each Ooze token it created will become 0. Unless another effect is raising its toughness above 0, each of these Ooze tokens will be put into its owner’s graveyard the next time state-based actions are checked."
+          "text": "If Gutter Grime leaves the battlefield, the power and toughness of each Ooze token it created will become 0. Unless another effect is raising its toughness above 0, each of these Ooze tokens will be put into its owner's graveyard the next time state-based actions are checked."
         }
       ],
       "text": "Whenever a nontoken creature you control dies, put a slime counter on Gutter Grime, then create a green Ooze creature token with \"This creature's power and toughness are each equal to the number of slime counters on Gutter Grime.\"",
@@ -22515,7 +22517,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "You declare which player or planeswalker each token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Kessig Cagebreakers is attacking."
+          "text": "You declare which player or planeswalker each token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Kessig Cagebreakers is attacking."
         },
         {
           "date": "2011-09-22",
@@ -22837,11 +22839,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Make a Wish isn’t put into its owner’s graveyard until it is finished resolving, so it can’t be returned by its own effect."
+          "text": "Make a Wish isn't put into its owner's graveyard until it is finished resolving, so it can't be returned by its own effect."
         },
         {
           "date": "2011-09-22",
-          "text": "The cards aren’t randomly chosen until Make a Wish resolves."
+          "text": "The cards aren't randomly chosen until Make a Wish resolves."
         },
         {
           "date": "2011-09-22",
@@ -23181,11 +23183,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If Moldgraf Monstrosity’s ability can’t exile it (perhaps because it’s not still in the graveyard when the ability resolves), the two creature cards are still returned to the battlefield."
+          "text": "If Moldgraf Monstrosity's ability can't exile it (perhaps because it's not still in the graveyard when the ability resolves), the two creature cards are still returned to the battlefield."
         },
         {
           "date": "2011-09-22",
-          "text": "If two Moldgraf Monstrosities die simultaneously, the first ability to resolve could return the other Moldgraf Monstrosity to the battlefield. If it does, the second Moldgraf Monstrosity’s ability won’t exile it but it will return two more creature cards to the battlefield."
+          "text": "If two Moldgraf Monstrosities die simultaneously, the first ability to resolve could return the other Moldgraf Monstrosity to the battlefield. If it does, the second Moldgraf Monstrosity's ability won't exile it but it will return two more creature cards to the battlefield."
         }
       ],
       "subtypes": [
@@ -23297,11 +23299,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Whether or not a creature is a Werewolf or a Wolf is checked only as combat damage is dealt. If the creature isn’t a Werewolf or a Wolf at that time, its combat damage will be prevented."
+          "text": "Whether or not a creature is a Werewolf or a Wolf is checked only as combat damage is dealt. If the creature isn't a Werewolf or a Wolf at that time, its combat damage will be prevented."
         },
         {
           "date": "2011-09-22",
-          "text": "Moonmist will prevent combat damage dealt by a creature that isn’t a Werewolf or a Wolf even if that creature wasn’t on the battlefield (or was a Werewolf or a Wolf) when Moonmist resolved."
+          "text": "Moonmist will prevent combat damage dealt by a creature that isn't a Werewolf or a Wolf even if that creature wasn't on the battlefield (or was a Werewolf or a Wolf) when Moonmist resolved."
         }
       ],
       "text": "Transform all Humans. Prevent all combat damage that would be dealt this turn by creatures other than Werewolves and Wolves. (Only double-faced cards can be transformed.)",
@@ -23753,11 +23755,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "All of the tokens enter the battlefield simultaneously. They’ll have the same name, color, type and subtype, abilities, power, toughness, and so on."
+          "text": "All of the tokens enter the battlefield simultaneously. They'll have the same name, color, type and subtype, abilities, power, toughness, and so on."
         },
         {
           "date": "2011-09-22",
-          "text": "If the effect is putting more than one kind of token onto the battlefield, it’ll put twice as many of each kind onto the battlefield. For example, if you cast Bestial Menace while controlling Parallel Lives, you’ll put two Snake tokens, two Wolf tokens, and two Elephant tokens onto the battlefield."
+          "text": "If the effect is putting more than one kind of token onto the battlefield, it'll put twice as many of each kind onto the battlefield. For example, if you cast Bestial Menace while controlling Parallel Lives, you'll put two Snake tokens, two Wolf tokens, and two Elephant tokens onto the battlefield."
         },
         {
           "date": "2011-09-22",
@@ -23765,7 +23767,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the effect creating the tokens instructs you to do something with those tokens at a later time, like exiling them at the end of combat, you’ll do that for all the tokens."
+          "text": "If the effect creating the tokens instructs you to do something with those tokens at a later time, like exiling them at the end of combat, you'll do that for all the tokens."
         }
       ],
       "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.",
@@ -24290,6 +24292,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -24309,7 +24315,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Spidery Grasp can target a creature that’s already untapped. It will still get +2/+4 and gain reach."
+          "text": "Spidery Grasp can target a creature that's already untapped. It will still get +2/+4 and gain reach."
         }
       ],
       "text": "Untap target creature. It gets +2/+4 and gains reach until end of turn. (It can block creatures with flying.)",
@@ -24414,11 +24420,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The ability that defines Splinterfright’s power and toughness works in all zones, not just the battlefield. If Splinterfright is in your graveyard, it will count itself."
+          "text": "The ability that defines Splinterfright's power and toughness works in all zones, not just the battlefield. If Splinterfright is in your graveyard, it will count itself."
         },
         {
           "date": "2011-09-22",
-          "text": "If Splinterfright’s controller has only one card in his or her library, he or she puts that card into his or her graveyard."
+          "text": "If Splinterfright's controller has only one card in his or her library, he or she puts that card into his or her graveyard."
         }
       ],
       "subtypes": [
@@ -24528,11 +24534,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can’t target the same creature twice to put two +1/+1 counters on it."
+          "text": "You can't target the same creature twice to put two +1/+1 counters on it."
         },
         {
           "date": "2011-09-22",
-          "text": "If Travel Preparations targets two creatures, and one of them is an illegal target by the time Travel Preparations resolves, you’ll still put a +1/+1 counter on the other creature."
+          "text": "If Travel Preparations targets two creatures, and one of them is an illegal target by the time Travel Preparations resolves, you'll still put a +1/+1 counter on the other creature."
         }
       ],
       "text": "Put a +1/+1 counter on each of up to two target creatures.\nFlashback {1}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -24638,7 +24644,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "When the ability resolves, Tree of Redemption’s toughness will become your former life total and you will gain or lose an amount of life necessary so that your life total equals Tree of Redemption’s former toughness. Other effects that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "When the ability resolves, Tree of Redemption's toughness will become your former life total and you will gain or lose an amount of life necessary so that your life total equals Tree of Redemption's former toughness. Other effects that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2011-09-22",
@@ -24646,7 +24652,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If Tree of Redemption isn’t on the battlefield when the ability resolves, the exchange can’t happen and the ability will have no effect."
+          "text": "If Tree of Redemption isn't on the battlefield when the ability resolves, the exchange can't happen and the ability will have no effect."
         }
       ],
       "subtypes": [
@@ -25207,11 +25213,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The creature card isn’t chosen at random until the ability resolves."
+          "text": "The creature card isn't chosen at random until the ability resolves."
         },
         {
           "date": "2011-09-22",
-          "text": "Woodland Sleuth could die in response to its own morbid ability. If this happens, the ability could return Woodland Sleuth to its owner’s hand."
+          "text": "Woodland Sleuth could die in response to its own morbid ability. If this happens, the ability could return Woodland Sleuth to its owner's hand."
         }
       ],
       "subtypes": [
@@ -25433,7 +25439,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Evil Twin copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it gains the activated ability. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Evil Twin copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it gains the activated ability. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2017-03-14",
@@ -25453,15 +25459,15 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named “Beast.”"
+          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named \"Beast.\""
         },
         {
           "date": "2017-03-14",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Evil Twin enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Evil Twin enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2017-03-14",
-          "text": "If Evil Twin somehow enters the battlefield at the same time as another creature, Evil Twin can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Evil Twin somehow enters the battlefield at the same time as another creature, Evil Twin can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2017-03-14",
@@ -25578,7 +25584,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Geist of Saint Traft is attacking."
+          "text": "You declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Geist of Saint Traft is attacking."
         },
         {
           "date": "2011-09-22",
@@ -25697,7 +25703,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the targeted creature is an illegal target by the time Grimgrin’s last ability resolves, the entire ability is countered and none of its effects will occur. You won’t put a +1/+1 counter on Grimgrin."
+          "text": "If the targeted creature is an illegal target by the time Grimgrin's last ability resolves, the entire ability is countered and none of its effects will occur. You won't put a +1/+1 counter on Grimgrin."
         },
         {
           "date": "2011-09-22",
@@ -25705,7 +25711,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Grimgrin’s last ability resolves, but the targeted creature isn’t destroyed (perhaps because it regenerated or has indestructible), you’ll still put a +1/+1 on Grimgrin."
+          "text": "If Grimgrin's last ability resolves, but the targeted creature isn't destroyed (perhaps because it regenerated or has indestructible), you'll still put a +1/+1 on Grimgrin."
         }
       ],
       "subtypes": [
@@ -25825,7 +25831,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If you activate Olivia Voldaren’s last ability, and before that ability resolves you lose control of Olivia Voldaren, the ability will resolve with no effect. You won’t gain control of the targeted Vampire."
+          "text": "If you activate Olivia Voldaren's last ability, and before that ability resolves you lose control of Olivia Voldaren, the ability will resolve with no effect. You won't gain control of the targeted Vampire."
         }
       ],
       "subtypes": [
@@ -25935,11 +25941,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If a Blazing Torch controlled by one player somehow winds up equipping a creature a different player controls, the damage ability can’t be activated by either player. Only the creature’s controller may activate the ability — but since that player can’t sacrifice Blazing Torch (a permanent he or she doesn’t control), the ability’s cost can’t be paid."
+          "text": "If a Blazing Torch controlled by one player somehow winds up equipping a creature a different player controls, the damage ability can't be activated by either player. Only the creature's controller may activate the ability — but since that player can't sacrifice Blazing Torch (a permanent he or she doesn't control), the ability's cost can't be paid."
         },
         {
           "date": "2009-10-01",
-          "text": "The source of the damage is Blazing Torch, not the equipped creature. However, the equipped creature’s ability is what targets the creature or player. If Blazing Torch is equipped to a red creature, for example, the ability couldn’t target a creature with protection from red. It could target a creature with protection from artifacts, but all the damage would be prevented."
+          "text": "The source of the damage is Blazing Torch, not the equipped creature. However, the equipped creature's ability is what targets the creature or player. If Blazing Torch is equipped to a red creature, for example, the ability couldn't target a creature with protection from red. It could target a creature with protection from artifacts, but all the damage would be prevented."
         }
       ],
       "subtypes": [
@@ -26329,11 +26335,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You don’t flip the coin until the ability resolves. If you want to respond to the ability, perhaps by regenerating the damaged creature, you’ll have to do so before you know the outcome of the flip."
+          "text": "You don't flip the coin until the ability resolves. If you want to respond to the ability, perhaps by regenerating the damaged creature, you'll have to do so before you know the outcome of the flip."
         },
         {
           "date": "2011-09-22",
-          "text": "If the combat damage Creepy Doll deals to a creature is lethal, you’ll still flip a coin. If the creature is still on the battlefield (perhaps because it regenerated), it could be destroyed a second time, depending on the coin flip."
+          "text": "If the combat damage Creepy Doll deals to a creature is lethal, you'll still flip a coin. If the creature is still on the battlefield (perhaps because it regenerated), it could be destroyed a second time, depending on the coin flip."
         }
       ],
       "subtypes": [
@@ -26639,7 +26645,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The target creature with flying is chosen when the ability triggers and goes on the stack. You choose whether or not Geistcatcher’s Rig will deal 4 damage to it when then ability resolves."
+          "text": "The target creature with flying is chosen when the ability triggers and goes on the stack. You choose whether or not Geistcatcher's Rig will deal 4 damage to it when then ability resolves."
         }
       ],
       "subtypes": [
@@ -26934,7 +26940,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "“Creature cards” includes each card with the type creature, even if it has additional types, such as artifact."
+          "text": "\"Creature cards\" includes each card with the type creature, even if it has additional types, such as artifact."
         }
       ],
       "supertypes": [
@@ -27035,11 +27041,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If a creature is equipped with a second Inquisitor’s Flail, combat damage dealt by and dealt to that creature will be multiplied by four. A third Inquisitor’s Flail would multiply the combat damage by eight, and so on."
+          "text": "If a creature is equipped with a second Inquisitor's Flail, combat damage dealt by and dealt to that creature will be multiplied by four. A third Inquisitor's Flail would multiply the combat damage by eight, and so on."
         },
         {
           "date": "2011-09-22",
-          "text": "If you divide the combat damage dealt by the equipped creature, perhaps because the creature has trample or is dealing combat damage to multiple creatures, you’ll divide the original amount and then double the results. For example, if a 5/5 creature with trample is blocked by a 2/2 creature, you can assign 2 damage to the blocker and 3 damage to the defending player. These amounts are then doubled to 4 and 6 damage, respectively. You can’t double the damage to 10 first and then assign 2 to the creature and 8 to the player."
+          "text": "If you divide the combat damage dealt by the equipped creature, perhaps because the creature has trample or is dealing combat damage to multiple creatures, you'll divide the original amount and then double the results. For example, if a 5/5 creature with trample is blocked by a 2/2 creature, you can assign 2 damage to the blocker and 3 damage to the defending player. These amounts are then doubled to 4 and 6 damage, respectively. You can't double the damage to 10 first and then assign 2 to the creature and 8 to the player."
         }
       ],
       "subtypes": [
@@ -27246,7 +27252,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If Mask of Avacyn somehow becomes attached to a creature an opponent controls, that creature can’t be the target of spells or abilities you control."
+          "text": "If Mask of Avacyn somehow becomes attached to a creature an opponent controls, that creature can't be the target of spells or abilities you control."
         }
       ],
       "subtypes": [
@@ -27707,6 +27713,10 @@
       "imageName": "traveler's amulet",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -28344,15 +28354,15 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won’t get to search for a land card."
+          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won't get to search for a land card."
         },
         {
           "date": "2011-09-22",
-          "text": "If the targeted land is an illegal target by the time Ghost Quarter’s ability resolves, it will be countered and none of its effects will happen. The land’s controller won’t get to search for a basic land card."
+          "text": "If the targeted land is an illegal target by the time Ghost Quarter's ability resolves, it will be countered and none of its effects will happen. The land's controller won't get to search for a basic land card."
         },
         {
           "date": "2013-07-01",
-          "text": "The target land’s controller gets to search for a basic land card even if that land wasn’t destroyed by Ghost Quarter’s ability. This may happen because the land has indestructible or because it was regenerated."
+          "text": "The target land's controller gets to search for a basic land card even if that land wasn't destroyed by Ghost Quarter's ability. This may happen because the land has indestructible or because it was regenerated."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it onto the battlefield, then shuffle his or her library.",
@@ -33843,6 +33853,16 @@
         {
           "language": "French",
           "name": "Forêt",
+          "multiverseid": 273108
+        },
+        {
+          "language": "French",
+          "name": "Forêt",
+          "multiverseid": 273109
+        },
+        {
+          "language": "French",
+          "name": "Forêt",
           "multiverseid": 273110
         },
         {
@@ -33923,17 +33943,7 @@
         {
           "language": "Spanish",
           "name": "Bosque",
-          "multiverseid": 273960
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
           "multiverseid": 273961
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 273962
         }
       ],
       "id": "e9abef8533c9ce6549147232c5fceff75ffb460a",
@@ -34225,6 +34235,16 @@
         {
           "language": "French",
           "name": "Forêt",
+          "multiverseid": 273108
+        },
+        {
+          "language": "French",
+          "name": "Forêt",
+          "multiverseid": 273109
+        },
+        {
+          "language": "French",
+          "name": "Forêt",
           "multiverseid": 273110
         },
         {
@@ -34305,17 +34325,7 @@
         {
           "language": "Spanish",
           "name": "Bosque",
-          "multiverseid": 273960
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
           "multiverseid": 273961
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 273962
         }
       ],
       "id": "3c509643d7f7827b2debf968c05cb800cb772360",

--- a/json/JOU.json
+++ b/json/JOU.json
@@ -144,7 +144,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Your opponent can’t target you with spells that deal damage or abilities that cause their sources to deal damage, even if he or she intends to redirect the damage to a planeswalker you control."
+          "text": "Your opponent can't target you with spells that deal damage or abilities that cause their sources to deal damage, even if he or she intends to redirect the damage to a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -259,19 +259,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -493,7 +493,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Armament of Nyx continuously checks to see whether the creature it’s enchanting is an enchantment or not. If the creature isn’t an enchantment and becomes one, or it is an enchantment and stops being one, the effect will change."
+          "text": "Armament of Nyx continuously checks to see whether the creature it's enchanting is an enchantment or not. If the creature isn't an enchantment and becomes one, or it is an enchantment and stops being one, the effect will change."
         }
       ],
       "subtypes": [
@@ -607,27 +607,27 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Banishing Light’s ability causes a zone change with a duration, a new style of ability that’s somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Banishing Light have a single ability that creates two one-shot effects: one that exiles the permanent when the ability resolves, and another that returns the exiled card to the battlefield immediately after Banishing Light leaves the battlefield."
+          "text": "Banishing Light's ability causes a zone change with a duration, a new style of ability that's somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Banishing Light have a single ability that creates two one-shot effects: one that exiles the permanent when the ability resolves, and another that returns the exiled card to the battlefield immediately after Banishing Light leaves the battlefield."
         },
         {
           "date": "2014-04-26",
-          "text": "If Banishing Light leaves the battlefield before its enters-the-battlefield ability resolves, the target nonland permanent won’t be exiled."
+          "text": "If Banishing Light leaves the battlefield before its enters-the-battlefield ability resolves, the target nonland permanent won't be exiled."
         },
         {
           "date": "2014-04-26",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         },
         {
           "date": "2014-04-26",
-          "text": "If a token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2014-04-26",
-          "text": "The exiled card returns to the battlefield immediately after Banishing Light leaves the battlefield. Nothing happens between the two events, including state-based actions. Banishing Light and the returned card aren’t on the battlefield at the same time."
+          "text": "The exiled card returns to the battlefield immediately after Banishing Light leaves the battlefield. Nothing happens between the two events, including state-based actions. Banishing Light and the returned card aren't on the battlefield at the same time."
         },
         {
           "date": "2014-04-26",
-          "text": "In a multiplayer game, if Banishing Light’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Banishing Light's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "When Banishing Light enters the battlefield, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield. (That permanent returns under its owner's control.)",
@@ -747,7 +747,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -862,11 +862,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Deicide looks at the card in exile, not the permanent that was exiled, to determine if it is a God. For each of the Gods in the Theros block, it won’t matter what your devotion to its color(s) was. The card is a God card when not on the battlefield."
+          "text": "Deicide looks at the card in exile, not the permanent that was exiled, to determine if it is a God. For each of the Gods in the Theros block, it won't matter what your devotion to its color(s) was. The card is a God card when not on the battlefield."
         },
         {
           "date": "2014-04-26",
-          "text": "When you search the target’s controller’s graveyard, hand, and library, you may leave any cards with that name in the zones they’re in. You don’t have to exile them."
+          "text": "When you search the target's controller's graveyard, hand, and library, you may leave any cards with that name in the zones they're in. You don't have to exile them."
         }
       ],
       "text": "Exile target enchantment. If the exiled card is a God card, search its controller's graveyard, hand, and library for any number of cards with the same name as that card and exile them, then that player shuffles his or her library.",
@@ -1193,7 +1193,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Eidolon of Rhetoric will look at the entire turn to see if a player has cast a spell yet that turn, even if Eidolon of Rhetoric wasn’t on the battlefield when that spell was cast. Specifically, you can’t cast Eidolon of Rhetoric and then cast another spell that turn."
+          "text": "Eidolon of Rhetoric will look at the entire turn to see if a player has cast a spell yet that turn, even if Eidolon of Rhetoric wasn't on the battlefield when that spell was cast. Specifically, you can't cast Eidolon of Rhetoric and then cast another spell that turn."
         }
       ],
       "subtypes": [
@@ -1411,15 +1411,15 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Godsend’s triggered ability will trigger only once no matter how many creatures the equipped creature blocks or becomes blocked by."
+          "text": "Godsend's triggered ability will trigger only once no matter how many creatures the equipped creature blocks or becomes blocked by."
         },
         {
           "date": "2014-04-26",
-          "text": "Godsend’s triggered ability doesn’t target any creature. You could exile a creature with protection from white, for example. You choose which creature to exile when the ability resolves."
+          "text": "Godsend's triggered ability doesn't target any creature. You could exile a creature with protection from white, for example. You choose which creature to exile when the ability resolves."
         },
         {
           "date": "2014-04-26",
-          "text": "If Godsend leaves the battlefield, and later another Godsend enters the battlefield, it is a new object (even if the two were represented by the same card). The new Godsend won’t stop opponents from casting cards with the same name as cards exiled with the first one."
+          "text": "If Godsend leaves the battlefield, and later another Godsend enters the battlefield, it is a new object (even if the two were represented by the same card). The new Godsend won't stop opponents from casting cards with the same name as cards exiled with the first one."
         },
         {
           "date": "2014-04-26",
@@ -1544,7 +1544,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -1672,7 +1672,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -1786,7 +1786,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You declare which player or planeswalker each token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker the original creature is attacking."
+          "text": "You declare which player or planeswalker each token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker the original creature is attacking."
         },
         {
           "date": "2014-04-26",
@@ -1794,19 +1794,19 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -1929,7 +1929,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -2043,11 +2043,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You decide whether to sacrifice Mortal Obstinacy as its triggered ability resolves. If it’s not on the battlefield at that time, you can’t sacrifice it and destroy the target enchantment."
+          "text": "You decide whether to sacrifice Mortal Obstinacy as its triggered ability resolves. If it's not on the battlefield at that time, you can't sacrifice it and destroy the target enchantment."
         },
         {
           "date": "2014-04-26",
-          "text": "If another player gains control of the enchanted creature, Mortal Obstinacy will be put into its owner’s graveyard."
+          "text": "If another player gains control of the enchanted creature, Mortal Obstinacy will be put into its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -2270,11 +2270,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The enchanted creature’s controller can choose to not attack or block with it even if it must attack or block if able. Players can’t be forced to pay a cost to attack or block."
+          "text": "The enchanted creature's controller can choose to not attack or block with it even if it must attack or block if able. Players can't be forced to pay a cost to attack or block."
         },
         {
           "date": "2014-07-18",
-          "text": "Activated abilities are written in the form “Cost: Effect.” Some keywords are activated abilities and will have colons in their reminder texts. Static and triggered abilities are unaffected by Oppressive Rays."
+          "text": "Activated abilities are written in the form \"Cost: Effect.\" Some keywords are activated abilities and will have colons in their reminder texts. Static and triggered abilities are unaffected by Oppressive Rays."
         }
       ],
       "subtypes": [
@@ -2495,19 +2495,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -2621,7 +2621,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Quarry Colossus’s ability is mandatory. If you control the only creatures when that ability triggers, you must choose a creature you control (which could be Quarry Colossus itself) as the target."
+          "text": "Quarry Colossus's ability is mandatory. If you control the only creatures when that ability triggers, you must choose a creature you control (which could be Quarry Colossus itself) as the target."
         },
         {
           "date": "2014-04-26",
@@ -2629,7 +2629,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If there are fewer than X cards in that player’s library, put the creature on the bottom of that library."
+          "text": "If there are fewer than X cards in that player's library, put the creature on the bottom of that library."
         }
       ],
       "subtypes": [
@@ -2860,15 +2860,15 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If you control more than one creature that can’t attack alone, they can both attack together, even if no other creatures attack."
+          "text": "If you control more than one creature that can't attack alone, they can both attack together, even if no other creatures attack."
         },
         {
           "date": "2014-04-26",
-          "text": "Although Sightless Brawler or the creature it enchants can’t attack alone, other attacking creatures don’t have to attack the same player or planeswalker. For example, Sightless Brawler could attack an opponent and another creature could attack a planeswalker that opponent controls."
+          "text": "Although Sightless Brawler or the creature it enchants can't attack alone, other attacking creatures don't have to attack the same player or planeswalker. For example, Sightless Brawler could attack an opponent and another creature could attack a planeswalker that opponent controls."
         },
         {
           "date": "2014-04-26",
-          "text": "If a creature that can’t attack alone also must attack if able, its controller must attack with it and another creature if able."
+          "text": "If a creature that can't attack alone also must attack if able, its controller must attack with it and another creature if able."
         },
         {
           "date": "2014-04-26",
@@ -2876,39 +2876,39 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
         },
         {
           "date": "2014-04-26",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2014-04-26",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2014-04-26",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-04-26",
-          "text": "You still control the Aura, even if it’s enchanting a creature controlled by another player."
+          "text": "You still control the Aura, even if it's enchanting a creature controlled by another player."
         },
         {
           "date": "2014-04-26",
-          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn’t change; you’ll control the resulting enchantment creature."
+          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn't change; you'll control the resulting enchantment creature."
         },
         {
           "date": "2014-04-26",
@@ -3031,7 +3031,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -3483,7 +3483,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -3597,19 +3597,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -3723,15 +3723,15 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Battlefield Thaumaturge’s first ability doesn’t change that spell’s mana cost or converted mana cost. It changes only the amount you actually pay (the “total cost” of the spell)."
+          "text": "Battlefield Thaumaturge's first ability doesn't change that spell's mana cost or converted mana cost. It changes only the amount you actually pay (the \"total cost\" of the spell)."
         },
         {
           "date": "2014-04-26",
-          "text": "To calculate the total cost of an instant or sorcery spell you’re casting, start with the mana cost (or alternative cost, if applicable), add all cost increases (including additional costs such as those imposed by strive abilities), then subtract all cost reductions (such as the one created by Battlefield Thaumaturge’s first ability)."
+          "text": "To calculate the total cost of an instant or sorcery spell you're casting, start with the mana cost (or alternative cost, if applicable), add all cost increases (including additional costs such as those imposed by strive abilities), then subtract all cost reductions (such as the one created by Battlefield Thaumaturge's first ability)."
         },
         {
           "date": "2014-04-26",
-          "text": "The cost reduction created by Battlefield Thaumaturge’s first ability can reduce only the generic portion of the spell’s total cost. Colored mana requirements aren’t affected."
+          "text": "The cost reduction created by Battlefield Thaumaturge's first ability can reduce only the generic portion of the spell's total cost. Colored mana requirements aren't affected."
         },
         {
           "date": "2014-04-26",
@@ -3747,7 +3747,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -3972,11 +3972,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "If the target spell is an illegal target when Countermand tries to resolve, Countermand will be countered and none of its effects will happen. The target’s controller won’t put any cards from the top of his or her library into his or her graveyard."
+          "text": "If the target spell is an illegal target when Countermand tries to resolve, Countermand will be countered and none of its effects will happen. The target's controller won't put any cards from the top of his or her library into his or her graveyard."
         },
         {
           "date": "2014-04-26",
-          "text": "You may target a spell that can’t be countered with Countermand. If you do, when Countermand resolves, the target spell won’t be countered, but its controller will still put the top four cards of his or her library into his or her graveyard."
+          "text": "You may target a spell that can't be countered with Countermand. If you do, when Countermand resolves, the target spell won't be countered, but its controller will still put the top four cards of his or her library into his or her graveyard."
         }
       ],
       "text": "Counter target spell. Its controller puts the top four cards of his or her library into his or her graveyard.",
@@ -4086,43 +4086,43 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Crystalline Nautilus’s middle ability functions as long as Crystalline Nautilus is on the battlefield, whether it’s a creature or an Aura."
+          "text": "Crystalline Nautilus's middle ability functions as long as Crystalline Nautilus is on the battlefield, whether it's a creature or an Aura."
         },
         {
           "date": "2014-04-26",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
         },
         {
           "date": "2014-04-26",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2014-04-26",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2014-04-26",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-04-26",
-          "text": "You still control the Aura, even if it’s enchanting a creature controlled by another player."
+          "text": "You still control the Aura, even if it's enchanting a creature controlled by another player."
         },
         {
           "date": "2014-04-26",
-          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn’t change; you’ll control the resulting enchantment creature."
+          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn't change; you'll control the resulting enchantment creature."
         },
         {
           "date": "2014-04-26",
@@ -4242,7 +4242,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You make the decision after all the cards are revealed. If you decide not to put the cards into their owners’ graveyards, the card each player draws will be the revealed card."
+          "text": "You make the decision after all the cards are revealed. If you decide not to put the cards into their owners' graveyards, the card each player draws will be the revealed card."
         }
       ],
       "subtypes": [
@@ -4358,11 +4358,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The exchange of control lasts indefinitely. It doesn’t expire when Daring Thief leaves the battlefield."
+          "text": "The exchange of control lasts indefinitely. It doesn't expire when Daring Thief leaves the battlefield."
         },
         {
           "date": "2014-04-26",
-          "text": "Gaining control of an Aura or Equipment doesn’t cause it to move, though gaining control of an Equipment will allow you to activate its equip ability to attach it to a creature you control later."
+          "text": "Gaining control of an Aura or Equipment doesn't cause it to move, though gaining control of an Equipment will allow you to activate its equip ability to attach it to a creature you control later."
         },
         {
           "date": "2014-04-26",
@@ -4370,15 +4370,15 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If the full exchange can’t happen, perhaps because one of the targets is illegal as the inspired ability tries to resolve, then nothing happens. No permanents change controllers."
+          "text": "If the full exchange can't happen, perhaps because one of the targets is illegal as the inspired ability tries to resolve, then nothing happens. No permanents change controllers."
         },
         {
           "date": "2014-04-26",
-          "text": "If another spell or ability allows you to change the targets of the ability (or perhaps copy it and choose new targets for the copy), you can change the targets only such that the final set of targets is still legal. For example, if the ability targets a creature you control and a creature an opponent controls, you couldn’t change just the second target to a noncreature permanent controlled by that player. You could, however, change just the second target to a creature controlled by a different opponent. The two new targets can share a different card type than the two original targets did."
+          "text": "If another spell or ability allows you to change the targets of the ability (or perhaps copy it and choose new targets for the copy), you can change the targets only such that the final set of targets is still legal. For example, if the ability targets a creature you control and a creature an opponent controls, you couldn't change just the second target to a noncreature permanent controlled by that player. You could, however, change just the second target to a creature controlled by a different opponent. The two new targets can share a different card type than the two original targets did."
         },
         {
           "date": "2014-04-26",
-          "text": "Although the permanent you control can’t be a land, the other target can, provided it shares a card type with the first target. For example, you could target an artifact you control and an artifact land controlled by an opponent."
+          "text": "Although the permanent you control can't be a land, the other target can, provided it shares a card type with the first target. For example, you could target an artifact you control and an artifact land controlled by an opponent."
         },
         {
           "date": "2014-04-26",
@@ -4386,11 +4386,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-04-26",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-04-26",
@@ -4836,19 +4836,19 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -5066,39 +5066,39 @@
       "rulings": [
         {
           "date": "2013-10-17",
-          "text": "If you Hypnotic Siren for its bestow cost, and you gain control of a creature with a constellation ability, that ability will trigger when Hypnotic Siren enters the battlefield. You’ll controll that triggered ability."
+          "text": "If you Hypnotic Siren for its bestow cost, and you gain control of a creature with a constellation ability, that ability will trigger when Hypnotic Siren enters the battlefield. You'll controll that triggered ability."
         },
         {
           "date": "2014-04-26",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2014-04-26",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
         },
         {
           "date": "2014-04-26",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2014-04-26",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2014-04-26",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -5212,7 +5212,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "If you reveal a card with converted mana cost 0, such as a land card, you won’t draw any cards. Otherwise, the card you revealed will be the first card you draw."
+          "text": "If you reveal a card with converted mana cost 0, such as a land card, you won't draw any cards. Otherwise, the card you revealed will be the first card you draw."
         }
       ],
       "text": "Scry 3, then reveal the top card of your library. Draw cards equal to that card's converted mana cost. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -5321,19 +5321,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -5553,19 +5553,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The creature that’s copied isn’t targeted by Polymorphous Rush. You choose that creature as the spell resolves. It can be one of the targeted creatures. A creature can become a copy of itself this way, though this usually won’t have any noticeable effect."
+          "text": "The creature that's copied isn't targeted by Polymorphous Rush. You choose that creature as the spell resolves. It can be one of the targeted creatures. A creature can become a copy of itself this way, though this usually won't have any noticeable effect."
         },
         {
           "date": "2014-04-26",
-          "text": "The target creatures copy the printed values of the chosen creature, plus any copy effects that have been applied to it. They won’t copy counters on that creature or effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "The target creatures copy the printed values of the chosen creature, plus any copy effects that have been applied to it. They won't copy counters on that creature or effects that have changed the creature's power, toughness, types, color, or so on."
         },
         {
           "date": "2014-04-26",
-          "text": "If the creatures copy a creature that’s copying a creature, they will become whatever the chosen creature is copying."
+          "text": "If the creatures copy a creature that's copying a creature, they will become whatever the chosen creature is copying."
         },
         {
           "date": "2014-04-26",
-          "text": "This effect can cause the targets to stop being creatures. For example, if they each become a copy of a land that has become a creature, the effect that turned that land into a creature won’t be copied. The targets will become noncreature lands."
+          "text": "This effect can cause the targets to stop being creatures. For example, if they each become a copy of a land that has become a creature, the effect that turned that land into a creature won't be copied. The targets will become noncreature lands."
         },
         {
           "date": "2014-04-26",
@@ -5573,19 +5573,19 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -5804,11 +5804,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "If Riptide Chimera is the only enchantment you control when its ability resolves, you must return it to its owner’s hand."
+          "text": "If Riptide Chimera is the only enchantment you control when its ability resolves, you must return it to its owner's hand."
         },
         {
           "date": "2014-04-26",
-          "text": "If you control no enchantments when Riptide Chimera’s ability resolves (perhaps because Riptide Chimera stops being an enchantment for some reason), then nothing happens."
+          "text": "If you control no enchantments when Riptide Chimera's ability resolves (perhaps because Riptide Chimera stops being an enchantment for some reason), then nothing happens."
         }
       ],
       "subtypes": [
@@ -6027,7 +6027,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You must remove all +1/+1 counters from Sage of Hours to activate its ability, even if the number of counters isn’t a multiple of five. For example, if you remove twelve counters to activate the ability, you’ll take two extra turns. If you remove three counters, you won’t take any extra turns."
+          "text": "You must remove all +1/+1 counters from Sage of Hours to activate its ability, even if the number of counters isn't a multiple of five. For example, if you remove twelve counters to activate the ability, you'll take two extra turns. If you remove three counters, you won't take any extra turns."
         },
         {
           "date": "2014-04-26",
@@ -6039,7 +6039,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -6385,7 +6385,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -6617,7 +6617,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -6851,7 +6851,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -6971,7 +6971,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -7099,7 +7099,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -7325,7 +7325,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Bloodcrazed Hoplite’s last ability will trigger whenever any +1/+1 counter is placed on it, not just ones due to its heroic ability."
+          "text": "Bloodcrazed Hoplite's last ability will trigger whenever any +1/+1 counter is placed on it, not just ones due to its heroic ability."
         },
         {
           "date": "2014-04-26",
@@ -7345,7 +7345,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -7461,7 +7461,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Brain Maggot’s ability causes a zone change with a duration, a new style of ability that’s somewhat reminiscent of older cards like Tidehollow Sculler. However, unlike Tidehollow Sculler, Brain Maggot has a single ability that creates two one-shot effects: one that exiles the nonland card when the ability resolves, and another that returns the exiled card to its owner’s hand immediately after Brain Maggot leaves the battlefield."
+          "text": "Brain Maggot's ability causes a zone change with a duration, a new style of ability that's somewhat reminiscent of older cards like Tidehollow Sculler. However, unlike Tidehollow Sculler, Brain Maggot has a single ability that creates two one-shot effects: one that exiles the nonland card when the ability resolves, and another that returns the exiled card to its owner's hand immediately after Brain Maggot leaves the battlefield."
         },
         {
           "date": "2014-04-26",
@@ -7469,11 +7469,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "The exiled card returns to its owner’s hand immediately after Brain Maggot leaves the battlefield. Nothing happens between the two events, including state-based actions."
+          "text": "The exiled card returns to its owner's hand immediately after Brain Maggot leaves the battlefield. Nothing happens between the two events, including state-based actions."
         },
         {
           "date": "2014-04-26",
-          "text": "In a multiplayer game, if Brain Maggot’s owner leaves the game, the exiled card will return to its owner’s hand. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Brain Maggot's owner leaves the game, the exiled card will return to its owner's hand. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "subtypes": [
@@ -7694,19 +7694,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -7828,7 +7828,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If multiple creatures you control die at the same time, Dictate of Erebos’s triggered ability will trigger that many times."
+          "text": "If multiple creatures you control die at the same time, Dictate of Erebos's triggered ability will trigger that many times."
         },
         {
           "date": "2014-04-26",
@@ -7836,7 +7836,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If you and an opponent each control a Dictate of Erebos and a creature dies, a chain reaction happens. First the ability of one player’s Dictate of Erebos will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player’s Dictate of Erebos to trigger, and so on."
+          "text": "If you and an opponent each control a Dictate of Erebos and a creature dies, a chain reaction happens. First the ability of one player's Dictate of Erebos will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player's Dictate of Erebos to trigger, and so on."
         }
       ],
       "text": "Flash\nWhenever a creature you control dies, each opponent sacrifices a creature.",
@@ -7953,7 +7953,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -8077,7 +8077,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -8618,39 +8618,39 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
         },
         {
           "date": "2014-04-26",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2014-04-26",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2014-04-26",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-04-26",
-          "text": "You still control the Aura, even if it’s enchanting a creature controlled by another player."
+          "text": "You still control the Aura, even if it's enchanting a creature controlled by another player."
         },
         {
           "date": "2014-04-26",
-          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn’t change; you’ll control the resulting enchantment creature."
+          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn't change; you'll control the resulting enchantment creature."
         },
         {
           "date": "2014-04-26",
@@ -8774,7 +8774,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -8901,11 +8901,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-04-26",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-04-26",
@@ -9136,7 +9136,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The value of X is calculated as the ability resolves. The effect won’t change later in the turn, even if the number of cards in your hand does."
+          "text": "The value of X is calculated as the ability resolves. The effect won't change later in the turn, even if the number of cards in your hand does."
         }
       ],
       "text": "Target creature gets -X/-X until end of turn, where X is the number of cards in your hand.",
@@ -9246,7 +9246,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Nyx Infusion continuously checks to see whether the creature it’s enchanting is an enchantment or not. If the creature isn’t an enchantment and becomes one, or it is an enchantment and stops being one, the effect will change."
+          "text": "Nyx Infusion continuously checks to see whether the creature it's enchanting is an enchantment or not. If the creature isn't an enchantment and becomes one, or it is an enchantment and stops being one, the effect will change."
         }
       ],
       "subtypes": [
@@ -9578,11 +9578,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "If the creature card leaves the graveyard in response to Ritual of the Returned, Ritual of the Returned will be countered and none of its effects will happen. You won’t get a Zombie token."
+          "text": "If the creature card leaves the graveyard in response to Ritual of the Returned, Ritual of the Returned will be countered and none of its effects will happen. You won't get a Zombie token."
         },
         {
           "date": "2014-04-26",
-          "text": "Use the creature card’s power and toughness as it last existed in the graveyard to determine the power and toughness of the Zombie token."
+          "text": "Use the creature card's power and toughness as it last existed in the graveyard to determine the power and toughness of the Zombie token."
         }
       ],
       "text": "Exile target creature card from your graveyard. Create a black Zombie creature token. Its power is equal to that card's power and its toughness is equal to that card's toughness.",
@@ -9798,23 +9798,23 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The creatures and Auras are exiled at the same time. Specifically, if an Aura is a permanent with bestow, it will be exiled. It won’t stop being an Aura and remain on the battlefield."
+          "text": "The creatures and Auras are exiled at the same time. Specifically, if an Aura is a permanent with bestow, it will be exiled. It won't stop being an Aura and remain on the battlefield."
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -9928,7 +9928,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You can’t cast Spiteful Blow without a legal creature and land to target. If one of those targets is illegal when Spiteful Below tries to resolve, the other one will still be destroyed."
+          "text": "You can't cast Spiteful Blow without a legal creature and land to target. If one of those targets is illegal when Spiteful Below tries to resolve, the other one will still be destroyed."
         }
       ],
       "text": "Destroy target creature and target land.",
@@ -10041,11 +10041,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Squelching Leeches’s power and toughness will change as the number of Swamps you control changes. Its ability counts all lands you control with the subtype Swamp, not just those named Swamp."
+          "text": "Squelching Leeches's power and toughness will change as the number of Swamps you control changes. Its ability counts all lands you control with the subtype Swamp, not just those named Swamp."
         },
         {
           "date": "2014-04-26",
-          "text": "The ability that defines Squelching Leeches’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Squelching Leeches's power and toughness works in all zones, not just the battlefield."
         }
       ],
       "subtypes": [
@@ -10164,7 +10164,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -10296,7 +10296,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "You must sacrifice exactly one creature to cast Tormented Thoughts. You can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast Tormented Thoughts. You can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2015-06-22",
@@ -10410,7 +10410,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The player you’re controlling is still the active player during that turn."
+          "text": "The player you're controlling is still the active player during that turn."
         },
         {
           "date": "2014-04-26",
@@ -10422,27 +10422,27 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You can’t make the affected player concede. That player may choose to concede at any time, even while you’re controlling him or her."
+          "text": "You can't make the affected player concede. That player may choose to concede at any time, even while you're controlling him or her."
         },
         {
           "date": "2014-04-26",
-          "text": "You can’t make any illegal decisions or illegal choices—you can’t do anything that player couldn’t do. You can’t make choices or decisions for that player that aren’t called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the affected player would normally make (such as Master Warcraft does), that effect takes precedence. In other words, if the affected player wouldn’t make a decision, you wouldn’t make that decision on his or her behalf."
+          "text": "You can't make any illegal decisions or illegal choices—you can't do anything that player couldn't do. You can't make choices or decisions for that player that aren't called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the affected player would normally make (such as Master Warcraft does), that effect takes precedence. In other words, if the affected player wouldn't make a decision, you wouldn't make that decision on his or her behalf."
         },
         {
           "date": "2014-04-26",
-          "text": "You also can’t make any choices or decisions for the player that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
+          "text": "You also can't make any choices or decisions for the player that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
         },
         {
           "date": "2014-04-26",
-          "text": "You can use only the affected player’s resources (cards, mana, and so on) to pay costs for that player; you can’t use your own. Similarly, you can use the affected player’s resources only to pay that player’s costs; you can’t spend them on your costs."
+          "text": "You can use only the affected player's resources (cards, mana, and so on) to pay costs for that player; you can't use your own. Similarly, you can use the affected player's resources only to pay that player's costs; you can't spend them on your costs."
         },
         {
           "date": "2014-04-26",
-          "text": "You only control the player. You don’t control any of his or her permanents, spells, or abilities."
+          "text": "You only control the player. You don't control any of his or her permanents, spells, or abilities."
         },
         {
           "date": "2014-04-26",
-          "text": "If the target player skips his or her next turn, you’ll control the next turn the affected player actually takes."
+          "text": "If the target player skips his or her next turn, you'll control the next turn the affected player actually takes."
         },
         {
           "date": "2014-04-26",
@@ -10450,15 +10450,15 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You could gain control of yourself using Worst Fears, but unless you do so to overwrite someone else’s player-controlling effect, this doesn’t do anything."
+          "text": "You could gain control of yourself using Worst Fears, but unless you do so to overwrite someone else's player-controlling effect, this doesn't do anything."
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "text": "You control target player during that player's next turn. Exile Worst Fears. (You see all cards that player could see and make all decisions for the player.)",
@@ -10577,7 +10577,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -10693,11 +10693,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The effect of the ability will destroy all permanents on the battlefield as it resolves. It doesn’t matter if those permanents were on the battlefield when Bearer of the Heavens died."
+          "text": "The effect of the ability will destroy all permanents on the battlefield as it resolves. It doesn't matter if those permanents were on the battlefield when Bearer of the Heavens died."
         },
         {
           "date": "2014-04-26",
-          "text": "If Bearer of the Heavens dies during an end step, the delayed triggered ability will trigger at the beginning of the next turn’s end step."
+          "text": "If Bearer of the Heavens dies during an end step, the delayed triggered ability will trigger at the beginning of the next turn's end step."
         }
       ],
       "subtypes": [
@@ -10818,11 +10818,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Intimidate looks at the current colors of a creature that has it. Normally, Bladetusk Boar can’t be blocked except by artifact creatures and/or red creatures. If it’s turned blue, then it can’t be blocked except by artifact creatures and/or blue creatures."
+          "text": "Intimidate looks at the current colors of a creature that has it. Normally, Bladetusk Boar can't be blocked except by artifact creatures and/or red creatures. If it's turned blue, then it can't be blocked except by artifact creatures and/or blue creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it’s blocked, changing its colors won’t change that."
+          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it's blocked, changing its colors won't change that."
         }
       ],
       "subtypes": [
@@ -10939,19 +10939,19 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -11066,7 +11066,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Cyclops of Eternal Fury’s ability gives itself haste."
+          "text": "Cyclops of Eternal Fury's ability gives itself haste."
         }
       ],
       "subtypes": [
@@ -11182,11 +11182,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Dictate of the Twin Gods applies to any damage, not just combat damage. It also doesn’t matter who controls the source of the damage that’s being dealt."
+          "text": "Dictate of the Twin Gods applies to any damage, not just combat damage. It also doesn't matter who controls the source of the damage that's being dealt."
         },
         {
           "date": "2014-04-26",
-          "text": "The source of the damage doesn’t change. A spell that deals damage will specify the source of the damage, often the spell itself. An ability that deals damage will also specify the source of the damage, although the ability itself will never be that source. Often the source of the ability is also the source of the damage."
+          "text": "The source of the damage doesn't change. A spell that deals damage will specify the source of the damage, often the spell itself. An ability that deals damage will also specify the source of the damage, although the ability itself will never be that source. Often the source of the ability is also the source of the damage."
         },
         {
           "date": "2014-04-26",
@@ -11194,7 +11194,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If multiple effects modify how damage will be dealt, the player being dealt damage or the controller of the permanent being dealt damage chooses the order to apply the effects. For example, the ability of Decorated Griffin says “Prevent the next 1 combat damage that would be dealt to you this turn.” Suppose you would be dealt 3 combat damage and you activate the ability of Decorated Griffin. You can either (a) prevent 1 damage first and then let Dictate of the Twin Gods’s effect double the remaining 2 damage, for a result of being dealt 4 damage, or (b) double the damage to 6 and then prevent 1 damage, for a result of being dealt 5 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player being dealt damage or the controller of the permanent being dealt damage chooses the order to apply the effects. For example, the ability of Decorated Griffin says \"Prevent the next 1 combat damage that would be dealt to you this turn.\" Suppose you would be dealt 3 combat damage and you activate the ability of Decorated Griffin. You can either (a) prevent 1 damage first and then let Dictate of the Twin Gods's effect double the remaining 2 damage, for a result of being dealt 4 damage, or (b) double the damage to 6 and then prevent 1 damage, for a result of being dealt 5 damage."
         }
       ],
       "text": "Flash\nIf a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
@@ -11305,11 +11305,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Casting Eidolon of the Great Revel doesn’t cause its own ability to trigger. It must be on the battlefield when the spell is cast in order for its ability to trigger."
+          "text": "Casting Eidolon of the Great Revel doesn't cause its own ability to trigger. It must be on the battlefield when the spell is cast in order for its ability to trigger."
         },
         {
           "date": "2014-04-26",
-          "text": "Casting a spell for an alternative cost, such as a bestow cost, doesn’t change its converted mana cost. Similarly, casting a spell with an additional cost, such as a spell with a strive ability, doesn’t change its converted mana cost. For example, casting Gnarled Scarhide (a card with mana cost {B} and bestow cost {3}{B}) for its bestow cost will cause Eidolon of the Great Revel’s ability to trigger."
+          "text": "Casting a spell for an alternative cost, such as a bestow cost, doesn't change its converted mana cost. Similarly, casting a spell with an additional cost, such as a spell with a strive ability, doesn't change its converted mana cost. For example, casting Gnarled Scarhide (a card with mana cost {B} and bestow cost {3}{B}) for its bestow cost will cause Eidolon of the Great Revel's ability to trigger."
         }
       ],
       "subtypes": [
@@ -11423,11 +11423,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You decide whether to sacrifice Flamespeaker’s Will as its triggered ability resolves. If it’s not on the battlefield at that time, you can’t sacrifice it and destroy the target artifact."
+          "text": "You decide whether to sacrifice Flamespeaker's Will as its triggered ability resolves. If it's not on the battlefield at that time, you can't sacrifice it and destroy the target artifact."
         },
         {
           "date": "2014-04-26",
-          "text": "If another player gains control of the enchanted creature, Flamespeaker’s Will will be put into its owner’s graveyard."
+          "text": "If another player gains control of the enchanted creature, Flamespeaker's Will will be put into its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -11753,7 +11753,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -11873,15 +11873,15 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2014-04-26",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2014-04-26",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -11994,27 +11994,27 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Harness by Force can target any creature, even one that’s untapped or one you already control."
+          "text": "Harness by Force can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2014-04-26",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -12128,11 +12128,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Knowledge and Power’s ability triggers only once each time you scry, no matter how many cards you look at."
+          "text": "Knowledge and Power's ability triggers only once each time you scry, no matter how many cards you look at."
         },
         {
           "date": "2014-04-26",
-          "text": "You choose the target of the ability as it’s put on the stack. You choose whether to pay {2} as it resolves. You can pay {2} only once each time you scry."
+          "text": "You choose the target of the ability as it's put on the stack. You choose whether to pay {2} as it resolves. You can pay {2} only once each time you scry."
         }
       ],
       "text": "Whenever you scry, you may pay {2}. If you do, Knowledge and Power deals 2 damage to target creature or player.",
@@ -12242,7 +12242,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "If Lightning Diadem’s target is an illegal target when it tries to resolve, it will be countered and won’t enter the battlefield. Its triggered ability won’t trigger."
+          "text": "If Lightning Diadem's target is an illegal target when it tries to resolve, it will be countered and won't enter the battlefield. Its triggered ability won't trigger."
         }
       ],
       "subtypes": [
@@ -12341,6 +12341,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Theros Block",
           "legality": "Legal"
         },
@@ -12367,7 +12371,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Magma Spray’s replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Magma Spray deals no damage to it (due to a prevention effect) or Magma Spray deals damage to a different creature (due to a redirection effect)."
+          "text": "Magma Spray's replacement effect will exile the target creature if it would die this turn for any reason, not just due to lethal damage. It applies to the target creature even if Magma Spray deals no damage to it (due to a prevention effect) or Magma Spray deals damage to a different creature (due to a redirection effect)."
         }
       ],
       "text": "Magma Spray deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
@@ -12477,47 +12481,47 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The controller of Mogis’s Warhound or the creature it’s enchanting chooses which player or planeswalker to attack."
+          "text": "The controller of Mogis's Warhound or the creature it's enchanting chooses which player or planeswalker to attack."
         },
         {
           "date": "2014-04-26",
-          "text": "If, during your declare attackers step, Mogis’s Warhound (or the creature it enchants) is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under its controller’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Mogis's Warhound (or the creature it enchants) is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under its controller's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2014-04-26",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
         },
         {
           "date": "2014-04-26",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2014-04-26",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2014-04-26",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-04-26",
-          "text": "You still control the Aura, even if it’s enchanting a creature controlled by another player."
+          "text": "You still control the Aura, even if it's enchanting a creature controlled by another player."
         },
         {
           "date": "2014-04-26",
-          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn’t change; you’ll control the resulting enchantment creature."
+          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn't change; you'll control the resulting enchantment creature."
         },
         {
           "date": "2014-04-26",
@@ -12745,15 +12749,15 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "If Prophetic Flamespeaker deals combat damage to a player multiple times in a turn (if it wasn’t blocked, for example), its triggered ability will trigger each time."
+          "text": "If Prophetic Flamespeaker deals combat damage to a player multiple times in a turn (if it wasn't blocked, for example), its triggered ability will trigger each time."
         },
         {
           "date": "2014-04-26",
-          "text": "The card is exiled face up. Playing it follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if it’s a creature card, you can cast it only during your main phase while the stack is empty."
+          "text": "The card is exiled face up. Playing it follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if it's a creature card, you can cast it only during your main phase while the stack is empty."
         },
         {
           "date": "2014-04-26",
-          "text": "If you exile a land card, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven’t played a land yet that turn."
+          "text": "If you exile a land card, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven't played a land yet that turn."
         }
       ],
       "subtypes": [
@@ -13079,19 +13083,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -13214,7 +13218,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -13553,7 +13557,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Spite of Mogis isn’t counted among the number of instant and sorcery cards in your graveyard. It isn’t put there until after it deals damage and you scry 1."
+          "text": "Spite of Mogis isn't counted among the number of instant and sorcery cards in your graveyard. It isn't put there until after it deals damage and you scry 1."
         }
       ],
       "text": "Spite of Mogis deals damage to target creature equal to the number of instant and sorcery cards in your graveyard. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -13766,7 +13770,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The tokens copy exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "The tokens copy exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2014-04-26",
@@ -13782,31 +13786,31 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2014-04-26",
-          "text": "The tokens see each other enter the battlefield. If any of them have a triggered ability that triggers whenever a creature enters the battlefield, they’ll trigger for one another."
+          "text": "The tokens see each other enter the battlefield. If any of them have a triggered ability that triggers whenever a creature enters the battlefield, they'll trigger for one another."
         },
         {
           "date": "2014-04-26",
-          "text": "If another creature becomes or enters the battlefield as a copy of the token, that creature will have haste, but you won’t exile it. However, if Twinflame creates multiple tokens copying a single creature due to a replacement effect (like the one Doubling Season creates), you’ll exile each of them."
+          "text": "If another creature becomes or enters the battlefield as a copy of the token, that creature will have haste, but you won't exile it. However, if Twinflame creates multiple tokens copying a single creature due to a replacement effect (like the one Doubling Season creates), you'll exile each of them."
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -13920,15 +13924,15 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2014-04-26",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2014-04-26",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -14155,19 +14159,19 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -14183,7 +14187,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "text": "Strive — Colossal Heroics costs {1}{G} more to cast for each target beyond the first.\nAny number of target creatures each get +2/+2 until end of turn. Untap those creatures.",
@@ -14292,19 +14296,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -14632,7 +14636,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -14970,11 +14974,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "The constellation ability doesn’t force any specific creature to block the target creature."
+          "text": "The constellation ability doesn't force any specific creature to block the target creature."
         },
         {
           "date": "2014-04-26",
-          "text": "If multiple attacking creatures must be blocked if able, the defending player must assign at least one blocker to each of them if possible. For example, if two such creatures were attacking and there were two potential blockers, they couldn’t both be assigned to block the same attacker."
+          "text": "If multiple attacking creatures must be blocked if able, the defending player must assign at least one blocker to each of them if possible. For example, if two such creatures were attacking and there were two potential blockers, they couldn't both be assigned to block the same attacker."
         },
         {
           "date": "2014-04-26",
@@ -14982,7 +14986,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -15103,11 +15107,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The value of X is determined using the power of Heroes’ Bane when the ability resolves."
+          "text": "The value of X is determined using the power of Heroes' Bane when the ability resolves."
         },
         {
           "date": "2014-04-26",
-          "text": "If Heroes’ Bane’s power is less than 0 when its second ability resolves, X is considered to be 0."
+          "text": "If Heroes' Bane's power is less than 0 when its second ability resolves, X is considered to be 0."
         }
       ],
       "subtypes": [
@@ -15226,7 +15230,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -15346,19 +15350,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The value of each X in Hydra Broodmaster’s last ability is equal to the value chosen for X when its monstrosity ability was activated."
+          "text": "The value of each X in Hydra Broodmaster's last ability is equal to the value chosen for X when its monstrosity ability was activated."
         },
         {
           "date": "2014-04-26",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2014-04-26",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2014-04-26",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -15683,19 +15687,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -15928,7 +15932,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -16057,7 +16061,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -16284,15 +16288,15 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2014-04-26",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2014-04-26",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -16407,7 +16411,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "If Renowned Weaver is attacking or blocking, and you activate its ability before combat damage is assigned and dealt, it won’t deal combat damage. If it was blocking a creature, that creature will remain blocked. If you don’t activate the ability before the combat damage step, it must survive combat for its ability to be activated later."
+          "text": "If Renowned Weaver is attacking or blocking, and you activate its ability before combat damage is assigned and dealt, it won't deal combat damage. If it was blocking a creature, that creature will remain blocked. If you don't activate the ability before the combat damage step, it must survive combat for its ability to be activated later."
         }
       ],
       "subtypes": [
@@ -16522,7 +16526,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose which mode you’re using—or whether to use both modes—as you’re casting the spell. Once this choice is made, it can’t be changed later while the spell is on the stack."
+          "text": "You choose which mode you're using—or whether to use both modes—as you're casting the spell. Once this choice is made, it can't be changed later while the spell is on the stack."
         },
         {
           "date": "2014-04-26",
@@ -16745,23 +16749,23 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Each of the two creatures that fight deals damage equal to its power to the other. If either one of the creatures isn’t on the battlefield when the ability that instructs them to fight resolves, no damage is dealt."
+          "text": "Each of the two creatures that fight deals damage equal to its power to the other. If either one of the creatures isn't on the battlefield when the ability that instructs them to fight resolves, no damage is dealt."
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -16879,19 +16883,19 @@
         },
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -17005,39 +17009,39 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spellas as though they have flash will."
         },
         {
           "date": "2014-04-26",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2014-04-26",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2014-04-26",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2014-04-26",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-04-26",
-          "text": "You still control the Aura, even if it’s enchanting a creature controlled by another player."
+          "text": "You still control the Aura, even if it's enchanting a creature controlled by another player."
         },
         {
           "date": "2014-04-26",
-          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn’t change; you’ll control the resulting enchantment creature."
+          "text": "If the enchanted creature leaves the battlefield, the Aura stops being an Aura and remains on the battlefield. Control of that permanent doesn't change; you'll control the resulting enchantment creature."
         },
         {
           "date": "2014-04-26",
@@ -17163,7 +17167,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -17277,15 +17281,15 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2014-04-26",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2014-04-26",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -17401,11 +17405,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You announce how many counters will be placed on each target creature as you activate Ajani’s first ability. Each target must receive at least one counter."
+          "text": "You announce how many counters will be placed on each target creature as you activate Ajani's first ability. Each target must receive at least one counter."
         },
         {
           "date": "2014-04-26",
-          "text": "If one or more, but not all, of the targets of the first ability are illegal when that ability tries to resolve, no counters will be placed on illegal targets. You can’t change the distribution you announced when you activated the ability; the excess counters are just lost."
+          "text": "If one or more, but not all, of the targets of the first ability are illegal when that ability tries to resolve, no counters will be placed on illegal targets. You can't change the distribution you announced when you activated the ability; the excess counters are just lost."
         }
       ],
       "subtypes": [
@@ -17520,27 +17524,27 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You are a creature’s owner if the card representing it began the game in your deck, or if it’s a token that entered the battlefield under your control."
+          "text": "You are a creature's owner if the card representing it began the game in your deck, or if it's a token that entered the battlefield under your control."
         },
         {
           "date": "2014-04-26",
-          "text": "Athreos’s last ability will trigger if a token creature you own dies. The target opponent has the option to pay 3 life, although the token can’t return to your hand."
+          "text": "Athreos's last ability will trigger if a token creature you own dies. The target opponent has the option to pay 3 life, although the token can't return to your hand."
         },
         {
           "date": "2014-04-26",
-          "text": "It doesn’t matter who controlled the creature when it died. Athreos’s last ability will trigger if you owned that creature."
+          "text": "It doesn't matter who controlled the creature when it died. Athreos's last ability will trigger if you owned that creature."
         },
         {
           "date": "2014-04-26",
-          "text": "The target opponent chooses whether to pay 3 life when Athreos’s last ability resolves. You won’t return the card to your hand if that player pays 3 life or if the card leaves the graveyard before the ability resolves."
+          "text": "The target opponent chooses whether to pay 3 life when Athreos's last ability resolves. You won't return the card to your hand if that player pays 3 life or if the card leaves the graveyard before the ability resolves."
         },
         {
           "date": "2014-04-26",
-          "text": "If there are no legal targets for Athreos’s last ability (perhaps because each of your opponents has hexproof), it will be removed from the stack with no effect. No one may pay 3 life and you won’t return the creature card to your hand."
+          "text": "If there are no legal targets for Athreos's last ability (perhaps because each of your opponents has hexproof), it will be removed from the stack with no effect. No one may pay 3 life and you won't return the creature card to your hand."
         },
         {
           "date": "2014-04-26",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2014-04-26",
@@ -17552,7 +17556,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2014-04-26",
@@ -17560,7 +17564,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-04-26",
@@ -17568,11 +17572,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
@@ -17696,19 +17700,19 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It’s legal to cast such a spell with no targets, although this is rarely a good idea. You can’t choose the same target more than once for a single strive spell."
+          "text": "You choose how many targets each spell with a strive ability has and what those targets are as you cast it. It's legal to cast such a spell with no targets, although this is rarely a good idea. You can't choose the same target more than once for a single strive spell."
         },
         {
           "date": "2014-04-26",
-          "text": "The mana cost and converted mana cost of strive spells don’t change no matter how many targets they have. Strive abilities affect only what you pay."
+          "text": "The mana cost and converted mana cost of strive spells don't change no matter how many targets they have. Strive abilities affect only what you pay."
         },
         {
           "date": "2014-04-26",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen. If one or more of its targets are legal when it tries to resolve, the spell will resolve and affect only those legal targets. It will have no effect on any illegal targets."
         },
         {
           "date": "2014-04-26",
-          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can’t be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "If such a spell is copied, and the effect that copies the spell allows a player to choose new targets for the copy, the number of targets can't be changed. The player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-04-26",
@@ -17824,7 +17828,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "If there’s an {X} in the mana cost of the card you discarded or the card you wish to search for, X is 0."
+          "text": "If there's an {X} in the mana cost of the card you discarded or the card you wish to search for, X is 0."
         },
         {
           "date": "2014-04-26",
@@ -17832,11 +17836,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won’t be able to attack that turn (unless they gain haste)."
+          "text": "If an inspired ability triggers during your untap step, the ability will be put on the stack at the beginning of your upkeep. If the ability creates one or more token creatures, those creatures won't be able to attack that turn (unless they gain haste)."
         },
         {
           "date": "2014-04-26",
-          "text": "Inspired abilities don’t trigger when the creature enters the battlefield."
+          "text": "Inspired abilities don't trigger when the creature enters the battlefield."
         },
         {
           "date": "2014-04-26",
@@ -17961,15 +17965,15 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2014-04-26",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2014-04-26",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -18086,11 +18090,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "Iroas’s last ability prevents all damage dealt to attacking creatures you control, not just combat damage."
+          "text": "Iroas's last ability prevents all damage dealt to attacking creatures you control, not just combat damage."
         },
         {
           "date": "2014-04-26",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2014-04-26",
@@ -18102,7 +18106,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2014-04-26",
@@ -18110,7 +18114,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-04-26",
@@ -18118,11 +18122,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
@@ -18246,7 +18250,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2014-04-26",
@@ -18258,7 +18262,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2014-04-26",
@@ -18266,7 +18270,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-04-26",
@@ -18274,11 +18278,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
@@ -18410,7 +18414,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2014-04-26",
@@ -18422,7 +18426,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2014-04-26",
@@ -18430,7 +18434,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-04-26",
@@ -18438,11 +18442,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
@@ -18677,7 +18681,7 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2014-04-26",
@@ -18689,7 +18693,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2014-04-26",
@@ -18697,7 +18701,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         },
         {
           "date": "2014-04-26",
@@ -18705,11 +18709,11 @@
         },
         {
           "date": "2014-04-26",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2014-04-26",
@@ -19056,7 +19060,7 @@
         },
         {
           "date": "2014-04-26",
-          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner’s graveyard. It won’t enter the battlefield and constellation abilities won’t trigger. An Aura spell with bestow won’t be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
+          "text": "An Aura spell without bestow that has an illegal target when it tries to resolve will be countered and put into its owner's graveyard. It won't enter the battlefield and constellation abilities won't trigger. An Aura spell with bestow won't be countered this way. It will revert to being an enchantment creature and resolve, entering the battlefield and triggering constellation abilities."
         },
         {
           "date": "2014-04-26",
@@ -19382,11 +19386,11 @@
       "rulings": [
         {
           "date": "2014-04-26",
-          "text": "The activated ability can target any creature, not just one that’s untapped."
+          "text": "The activated ability can target any creature, not just one that's untapped."
         },
         {
           "date": "2014-04-26",
-          "text": "As long as Deserter’s Quarters remains tapped, the effect stopping the creature from untapping during its controller’s untap step remains even if that creature untaps some other way (for example, with Colossal Heroics)."
+          "text": "As long as Deserter's Quarters remains tapped, the effect stopping the creature from untapping during its controller's untap step remains even if that creature untaps some other way (for example, with Colossal Heroics)."
         }
       ],
       "text": "You may choose not to untap Deserter's Quarters during your untap step.\n{6}, {T}: Tap target creature. It doesn't untap during its controller's untap step for as long as Deserter's Quarters remains tapped.",

--- a/json/JUD.json
+++ b/json/JUD.json
@@ -984,19 +984,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t acquire the Ante cards. They are considered still “in the game” as are cards in the library and the graveyard."
+          "text": "Can't acquire the Ante cards. They are considered still \"in the game\" as are cards in the library and the graveyard."
         },
         {
           "date": "2007-09-16",
-          "text": "Can’t acquire cards that are phased out."
+          "text": "Can't acquire cards that are phased out."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t acquire exiled cards because those cards are still in one of the game’s zones."
+          "text": "You can't acquire exiled cards because those cards are still in one of the game's zones."
         },
         {
           "date": "2009-10-01",
-          "text": "In a sanctioned event, a card that’s “outside the game” is one that’s in your sideboard. In an unsanctioned event, you may choose any card from your collection."
+          "text": "In a sanctioned event, a card that's \"outside the game\" is one that's in your sideboard. In an unsanctioned event, you may choose any card from your collection."
         }
       ],
       "text": "You may choose an artifact or enchantment card you own from outside the game, reveal that card, and put it into your hand. Exile Golden Wish.",
@@ -1238,11 +1238,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t choose which creature the Aura will enter the battlefield attached to until the ability resolves. You must choose a creature the Aura can legally enchant. (For example, you can’t choose a creature with protection from black if the targeted Aura card is black.) If you don’t control any creatures that the Aura can enchant, it remains in the graveyard."
+          "text": "You don't choose which creature the Aura will enter the battlefield attached to until the ability resolves. You must choose a creature the Aura can legally enchant. (For example, you can't choose a creature with protection from black if the targeted Aura card is black.) If you don't control any creatures that the Aura can enchant, it remains in the graveyard."
         },
         {
           "date": "2007-07-15",
-          "text": "Nomad Mythmaker’s ability can target an Aura card in any graveyard, not just yours."
+          "text": "Nomad Mythmaker's ability can target an Aura card in any graveyard, not just yours."
         }
       ],
       "subtypes": [
@@ -1602,7 +1602,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t activate this ability unless a single opponent has at least three cards in his or her graveyard to target and you have a creature card in your graveyard to target."
+          "text": "You can't activate this ability unless a single opponent has at least three cards in his or her graveyard to target and you have a creature card in your graveyard to target."
         }
       ],
       "subtypes": [
@@ -1773,7 +1773,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The reminder text printed on Selfless Exorcist is no longer correct. Abilities that define a creature’s power (and toughness) apply in every zone. The value of * is defined by such an ability."
+          "text": "The reminder text printed on Selfless Exorcist is no longer correct. Abilities that define a creature's power (and toughness) apply in every zone. The value of * is defined by such an ability."
         }
       ],
       "subtypes": [
@@ -2250,7 +2250,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t activate this ability unless a single opponent has at least two cards in their graveyard to target."
+          "text": "You can't activate this ability unless a single opponent has at least two cards in their graveyard to target."
         }
       ],
       "subtypes": [
@@ -3081,7 +3081,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t acquire the Ante cards. They are considered still “in the game” as are cards in the library and the graveyard."
+          "text": "Can't acquire the Ante cards. They are considered still \"in the game\" as are cards in the library and the graveyard."
         },
         {
           "date": "2007-05-01",
@@ -3093,15 +3093,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Can’t acquire cards that are phased out."
+          "text": "Can't acquire cards that are phased out."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t acquire exiled cards because those cards are still in one of the game’s zones."
+          "text": "You can't acquire exiled cards because those cards are still in one of the game's zones."
         },
         {
           "date": "2009-10-01",
-          "text": "In a sanctioned event, a card that’s “outside the game” is one that’s in your sideboard. In an unsanctioned event, you may choose any card from your collection."
+          "text": "In a sanctioned event, a card that's \"outside the game\" is one that's in your sideboard. In an unsanctioned event, you may choose any card from your collection."
         }
       ],
       "text": "You may choose an instant card you own from outside the game, reveal that card, and put it into your hand. Exile Cunning Wish.",
@@ -3724,11 +3724,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can take the “exile three cards” action any time you have priority without using the stack."
+          "text": "You can take the \"exile three cards\" action any time you have priority without using the stack."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -4123,7 +4123,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “repeat this process” means to repeat as often as it takes to not get a matching pair."
+          "text": "The \"repeat this process\" means to repeat as often as it takes to not get a matching pair."
         }
       ],
       "subtypes": [
@@ -4207,7 +4207,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you cast an instant or sorcery, it goes to its owner’s graveyard when it resolves."
+          "text": "If you cast an instant or sorcery, it goes to its owner's graveyard when it resolves."
         },
         {
           "date": "2004-10-04",
@@ -4215,7 +4215,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If you use this on an opponent’s spell which has Buyback, you may pay the Buyback cost as you cast it. If you do so, the card will go to its owner’s hand upon resolution. It will not go to your hand, nor to any player’s graveyard."
+          "text": "If you use this on an opponent's spell which has Buyback, you may pay the Buyback cost as you cast it. If you do so, the card will go to its owner's hand upon resolution. It will not go to your hand, nor to any player's graveyard."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may play it without paying its mana cost for as long as it remains exiled. (If it has X in its mana cost, X is 0.)",
@@ -4371,7 +4371,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "At the beginning of combat on each opponent's turn, that player may exile a card from his or her graveyard. If the player doesn't, creatures he or she controls can't attack you this turn.",
@@ -5281,7 +5281,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t acquire the Ante cards. They are considered still “in the game” as are cards in the library and the graveyard."
+          "text": "Can't acquire the Ante cards. They are considered still \"in the game\" as are cards in the library and the graveyard."
         },
         {
           "date": "2007-05-01",
@@ -5297,15 +5297,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Can’t acquire cards that are phased out."
+          "text": "Can't acquire cards that are phased out."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t acquire exiled cards because those cards are still in one of the game’s zones."
+          "text": "You can't acquire exiled cards because those cards are still in one of the game's zones."
         },
         {
           "date": "2009-10-01",
-          "text": "In a sanctioned event, a card that’s “outside the game” is one that’s in your sideboard. In an unsanctioned event, you may choose any card from your collection."
+          "text": "In a sanctioned event, a card that's \"outside the game\" is one that's in your sideboard. In an unsanctioned event, you may choose any card from your collection."
         }
       ],
       "text": "You may choose a card you own from outside the game and put it into your hand. You lose half your life, rounded up. Exile Death Wish.",
@@ -5622,7 +5622,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -5946,7 +5946,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Checks the number of cards in your graveyard when it starts resolving. You may drop below seven cards during resolution, but that won’t stop it from resolving."
+          "text": "Checks the number of cards in your graveyard when it starts resolving. You may drop below seven cards during resolution, but that won't stop it from resolving."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.\nThreshold — Return that card from your graveyard to the battlefield instead if seven or more cards are in your graveyard.",
@@ -6032,15 +6032,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If any of the creature cards you exile has a characteristic-defining ability that defines its power and/or toughness, that ability will apply. For example, if Dungrove Elder is exiled this way, its power and toughness while it’s in exile are equal to the number of Forests you control, and Sutured Ghoul’s power and toughness will change as the number of Forests you control changes. If the characteristic-defining ability can’t be applied (for instance, it relies on a choice made as the card enters the battlefield), then use 0."
+          "text": "If any of the creature cards you exile has a characteristic-defining ability that defines its power and/or toughness, that ability will apply. For example, if Dungrove Elder is exiled this way, its power and toughness while it's in exile are equal to the number of Forests you control, and Sutured Ghoul's power and toughness will change as the number of Forests you control changes. If the characteristic-defining ability can't be applied (for instance, it relies on a choice made as the card enters the battlefield), then use 0."
         },
         {
           "date": "2011-09-22",
-          "text": "In zones other than the battlefield, Sutured Ghoul’s power and toughness are each 0."
+          "text": "In zones other than the battlefield, Sutured Ghoul's power and toughness are each 0."
         },
         {
           "date": "2011-09-22",
-          "text": "You can’t have Sutured Ghoul exile itself, even if it’s entering the battlefield from your graveyard."
+          "text": "You can't have Sutured Ghoul exile itself, even if it's entering the battlefield from your graveyard."
         }
       ],
       "subtypes": [
@@ -6278,7 +6278,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The Threshold ability can’t count this card (soon to be in the graveyard) when checking for Threshold."
+          "text": "The Threshold ability can't count this card (soon to be in the graveyard) when checking for Threshold."
         }
       ],
       "subtypes": [
@@ -6368,7 +6368,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The timestamp for the “in your graveyard” ability is set at the time that this card goes to your graveyard, regardless of whether you control a Mountain at that time."
+          "text": "The timestamp for the \"in your graveyard\" ability is set at the time that this card goes to your graveyard, regardless of whether you control a Mountain at that time."
         }
       ],
       "subtypes": [
@@ -6859,7 +6859,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t acquire the Ante cards. They are considered still “in the game” as are cards in the library and the graveyard."
+          "text": "Can't acquire the Ante cards. They are considered still \"in the game\" as are cards in the library and the graveyard."
         },
         {
           "date": "2007-05-01",
@@ -6871,15 +6871,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Can’t acquire cards that are phased out."
+          "text": "Can't acquire cards that are phased out."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t acquire exiled cards because those cards are still in one of the game’s zones."
+          "text": "You can't acquire exiled cards because those cards are still in one of the game's zones."
         },
         {
           "date": "2009-10-01",
-          "text": "In a sanctioned event, a card that’s “outside the game” is one that’s in your sideboard. In an unsanctioned event, you may choose any card from your collection."
+          "text": "In a sanctioned event, a card that's \"outside the game\" is one that's in your sideboard. In an unsanctioned event, you may choose any card from your collection."
         }
       ],
       "text": "You may choose a sorcery card you own from outside the game, reveal that card, and put it into your hand. Exile Burning Wish.",
@@ -7363,7 +7363,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The “damage can’t be prevented” statement overrides all forms of preventing damage. Damage prevention spells and abilities can still be cast and activated, they just don’t do anything."
+          "text": "The \"damage can't be prevented\" statement overrides all forms of preventing damage. Damage prevention spells and abilities can still be cast and activated, they just don't do anything."
         }
       ],
       "text": "Damage can't be prevented this turn.\nFlashback {R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -7608,7 +7608,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t return this card to the battlefield onto something it can’t enchant. For example, you can’t place this card on a permanent with protection from red."
+          "text": "You can't return this card to the battlefield onto something it can't enchant. For example, you can't place this card on a permanent with protection from red."
         }
       ],
       "subtypes": [
@@ -8088,7 +8088,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card does not allow you to activate the abilities of cards in other people’s graveyards."
+          "text": "This card does not allow you to activate the abilities of cards in other people's graveyards."
         },
         {
           "date": "2004-10-04",
@@ -8335,7 +8335,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t cast this spell unless you have two different legal targets."
+          "text": "You can't cast this spell unless you have two different legal targets."
         }
       ],
       "text": "Swelter deals 2 damage to each of two target creatures.",
@@ -8416,7 +8416,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card does nothing if you don’t have seven cards in your graveyard when it resolves."
+          "text": "This card does nothing if you don't have seven cards in your graveyard when it resolves."
         }
       ],
       "text": "Threshold — Swirling Sandstorm deals 5 damage to each creature without flying if seven or more cards are in your graveyard.",
@@ -8499,15 +8499,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "It is possible for Worldgorger Dragon to leave the battlefield before its “enters the battlefield” trigger resolves. If this happens, then the “leaves the battlefield” trigger will have nothing to return. Then its “enters the battlefield” trigger resolves, and all other permanents you control are exiled forever."
+          "text": "It is possible for Worldgorger Dragon to leave the battlefield before its \"enters the battlefield\" trigger resolves. If this happens, then the \"leaves the battlefield\" trigger will have nothing to return. Then its \"enters the battlefield\" trigger resolves, and all other permanents you control are exiled forever."
         },
         {
           "date": "2016-06-08",
-          "text": "If an Aura is exiled with Worldgorger Dragon, the player who controls the Aura when it enters the battlefield chooses what it will enchant. It doesn’t have to go back to the same place. It can’t enter the battlefield enchanting a permanent that enters the battlefield at the same time."
+          "text": "If an Aura is exiled with Worldgorger Dragon, the player who controls the Aura when it enters the battlefield chooses what it will enchant. It doesn't have to go back to the same place. It can't enter the battlefield enchanting a permanent that enters the battlefield at the same time."
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead is put onto the battlefield enchanting Worldgorger Dragon, Worldgorger Dragon’s enters-the-battlefield trigger will exile Animate Dead, which causes you to sacrifice Worldgorger Dragon, which causes Animate Dead to return to the battlefield attached to a creature card in a graveyard of your choice. If you can choose a creature card other than Worldgorger Dragon, you must do so after as many iterations of this loop as you’d like. If you can’t choose a different card, and no player chooses to break the loop, the game ends in a draw."
+          "text": "If Animate Dead is put onto the battlefield enchanting Worldgorger Dragon, Worldgorger Dragon's enters-the-battlefield trigger will exile Animate Dead, which causes you to sacrifice Worldgorger Dragon, which causes Animate Dead to return to the battlefield attached to a creature card in a graveyard of your choice. If you can choose a creature card other than Worldgorger Dragon, you must do so after as many iterations of this loop as you'd like. If you can't choose a different card, and no player chooses to break the loop, the game ends in a draw."
         }
       ],
       "subtypes": [
@@ -8761,7 +8761,7 @@
       "subtypes": [
         "Centaur"
       ],
-      "text": "Threshold — Put three cards from your graveyard on the bottom of your library: Battlefield Scrounger gets +3/+3 until end of turn. Activate this ability only once each turn, and only if seven or more cards are in your graveyard.",
+      "text": "Threshold — Put three cards from your graveyard on the bottom of your library: Battlefield Scrounger gets +3/+3 until end of turn. Activate this ability only once each turn and only if seven or more cards are in your graveyard.",
       "toughness": "3",
       "type": "Creature — Centaur",
       "types": [
@@ -8777,7 +8777,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"‘I have arrived,' bellowed Brawn, and the plane shuddered.\"\n—Scroll of Beginnings",
+      "flavor": "\"'I have arrived,' bellowed Brawn, and the plane shuddered.\"\n—Scroll of Beginnings",
       "foreignNames": [
         {
           "language": "French",
@@ -9155,7 +9155,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If Elephant Guide enchants an opponent’s creature, you get the Elephant when that creature dies."
+          "text": "If Elephant Guide enchants an opponent's creature, you get the Elephant when that creature dies."
         }
       ],
       "subtypes": [
@@ -9326,7 +9326,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different player’s creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
+          "text": "In multiplayer games you can choose a different player's creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
         },
         {
           "date": "2004-10-04",
@@ -10227,7 +10227,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t acquire the Ante cards. They are considered still “in the game” as are cards in the library and the graveyard."
+          "text": "Can't acquire the Ante cards. They are considered still \"in the game\" as are cards in the library and the graveyard."
         },
         {
           "date": "2007-05-01",
@@ -10239,15 +10239,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Can’t acquire cards that are phased out."
+          "text": "Can't acquire cards that are phased out."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t acquire exiled cards because those cards are still in one of the game’s zones."
+          "text": "You can't acquire exiled cards because those cards are still in one of the game's zones."
         },
         {
           "date": "2009-10-01",
-          "text": "In a sanctioned event, a card that’s “outside the game” is one that’s in your sideboard. In an unsanctioned event, you may choose any card from your collection."
+          "text": "In a sanctioned event, a card that's \"outside the game\" is one that's in your sideboard. In an unsanctioned event, you may choose any card from your collection."
         }
       ],
       "text": "You may choose a creature or land card you own from outside the game, reveal that card, and put it into your hand. Exile Living Wish.",
@@ -10412,7 +10412,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t activate this ability unless a single opponent has at least two cards in their graveyard to target."
+          "text": "You can't activate this ability unless a single opponent has at least two cards in their graveyard to target."
         }
       ],
       "subtypes": [
@@ -10498,7 +10498,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If this card is going to take damage from a black source, you can choose to apply Protection from Black’s damage prevention ability prior to applying this card’s built-in ability. This means you don’t have to remove a counter."
+          "text": "If this card is going to take damage from a black source, you can choose to apply Protection from Black's damage prevention ability prior to applying this card's built-in ability. This means you don't have to remove a counter."
         },
         {
           "date": "2004-10-04",
@@ -10798,7 +10798,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You only get an extra turn if an opponent cast a blue spell this turn prior to this spell resolving. Note that “casting” a spell only requires it to be announced, so an unresolved spell still counts as having been cast."
+          "text": "You only get an extra turn if an opponent cast a blue spell this turn prior to this spell resolving. Note that \"casting\" a spell only requires it to be announced, so an unresolved spell still counts as having been cast."
         }
       ],
       "text": "Cast Seedtime only during your turn.\nTake an extra turn after this one if an opponent cast a blue spell this turn.",
@@ -11759,11 +11759,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\nThreshold — {G}{W}: Nantuko Monastery becomes a 4/4 green and white Insect Monk creature with first strike until end of turn. It's still a land. Activate this ability only if seven or more cards are in your graveyard.",

--- a/json/KLD.json
+++ b/json/KLD.json
@@ -131,11 +131,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "After the creature returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won’t be in combat or have any additional abilities it may have had before it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
+          "text": "After the creature returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won't be in combat or have any additional abilities it may have had before it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
         },
         {
           "date": "2016-09-20",
-          "text": "If a creature token is exiled this way, it will cease to exist and won’t return to the battlefield."
+          "text": "If a creature token is exiled this way, it will cease to exist and won't return to the battlefield."
         }
       ],
       "text": "Exile target creature you control, then return that card to the battlefield under its owner's control.\nDraw a card.",
@@ -366,11 +366,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Aetherstorm Roc’s second triggered ability resolves before blockers are chosen. A creature tapped this way won’t be able to block."
+          "text": "Aetherstorm Roc's second triggered ability resolves before blockers are chosen. A creature tapped this way won't be able to block."
         },
         {
           "date": "2016-09-20",
-          "text": "You don’t have to target a creature with Aetherstorm Roc’s last ability. If you do choose a target, and that target becomes illegal, the ability is countered and you won’t be able to pay {E}{E} to put a counter on Aetherstorm Roc."
+          "text": "You don't have to target a creature with Aetherstorm Roc's last ability. If you do choose a target, and that target becomes illegal, the ability is countered and you won't be able to pay {E}{E} to put a counter on Aetherstorm Roc."
         },
         {
           "date": "2017-02-09",
@@ -378,7 +378,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -390,19 +390,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         },
         {
           "date": "2017-02-09",
-          "text": "If a triggered ability with one or more targets states that you “may pay” some amount of {E}, and each permanent that it targets has become an illegal target, the ability is countered. You can’t pay {E} even if you want to."
+          "text": "If a triggered ability with one or more targets states that you \"may pay\" some amount of {E}, and each permanent that it targets has become an illegal target, the ability is countered. You can't pay {E} even if you want to."
         }
       ],
       "subtypes": [
@@ -523,11 +523,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -977,27 +977,27 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "When you attach Captured by the Consulate to an opponent’s creature, you still control Captured by the Consulate. Its last ability triggers whenever your opponents cast a spell with a single target, not when an opponent of the creature’s controller casts a spell with a single target."
+          "text": "When you attach Captured by the Consulate to an opponent's creature, you still control Captured by the Consulate. Its last ability triggers whenever your opponents cast a spell with a single target, not when an opponent of the creature's controller casts a spell with a single target."
         },
         {
           "date": "2016-09-20",
-          "text": "When a player casts an Aura spell, it targets the creature that it will enchant and may cause Captured by the Consulate’s last ability to trigger."
+          "text": "When a player casts an Aura spell, it targets the creature that it will enchant and may cause Captured by the Consulate's last ability to trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "If a spell has multiple targets, it doesn’t have a single target even if the same object is chosen for each of those targets."
+          "text": "If a spell has multiple targets, it doesn't have a single target even if the same object is chosen for each of those targets."
         },
         {
           "date": "2016-09-20",
-          "text": "If the spell can’t target the enchanted creature, its target remains unchanged."
+          "text": "If the spell can't target the enchanted creature, its target remains unchanged."
         },
         {
           "date": "2016-09-20",
           "text": "If there is more than one Captured by the Consulate on the battlefield, the triggered ability of each one will change the target if able. The last one to resolve determines what that spell finally targets. If one player controls more than one Capture by the Consulate, he or she chooses the order in which they resolve. If multiple players control those Auras, the first player among them in turn order (starting with the player whose turn it is now) is the one whose triggered ability resolves last."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "subtypes": [
@@ -1123,15 +1123,15 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Cataclysmic Gearhulk will be sacrificed to its own ability if you don’t choose it as your artifact or your creature."
+          "text": "Cataclysmic Gearhulk will be sacrificed to its own ability if you don't choose it as your artifact or your creature."
         },
         {
           "date": "2016-09-20",
-          "text": "Lands can’t be chosen and won’t be sacrificed, even if they have other types (such as an artifact land)."
+          "text": "Lands can't be chosen and won't be sacrificed, even if they have other types (such as an artifact land)."
         },
         {
           "date": "2016-09-20",
-          "text": "If you don’t control any permanents of one of the types, you’ll still choose the permanents of the types you do control."
+          "text": "If you don't control any permanents of one of the types, you'll still choose the permanents of the types you do control."
         }
       ],
       "subtypes": [
@@ -1248,7 +1248,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Consulate Surveillance’s second ability doesn’t target anything. You choose a source of damage as it resolves."
+          "text": "Consulate Surveillance's second ability doesn't target anything. You choose a source of damage as it resolves."
         },
         {
           "date": "2016-09-20",
@@ -1256,7 +1256,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If multiple prevention and/or replacement effects are trying to apply to the same damage, the player who would be dealt damage chooses the order in which to apply them. Notably, if noncombat damage would be dealt to you by a source controlled by an opponent, and you control a planeswalker, you choose the order in which to apply Consulate Surveillance’s effect and the planeswalker redirection effect. If you apply Consulate Surveillance’s effect first, the damage is prevented and the planeswalker redirection effect won’t apply."
+          "text": "If multiple prevention and/or replacement effects are trying to apply to the same damage, the player who would be dealt damage chooses the order in which to apply them. Notably, if noncombat damage would be dealt to you by a source controlled by an opponent, and you control a planeswalker, you choose the order in which to apply Consulate Surveillance's effect and the planeswalker redirection effect. If you apply Consulate Surveillance's effect first, the damage is prevented and the planeswalker redirection effect won't apply."
         },
         {
           "date": "2017-02-09",
@@ -1264,7 +1264,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -1276,11 +1276,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "When Consulate Surveillance enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\nPay {E}{E}: Prevent all damage that would be dealt to you this turn by a source of your choice.",
@@ -1397,7 +1397,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -1409,19 +1409,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         },
         {
           "date": "2017-02-09",
-          "text": "If a triggered ability with one or more targets states that you “may pay” some amount of {E}, and each permanent that it targets has become an illegal target, the ability is countered. You can’t pay {E} even if you want to."
+          "text": "If a triggered ability with one or more targets states that you \"may pay\" some amount of {E}, and each permanent that it targets has become an illegal target, the ability is countered. You can't pay {E} even if you want to."
         }
       ],
       "subtypes": [
@@ -1543,7 +1543,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -1555,19 +1555,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         },
         {
           "date": "2017-02-09",
-          "text": "If a triggered ability with one or more targets states that you “may pay” some amount of {E}, and each permanent that it targets has become an illegal target, the ability is countered. You can’t pay {E} even if you want to."
+          "text": "If a triggered ability with one or more targets states that you \"may pay\" some amount of {E}, and each permanent that it targets has become an illegal target, the ability is countered. You can't pay {E} even if you want to."
         }
       ],
       "subtypes": [
@@ -1685,15 +1685,15 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If Fairgrounds Warden leaves the battlefield before its triggered ability resolves, the target creature won’t be exiled."
+          "text": "If Fairgrounds Warden leaves the battlefield before its triggered ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2016-09-20",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         },
         {
           "date": "2016-09-20",
-          "text": "If a creature token is exiled this way, it will cease to exist and won’t return to the battlefield."
+          "text": "If a creature token is exiled this way, it will cease to exist and won't return to the battlefield."
         },
         {
           "date": "2016-09-20",
@@ -1701,7 +1701,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "In a multiplayer game, if Fairgrounds Warden’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Fairgrounds Warden's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "subtypes": [
@@ -1823,7 +1823,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The converted mana cost of a token that isn’t a copy of another object is 0. A token that is a copy of another object has the same mana cost as that object."
+          "text": "The converted mana cost of a token that isn't a copy of another object is 0. A token that is a copy of another object has the same mana cost as that object."
         }
       ],
       "text": "Destroy target artifact or enchantment with converted mana cost 4 or less.",
@@ -1936,11 +1936,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Creatures destroyed this way count toward the life gained even if they’re put into a zone other than a graveyard."
+          "text": "Creatures destroyed this way count toward the life gained even if they're put into a zone other than a graveyard."
         },
         {
           "date": "2016-09-20",
-          "text": "Creatures with indestructible aren’t destroyed this way."
+          "text": "Creatures with indestructible aren't destroyed this way."
         }
       ],
       "text": "Destroy all creatures. You gain 1 life for each creature destroyed this way.",
@@ -2054,7 +2054,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Gearshift Ace’s triggered ability triggers when it becomes tapped to activate a crew ability. Even if Gearshift Ace leaves the battlefield before its triggered ability resolves, that Vehicle still gains first strike until end of turn."
+          "text": "Gearshift Ace's triggered ability triggers when it becomes tapped to activate a crew ability. Even if Gearshift Ace leaves the battlefield before its triggered ability resolves, that Vehicle still gains first strike until end of turn."
         }
       ],
       "subtypes": [
@@ -2177,11 +2177,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -2534,7 +2534,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The set of creatures affected by Inspired Charge is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won’t get +2/+1."
+          "text": "The set of creatures affected by Inspired Charge is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get +2/+1."
         }
       ],
       "text": "Creatures you control get +2/+1 until end of turn.",
@@ -2767,11 +2767,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If Ninth Bridge Patrol and another creature you control die simultaneously (perhaps because they were both attacking or blocking), Ninth Bridge Patrol won’t be on the battlefield as its triggered ability resolves. It can’t be saved by the +1/+1 counter that would have been put on it."
+          "text": "If Ninth Bridge Patrol and another creature you control die simultaneously (perhaps because they were both attacking or blocking), Ninth Bridge Patrol won't be on the battlefield as its triggered ability resolves. It can't be saved by the +1/+1 counter that would have been put on it."
         },
         {
           "date": "2016-09-20",
-          "text": "Ninth Bridge Patrol’s ability doesn’t care where the creature went or whether it’s a creature in its new zone. It may have died, been exiled, returned to your hand, and so on. It won’t trigger if an object remains on the battlefield but ceases to be a creature."
+          "text": "Ninth Bridge Patrol's ability doesn't care where the creature went or whether it's a creature in its new zone. It may have died, been exiled, returned to your hand, and so on. It won't trigger if an object remains on the battlefield but ceases to be a creature."
         }
       ],
       "subtypes": [
@@ -3006,11 +3006,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -3564,7 +3564,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If the target creature’s power becomes 2 or less before Skywhaler’s Shot resolves, the spell is countered. The creature remains on the battlefield and you won’t scry 1."
+          "text": "If the target creature's power becomes 2 or less before Skywhaler's Shot resolves, the spell is countered. The creature remains on the battlefield and you won't scry 1."
         }
       ],
       "text": "Destroy target creature with power 3 or greater. Scry 1.",
@@ -3792,7 +3792,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -3804,15 +3804,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -3930,7 +3930,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If you control no artifacts as your combat phase begins, Toolcraft Exemplar’s triggered ability doesn’t trigger at all. If you control no artifacts as the triggered ability resolves, it has no effect."
+          "text": "If you control no artifacts as your combat phase begins, Toolcraft Exemplar's triggered ability doesn't trigger at all. If you control no artifacts as the triggered ability resolves, it has no effect."
         },
         {
           "date": "2016-09-20",
@@ -4053,19 +4053,19 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Trusty Companion can be declared as an attacker only if another creature is declared as an attacker at the same time. Once it’s attacking, removing the other creature won’t cause Trusty Companion to stop attacking."
+          "text": "Trusty Companion can be declared as an attacker only if another creature is declared as an attacker at the same time. Once it's attacking, removing the other creature won't cause Trusty Companion to stop attacking."
         },
         {
           "date": "2016-09-20",
-          "text": "If you control more than one creature that can’t attack alone, they can attack together, even if no other creatures attack."
+          "text": "If you control more than one creature that can't attack alone, they can attack together, even if no other creatures attack."
         },
         {
           "date": "2016-09-20",
-          "text": "Although Trusty Companion can’t attack alone, other attacking creatures don’t have to attack the same player or planeswalker. For example, Trusty Companion could attack an opponent and another creature could attack a planeswalker that opponent controls."
+          "text": "Although Trusty Companion can't attack alone, other attacking creatures don't have to attack the same player or planeswalker. For example, Trusty Companion could attack an opponent and another creature could attack a planeswalker that opponent controls."
         },
         {
           "date": "2016-09-20",
-          "text": "If a creature that can’t attack alone also must attack if able, its controller must attack with it and another creature if able."
+          "text": "If a creature that can't attack alone also must attack if able, its controller must attack with it and another creature if able."
         },
         {
           "date": "2016-09-20",
@@ -4191,11 +4191,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -4313,15 +4313,15 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2016-09-20",
-          "text": "If a creature token is exiled this way, it will cease to exist and won’t return to the battlefield."
+          "text": "If a creature token is exiled this way, it will cease to exist and won't return to the battlefield."
         },
         {
           "date": "2016-09-20",
-          "text": "Wispweaver Angel’s triggered ability can target another Wispweaver Angel. If so, the two Angels can loop in and out of exile as many times as you’d like before you choose to target another creature or not to use the triggered ability."
+          "text": "Wispweaver Angel's triggered ability can target another Wispweaver Angel. If so, the two Angels can loop in and out of exile as many times as you'd like before you choose to target another creature or not to use the triggered ability."
         }
       ],
       "subtypes": [
@@ -4437,7 +4437,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If the target creature or Vehicle becomes an illegal target while Aether Meltdown is on the stack, Aether Meltdown will be countered. It won’t enter the battlefield and you won’t get {E}{E}."
+          "text": "If the target creature or Vehicle becomes an illegal target while Aether Meltdown is on the stack, Aether Meltdown will be countered. It won't enter the battlefield and you won't get {E}{E}."
         },
         {
           "date": "2017-02-09",
@@ -4445,7 +4445,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -4457,11 +4457,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -4581,7 +4581,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -4593,11 +4593,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -4721,7 +4721,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If one target permanent becomes an illegal target, the other will be returned to its owner’s hand. If both targets become illegal, Aether Tradewinds will be countered."
+          "text": "If one target permanent becomes an illegal target, the other will be returned to its owner's hand. If both targets become illegal, Aether Tradewinds will be countered."
         }
       ],
       "text": "Return target permanent you control and target permanent you don't control to their owners' hands.",
@@ -4838,7 +4838,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -4850,11 +4850,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -5078,7 +5078,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You choose the target artifact or creature as you cast Confiscation Coup. You don’t choose whether or not to pay an amount of {E} until Confiscation Coup resolves. If the target becomes an illegal target, Confiscation Coup will be countered and you won’t get {E}{E}{E}{E}."
+          "text": "You choose the target artifact or creature as you cast Confiscation Coup. You don't choose whether or not to pay an amount of {E} until Confiscation Coup resolves. If the target becomes an illegal target, Confiscation Coup will be countered and you won't get {E}{E}{E}{E}."
         },
         {
           "date": "2016-09-20",
@@ -5090,11 +5090,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The converted mana cost of a token that isn’t a copy of another object is 0. A token that is a copy of another object has the same mana cost as that object."
+          "text": "The converted mana cost of a token that isn't a copy of another object is 0. A token that is a copy of another object has the same mana cost as that object."
         },
         {
           "date": "2016-09-20",
-          "text": "In a multiplayer game, if a permanent’s owner leaves the game after you’ve gained control of it, the permanent leaves with that player. If you leave the game before that player, the control-change effect ends."
+          "text": "In a multiplayer game, if a permanent's owner leaves the game after you've gained control of it, the permanent leaves with that player. If you leave the game before that player, the control-change effect ends."
         },
         {
           "date": "2017-02-09",
@@ -5102,7 +5102,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -5114,15 +5114,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Choose target artifact or creature. You get {E}{E}{E}{E} (four energy counters), then you may pay an amount of {E} equal to that permanent's converted mana cost. If you do, gain control of it.",
@@ -5559,11 +5559,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If a creature that is both an artifact and an Artificer enters the battlefield under your control, Era of Innovation’s triggered ability triggers only once."
+          "text": "If a creature that is both an artifact and an Artificer enters the battlefield under your control, Era of Innovation's triggered ability triggers only once."
         },
         {
           "date": "2016-09-20",
-          "text": "You can pay {1} only once each time Era of Innovation’s first ability resolves. You can’t pay more to get more than {E}{E}."
+          "text": "You can pay {1} only once each time Era of Innovation's first ability resolves. You can't pay more to get more than {E}{E}."
         },
         {
           "date": "2017-02-09",
@@ -5571,7 +5571,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -5583,11 +5583,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Whenever an artifact or Artificer enters the battlefield under your control, you may pay {1}. If you do, you get {E}{E} (two energy counters).\nPay {E}{E}{E}{E}{E}{E}, Sacrifice Era of Innovation: Draw three cards.",
@@ -5925,15 +5925,15 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Once a player has announced that he or she is casting Gearseeker Serpent, no player may take actions to try to change the number of artifacts its controller controls before the spell’s cost is locked in."
+          "text": "Once a player has announced that he or she is casting Gearseeker Serpent, no player may take actions to try to change the number of artifacts its controller controls before the spell's cost is locked in."
         },
         {
           "date": "2016-09-20",
-          "text": "Gearseeker Serpent’s first ability can’t reduce the total cost to cast the spell below {U}{U}."
+          "text": "Gearseeker Serpent's first ability can't reduce the total cost to cast the spell below {U}{U}."
         },
         {
           "date": "2016-09-20",
-          "text": "Once Gearseeker Serpent has been blocked, activating its last ability won’t cause it to become unblocked."
+          "text": "Once Gearseeker Serpent has been blocked, activating its last ability won't cause it to become unblocked."
         }
       ],
       "subtypes": [
@@ -6054,7 +6054,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -6066,11 +6066,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Scry 2, then draw two cards. You get {E}{E} (two energy counters).",
@@ -6298,7 +6298,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -6310,11 +6310,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -6443,27 +6443,27 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger."
+          "text": "The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2016-09-20",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. A different mode cannot be chosen."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. A different mode cannot be chosen."
         },
         {
           "date": "2016-09-20",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Eliminate the Competition does), the copy will have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Eliminate the Competition does), the copy will have the same value of X."
         },
         {
           "date": "2016-09-20",
-          "text": "If the spell has damage divided as it was cast (like Chandra’s Pyrohelix), the division can’t be changed (although the targets receiving that damage still can)."
+          "text": "If the spell has damage divided as it was cast (like Chandra's Pyrohelix), the division can't be changed (although the targets receiving that damage still can)."
         },
         {
           "date": "2016-09-20",
-          "text": "The controller of a copy can’t choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
+          "text": "The controller of a copy can't choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
         }
       ],
       "text": "Choose one —\n• Counter target spell.\n• You may choose new targets for target spell.\n• Copy target instant or sorcery spell. You may choose new targets for the copy.",
@@ -6581,7 +6581,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -6593,11 +6593,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -6936,19 +6936,19 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "For a spell with {X} in its mana cost, use the value chosen for X to determine its converted mana cost. For example, Clash of Wills is an instant spell with mana cost {X}{U}. If you chose 2 as the value of X, then Clash of Wills has converted mana cost 3, and Metallurgic Summonings’s ability will create a 3/3 token."
+          "text": "For a spell with {X} in its mana cost, use the value chosen for X to determine its converted mana cost. For example, Clash of Wills is an instant spell with mana cost {X}{U}. If you chose 2 as the value of X, then Clash of Wills has converted mana cost 3, and Metallurgic Summonings's ability will create a 3/3 token."
         },
         {
           "date": "2016-09-20",
-          "text": "Metallurgic Summonings’s first ability resolves before the spell that caused it to trigger."
+          "text": "Metallurgic Summonings's first ability resolves before the spell that caused it to trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "If Metallurgic Summonings’s first ability resolves and the spell that caused it to trigger has been countered, use that spell’s converted mana cost as it last existed on the stack to determine the value of X."
+          "text": "If Metallurgic Summonings's first ability resolves and the spell that caused it to trigger has been countered, use that spell's converted mana cost as it last existed on the stack to determine the value of X."
         },
         {
           "date": "2016-09-20",
-          "text": "The number of artifacts you control is checked only as you activate Metallurgic Summonings’s last ability. It’s not checked again as it resolves."
+          "text": "The number of artifacts you control is checked only as you activate Metallurgic Summonings's last ability. It's not checked again as it resolves."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell, create an X/X colorless Construct artifact creature token, where X is that spell's converted mana cost.\n{3}{U}{U}, Exile Metallurgic Summonings: Return all instant and sorcery cards from your graveyard to your hand. Activate this ability only if you control six or more artifacts.",
@@ -7066,7 +7066,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -7078,11 +7078,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -7322,11 +7322,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If you don’t control an artifact with the highest converted mana cost as your upkeep begins, Padeem’s second ability won’t trigger. You can’t cast an instant to destroy an opponent’s artifact during your turn before your upkeep begins."
+          "text": "If you don't control an artifact with the highest converted mana cost as your upkeep begins, Padeem's second ability won't trigger. You can't cast an instant to destroy an opponent's artifact during your turn before your upkeep begins."
         },
         {
           "date": "2016-09-20",
-          "text": "If you no longer control an artifact with the highest converted mana cost as Padeem’s triggered ability resolves, you don’t draw a card."
+          "text": "If you no longer control an artifact with the highest converted mana cost as Padeem's triggered ability resolves, you don't draw a card."
         }
       ],
       "subtypes": [
@@ -7447,11 +7447,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If you control but don’t own some of the target permanents, they won’t count when determining how many cards you draw."
+          "text": "If you control but don't own some of the target permanents, they won't count when determining how many cards you draw."
         },
         {
           "date": "2016-09-20",
-          "text": "If a melded permanent is returned to your hand this way, you’ll draw two cards for it."
+          "text": "If a melded permanent is returned to your hand this way, you'll draw two cards for it."
         }
       ],
       "text": "Return any number of target nonland, nontoken permanents you control to their owners' hands. Draw a card for each card returned to your hand this way.",
@@ -7671,7 +7671,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The token copies exactly what was printed on the original permanent and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "The token copies exactly what was printed on the original permanent and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2016-09-20",
@@ -7687,11 +7687,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If the copied permanent is a token, the token created with Saheeli’s Artistry copies the original characteristics of that token as stated by the effect that that created that token."
+          "text": "If the copied permanent is a token, the token created with Saheeli's Artistry copies the original characteristics of that token as stated by the effect that that created that token."
         },
         {
           "date": "2016-09-20",
-          "text": "Any enters-the-battlefield abilities of the copied permanent will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the chosen permanent will also work."
+          "text": "Any enters-the-battlefield abilities of the copied permanent will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the chosen permanent will also work."
         },
         {
           "date": "2016-09-20",
@@ -7699,11 +7699,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If you choose both modes, the tokens enter one at a time. Thus, if the token created by the second mode has an ability that triggers “whenever an artifact enters the battlefield,” the token created by the first mode will already be on the battlefield and won’t cause that ability to trigger."
+          "text": "If you choose both modes, the tokens enter one at a time. Thus, if the token created by the second mode has an ability that triggers \"whenever an artifact enters the battlefield,\" the token created by the first mode will already be on the battlefield and won't cause that ability to trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "Any abilities that trigger during the resolution of Saheeli’s Artistry will wait to be put onto the stack until Saheeli’s Artistry finishes resolving. An ability that triggers on the first token entering the battlefield may target the second token and vice versa."
+          "text": "Any abilities that trigger during the resolution of Saheeli's Artistry will wait to be put onto the stack until Saheeli's Artistry finishes resolving. An ability that triggers on the first token entering the battlefield may target the second token and vice versa."
         }
       ],
       "text": "Choose one or both —\n• Create a token that's a copy of target artifact.\n• Create a token that's a copy of target creature, except it's an artifact in addition to its other types.",
@@ -7815,7 +7815,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If the target creature becomes untapped or otherwise becomes an illegal target before Select for Inspection resolves, the spell is countered. The creature remains on the battlefield and you won’t scry 1."
+          "text": "If the target creature becomes untapped or otherwise becomes an illegal target before Select for Inspection resolves, the spell is countered. The creature remains on the battlefield and you won't scry 1."
         }
       ],
       "text": "Return target tapped creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -7928,11 +7928,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If one of the target permanents is an illegal target as Shrewd Negotiation resolves, the exchange won’t happen."
+          "text": "If one of the target permanents is an illegal target as Shrewd Negotiation resolves, the exchange won't happen."
         },
         {
           "date": "2016-09-20",
-          "text": "Gaining control of an Equipment doesn’t cause it to move, though it will allow you to activate its equip ability later to attach it to a creature you control."
+          "text": "Gaining control of an Equipment doesn't cause it to move, though it will allow you to activate its equip ability later to attach it to a creature you control."
         },
         {
           "date": "2016-09-20",
@@ -8049,7 +8049,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "No player may take actions between the time you draw three cards and the time you discard. Notably, you can’t try to get an artifact onto the battlefield using the three cards you drew to avoid discarding."
+          "text": "No player may take actions between the time you draw three cards and the time you discard. Notably, you can't try to get an artifact onto the battlefield using the three cards you drew to avoid discarding."
         }
       ],
       "text": "Draw three cards. If you control no artifacts, discard a card.",
@@ -8167,7 +8167,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -8179,15 +8179,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -8305,11 +8305,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If you cast the card, you do so as part of the resolution of Torrential Gearhulk’s triggered ability. You can’t wait to cast it later in the turn. Timing restrictions (such as “Cast [this card] only during combat”) still apply."
+          "text": "If you cast the card, you do so as part of the resolution of Torrential Gearhulk's triggered ability. You can't wait to cast it later in the turn. Timing restrictions (such as \"Cast [this card] only during combat\") still apply."
         },
         {
           "date": "2016-09-20",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Incendiary Sabotage, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Incendiary Sabotage, you must pay those to cast the card."
         },
         {
           "date": "2016-09-20",
@@ -8795,7 +8795,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "You choose which counters to move as Aetherborn Marauder’s triggered ability resolves."
+          "text": "You choose which counters to move as Aetherborn Marauder's triggered ability resolves."
         },
         {
           "date": "2016-09-20",
@@ -8926,11 +8926,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -9048,11 +9048,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The set of creatures affected by Demon of Dark Schemes’s first triggered ability is determined as the ability resolves. Creatures that enter the battlefield later in the turn and noncreature permanents that become creatures later in the turn won’t get -2/-2."
+          "text": "The set of creatures affected by Demon of Dark Schemes's first triggered ability is determined as the ability resolves. Creatures that enter the battlefield later in the turn and noncreature permanents that become creatures later in the turn won't get -2/-2."
         },
         {
           "date": "2016-09-20",
-          "text": "Demon of Dark Schemes’s second triggered ability triggers whenever another creature dies for any reason, not just due to the first triggered ability."
+          "text": "Demon of Dark Schemes's second triggered ability triggers whenever another creature dies for any reason, not just due to the first triggered ability."
         },
         {
           "date": "2016-09-20",
@@ -9060,7 +9060,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If a creature’s owner leaves the game after you’ve put that creature onto the battlefield with Demon of Dark Schemes’s last ability, the creature leaves with that player. If you leave the game before that player, the creature is exiled."
+          "text": "If a creature's owner leaves the game after you've put that creature onto the battlefield with Demon of Dark Schemes's last ability, the creature leaves with that player. If you leave the game before that player, the creature is exiled."
         },
         {
           "date": "2017-02-09",
@@ -9068,7 +9068,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -9080,11 +9080,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -9436,11 +9436,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You choose the target creature as you cast Die Young. You don’t choose how much {E} to pay until Die Young is resolving. No player may take actions between the time you choose how much {E} to pay and the time the creature gets -1/-1 for each {E} paid this way."
+          "text": "You choose the target creature as you cast Die Young. You don't choose how much {E} to pay until Die Young is resolving. No player may take actions between the time you choose how much {E} to pay and the time the creature gets -1/-1 for each {E} paid this way."
         },
         {
           "date": "2016-09-20",
-          "text": "If the target creature becomes an illegal target, Die Young is countered and none of its effects happen. You won’t get {E}{E} or be able to pay any {E}."
+          "text": "If the target creature becomes an illegal target, Die Young is countered and none of its effects happen. You won't get {E}{E} or be able to pay any {E}."
         },
         {
           "date": "2017-02-09",
@@ -9448,7 +9448,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -9460,11 +9460,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Choose target creature. You get {E}{E} (two energy counters), then you may pay any amount of {E}. The creature gets -1/-1 until end of turn for each {E} paid this way.",
@@ -9689,11 +9689,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Once you announce that you’re casting Eliminate the Competition, players can’t try to remove creatures you’d like to sacrifice."
+          "text": "Once you announce that you're casting Eliminate the Competition, players can't try to remove creatures you'd like to sacrifice."
         },
         {
           "date": "2016-09-20",
-          "text": "If you somehow cast Eliminate the Competition without paying its mana cost, you’ll still choose a value for X and sacrifice X creatures."
+          "text": "If you somehow cast Eliminate the Competition without paying its mana cost, you'll still choose a value for X and sacrifice X creatures."
         }
       ],
       "text": "As an additional cost to cast Eliminate the Competition, sacrifice X creatures.\nDestroy X target creatures.",
@@ -9807,7 +9807,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Once a creature has blocked Embraal Bruiser, gaining menace won’t cause Embraal Bruiser to become unblocked."
+          "text": "Once a creature has blocked Embraal Bruiser, gaining menace won't cause Embraal Bruiser to become unblocked."
         }
       ],
       "subtypes": [
@@ -9925,7 +9925,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If the target creature becomes an illegal target, Essence Extraction is countered and you don’t gain life."
+          "text": "If the target creature becomes an illegal target, Essence Extraction is countered and you don't gain life."
         }
       ],
       "text": "Essence Extraction deals 3 damage to target creature and you gain 3 life.",
@@ -10258,7 +10258,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You lose 1 life even if you can’t put a +1/+1 counter on Fretwork Colony, perhaps because it left the battlefield in response to its triggered ability."
+          "text": "You lose 1 life even if you can't put a +1/+1 counter on Fretwork Colony, perhaps because it left the battlefield in response to its triggered ability."
         }
       ],
       "subtypes": [
@@ -10375,23 +10375,23 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You may look at and cast that card (and spend mana as though it were mana of any type to do so) even if Gonti leaves the battlefield. If another player gains control of Gonti, that player can’t look at or cast the card, and you still can."
+          "text": "You may look at and cast that card (and spend mana as though it were mana of any type to do so) even if Gonti leaves the battlefield. If another player gains control of Gonti, that player can't look at or cast the card, and you still can."
         },
         {
           "date": "2016-09-20",
-          "text": "An effect that instructs you to “cast” a card doesn’t allow you to play lands."
+          "text": "An effect that instructs you to \"cast\" a card doesn't allow you to play lands."
         },
         {
           "date": "2016-09-20",
-          "text": "You pay the costs for the exiled card if you cast it. You may pay alternative costs such as emerge rather than the card’s mana cost."
+          "text": "You pay the costs for the exiled card if you cast it. You may pay alternative costs such as emerge rather than the card's mana cost."
         },
         {
           "date": "2016-09-20",
-          "text": "Gonti doesn’t change when you can cast the exiled card. For example, if you exile a creature card without flash, you can cast it only during your main phase when the stack is empty."
+          "text": "Gonti doesn't change when you can cast the exiled card. For example, if you exile a creature card without flash, you can cast it only during your main phase when the stack is empty."
         },
         {
           "date": "2016-09-20",
-          "text": "Casting the card causes it to leave exile. You can’t cast it multiple times."
+          "text": "Casting the card causes it to leave exile. You can't cast it multiple times."
         },
         {
           "date": "2016-09-20",
@@ -10405,7 +10405,7 @@
       "supertypes": [
         "Legendary"
       ],
-      "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. For as long as that card remains exiled, you may look at it, you may cast it, and you may spend mana as though it were mana of any type to cast it.",
+      "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. You may look at and cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
       "toughness": "3",
       "type": "Legendary Creature — Aetherborn Rogue",
       "types": [
@@ -10746,7 +10746,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -10758,11 +10758,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "You draw two cards, lose 2 life, and get {E}{E} (two energy counters).",
@@ -10982,7 +10982,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The set of creatures affected by Make Obsolete is determined as the spell resolves. Creatures your opponents begin to control later in the turn and noncreature permanents that become creatures later in the turn won’t get -1/-1."
+          "text": "The set of creatures affected by Make Obsolete is determined as the spell resolves. Creatures your opponents begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get -1/-1."
         }
       ],
       "text": "Creatures your opponents control get -1/-1 until end of turn.",
@@ -11095,19 +11095,19 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The amount of life lost is determined as Marionette Master’s last ability resolves. If Marionette Master is no longer on the battlefield, use its power as it last existed on the battlefield to determine how much life is lost."
+          "text": "The amount of life lost is determined as Marionette Master's last ability resolves. If Marionette Master is no longer on the battlefield, use its power as it last existed on the battlefield to determine how much life is lost."
         },
         {
           "date": "2016-09-20",
-          "text": "If Marionette Master’s power is negative, the target opponent doesn’t lose (or gain) life."
+          "text": "If Marionette Master's power is negative, the target opponent doesn't lose (or gain) life."
         },
         {
           "date": "2016-09-20",
-          "text": "If Marionette Master and an artifact you control are put into a graveyard at the same time, Marionette Master’s ability triggers."
+          "text": "If Marionette Master and an artifact you control are put into a graveyard at the same time, Marionette Master's ability triggers."
         },
         {
           "date": "2016-09-20",
-          "text": "Artifact tokens that are sacrificed or destroyed are put into their owner’s graveyard before ceasing to exist. If you controlled the token, Marionette Master’s last ability will trigger."
+          "text": "Artifact tokens that are sacrificed or destroyed are put into their owner's graveyard before ceasing to exist. If you controlled the token, Marionette Master's last ability will trigger."
         },
         {
           "date": "2016-09-20",
@@ -11115,11 +11115,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -11242,11 +11242,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -11371,7 +11371,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If Midnight Oil has no hour counters on it, its first triggered ability will continue to trigger and have you draw an additional card, even though you can’t remove any counters from it."
+          "text": "If Midnight Oil has no hour counters on it, its first triggered ability will continue to trigger and have you draw an additional card, even though you can't remove any counters from it."
         },
         {
           "date": "2016-09-20",
@@ -11379,7 +11379,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If you discard a card during your cleanup step while you control Midnight Oil, its last ability will trigger, and players will get priority in your cleanup step. You’ll have another cleanup step after that one before continuing to the next player’s turn."
+          "text": "If you discard a card during your cleanup step while you control Midnight Oil, its last ability will trigger, and players will get priority in your cleanup step. You'll have another cleanup step after that one before continuing to the next player's turn."
         }
       ],
       "text": "Midnight Oil enters the battlefield with seven hour counters on it.\nAt the beginning of your draw step, draw an additional card and remove two hour counters from Midnight Oil.\nYour maximum hand size is equal to the number of hour counters on Midnight Oil.\nWhenever you discard a card, you lose 1 life.",
@@ -11633,7 +11633,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If an effect copies Morbid Curiosity, the controller of the copy will draw the same number of cards as determined by the original. Its controller can’t and doesn’t have to sacrifice a permanent."
+          "text": "If an effect copies Morbid Curiosity, the controller of the copy will draw the same number of cards as determined by the original. Its controller can't and doesn't have to sacrifice a permanent."
         }
       ],
       "text": "As an additional cost to cast Morbid Curiosity, sacrifice an artifact or creature.\nDraw cards equal to the converted mana cost of the sacrificed permanent.",
@@ -11747,15 +11747,15 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "This is a triggered ability, not an activated ability. It doesn’t allow you to tap Night Market Lookout whenever you want; rather, you need some other way of tapping it, such as by attacking."
+          "text": "This is a triggered ability, not an activated ability. It doesn't allow you to tap Night Market Lookout whenever you want; rather, you need some other way of tapping it, such as by attacking."
         },
         {
           "date": "2016-09-20",
-          "text": "For the ability to trigger, Night Market Lookout has to actually change from untapped to tapped. If an effect attempts to tap it, but it was already tapped at the time, this ability won’t trigger."
+          "text": "For the ability to trigger, Night Market Lookout has to actually change from untapped to tapped. If an effect attempts to tap it, but it was already tapped at the time, this ability won't trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "In a Two-Headed Giant game, Night Market Lookout’s ability causes the opposing team to lose a total of 2 life."
+          "text": "In a Two-Headed Giant game, Night Market Lookout's ability causes the opposing team to lose a total of 2 life."
         }
       ],
       "subtypes": [
@@ -11878,7 +11878,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If the target creature has indestructible, it isn’t destroyed this way and you won’t gain life. If it is destroyed but put into a zone other than a graveyard, you’ll gain life."
+          "text": "If the target creature has indestructible, it isn't destroyed this way and you won't gain life. If it is destroyed but put into a zone other than a graveyard, you'll gain life."
         }
       ],
       "subtypes": [
@@ -11997,7 +11997,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Ovalchase Daredevil’s ability triggers only if it’s already in your graveyard as an artifact enters the battlefield under your control."
+          "text": "Ovalchase Daredevil's ability triggers only if it's already in your graveyard as an artifact enters the battlefield under your control."
         }
       ],
       "subtypes": [
@@ -12558,7 +12558,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -12570,15 +12570,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -12695,7 +12695,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If the target creature becomes an illegal target before Tidy Conclusion resolves, the spell is countered. You don’t gain any life."
+          "text": "If the target creature becomes an illegal target before Tidy Conclusion resolves, the spell is countered. You don't gain any life."
         },
         {
           "date": "2016-09-20",
@@ -12811,15 +12811,15 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You can pay {1} only once each time Underhanded Designs’s triggered ability resolves. You can’t pay more to cause your opponents to lose more life."
+          "text": "You can pay {1} only once each time Underhanded Designs's triggered ability resolves. You can't pay more to cause your opponents to lose more life."
         },
         {
           "date": "2016-09-20",
-          "text": "The number of artifacts you control is checked only as you activate Underhanded Designs’s last ability. It’s not checked again as it resolves."
+          "text": "The number of artifacts you control is checked only as you activate Underhanded Designs's last ability. It's not checked again as it resolves."
         },
         {
           "date": "2016-09-20",
-          "text": "In a Two-Headed Giant game, Underhanded Designs’s first ability causes the opposing team to lose a total of 2 life. You still gain only 1 life."
+          "text": "In a Two-Headed Giant game, Underhanded Designs's first ability causes the opposing team to lose a total of 2 life. You still gain only 1 life."
         }
       ],
       "text": "Whenever an artifact enters the battlefield under your control, you may pay {1}. If you do, each opponent loses 1 life and you gain 1 life.\n{1}{B}, Sacrifice Underhanded Designs: Destroy target creature. Activate this ability only if you control two or more artifacts.",
@@ -12937,11 +12937,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -13063,7 +13063,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -13075,11 +13075,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -13422,7 +13422,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Because discarding two cards is an additional cost, you can’t cast Cathartic Reunion if you don’t have at least two other cards in hand."
+          "text": "Because discarding two cards is an additional cost, you can't cast Cathartic Reunion if you don't have at least two other cards in hand."
         }
       ],
       "text": "As an additional cost to cast Cathartic Reunion, discard two cards.\nDraw three cards.",
@@ -13535,31 +13535,31 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "An effect that instructs you to “cast” a card doesn’t allow you to play lands. If the card exiled with Chandra’s first ability is a land card, you can’t play it and Chandra deals 2 damage to each opponent."
+          "text": "An effect that instructs you to \"cast\" a card doesn't allow you to play lands. If the card exiled with Chandra's first ability is a land card, you can't play it and Chandra deals 2 damage to each opponent."
         },
         {
           "date": "2016-09-20",
-          "text": "If you cast the exiled card, you do so as part of the resolution of Chandra’s ability. You can’t wait to cast it later in the turn. Timing permissions based on the card’s type are ignored, but other restrictions (such as “Cast [this card] only during combat”) are not."
+          "text": "If you cast the exiled card, you do so as part of the resolution of Chandra's ability. You can't wait to cast it later in the turn. Timing permissions based on the card's type are ignored, but other restrictions (such as \"Cast [this card] only during combat\") are not."
         },
         {
           "date": "2016-09-20",
-          "text": "You pay the costs for the exiled card if you cast it. You may pay alternative costs such as emerge rather than the card’s mana cost."
+          "text": "You pay the costs for the exiled card if you cast it. You may pay alternative costs such as emerge rather than the card's mana cost."
         },
         {
           "date": "2016-09-20",
-          "text": "Loyalty abilities can’t be mana abilities. Chandra’s second ability uses the stack and can be countered or otherwise responded to. Like all loyalty abilities, it can be activated only once per turn, during your main phase, when the stack is empty, and only if no other loyalty abilities of the planeswalker have been activated this turn."
+          "text": "Loyalty abilities can't be mana abilities. Chandra's second ability uses the stack and can be countered or otherwise responded to. Like all loyalty abilities, it can be activated only once per turn, during your main phase, when the stack is empty, and only if no other loyalty abilities of the planeswalker have been activated this turn."
         },
         {
           "date": "2016-09-20",
-          "text": "The emblem created by Chandra’s last ability is colorless. The damage it deals is from a colorless source."
+          "text": "The emblem created by Chandra's last ability is colorless. The damage it deals is from a colorless source."
         },
         {
           "date": "2016-09-20",
-          "text": "Chandra’s emblem’s ability resolves before the spell that caused it to trigger."
+          "text": "Chandra's emblem's ability resolves before the spell that caused it to trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "In a Two-Headed Giant game, Chandra’s first ability causes 4 damage total to be dealt to the opposing team."
+          "text": "In a Two-Headed Giant game, Chandra's first ability causes 4 damage total to be dealt to the opposing team."
         }
       ],
       "subtypes": [
@@ -13675,11 +13675,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You divide the damage as you cast Chandra’s Pyrohelix, not as it resolves. Each target must be assigned at least 1 damage. In other words, as you cast Chandra’s Pyrohelix, you choose whether to have it deal 2 damage to a single target, or deal 1 damage to each of two targets."
+          "text": "You divide the damage as you cast Chandra's Pyrohelix, not as it resolves. Each target must be assigned at least 1 damage. In other words, as you cast Chandra's Pyrohelix, you choose whether to have it deal 2 damage to a single target, or deal 1 damage to each of two targets."
         },
         {
           "date": "2016-09-20",
-          "text": "If Chandra’s Pyrohelix targets two creatures and one becomes an illegal target, the remaining target is dealt 1 damage, not 2."
+          "text": "If Chandra's Pyrohelix targets two creatures and one becomes an illegal target, the remaining target is dealt 1 damage, not 2."
         }
       ],
       "text": "Chandra's Pyrohelix deals 2 damage divided as you choose among one or two target creatures and/or players.",
@@ -13797,11 +13797,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If you have fewer than three cards in your library, the opponent may choose to have you draw three cards. If so, you’ll lose the game as state-based actions are performed."
+          "text": "If you have fewer than three cards in your library, the opponent may choose to have you draw three cards. If so, you'll lose the game as state-based actions are performed."
         },
         {
           "date": "2016-09-20",
-          "text": "While Combustible Gearhulk’s triggered ability is resolving, no player may take any actions other than those specified by the Gearhulk. Once the opponent makes a choice, players can’t cast spells or activate abilities until after the cards are drawn or put into the graveyard and damage has been dealt (if applicable)."
+          "text": "While Combustible Gearhulk's triggered ability is resolving, no player may take any actions other than those specified by the Gearhulk. Once the opponent makes a choice, players can't cast spells or activate abilities until after the cards are drawn or put into the graveyard and damage has been dealt (if applicable)."
         }
       ],
       "subtypes": [
@@ -14052,15 +14052,15 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The number of cards in your hand is counted only as Fateful Showdown resolves. Fateful Showdown is on the stack at this time, so it’s not counted."
+          "text": "The number of cards in your hand is counted only as Fateful Showdown resolves. Fateful Showdown is on the stack at this time, so it's not counted."
         },
         {
           "date": "2016-09-20",
-          "text": "If Fateful Showdown’s target becomes an illegal target, you won’t discard your hand or draw any cards."
+          "text": "If Fateful Showdown's target becomes an illegal target, you won't discard your hand or draw any cards."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Fateful Showdown deals damage to target creature or player equal to the number of cards in your hand. Discard all the cards in your hand, then draw that many cards.",
@@ -14174,7 +14174,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You can’t target the same creature or player twice to have one recipient be dealt 4 damage."
+          "text": "You can't target the same creature or player twice to have one recipient be dealt 4 damage."
         }
       ],
       "text": "Furious Reprisal deals 2 damage to each of two target creatures and/or players.",
@@ -14396,11 +14396,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You choose the target creature as you cast Harnessed Lightning. You don’t choose how much {E} to pay until Harnessed Lightning is resolving. No player may take actions between the time you choose how much {E} to pay and the time the creature takes damage equal to the {E} paid this way."
+          "text": "You choose the target creature as you cast Harnessed Lightning. You don't choose how much {E} to pay until Harnessed Lightning is resolving. No player may take actions between the time you choose how much {E} to pay and the time the creature takes damage equal to the {E} paid this way."
         },
         {
           "date": "2016-09-20",
-          "text": "If the target creature becomes an illegal target, Harnessed Lightning is countered and none of its effects happen. You won’t get {E}{E}{E} or be able to pay any {E}."
+          "text": "If the target creature becomes an illegal target, Harnessed Lightning is countered and none of its effects happen. You won't get {E}{E}{E} or be able to pay any {E}."
         },
         {
           "date": "2017-02-09",
@@ -14408,7 +14408,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -14420,11 +14420,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Choose target creature. You get {E}{E}{E} (three energy counters), then you may pay any amount of {E}. Harnessed Lightning deals that much damage to that creature.",
@@ -14868,7 +14868,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -14880,11 +14880,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -15004,15 +15004,15 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Once Madcap Experiment begins resolving, no player may take any actions other than those specified by Madcap Experiment until it’s done resolving."
+          "text": "Once Madcap Experiment begins resolving, no player may take any actions other than those specified by Madcap Experiment until it's done resolving."
         },
         {
           "date": "2016-09-20",
-          "text": "Any abilities that trigger as the artifact enters the battlefield aren’t put onto the stack until Madcap Experiment is done resolving."
+          "text": "Any abilities that trigger as the artifact enters the battlefield aren't put onto the stack until Madcap Experiment is done resolving."
         },
         {
           "date": "2016-09-20",
-          "text": "If you don’t reveal an artifact card, you’ll randomize your library and be dealt damage equal to the number of cards in your library."
+          "text": "If you don't reveal an artifact card, you'll randomize your library and be dealt damage equal to the number of cards in your library."
         }
       ],
       "text": "Reveal cards from the top of your library until you reveal an artifact card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. Madcap Experiment deals damage to you equal to the number of cards revealed this way.",
@@ -15126,7 +15126,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The target creature can’t block any creatures this turn. The effect isn’t restricted to just whether the creature can block Maulfist Doorbuster."
+          "text": "The target creature can't block any creatures this turn. The effect isn't restricted to just whether the creature can block Maulfist Doorbuster."
         },
         {
           "date": "2017-02-09",
@@ -15134,7 +15134,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -15146,19 +15146,19 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         },
         {
           "date": "2017-02-09",
-          "text": "If a triggered ability with one or more targets states that you “may pay” some amount of {E}, and each permanent that it targets has become an illegal target, the ability is countered. You can’t pay {E} even if you want to."
+          "text": "If a triggered ability with one or more targets states that you \"may pay\" some amount of {E}, and each permanent that it targets has become an illegal target, the ability is countered. You can't pay {E} even if you want to."
         }
       ],
       "subtypes": [
@@ -15276,11 +15276,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Once a creature has blocked an attacking creature, activating Pia Nalaar’s last ability won’t cause the attacking creature to become unblocked."
+          "text": "Once a creature has blocked an attacking creature, activating Pia Nalaar's last ability won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-09-20",
-          "text": "The “legend rule” cares about legendary permanents with the exact same English name. The Kaladesh™ card Pia Nalaar and the Magic Origins™ card Pia and Kiran Nalaar have different names, so you can control both at the same time."
+          "text": "The \"legend rule\" cares about legendary permanents with the exact same English name. The Kaladesh™ card Pia Nalaar and the Magic Origins™ card Pia and Kiran Nalaar have different names, so you can control both at the same time."
         }
       ],
       "subtypes": [
@@ -15515,7 +15515,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "In a Two-Headed Giant game, Reckless Fireweaver’s ability causes 2 damage total to be dealt to the opposing team."
+          "text": "In a Two-Headed Giant game, Reckless Fireweaver's ability causes 2 damage total to be dealt to the opposing team."
         }
       ],
       "subtypes": [
@@ -16075,7 +16075,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You can’t cast Spark of Creativity without targeting a creature. If the creature becomes an illegal target for Spark of Creativity, none of its effects happen. You don’t exile the top card of your library."
+          "text": "You can't cast Spark of Creativity without targeting a creature. If the creature becomes an illegal target for Spark of Creativity, none of its effects happen. You don't exile the top card of your library."
         },
         {
           "date": "2016-09-20",
@@ -16091,7 +16091,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Spark of Creativity doesn’t change when you can play the exiled card. For example, if you exile a creature card without flash, you can cast it only during your main phase when the stack is empty."
+          "text": "Spark of Creativity doesn't change when you can play the exiled card. For example, if you exile a creature card without flash, you can cast it only during your main phase when the stack is empty."
         }
       ],
       "text": "Choose target creature. Exile the top card of your library. You may have Spark of Creativity deal damage to that creature equal to the exiled card's converted mana cost. If you don't, you may play that card until end of turn.",
@@ -16205,7 +16205,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Speedway Fanatic’s triggered ability triggers when it becomes tapped to activate a crew ability. Even if Speedway Fanatic leaves the battlefield before its triggered ability resolves, that Vehicle still gains haste until end of turn."
+          "text": "Speedway Fanatic's triggered ability triggers when it becomes tapped to activate a crew ability. Even if Speedway Fanatic leaves the battlefield before its triggered ability resolves, that Vehicle still gains haste until end of turn."
         }
       ],
       "subtypes": [
@@ -16324,11 +16324,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "This is a triggered ability, not an activated ability. It doesn’t allow you to tap Spireside Infiltrator whenever you want; rather, you need some other way of tapping it, such as by attacking."
+          "text": "This is a triggered ability, not an activated ability. It doesn't allow you to tap Spireside Infiltrator whenever you want; rather, you need some other way of tapping it, such as by attacking."
         },
         {
           "date": "2016-09-20",
-          "text": "For the ability to trigger, Spireside Infiltrator has to actually change from untapped to tapped. If an effect attempts to tap it, but it was already tapped at the time, this ability won’t trigger."
+          "text": "For the ability to trigger, Spireside Infiltrator has to actually change from untapped to tapped. If an effect attempts to tap it, but it was already tapped at the time, this ability won't trigger."
         }
       ],
       "subtypes": [
@@ -16451,7 +16451,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -16463,11 +16463,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -16589,7 +16589,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The set of Vehicles and creatures affected by Start Your Engines is determined as the spell resolves. Creatures you begin to control later in the turn won’t get +2/+0, and Vehicles you begin to control later in the turn won’t automatically become creatures and won’t get +2/+0."
+          "text": "The set of Vehicles and creatures affected by Start Your Engines is determined as the spell resolves. Creatures you begin to control later in the turn won't get +2/+0, and Vehicles you begin to control later in the turn won't automatically become creatures and won't get +2/+0."
         }
       ],
       "text": "Vehicles you control become artifact creatures until end of turn. Creatures you control get +2/+0 until end of turn.",
@@ -16711,7 +16711,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -16723,11 +16723,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -16959,7 +16959,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -16971,15 +16971,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -17549,7 +17549,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -17561,11 +17561,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -17685,11 +17685,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The number of creatures you control with +1/+1 counters on them is counted only as Armorcraft Judge’s triggered ability resolves. Players may respond to the triggered ability by trying to change that number."
+          "text": "The number of creatures you control with +1/+1 counters on them is counted only as Armorcraft Judge's triggered ability resolves. Players may respond to the triggered ability by trying to change that number."
         },
         {
           "date": "2016-09-20",
-          "text": "Armorcraft Judge’s ability counts the number of creatures, not the number of counters. A creature with more than one +1/+1 counter won’t cause you to draw more than one card."
+          "text": "Armorcraft Judge's ability counts the number of creatures, not the number of counters. A creature with more than one +1/+1 counter won't cause you to draw more than one card."
         }
       ],
       "subtypes": [
@@ -17811,7 +17811,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -17823,11 +17823,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library. You get {E}{E} (two energy counters).",
@@ -18051,7 +18051,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -18063,11 +18063,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -18524,15 +18524,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The value of X is determined as Cultivator of Blades’s last ability resolves. It won’t change later, even if its power changes. If Cultivator of Blades is no longer on the battlefield, use its power as it last existed on the battlefield to determine the value of X."
+          "text": "The value of X is determined as Cultivator of Blades's last ability resolves. It won't change later, even if its power changes. If Cultivator of Blades is no longer on the battlefield, use its power as it last existed on the battlefield to determine the value of X."
         },
         {
           "date": "2016-09-20",
-          "text": "You choose whether or not to have your other attacking creatures get +X/+X as Cultivator of Blades’s triggered ability resolves, not as you put it onto the stack."
-        },
-        {
-          "date": "2016-09-20",
-          "text": "If Cultivator of Blades’s power becomes negative, its last ability will lower power and toughness. For example, if Cultivator of Blades’s power is -2, its last ability gives -2/-2 (if you choose to give the creatures +X/+X)."
+          "text": "You choose whether or not to have your other attacking creatures get +X/+X as Cultivator of Blades's triggered ability resolves, not as you put it onto the stack."
         },
         {
           "date": "2016-09-20",
@@ -18540,11 +18536,15 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
+        },
+        {
+          "date": "2017-06-27",
+          "text": "If this creature's power is negative as its ability resolves, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -18673,7 +18673,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The cards that you look at but don’t exile never leave your library. They’re shuffled along with the rest of your library."
+          "text": "The cards that you look at but don't exile never leave your library. They're shuffled along with the rest of your library."
         },
         {
           "date": "2016-09-20",
@@ -18789,11 +18789,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You don’t choose whether to pay {1} until Durable Handicraft’s triggered ability is resolving. No player may take actions between the time you choose to pay and the time the creature gets a +1/+1 counter."
+          "text": "You don't choose whether to pay {1} until Durable Handicraft's triggered ability is resolving. No player may take actions between the time you choose to pay and the time the creature gets a +1/+1 counter."
         },
         {
           "date": "2016-09-20",
-          "text": "You can pay {1} only once each time Durable Handicraft’s triggered ability resolves. You can’t pay more to put multiple +1/+1 counters on a creature."
+          "text": "You can pay {1} only once each time Durable Handicraft's triggered ability resolves. You can't pay more to put multiple +1/+1 counters on a creature."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, you may pay {1}. If you do, put a +1/+1 counter on that creature.\n{5}{G}, Sacrifice Durable Handicraft: Put a +1/+1 counter on each creature you control.",
@@ -18906,7 +18906,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Once a creature with power 3 or greater has blocked Elegant Edgecrafters, changing the power of the blocking creature won’t cause Elegant Edgecrafters to become unblocked."
+          "text": "Once a creature with power 3 or greater has blocked Elegant Edgecrafters, changing the power of the blocking creature won't cause Elegant Edgecrafters to become unblocked."
         },
         {
           "date": "2016-09-20",
@@ -18914,11 +18914,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -19037,11 +19037,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Fairgrounds Trumpeter’s ability triggers if, at any point during this turn, a +1/+1 counter was placed on a permanent that you controlled as the counter was placed. It doesn’t matter whether you still control the permanent or whether it still has a counter."
+          "text": "Fairgrounds Trumpeter's ability triggers if, at any point during this turn, a +1/+1 counter was placed on a permanent that you controlled as the counter was placed. It doesn't matter whether you still control the permanent or whether it still has a counter."
         },
         {
           "date": "2016-09-20",
-          "text": "If a +1/+1 counter hasn’t been placed yet at the moment an end step begins, Fairgrounds Trumpeter’s ability doesn’t trigger at all. If another ability triggers during the end step and puts a +1/+1 counter on a permanent you control, you won’t put an additional +1/+1 counter on Fairgrounds Trumpeter."
+          "text": "If a +1/+1 counter hasn't been placed yet at the moment an end step begins, Fairgrounds Trumpeter's ability doesn't trigger at all. If another ability triggers during the end step and puts a +1/+1 counter on a permanent you control, you won't put an additional +1/+1 counter on Fairgrounds Trumpeter."
         }
       ],
       "subtypes": [
@@ -19159,7 +19159,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Once an attacking creature has been blocked, activating Ghirapur Guide’s ability won’t cause it to become unblocked. If a creature with power 3 or greater has blocked a creature affected by Ghirapur Guide’s ability, changing the power of the blocking creature won’t cause the attacking creature to become unblocked."
+          "text": "Once an attacking creature has been blocked, activating Ghirapur Guide's ability won't cause it to become unblocked. If a creature with power 3 or greater has blocked a creature affected by Ghirapur Guide's ability, changing the power of the blocking creature won't cause the attacking creature to become unblocked."
         }
       ],
       "subtypes": [
@@ -19281,11 +19281,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -19409,16 +19409,8 @@
       "rarity": "Common",
       "rulings": [
         {
-          "date": "2014-11-24",
-          "text": "If either target is an illegal target as Hunt the Weak tries to resolve, neither creature will deal or be dealt damage."
-        },
-        {
-          "date": "2014-11-24",
-          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won’t put a +1/+1 counter on it. If that creature is a legal target but the creature you don’t control isn’t, you’ll still put the counter on the creature you control."
-        },
-        {
           "date": "2016-09-20",
-          "text": "You can’t cast Hunt the Weak unless you choose both a creature you control and a creature you don’t control as targets."
+          "text": "You can't cast Hunt the Weak unless you choose both a creature you control and a creature you don't control as targets."
         },
         {
           "date": "2016-09-20",
@@ -19426,7 +19418,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won’t put a +1/+1 counter on it. If that creature is a legal target but the other creature isn’t, you’ll still put the counter on the creature you control."
+          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won't put a +1/+1 counter on it. If that creature is a legal target but the other creature isn't, you'll still put the counter on the creature you control."
         }
       ],
       "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
@@ -19770,7 +19762,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -19782,11 +19774,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -19903,19 +19895,19 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You can’t cast Nature’s Way unless you choose both a creature you control and a creature you don’t control as targets."
+          "text": "You can't cast Nature's Way unless you choose both a creature you control and a creature you don't control as targets."
         },
         {
           "date": "2016-09-20",
-          "text": "If either target is an illegal target as Nature’s Way resolves, no damage will be dealt."
+          "text": "If either target is an illegal target as Nature's Way resolves, no damage will be dealt."
         },
         {
           "date": "2016-09-20",
-          "text": "If the creature you don’t control is an illegal target as Nature’s Way tries to resolve, the creature you control will still gain vigilance and trample."
+          "text": "If the creature you don't control is an illegal target as Nature's Way tries to resolve, the creature you control will still gain vigilance and trample."
         },
         {
           "date": "2016-09-20",
-          "text": "Trample only applies to the assignment of combat damage, not the damage Nature’s Way has the creature deal."
+          "text": "Trample only applies to the assignment of combat damage, not the damage Nature's Way has the creature deal."
         }
       ],
       "text": "Target creature you control gains vigilance and trample until end of turn. It deals damage equal to its power to target creature you don't control.",
@@ -20028,11 +20020,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You can activate Nissa’s first ability targeting a land that’s already untapped."
+          "text": "You can activate Nissa's first ability targeting a land that's already untapped."
         },
         {
           "date": "2016-09-20",
-          "text": "After resolving Nissa’s first ability, the target land still has any abilities it had before it became a creature and any other types it had."
+          "text": "After resolving Nissa's first ability, the target land still has any abilities it had before it became a creature and any other types it had."
         },
         {
           "date": "2016-09-20",
@@ -20266,11 +20258,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The value of X is determined only as Oviya Pashiri’s last ability resolves. The token’s power and toughness won’t change as the number of creatures you control changes."
+          "text": "The value of X is determined only as Oviya Pashiri's last ability resolves. The token's power and toughness won't change as the number of creatures you control changes."
         },
         {
           "date": "2016-09-20",
-          "text": "The Construct token you’re creating doesn’t count towards X for the ability that creates it."
+          "text": "The Construct token you're creating doesn't count towards X for the ability that creates it."
         }
       ],
       "subtypes": [
@@ -20396,11 +20388,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -20522,7 +20514,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -20534,15 +20526,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -20664,7 +20656,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -20676,11 +20668,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -20803,7 +20795,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -20815,11 +20807,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -21049,7 +21041,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -21061,15 +21053,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -21187,11 +21179,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You choose how the counters will be distributed as you put Verdurous Gearhulk’s triggered ability onto the stack. Each target creature must be assigned at least one counter."
+          "text": "You choose how the counters will be distributed as you put Verdurous Gearhulk's triggered ability onto the stack. Each target creature must be assigned at least one counter."
         },
         {
           "date": "2016-09-20",
-          "text": "If one of the target creatures becomes an illegal target in response to Verdurous Gearhulk’s triggered ability, the +1/+1 counters that would have been put on that creature are lost. They can’t be put on another legal target."
+          "text": "If one of the target creatures becomes an illegal target in response to Verdurous Gearhulk's triggered ability, the +1/+1 counters that would have been put on that creature are lost. They can't be put on another legal target."
         },
         {
           "date": "2016-09-20",
@@ -21426,7 +21418,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If each target card is an illegal target as Wildest Dreams resolves, Wildest Dreams is countered and is put into its owner’s graveyard. It’s not exiled."
+          "text": "If each target card is an illegal target as Wildest Dreams resolves, Wildest Dreams is countered and is put into its owner's graveyard. It's not exiled."
         }
       ],
       "text": "Return X target cards from your graveyard to your hand. Exile Wildest Dreams.",
@@ -21770,7 +21762,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If multiple artifacts enter the battlefield simultaneously, you’ll scry 1 that many times. You won’t look at more than one card from your library at once."
+          "text": "If multiple artifacts enter the battlefield simultaneously, you'll scry 1 that many times. You won't look at more than one card from your library at once."
         }
       ],
       "subtypes": [
@@ -21890,11 +21882,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Depala, Pilot Exemplar’s last ability is a triggered ability, not an activated ability. It doesn’t allow you to tap Depala whenever you want; rather, you need some other way of tapping it, such as by attacking."
+          "text": "Depala, Pilot Exemplar's last ability is a triggered ability, not an activated ability. It doesn't allow you to tap Depala whenever you want; rather, you need some other way of tapping it, such as by attacking."
         },
         {
           "date": "2016-09-20",
-          "text": "For the ability to trigger, Depala has to actually change from untapped to tapped. If an effect attempts to tap Depala, but it was already tapped at the time, this ability won’t trigger."
+          "text": "For the ability to trigger, Depala has to actually change from untapped to tapped. If an effect attempts to tap Depala, but it was already tapped at the time, this ability won't trigger."
         }
       ],
       "subtypes": [
@@ -22017,15 +22009,15 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Dovin Baan’s first ability can target any creature, not just one with an activated ability. It can also be activated targeting no creature at all."
+          "text": "Dovin Baan's first ability can target any creature, not just one with an activated ability. It can also be activated targeting no creature at all."
         },
         {
           "date": "2016-09-20",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2016-09-20",
-          "text": "An opponent affected by Dovin Baan’s emblem chooses which two of his or her permanents to untap, not you."
+          "text": "An opponent affected by Dovin Baan's emblem chooses which two of his or her permanents to untap, not you."
         }
       ],
       "subtypes": [
@@ -22148,7 +22140,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -22160,11 +22152,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -22283,7 +22275,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The set of creatures affected by Engineered Might’s second mode is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won’t get +2/+2 or gain vigilance."
+          "text": "The set of creatures affected by Engineered Might's second mode is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get +2/+2 or gain vigilance."
         }
       ],
       "text": "Choose one —\n• Target creature gets +5/+5 and gains trample until end of turn.\n• Creatures you control get +2/+2 and gain vigilance until end of turn.",
@@ -22398,11 +22390,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Hazardous Conditions doesn’t care what kind of counter a creature has on it. Whether +1/+1, -1/-1, charge, or fate, any kind of counter causes a creature to be unaffected."
+          "text": "Hazardous Conditions doesn't care what kind of counter a creature has on it. Whether +1/+1, -1/-1, charge, or fate, any kind of counter causes a creature to be unaffected."
         },
         {
           "date": "2016-09-20",
-          "text": "The set of creatures affected by Hazardous Conditions is determined as the spell resolves. Creatures that get a counter later in the turn will continue to get -2/-2. Creatures that enter the battlefield or lose their counters later in the turn and noncreature permanents that become creatures later in the turn won’t get -2/-2."
+          "text": "The set of creatures affected by Hazardous Conditions is determined as the spell resolves. Creatures that get a counter later in the turn will continue to get -2/-2. Creatures that enter the battlefield or lose their counters later in the turn and noncreature permanents that become creatures later in the turn won't get -2/-2."
         }
       ],
       "text": "Creatures with no counters on them get -2/-2 until end of turn.",
@@ -22518,11 +22510,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Kambal’s ability resolves before the spell that caused it to trigger."
+          "text": "Kambal's ability resolves before the spell that caused it to trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "A noncreature spell is a spell that isn’t a creature at all. An artifact creature spell isn’t a noncreature spell. Lands are never spells."
+          "text": "A noncreature spell is a spell that isn't a creature at all. An artifact creature spell isn't a noncreature spell. Lands are never spells."
         }
       ],
       "subtypes": [
@@ -22649,31 +22641,31 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Rashmi’s ability triggers when you cast your first spell each turn, not just on your turn."
+          "text": "Rashmi's ability triggers when you cast your first spell each turn, not just on your turn."
         },
         {
           "date": "2016-09-20",
-          "text": "Rashmi has to be on the battlefield at the moment you cast your first spell. If that spell is Rashmi itself, Rashmi’s ability can’t trigger. If that spell causes Rashmi to leave the battlefield as an additional cost to cast it, Rashmi’s ability can’t trigger."
+          "text": "Rashmi has to be on the battlefield at the moment you cast your first spell. If that spell is Rashmi itself, Rashmi's ability can't trigger. If that spell causes Rashmi to leave the battlefield as an additional cost to cast it, Rashmi's ability can't trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "Rashmi’s ability resolves before the spell that caused it to trigger. If you cast a spell using the ability, it will also resolve before the initial spell."
+          "text": "Rashmi's ability resolves before the spell that caused it to trigger. If you cast a spell using the ability, it will also resolve before the initial spell."
         },
         {
           "date": "2016-09-20",
-          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine the spell’s converted mana cost. For cards in your library with {X} in their mana costs, X is considered to be 0."
+          "text": "For spells with {X} in their mana costs, use the value chosen for X to determine the spell's converted mana cost. For cards in your library with {X} in their mana costs, X is considered to be 0."
         },
         {
           "date": "2016-09-20",
-          "text": "If Rashmi’s ability resolves and the spell that caused it to trigger has been countered, use that spell’s converted mana cost as it last existed on the stack to determine whether or not you may cast the top card of your library."
+          "text": "If Rashmi's ability resolves and the spell that caused it to trigger has been countered, use that spell's converted mana cost as it last existed on the stack to determine whether or not you may cast the top card of your library."
         },
         {
           "date": "2016-09-20",
-          "text": "If you cast the top card of your library, you do so as part of the resolution of Rashmi’s ability. You can’t wait to cast it later in the turn. Timing permissions based on the card’s type are ignored, but other restrictions (such as “Cast [this card] only during combat”) are not."
+          "text": "If you cast the top card of your library, you do so as part of the resolution of Rashmi's ability. You can't wait to cast it later in the turn. Timing permissions based on the card's type are ignored, but other restrictions (such as \"Cast [this card] only during combat\") are not."
         },
         {
           "date": "2016-09-20",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, those must be paid to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Cathartic Reunion, those must be paid to cast the card."
         },
         {
           "date": "2016-09-20",
@@ -22915,11 +22907,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The token copies exactly what was printed on the original permanent and nothing else (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "The token copies exactly what was printed on the original permanent and nothing else (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2016-09-20",
-          "text": "The token is an artifact in addition to its other types. This is a copiable value of the token that other effects may copy. Haste and the ability’s delayed triggered ability aren’t copiable."
+          "text": "The token is an artifact in addition to its other types. This is a copiable value of the token that other effects may copy. Haste and the ability's delayed triggered ability aren't copiable."
         },
         {
           "date": "2016-09-20",
@@ -22935,15 +22927,15 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Any enters-the-battlefield abilities of the copied permanent will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the chosen permanent will also work."
+          "text": "Any enters-the-battlefield abilities of the copied permanent will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the chosen permanent will also work."
         },
         {
           "date": "2016-09-20",
-          "text": "As Saheeli’s last ability resolves, all three artifacts enter the battlefield at the same time. Triggered abilities of any of those artifacts will see all three entering the battlefield. Replacement effects, such as that of Sculpting Steel, won’t see the others on the battlefield as they are being applied."
+          "text": "As Saheeli's last ability resolves, all three artifacts enter the battlefield at the same time. Triggered abilities of any of those artifacts will see all three entering the battlefield. Replacement effects, such as that of Sculpting Steel, won't see the others on the battlefield as they are being applied."
         },
         {
           "date": "2016-09-20",
-          "text": "In a Two-Headed Giant game, Saheeli’s first ability causes 2 damage total to be dealt to the opposing team."
+          "text": "In a Two-Headed Giant game, Saheeli's first ability causes 2 damage total to be dealt to the opposing team."
         }
       ],
       "subtypes": [
@@ -23065,11 +23057,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If the target creature is a legal target but isn’t destroyed by Unlicensed Disintegration, most likely because it has indestructible, Unlicensed Disintegration still deals 3 damage to the creature’s controller."
+          "text": "If the target creature is a legal target but isn't destroyed by Unlicensed Disintegration, most likely because it has indestructible, Unlicensed Disintegration still deals 3 damage to the creature's controller."
         },
         {
           "date": "2016-09-20",
-          "text": "Whether or not you control an artifact is checked only as Unlicensed Disintegration resolves, after the creature is destroyed. For example, if you destroy a Fairgrounds Warden that exiled your artifact creature, Unlicensed Disintegration deals 3 damage to Fairgrounds Warden’s controller."
+          "text": "Whether or not you control an artifact is checked only as Unlicensed Disintegration resolves, after the creature is destroyed. For example, if you destroy a Fairgrounds Warden that exiled your artifact creature, Unlicensed Disintegration deals 3 damage to Fairgrounds Warden's controller."
         }
       ],
       "text": "Destroy target creature. If you control an artifact, Unlicensed Disintegration deals 3 damage to that creature's controller.",
@@ -23185,11 +23177,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Veteran Motorist’s last ability triggers when it becomes tapped to activate a crew ability. Even if Veteran Motorist leaves the battlefield before its triggered ability resolves, that Vehicle still gets +1/+1 until end of turn."
+          "text": "Veteran Motorist's last ability triggers when it becomes tapped to activate a crew ability. Even if Veteran Motorist leaves the battlefield before its triggered ability resolves, that Vehicle still gets +1/+1 until end of turn."
         },
         {
           "date": "2016-09-20",
-          "text": "Veteran Motorist’s last ability resolves before the crew ability that it was tapped to activate. The +1/+1 bonus will be in effect as the Vehicle becomes an artifact creature."
+          "text": "Veteran Motorist's last ability resolves before the crew ability that it was tapped to activate. The +1/+1 bonus will be in effect as the Vehicle becomes an artifact creature."
         }
       ],
       "subtypes": [
@@ -23313,7 +23305,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -23325,15 +23317,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
           "date": "2017-02-09",
-          "text": "Some triggered abilities state that you “may pay” a certain amount of {E}. You can’t pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability’s effect after you make your choice."
+          "text": "Some triggered abilities state that you \"may pay\" a certain amount of {E}. You can't pay that amount multiple times to multiply the effect. You simply choose whether or not to pay that amount of {E} as the ability resolves, and no player may take actions to try to stop the ability's effect after you make your choice."
         }
       ],
       "subtypes": [
@@ -23458,7 +23450,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -23470,11 +23462,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -23591,11 +23583,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -23711,15 +23703,15 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The first ability counts spells you cast earlier in the turn even if you didn’t control Aetherflux Reservoir as you cast them, and even if those spells were countered."
+          "text": "The first ability counts spells you cast earlier in the turn even if you didn't control Aetherflux Reservoir as you cast them, and even if those spells were countered."
         },
         {
           "date": "2016-09-20",
-          "text": "The number of spells you’ve cast is counted only as Aetherflux Reservoir’s triggered ability resolves. For example, if you cast a spell, then respond to the triggered ability with a second spell, you’ll gain 4 life total."
+          "text": "The number of spells you've cast is counted only as Aetherflux Reservoir's triggered ability resolves. For example, if you cast a spell, then respond to the triggered ability with a second spell, you'll gain 4 life total."
         },
         {
           "date": "2016-09-20",
-          "text": "Aetherflux Reservoir’s first ability doesn’t trigger when you cast Aetherflux Reservoir itself."
+          "text": "Aetherflux Reservoir's first ability doesn't trigger when you cast Aetherflux Reservoir itself."
         }
       ],
       "text": "Whenever you cast a spell, you gain 1 life for each spell you've cast this turn.\nPay 50 life: Aetherflux Reservoir deals 50 damage to target creature or player.",
@@ -23825,19 +23817,19 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Aetherworks Marvel’s first ability triggers whenever any permanent you control is put into a graveyard from the battlefield, including Aetherworks Marvel itself and other permanents put into a graveyard at the same time as it."
+          "text": "Aetherworks Marvel's first ability triggers whenever any permanent you control is put into a graveyard from the battlefield, including Aetherworks Marvel itself and other permanents put into a graveyard at the same time as it."
         },
         {
           "date": "2016-09-20",
-          "text": "Tokens that are sacrificed or destroyed are put into their owner’s graveyard before ceasing to exist. If you controlled the token, Aetherworks Marvel’s first ability will trigger."
+          "text": "Tokens that are sacrificed or destroyed are put into their owner's graveyard before ceasing to exist. If you controlled the token, Aetherworks Marvel's first ability will trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "The card cast with Aetherworks Marvel’s second ability is cast from your library."
+          "text": "The card cast with Aetherworks Marvel's second ability is cast from your library."
         },
         {
           "date": "2016-09-20",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Incendiary Sabotage, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Incendiary Sabotage, you must pay those to cast the card."
         },
         {
           "date": "2016-09-20",
@@ -23849,7 +23841,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -23861,11 +23853,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "supertypes": [
@@ -23975,7 +23967,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If +1/+1 counters are placed on more than one permanent you control at the same time, Animation Module’s first ability triggers once for each of those permanents."
+          "text": "If +1/+1 counters are placed on more than one permanent you control at the same time, Animation Module's first ability triggers once for each of those permanents."
         },
         {
           "date": "2016-09-20",
@@ -23983,7 +23975,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "You can pay {1} only once each time Animation Module’s first ability resolves. You can’t pay more to create extra Servo tokens."
+          "text": "You can pay {1} only once each time Animation Module's first ability resolves. You can't pay more to create extra Servo tokens."
         }
       ],
       "text": "Whenever one or more +1/+1 counters are put on a permanent you control, you may pay {1}. If you do, create a 1/1 colorless Servo artifact creature token.\n{3}, {T}: Choose a counter on target permanent or player. Give that permanent or player another counter of that kind.",
@@ -24091,19 +24083,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -24115,15 +24107,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -24131,11 +24123,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -24246,23 +24238,23 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Ballista Charger’s triggered ability resolves before blockers are chosen. A creature dealt lethal damage this way won’t be around to block."
+          "text": "Ballista Charger's triggered ability resolves before blockers are chosen. A creature dealt lethal damage this way won't be around to block."
         },
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -24274,15 +24266,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -24290,11 +24282,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -24409,7 +24401,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Once Bastion Mastodon is tapped and attacking, gaining vigilance won’t cause it to become untapped."
+          "text": "Once Bastion Mastodon is tapped and attacking, gaining vigilance won't cause it to become untapped."
         }
       ],
       "subtypes": [
@@ -24521,19 +24513,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -24545,15 +24537,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -24561,11 +24553,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -24679,7 +24671,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Each Bomat Courier you control has its own cache of cards. Bomat Courier’s last ability only puts those cards into your hand, not those of any other Bomat Courier."
+          "text": "Each Bomat Courier you control has its own cache of cards. Bomat Courier's last ability only puts those cards into your hand, not those of any other Bomat Courier."
         },
         {
           "date": "2016-09-20",
@@ -24687,7 +24679,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "You can pay the cost of “discard your hand” even if your hand contains zero cards."
+          "text": "You can pay the cost of \"discard your hand\" even if your hand contains zero cards."
         }
       ],
       "subtypes": [
@@ -25117,23 +25109,23 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "As long as Cultivator’s Caravan isn’t an artifact creature, its {T} ability can be activated if it came under your control this turn."
+          "text": "As long as Cultivator's Caravan isn't an artifact creature, its {T} ability can be activated if it came under your control this turn."
         },
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -25145,15 +25137,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -25161,11 +25153,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -25275,19 +25267,19 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2016-09-20",
-          "text": "Once a player has announced an ability, Deadlock Trap can’t be used to undo it. The last ability must be activated before that player activates that ability."
+          "text": "Once a player has announced an ability, Deadlock Trap can't be used to undo it. The last ability must be activated before that player activates that ability."
         },
         {
           "date": "2016-09-20",
-          "text": "Players may respond to Deadlock Trap’s last ability by activating an ability of the target permanent if that ability’s timing permissions allow it."
+          "text": "Players may respond to Deadlock Trap's last ability by activating an ability of the target permanent if that ability's timing permissions allow it."
         },
         {
           "date": "2016-09-20",
-          "text": "After a planeswalker enters the battlefield, the active player receives priority and may activate an ability of that planeswalker before any player can activate Deadlock Trap’s last ability."
+          "text": "After a planeswalker enters the battlefield, the active player receives priority and may activate an ability of that planeswalker before any player can activate Deadlock Trap's last ability."
         },
         {
           "date": "2016-09-20",
@@ -25295,7 +25287,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If the tapped creature somehow becomes untapped, it can attack and block as normal, but its abilities still can’t be activated this turn."
+          "text": "If the tapped creature somehow becomes untapped, it can attack and block as normal, but its abilities still can't be activated this turn."
         },
         {
           "date": "2017-02-09",
@@ -25303,7 +25295,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -25315,15 +25307,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "Deadlock Trap enters the battlefield tapped.\nWhen Deadlock Trap enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Tap target creature or planeswalker. Its activated abilities can't be activated this turn.",
@@ -25435,7 +25427,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -25447,11 +25439,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, you get {E} (an energy counter).\n{4}, {T}: Return target creature you control to its owner's hand.",
@@ -25558,23 +25550,23 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Once a creature with power 3 or greater has blocked Demolition Stomper, changing the power of the blocking creature won’t cause Demolition Stomper to become unblocked."
+          "text": "Once a creature with power 3 or greater has blocked Demolition Stomper, changing the power of the blocking creature won't cause Demolition Stomper to become unblocked."
         },
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -25586,15 +25578,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -25602,11 +25594,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -25721,7 +25713,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Activating Dukhara Peafowl’s ability after it’s been blocked by a creature without flying or reach won’t cause it to become unblocked."
+          "text": "Activating Dukhara Peafowl's ability after it's been blocked by a creature without flying or reach won't cause it to become unblocked."
         }
       ],
       "subtypes": [
@@ -25833,7 +25825,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Dynavolt Tower’s triggered ability resolves before the spell that caused it to trigger."
+          "text": "Dynavolt Tower's triggered ability resolves before the spell that caused it to trigger."
         },
         {
           "date": "2017-02-09",
@@ -25841,7 +25833,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -25853,11 +25845,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell, you get {E}{E} (two energy counters).\n{T}, Pay {E}{E}{E}{E}{E}: Dynavolt Tower deals 3 damage to target creature or player.",
@@ -25965,7 +25957,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "As Eager Construct’s triggered ability resolves, first the player whose turn it is scrys 1, then each other player in turn order does the same. Each player will know the choices made by players who chose before them."
+          "text": "As Eager Construct's triggered ability resolves, first the player whose turn it is scrys 1, then each other player in turn order does the same. Each player will know the choices made by players who chose before them."
         }
       ],
       "subtypes": [
@@ -26077,11 +26069,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The value of X is determined as Electrostatic Pummeler’s last ability resolves."
-        },
-        {
-          "date": "2016-09-20",
-          "text": "If Electrostatic Pummeler’s power becomes negative, its last ability will lower power and toughness. For example, if Electrostatic Pummeler’s power is -2, its last ability gives it -2/-2."
+          "text": "The value of X is determined as Electrostatic Pummeler's last ability resolves."
         },
         {
           "date": "2017-02-09",
@@ -26089,7 +26077,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -26101,11 +26089,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
+        },
+        {
+          "date": "2017-06-27",
+          "text": "If this creature's power is negative as its ability resolves, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -26217,7 +26209,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If you get multiple {E} at once, you only put one +1/+1 counter on a creature, not one counter for each {E}. If you get multiple {E} at different times, Fabrication Module’s ability triggers once each time."
+          "text": "If you get multiple {E} at once, you only put one +1/+1 counter on a creature, not one counter for each {E}. If you get multiple {E} at different times, Fabrication Module's ability triggers once each time."
         },
         {
           "date": "2017-02-09",
@@ -26225,7 +26217,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -26237,11 +26229,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "Whenever you get one or more {E} (energy counters), put a +1/+1 counter on target creature you control.\n{4}, {T}: You get {E}.",
@@ -26558,19 +26550,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -26582,15 +26574,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -26598,11 +26590,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -26718,7 +26710,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Once a player has announced an artifact spell, no player may take actions to try to remove Foundry Inspector from the battlefield before that spell’s cost is locked in."
+          "text": "Once a player has announced an artifact spell, no player may take actions to try to remove Foundry Inspector from the battlefield before that spell's cost is locked in."
         }
       ],
       "subtypes": [
@@ -26830,27 +26822,27 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Ghirapur Orrery’s first ability allows a player to play an additional land during his or her main phase. Doing so follows the normal timing rules for playing lands."
+          "text": "Ghirapur Orrery's first ability allows a player to play an additional land during his or her main phase. Doing so follows the normal timing rules for playing lands."
         },
         {
           "date": "2016-09-20",
-          "text": "Ghirapur Orrery’s first ability is cumulative if more than one is on the battlefield."
+          "text": "Ghirapur Orrery's first ability is cumulative if more than one is on the battlefield."
         },
         {
           "date": "2016-09-20",
-          "text": "No player may take actions in a turn before Ghirapur Orrery’s second ability checks to see if it should trigger. If the player whose turn it is has any cards in hand, it won’t trigger."
+          "text": "No player may take actions in a turn before Ghirapur Orrery's second ability checks to see if it should trigger. If the player whose turn it is has any cards in hand, it won't trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "If the player has any cards in hand as Ghirapur Orrery’s second ability resolves, the ability does nothing. Notably, a second Ghirapur Orrery won’t have a player draw another three cards unless the player empties his or her hand after resolving the first one’s trigger."
+          "text": "If the player has any cards in hand as Ghirapur Orrery's second ability resolves, the ability does nothing. Notably, a second Ghirapur Orrery won't have a player draw another three cards unless the player empties his or her hand after resolving the first one's trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "The draw step is after the upkeep step, so drawing a card as a turn-based action won’t affect whether Ghirapur Orrery’s second ability triggers."
+          "text": "The draw step is after the upkeep step, so drawing a card as a turn-based action won't affect whether Ghirapur Orrery's second ability triggers."
         },
         {
           "date": "2016-09-20",
-          "text": "In a Two-Headed Giant game, Ghirapur Orrery’s second ability triggers for each player on a team separately. If one player has cards in hand, it can still trigger for the other player."
+          "text": "In a Two-Headed Giant game, Ghirapur Orrery's second ability triggers for each player on a team separately. If one player has cards in hand, it can still trigger for the other player."
         }
       ],
       "text": "Each player may play an additional land on each of his or her turns.\nAt the beginning of each player's upkeep, if that player has no cards in hand, that player draws three cards.",
@@ -26963,7 +26955,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -26975,11 +26967,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "When Glassblower's Puzzleknot enters the battlefield, scry 2, then you get {E}{E}. (You get two energy counters. To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\n{2}{U}, Sacrifice Glassblower's Puzzleknot: Scry 2, then you get {E}{E}.",
@@ -27085,7 +27077,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If the Artificer that entered the battlefield leaves the battlefield before Inventor’s Goggles becomes attached, Inventor’s Goggles stays as it was. If it’s already attached to another creature, it remains attached to that creature."
+          "text": "If the Artificer that entered the battlefield leaves the battlefield before Inventor's Goggles becomes attached, Inventor's Goggles stays as it was. If it's already attached to another creature, it remains attached to that creature."
         }
       ],
       "subtypes": [
@@ -27200,11 +27192,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Fabricate doesn’t cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
+          "text": "Fabricate doesn't cause the creature with the ability to enter the battlefield with +1/+1 counters already on it. For example, Weaponcraft Enthusiast will enter the battlefield as a 0/1 creature, then its fabricate ability goes on the stack. Players may take actions (such as casting instants) while the ability is waiting to resolve."
         },
         {
           "date": "2016-09-20",
-          "text": "If you can’t put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it’s no longer on the battlefield), you just create Servo tokens."
+          "text": "If you can't put +1/+1 counters on the creature for any reason as fabricate resolves (for instance, if it's no longer on the battlefield), you just create Servo tokens."
         }
       ],
       "subtypes": [
@@ -27316,19 +27308,19 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You can activate Key to the City’s first ability without targeting any creature."
+          "text": "You can activate Key to the City's first ability without targeting any creature."
         },
         {
           "date": "2016-09-20",
-          "text": "Activating Key to the City’s ability targeting a creature that has already been blocked won’t cause it to become unblocked."
+          "text": "Activating Key to the City's ability targeting a creature that has already been blocked won't cause it to become unblocked."
         },
         {
           "date": "2016-09-20",
-          "text": "Key to the City’s last ability triggers during your untap step, but it’s put onto the stack at the same time as abilities that trigger at the beginning of your upkeep step. Even though Key to the City’s ability triggered first, you may order it before or after other abilities you control that are put onto the stack at this time."
+          "text": "Key to the City's last ability triggers during your untap step, but it's put onto the stack at the same time as abilities that trigger at the beginning of your upkeep step. Even though Key to the City's ability triggered first, you may order it before or after other abilities you control that are put onto the stack at this time."
         },
         {
           "date": "2016-09-20",
-          "text": "You can pay {2} only once each time Key to the City’s triggered ability resolves. You can’t pay more to draw additional cards."
+          "text": "You can pay {2} only once each time Key to the City's triggered ability resolves. You can't pay more to draw additional cards."
         }
       ],
       "text": "{T}, Discard a card: Up to one target creature can't be blocked this turn.\nWhenever Key to the City becomes untapped, you may pay {2}. If you do, draw a card.",
@@ -27550,11 +27542,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Once a player has announced that he or she is casting Metalwork Colossus, no player may take actions to try to change the number of artifacts its controller controls before that spell’s cost is locked in."
+          "text": "Once a player has announced that he or she is casting Metalwork Colossus, no player may take actions to try to change the number of artifacts its controller controls before that spell's cost is locked in."
         },
         {
           "date": "2016-09-20",
-          "text": "Metalwork Colossus’s last ability can be activated only if it is in your graveyard."
+          "text": "Metalwork Colossus's last ability can be activated only if it is in your graveyard."
         }
       ],
       "subtypes": [
@@ -27666,7 +27658,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "As you activate one of Multiform Wonder’s two activated abilities, you must announce which one you’re activating. However, you don’t choose that ability’s effect until it resolves. For example, you must announce that you’re activating Multiform Wonder’s middle ability specifically, but you don’t choose which of the keywords it gains until the ability resolves."
+          "text": "As you activate one of Multiform Wonder's two activated abilities, you must announce which one you're activating. However, you don't choose that ability's effect until it resolves. For example, you must announce that you're activating Multiform Wonder's middle ability specifically, but you don't choose which of the keywords it gains until the ability resolves."
         },
         {
           "date": "2016-09-20",
@@ -27678,7 +27670,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -27690,11 +27682,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "subtypes": [
@@ -27917,19 +27909,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -27941,15 +27933,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -27957,11 +27949,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -28072,7 +28064,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Panharmonicon affects an artifact or creature’s own enters-the-battlefield triggered abilities as well as other triggered abilities that would trigger when an artifact or creature enters the battlefield. Such triggered abilities start with “when” or “whenever.”"
+          "text": "Panharmonicon affects an artifact or creature's own enters-the-battlefield triggered abilities as well as other triggered abilities that would trigger when an artifact or creature enters the battlefield. Such triggered abilities start with \"when\" or \"whenever.\""
         },
         {
           "date": "2016-09-20",
@@ -28080,19 +28072,19 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Abilities that apply “as [this creature] enters the battlefield,” such as choosing a creature to copy with Clone, are unaffected."
+          "text": "Abilities that apply \"as [this creature] enters the battlefield,\" such as choosing a creature to copy with Clone, are unaffected."
         },
         {
           "date": "2016-09-20",
-          "text": "Panharmonicon’s effect doesn’t copy the triggered ability; it just causes it to trigger twice. Any choices made as you put it onto the stack, such as modes and targets, are made separately for each instance of the ability. Any choices made on resolution, such as whether to get counters or Servos for fabricate, are also made individually."
+          "text": "Panharmonicon's effect doesn't copy the triggered ability; it just causes it to trigger twice. Any choices made as you put it onto the stack, such as modes and targets, are made separately for each instance of the ability. Any choices made on resolution, such as whether to get counters or Servos for fabricate, are also made individually."
         },
         {
           "date": "2016-09-20",
-          "text": "The trigger event doesn’t have to specifically refer to “artifacts” or “creatures.” For example, Amulet of Vigor says “Whenever a permanent enters the battlefield tapped and under your control, untap it.” If a creature enters the battlefield tapped and under your control, Amulet of Vigor’s ability would trigger twice. If a land (that isn’t also an artifact or a creature) enters the battlefield tapped and under your control, Amulet of Vigor’s ability would trigger only once."
+          "text": "The trigger event doesn't have to specifically refer to \"artifacts\" or \"creatures.\" For example, Amulet of Vigor says \"Whenever a permanent enters the battlefield tapped and under your control, untap it.\" If a creature enters the battlefield tapped and under your control, Amulet of Vigor's ability would trigger twice. If a land (that isn't also an artifact or a creature) enters the battlefield tapped and under your control, Amulet of Vigor's ability would trigger only once."
         },
         {
           "date": "2016-09-20",
-          "text": "Look at the permanent as it exists on the battlefield, taking into account continuous effects, to determine whether any triggered abilities will trigger multiple times. For example, if you control Mycosynth Lattice, which says, in part, “All permanents are artifacts in addition to their other types,” an enchantment entering the battlefield will cause triggered abilities to trigger an additional time."
+          "text": "Look at the permanent as it exists on the battlefield, taking into account continuous effects, to determine whether any triggered abilities will trigger multiple times. For example, if you control Mycosynth Lattice, which says, in part, \"All permanents are artifacts in addition to their other types,\" an enchantment entering the battlefield will cause triggered abilities to trigger an additional time."
         },
         {
           "date": "2016-09-20",
@@ -28100,7 +28092,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Panharmonicon affects triggered abilities of permanents you control that trigger when an artifact or creature enters the battlefield under any player’s control, not just yours."
+          "text": "Panharmonicon affects triggered abilities of permanents you control that trigger when an artifact or creature enters the battlefield under any player's control, not just yours."
         },
         {
           "date": "2016-09-20",
@@ -28108,11 +28100,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If a triggered ability is linked to a second ability, additional instances of that triggered ability are also linked to that second ability. If the second ability refers to “the exiled card,” it refers to all cards exiled by instances of the triggered ability. For example, if Isochron Scepter’s enters-the-battlefield ability triggers twice and two instant cards are exiled, both will be copied when its second ability is activated. You may cast either or both of the copies in any order."
+          "text": "If a triggered ability is linked to a second ability, additional instances of that triggered ability are also linked to that second ability. If the second ability refers to \"the exiled card,\" it refers to all cards exiled by instances of the triggered ability. For example, if Isochron Scepter's enters-the-battlefield ability triggers twice and two instant cards are exiled, both will be copied when its second ability is activated. You may cast either or both of the copies in any order."
         },
         {
           "date": "2016-09-20",
-          "text": "In some cases involving linked abilities, an ability requires information about “the exiled card.” When this happens, the ability gets multiple answers. If these answers are being used to determine the value of a variable, the sum is used. For example, if Elite Arcanist’s enters-the-battlefield ability triggers twice, two cards are exiled. The value of X in the activation cost of Elite Arcanist’s other ability is the sum of the two cards’ converted mana costs. As the ability resolves, you create copies of both cards and can cast none, one, or both of the copies in any order."
+          "text": "In some cases involving linked abilities, an ability requires information about \"the exiled card.\" When this happens, the ability gets multiple answers. If these answers are being used to determine the value of a variable, the sum is used. For example, if Elite Arcanist's enters-the-battlefield ability triggers twice, two cards are exiled. The value of X in the activation cost of Elite Arcanist's other ability is the sum of the two cards' converted mana costs. As the ability resolves, you create copies of both cards and can cast none, one, or both of the copies in any order."
         }
       ],
       "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
@@ -28219,7 +28211,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You can activate Perpetual Timepiece’s second ability with no targets just to shuffle your library. If you choose any targets and they all become illegal targets, the ability will be countered and you won’t shuffle your library."
+          "text": "You can activate Perpetual Timepiece's second ability with no targets just to shuffle your library. If you choose any targets and they all become illegal targets, the ability will be countered and you won't shuffle your library."
         }
       ],
       "text": "{T}: Put the top two cards of your library into your graveyard.\n{2}, Exile Perpetual Timepiece: Shuffle any number of target cards from your graveyard into your library.",
@@ -28330,7 +28322,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Multiple instances of lifelink are redundant."
+          "text": "multiple instances of lifelink on the same creature are redundant."
         }
       ],
       "subtypes": [
@@ -28554,19 +28546,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -28578,15 +28570,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -28594,11 +28586,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -28926,19 +28918,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -28950,15 +28942,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -28966,11 +28958,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -29081,19 +29073,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -29105,15 +29097,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -29121,11 +29113,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -29239,19 +29231,19 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Each Vehicle is printed with a power and toughness, but it’s not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
+          "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability, but the Kaladesh set includes other such effects), it will have that power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle’s printed power and toughness."
+          "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
         },
         {
           "date": "2017-02-09",
-          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that’s crewed won’t have any creature type."
+          "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't have any creature type."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability’s been paid for. Notably, players can’t try to stop the ability by changing a creature’s power or by removing or tapping a creature."
+          "text": "Once a player announces that he or she is activating a crew ability, no player may take other actions until the ability's been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
         },
         {
           "date": "2017-02-09",
@@ -29263,15 +29255,15 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Creatures that crew a Vehicle aren’t attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don’t affect the creatures that crewed it and vice versa."
+          "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it and vice versa."
         },
         {
           "date": "2017-02-09",
-          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can’t attack unless you’ve controlled it continuously since your turn began, it can block if it’s untapped, it can be tapped to pay a Vehicle’s crew cost, and so on."
+          "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
         },
         {
           "date": "2017-02-09",
-          "text": "You may activate a crew ability of a Vehicle even if it’s already an artifact creature. Doing so has no effect on the Vehicle. It doesn’t change its power and toughness."
+          "text": "You may activate a crew ability of a Vehicle even if it's already an artifact creature. Doing so has no effect on the Vehicle. It doesn't change its power and toughness."
         },
         {
           "date": "2017-02-09",
@@ -29279,11 +29271,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "When a Vehicle becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a Vehicle becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2017-02-09",
-          "text": "If a permanent becomes a copy of a Vehicle, the copy won’t be a creature, even if the Vehicle it’s copying has become an artifact creature."
+          "text": "If a permanent becomes a copy of a Vehicle, the copy won't be a creature, even if the Vehicle it's copying has become an artifact creature."
         }
       ],
       "subtypes": [
@@ -29609,7 +29601,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Once a creature has blocked Weldfast Monitor, gaining menace won’t cause Weldfast Monitor to become unblocked."
+          "text": "Once a creature has blocked Weldfast Monitor, gaining menace won't cause Weldfast Monitor to become unblocked."
         },
         {
           "date": "2016-09-20",
@@ -29832,7 +29824,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -29844,11 +29836,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "When Woodweaver's Puzzleknot enters the battlefield, you gain 3 life and get {E}{E}{E} (three energy counters).\n{2}{G}, Sacrifice Woodweaver's Puzzleknot: You gain 3 life and get {E}{E}{E}.",
@@ -29956,7 +29948,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If another artifact card is put into your graveyard at the same time as Workshop Assistant, you can target it with Workshop Assistant’s triggered ability."
+          "text": "If another artifact card is put into your graveyard at the same time as Workshop Assistant, you can target it with Workshop Assistant's triggered ability."
         }
       ],
       "subtypes": [
@@ -30070,7 +30062,7 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters are a kind of counter that a player may have. They’re not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
+          "text": "Energy counters are a kind of counter that a player may have. They're not associated with specific permanents. (Other kinds of counters that players may have include poison and experience.)"
         },
         {
           "date": "2017-02-09",
@@ -30082,11 +30074,11 @@
         },
         {
           "date": "2017-02-09",
-          "text": "Energy counters aren’t mana. They don’t go away as steps, phases, and turns end, and effects that add mana “of any type” to your mana pool can’t give you energy counters."
+          "text": "Energy counters aren't mana. They don't go away as steps, phases, and turns end, and effects that add mana \"of any type\" to your mana pool can't give you energy counters."
         },
         {
           "date": "2017-02-09",
-          "text": "You can’t pay more energy counters than you have."
+          "text": "You can't pay more energy counters than you have."
         }
       ],
       "text": "When Aether Hub enters the battlefield, you get {E} (an energy counter).\n{T}: Add {C} to your mana pool.\n{T}, Pay {E}: Add one mana of any color to your mana pool.",
@@ -30199,7 +30191,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Blooming Marsh enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {G} to your mana pool.",
@@ -30312,7 +30304,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Botanical Sanctum enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {U} to your mana pool.",
@@ -30425,7 +30417,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Concealed Courtyard enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {B} to your mana pool.",
@@ -30538,7 +30530,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Inspiring Vantage enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {W} to your mana pool.",
@@ -30642,19 +30634,19 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "No player may take actions in a turn before Inventors’ Fair’s triggered ability checks to see if it should trigger. If you don’t control three or more artifacts, it won’t trigger."
+          "text": "No player may take actions in a turn before Inventors' Fair's triggered ability checks to see if it should trigger. If you don't control three or more artifacts, it won't trigger."
         },
         {
           "date": "2016-09-20",
-          "text": "If you control three artifacts as the ability resolves, you gain 1 life. The artifacts you control as the ability resolves don’t have to be the same ones you controlled as it triggered. If you don’t control three artifacts at that time, you won’t gain life."
+          "text": "If you control three artifacts as the ability resolves, you gain 1 life. The artifacts you control as the ability resolves don't have to be the same ones you controlled as it triggered. If you don't control three artifacts at that time, you won't gain life."
         },
         {
           "date": "2016-09-20",
-          "text": "When using Inventors’ Fair’s activated ability, the number of artifacts you control is checked only as you activate it. It’s not checked again as the ability resolves."
+          "text": "When using Inventors' Fair's activated ability, the number of artifacts you control is checked only as you activate it. It's not checked again as the ability resolves."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "supertypes": [
@@ -30762,7 +30754,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "Sequestered Stash’s ability doesn’t target the artifact card in your graveyard. You may choose one of the five cards you put there from your library."
+          "text": "Sequestered Stash's ability doesn't target the artifact card in your graveyard. You may choose one of the five cards you put there from your library."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}, {T}, Sacrifice Sequestered Stash: Put the top five cards of your library into your graveyard. Then you may put an artifact card from your graveyard on top of your library.",
@@ -30875,7 +30867,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Spirebluff Canal enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {R} to your mana pool.",
@@ -31001,19 +30993,19 @@
           "multiverseid": 419935
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 419936
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 420463
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 419937
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 420464
         },
         {
-          "language": "Russian",
-          "name": "Равнина",
-          "multiverseid": 420199
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 420465
         }
       ],
       "id": "3de777fa9d259a87dda932a87d0f8dbd5f6c8982",
@@ -31761,19 +31753,19 @@
           "multiverseid": 419935
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 419936
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 420463
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 419937
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 420464
         },
         {
-          "language": "Russian",
-          "name": "Равнина",
-          "multiverseid": 420199
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 420465
         }
       ],
       "id": "27cffa58e0a099271f8722b5bc61be2d5a5b6e1d",
@@ -32409,11 +32401,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "海岛",
-          "multiverseid": 418090
-        },
-        {
           "language": "Chinese Traditional",
           "name": "海島",
           "multiverseid": 418354
@@ -32524,14 +32511,19 @@
           "multiverseid": 420202
         },
         {
-          "language": "Russian",
-          "name": "Остров",
-          "multiverseid": 420203
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 420466
         },
         {
-          "language": "Russian",
-          "name": "Остров",
-          "multiverseid": 420204
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 420467
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 420468
         }
       ],
       "id": "fc96edd0e0f1ab2f094118cfcd591d785bd08996",
@@ -33275,19 +33267,19 @@
           "multiverseid": 419941
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 419942
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 420469
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 419943
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 420470
         },
         {
-          "language": "Russian",
-          "name": "Болото",
-          "multiverseid": 420205
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 420471
         }
       ],
       "id": "6a3dfa707a9af13718baaadd3181fa917d39b2fd",
@@ -34041,19 +34033,19 @@
           "multiverseid": 419941
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 419942
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 420469
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 419943
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 420470
         },
         {
-          "language": "Russian",
-          "name": "Болото",
-          "multiverseid": 420205
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 420471
         }
       ],
       "id": "2ea5c79a4d8a7cdbfef5f2d0e2d6510f5d84130f",
@@ -34803,24 +34795,24 @@
           "multiverseid": 419682
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 419944
-        },
-        {
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 420208
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 420209
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 420472
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 420210
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 420473
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 420474
         }
       ],
       "id": "8e90f91cff3992391a0cd4c3804e50b1786e601b",
@@ -35187,24 +35179,24 @@
           "multiverseid": 419682
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 419944
-        },
-        {
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 420208
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 420209
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 420472
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 420210
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 420473
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 420474
         }
       ],
       "id": "82dc402225c8d8d0d2717c008f2658a2f25fe862",
@@ -35466,6 +35458,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "树林",
+          "multiverseid": 418099
+        },
+        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 418363
@@ -35561,6 +35558,16 @@
           "multiverseid": 419947
         },
         {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 419948
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 419949
+        },
+        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 420211
@@ -35574,21 +35581,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 420213
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 420475
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 420476
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 420477
         }
       ],
       "id": "2b038f6d34d18ce021045f9dde31d07880032ddc",
@@ -35848,6 +35840,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "树林",
+          "multiverseid": 418099
+        },
+        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 418363
@@ -35943,6 +35940,16 @@
           "multiverseid": 419947
         },
         {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 419948
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 419949
+        },
+        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 420211
@@ -35956,21 +35963,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 420213
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 420475
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 420476
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 420477
         }
       ],
       "id": "e1a38b5bdeb8450eb8e26e98fea2c9f02807570d",
@@ -36230,6 +36222,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "树林",
+          "multiverseid": 418099
+        },
+        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 418363
@@ -36325,6 +36322,16 @@
           "multiverseid": 419947
         },
         {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 419948
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 419949
+        },
+        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 420211
@@ -36338,21 +36345,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 420213
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 420475
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 420476
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 420477
         }
       ],
       "id": "39005241028ff1bbc35ff2272f03070c4d0f5d23",
@@ -36709,11 +36701,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The last ability of Chandra, Pyrogenius doesn’t target the creatures. A creature with hexproof the target player controls will be dealt damage this way."
+          "text": "The last ability of Chandra, Pyrogenius doesn't target the creatures. A creature with hexproof the target player controls will be dealt damage this way."
         },
         {
           "date": "2016-09-20",
-          "text": "In a Two-Headed Giant game, Chandra’s first ability causes 4 damage total to be dealt to the opposing team."
+          "text": "In a Two-Headed Giant game, Chandra's first ability causes 4 damage total to be dealt to the opposing team."
         }
       ],
       "subtypes": [
@@ -36935,7 +36927,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If the target creature becomes an illegal target for Liberating Combustion, the spell will be countered and none of its effects will happen. You won’t search for Chandra, Pyrogenius."
+          "text": "If the target creature becomes an illegal target for Liberating Combustion, the spell will be countered and none of its effects will happen. You won't search for Chandra, Pyrogenius."
         }
       ],
       "text": "Liberating Combustion deals 6 damage to target creature. You may search your library and/or graveyard for a card named Chandra, Pyrogenius, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
@@ -37274,7 +37266,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "The set of creatures affected by Nissa’s last ability is determined as the ability resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won’t get +5/+5 or gain trample."
+          "text": "The set of creatures affected by Nissa's last ability is determined as the ability resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get +5/+5 or gain trample."
         }
       ],
       "subtypes": [
@@ -37390,7 +37382,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "This card’s printing in Nissa’s Kaladesh Planeswalker Deck has an incorrect artist credit. The correct artist is Christine Choi."
+          "text": "This card's printing in Nissa's Kaladesh Planeswalker Deck has an incorrect artist credit. The correct artist is Christine Choi."
         }
       ],
       "subtypes": [
@@ -37507,7 +37499,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "This card’s printing in Nissa’s Kaladesh Planeswalker Deck has an incorrect artist credit. The correct artist is Magali Villeneuve."
+          "text": "This card's printing in Nissa's Kaladesh Planeswalker Deck has an incorrect artist credit. The correct artist is Magali Villeneuve."
         }
       ],
       "subtypes": [

--- a/json/KTK.json
+++ b/json/KTK.json
@@ -145,7 +145,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -267,7 +267,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -388,7 +388,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -1395,7 +1395,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -1520,7 +1520,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "High Sentinels of Arashin gets +1/+1 per creature, not per +1/+1 counter. It doesn’t matter how many +1/+1 counters are on any other creature you control as long as there’s one or more."
+          "text": "High Sentinels of Arashin gets +1/+1 per creature, not per +1/+1 counter. It doesn't matter how many +1/+1 counters are on any other creature you control as long as there's one or more."
         }
       ],
       "subtypes": [
@@ -1637,7 +1637,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -1645,7 +1645,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -1979,11 +1979,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -2108,27 +2108,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -2367,27 +2367,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -2508,7 +2508,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -2630,11 +2630,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Multiple instances of lifelink are redundant. If Seeker of the Way’s last ability resolves more than once in a turn, damage Seeker of the Way deals won’t cause you to gain additional life."
+          "text": "multiple instances of lifelink on the same creature are redundant. If Seeker of the Way's last ability resolves more than once in a turn, damage Seeker of the Way deals won't cause you to gain additional life."
         },
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -2642,7 +2642,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -2985,7 +2985,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Suspension Field’s ability causes a zone change with a duration. It’s a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Suspension Field leaves the battlefield."
+          "text": "Suspension Field's ability causes a zone change with a duration. It's a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Suspension Field leaves the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -2993,23 +2993,23 @@
         },
         {
           "date": "2014-09-20",
-          "text": "If Suspension Field leaves the battlefield before its enters-the-battlefield ability resolves, the target creature won’t be exiled."
+          "text": "If Suspension Field leaves the battlefield before its enters-the-battlefield ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2014-09-20",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2014-09-20",
-          "text": "If a token is exiled this way, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a token is exiled this way, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2014-09-20",
-          "text": "The exiled card returns to the battlefield immediately after Suspension Field leaves the battlefield. Nothing happens between these two events, including state-based actions. Suspension Field and the returned card aren’t on the battlefield at the same time."
+          "text": "The exiled card returns to the battlefield immediately after Suspension Field leaves the battlefield. Nothing happens between these two events, including state-based actions. Suspension Field and the returned card aren't on the battlefield at the same time."
         },
         {
           "date": "2014-09-20",
-          "text": "In a multiplayer game, if Suspension Field’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Suspension Field's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "When Suspension Field enters the battlefield, you may exile target creature with toughness 3 or greater until Suspension Field leaves the battlefield. (That creature returns under its owner's control.)",
@@ -3223,11 +3223,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -3461,27 +3461,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -3609,27 +3609,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -3749,15 +3749,15 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Count the number of attacking creatures when the last ability resolves, including Wingmate Roc itself if it’s still on the battlefield, to determine how much life you gain."
+          "text": "Count the number of attacking creatures when the last ability resolves, including Wingmate Roc itself if it's still on the battlefield, to determine how much life you gain."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -3872,7 +3872,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Blinding Spray doesn’t affect creatures that enter the battlefield or come under the control of one of your opponents after it resolves."
+          "text": "Blinding Spray doesn't affect creatures that enter the battlefield or come under the control of one of your opponents after it resolves."
         },
         {
           "date": "2014-09-20",
@@ -3977,6 +3977,10 @@
         },
         {
           "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -4126,19 +4130,19 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You choose which nonland permanent Clever Impersonator will copy, if any, as it enters the battlefield. This doesn’t target that nonland permanent."
+          "text": "You choose which nonland permanent Clever Impersonator will copy, if any, as it enters the battlefield. This doesn't target that nonland permanent."
         },
         {
           "date": "2014-09-20",
-          "text": "Remember that if you control more than one legendary permanent with the same name, or more than one planeswalker with the same type, you’ll choose one to remain on the battlefield and put the rest into their owner’s graveyard."
+          "text": "Remember that if you control more than one legendary permanent with the same name, or more than one planeswalker with the same type, you'll choose one to remain on the battlefield and put the rest into their owner's graveyard."
         },
         {
           "date": "2014-09-20",
-          "text": "If Clever Impersonator enters the battlefield as a copy of a planeswalker, it will enter the battlefield with a number of loyalty counters on it equal to the loyalty printed in the lower right corner of the planeswalker card. It won’t copy the number of loyalty counters on the original planeswalker."
+          "text": "If Clever Impersonator enters the battlefield as a copy of a planeswalker, it will enter the battlefield with a number of loyalty counters on it equal to the loyalty printed in the lower right corner of the planeswalker card. It won't copy the number of loyalty counters on the original planeswalker."
         },
         {
           "date": "2014-09-20",
-          "text": "Clever Impersonator copies exactly what is printed on the chosen permanent (unless that permanent is copying something else or is a token; see below). It doesn’t copy whether that permanent is tapped or untapped, whether that permanent has any counters on it or any Auras and/or Equipment attached to it, and it doesn’t copy any non-copy effects that have changed that permanent’s power, toughness, types, color, abilities, or so on."
+          "text": "Clever Impersonator copies exactly what is printed on the chosen permanent (unless that permanent is copying something else or is a token; see below). It doesn't copy whether that permanent is tapped or untapped, whether that permanent has any counters on it or any Auras and/or Equipment attached to it, and it doesn't copy any non-copy effects that have changed that permanent's power, toughness, types, color, abilities, or so on."
         },
         {
           "date": "2014-09-20",
@@ -4154,15 +4158,15 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Any enters-the-battlefield abilities of the chosen permanent will trigger when Clever Impersonator enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the chosen permanent will also work."
+          "text": "Any enters-the-battlefield abilities of the chosen permanent will trigger when Clever Impersonator enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the chosen permanent will also work."
         },
         {
           "date": "2014-09-20",
-          "text": "If Clever Impersonator enters the battlefield at the same time as another permanent, it can’t become a copy of that permanent. You may only choose a nonland permanent that’s already on the battlefield."
+          "text": "If Clever Impersonator enters the battlefield at the same time as another permanent, it can't become a copy of that permanent. You may only choose a nonland permanent that's already on the battlefield."
         },
         {
           "date": "2014-09-20",
-          "text": "You can choose not to copy anything. In that case, Clever Impersonator enters the battlefield as a 0/0 creature, and it’s put into the graveyard immediately (unless something is raising its toughness above 0)."
+          "text": "You can choose not to copy anything. In that case, Clever Impersonator enters the battlefield as a 0/0 creature, and it's put into the graveyard immediately (unless something is raising its toughness above 0)."
         }
       ],
       "subtypes": [
@@ -4282,7 +4286,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Crippling Chill can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Crippling Chill can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         }
       ],
       "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
@@ -4392,23 +4396,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nLook at the top seven cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order.",
@@ -4521,7 +4525,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "A face-down spell has converted mana cost 0 and can’t be targeted by Disdainful Stroke."
+          "text": "A face-down spell has converted mana cost 0 and can't be targeted by Disdainful Stroke."
         }
       ],
       "text": "Counter target spell with converted mana cost 4 or greater.",
@@ -4639,27 +4643,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -4890,11 +4894,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Some ferocious abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
+          "text": "Some ferocious abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
         },
         {
           "date": "2014-09-20",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” will provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" will provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Return target creature to its owner's hand.\nFerocious — If you control a creature with power 4 or greater, you may draw a card. If you do, discard a card.",
@@ -5014,27 +5018,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -5154,23 +5158,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You check if you control a creature with power 4 or greater as Icy Blast resolves. It doesn’t matter if you control such a creature during any of the relevant untap steps."
+          "text": "You check if you control a creature with power 4 or greater as Icy Blast resolves. It doesn't matter if you control such a creature during any of the relevant untap steps."
         },
         {
           "date": "2014-09-20",
-          "text": "Icy Blast can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Icy Blast can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         },
         {
           "date": "2014-09-20",
-          "text": "Icy Blast tracks the creature, but not its controller. If the creature changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "Icy Blast tracks the creature, but not its controller. If the creature changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-09-20",
-          "text": "Some ferocious abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
+          "text": "Some ferocious abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
         },
         {
           "date": "2014-09-20",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” will provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" will provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Tap X target creatures.\nFerocious — If you control a creature with power 4 or greater, those creatures don't untap during their controllers' next untap steps.",
@@ -5282,7 +5286,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -5290,7 +5294,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -5407,7 +5411,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -5415,7 +5419,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -5531,11 +5535,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You can target a spell you control with Kheru Spellsnatcher’s triggered ability. This will give you the ability to cast the card later without paying its mana cost."
+          "text": "You can target a spell you control with Kheru Spellsnatcher's triggered ability. This will give you the ability to cast the card later without paying its mana cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Because you’re already casting the card using an alternative cost (by casting it without paying its mana cost), you can’t pay any other alternative costs for the card, including casting it face down using the morph ability. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
+          "text": "Because you're already casting the card using an alternative cost (by casting it without paying its mana cost), you can't pay any other alternative costs for the card, including casting it face down using the morph ability. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2014-09-20",
@@ -5551,27 +5555,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -5699,27 +5703,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -5840,7 +5844,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If an attacking face-down Monastery Flock is turned face up, it will continue to be attacking even though it will have defender. If it’s turned face up before blockers are declared, then creatures without flying or reach won’t be able to block it."
+          "text": "If an attacking face-down Monastery Flock is turned face up, it will continue to be attacking even though it will have defender. If it's turned face up before blockers are declared, then creatures without flying or reach won't be able to block it."
         },
         {
           "date": "2014-09-20",
@@ -5852,27 +5856,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -6004,27 +6008,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -6144,11 +6148,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "A spell or ability that counters spells can still target Pearl Lake Ancient. When one resolves, Pearl Lake Ancient won’t be countered, but any additional effects of that spell or ability will still happen."
+          "text": "A spell or ability that counters spells can still target Pearl Lake Ancient. When one resolves, Pearl Lake Ancient won't be countered, but any additional effects of that spell or ability will still happen."
         },
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -6156,7 +6160,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -6274,11 +6278,11 @@
         },
         {
           "date": "2014-09-20",
-          "text": "The ability can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "The ability can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         },
         {
           "date": "2014-09-20",
-          "text": "The ability tracks the creature, but not its controller. If the creature changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "The ability tracks the creature, but not its controller. If the creature changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         }
       ],
       "text": "Whenever you cast a noncreature spell, you may pay {1}. If you do, tap target creature an opponent controls and it doesn't untap during its controller's next untap step.",
@@ -6390,7 +6394,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -6398,7 +6402,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -6735,23 +6739,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nPut target nonland permanent on top of its owner's library.",
@@ -6861,11 +6865,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Singing Bell Strike can be cast targeting any creature, including one that’s already tapped."
+          "text": "Singing Bell Strike can be cast targeting any creature, including one that's already tapped."
         },
         {
           "date": "2014-09-20",
-          "text": "The activated ability that untaps the creature is granted to the enchanted creature. Only the creature’s controller can activate this ability."
+          "text": "The activated ability that untaps the creature is granted to the enchanted creature. Only the creature's controller can activate this ability."
         }
       ],
       "subtypes": [
@@ -6978,11 +6982,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Some ferocious abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
+          "text": "Some ferocious abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
         },
         {
           "date": "2014-09-20",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” will provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" will provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Counter target noncreature spell unless its controller pays {1}.\nFerocious — If you control a creature with power 4 or greater, counter that spell instead.",
@@ -7200,7 +7204,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "It doesn’t matter if Thousand Winds is tapped or untapped (or even on the battlefield) when its last ability resolves. Tapped creatures except Thousand Winds will be returned to their owners’ hands."
+          "text": "It doesn't matter if Thousand Winds is tapped or untapped (or even on the battlefield) when its last ability resolves. Tapped creatures except Thousand Winds will be returned to their owners' hands."
         },
         {
           "date": "2014-09-20",
@@ -7212,27 +7216,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -7352,23 +7356,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDraw three cards.",
@@ -7795,7 +7799,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -7803,7 +7807,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -7919,11 +7923,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -8149,11 +8153,11 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -8273,27 +8277,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Dead Drop doesn’t target any creature. The target player could sacrifice a creature with hexproof, for example."
+          "text": "Dead Drop doesn't target any creature. The target player could sacrifice a creature with hexproof, for example."
         },
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTarget player sacrifices two creatures.",
@@ -8623,7 +8627,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -8856,23 +8860,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nCreate X tapped 2/2 black Zombie creature tokens.",
@@ -8994,27 +8998,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -9244,7 +9248,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Kheru Bloodsucker’s triggered ability will trigger when it dies if its toughness is 4 or greater."
+          "text": "Kheru Bloodsucker's triggered ability will trigger when it dies if its toughness is 4 or greater."
         }
       ],
       "subtypes": [
@@ -9486,27 +9490,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -9626,11 +9630,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -9746,7 +9750,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -9866,7 +9870,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The regeneration ability is granted to the enchanted creature. Only the creature’s controller can activate the regeneration ability."
+          "text": "The regeneration ability is granted to the enchanted creature. Only the creature's controller can activate the regeneration ability."
         }
       ],
       "subtypes": [
@@ -9979,23 +9983,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDestroy target creature.",
@@ -10108,23 +10112,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "subtypes": [
@@ -10453,7 +10457,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Once you announce that you are activating the ability of Retribution of the Ancients, no player may take any actions before you pay its costs. Notably, opponents can’t try to remove a creature with counters on it to stop you from paying."
+          "text": "Once you announce that you are activating the ability of Retribution of the Ancients, no player may take any actions before you pay its costs. Notably, opponents can't try to remove a creature with counters on it to stop you from paying."
         }
       ],
       "text": "{B}, Remove X +1/+1 counters from among creatures you control: Target creature gets -X/-X until end of turn.",
@@ -10568,15 +10572,15 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Rite of the Serpent won’t create more than one Snake token, even if the target creature had more than one +1/+1 counter on it."
+          "text": "Rite of the Serpent won't create more than one Snake token, even if the target creature had more than one +1/+1 counter on it."
         },
         {
           "date": "2014-09-20",
-          "text": "If the creature is an illegal target as Rite of the Serpent tries to resolve, Rite of the Serpent will be countered and none of its effects will occur. You won’t get a Snake token."
+          "text": "If the creature is an illegal target as Rite of the Serpent tries to resolve, Rite of the Serpent will be countered and none of its effects will occur. You won't get a Snake token."
         },
         {
           "date": "2014-09-20",
-          "text": "If Rite of the Serpent resolves but the creature isn’t destroyed (perhaps because it has indestructible or it regenerated), you’ll get a Snake token if the creature has a +1/+1 counter on it."
+          "text": "If Rite of the Serpent resolves but the creature isn't destroyed (perhaps because it has indestructible or it regenerated), you'll get a Snake token if the creature has a +1/+1 counter on it."
         }
       ],
       "text": "Destroy target creature. If that creature had a +1/+1 counter on it, create a 1/1 green Snake creature token.",
@@ -10803,27 +10807,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -10944,23 +10948,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "subtypes": [
@@ -11084,27 +11088,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -11225,23 +11229,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "subtypes": [
@@ -11703,15 +11707,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Act of Treason can target any creature, even one that’s untapped or one you already control."
+          "text": "Act of Treason can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2013-07-01",
-          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you’ll choose one to remain on the battlefield and put the other into its owner’s graveyard."
+          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you'll choose one to remain on the battlefield and put the other into its owner's graveyard."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
@@ -11831,27 +11835,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -12094,11 +12098,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "text": "Arrow Storm deals 4 damage to target creature or player.\nRaid — If you attacked with a creature this turn, instead Arrow Storm deals 5 damage to that creature or player and the damage can't be prevented.",
@@ -12209,15 +12213,15 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If Ashcloud Phoenix is face down, you can turn it face up for its morph cost, even if you didn’t cast Ashcloud Phoenix face down using its morph ability."
+          "text": "If Ashcloud Phoenix is face down, you can turn it face up for its morph cost, even if you didn't cast Ashcloud Phoenix face down using its morph ability."
         },
         {
           "date": "2014-09-20",
-          "text": "If Ashcloud Phoenix leaves the graveyard before its “dies” ability resolves, it won’t return to the battlefield."
+          "text": "If Ashcloud Phoenix leaves the graveyard before its \"dies\" ability resolves, it won't return to the battlefield."
         },
         {
           "date": "2014-09-20",
-          "text": "Once Ashcloud Phoenix returns to the battlefield face down, each player will know which face-down creature it is. You can’t mix up the positions of your face-down permanents to disguise this."
+          "text": "Once Ashcloud Phoenix returns to the battlefield face down, each player will know which face-down creature it is. You can't mix up the positions of your face-down permanents to disguise this."
         },
         {
           "date": "2014-09-20",
@@ -12229,27 +12233,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -12367,15 +12371,15 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Barrage of Boulders deals damage only to creatures you don’t control as it resolves. However, the ferocious ability affects all creatures, including ones you control and ones that weren’t on the battlefield as Barrage of Boulders resolved."
+          "text": "Barrage of Boulders deals damage only to creatures you don't control as it resolves. However, the ferocious ability affects all creatures, including ones you control and ones that weren't on the battlefield as Barrage of Boulders resolved."
         },
         {
           "date": "2014-09-20",
-          "text": "Some ferocious abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
+          "text": "Some ferocious abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
         },
         {
           "date": "2014-09-20",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” will provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" will provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Barrage of Boulders deals 1 damage to each creature you don't control.\nFerocious — If you control a creature with power 4 or greater, creatures can't block this turn.",
@@ -12487,7 +12491,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -12495,7 +12499,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -12828,7 +12832,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If the creature doesn’t die that turn, the delayed triggered ability will simply cease to exist. It won’t trigger on a future turn."
+          "text": "If the creature doesn't die that turn, the delayed triggered ability will simply cease to exist. It won't trigger on a future turn."
         }
       ],
       "text": "Burn Away deals 6 damage to target creature. When that creature dies this turn, exile all cards from its controller's graveyard.",
@@ -12947,27 +12951,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -13087,15 +13091,15 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If you control a creature with power 4 or greater, Crater’s Claws with X equals 0 will deal 2 damage, with X equals 1 will deal 3 damage, and so on."
+          "text": "If you control a creature with power 4 or greater, Crater's Claws with X equals 0 will deal 2 damage, with X equals 1 will deal 3 damage, and so on."
         },
         {
           "date": "2014-09-20",
-          "text": "Some ferocious abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
+          "text": "Some ferocious abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
         },
         {
           "date": "2014-09-20",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” will provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" will provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Crater's Claws deals X damage to target creature or player.\nFerocious — Crater's Claws deals X plus 2 damage to that creature or player instead if you control a creature with power 4 or greater.",
@@ -13205,7 +13209,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If you’re using Dragon Grip’s ferocious ability to cast it as though it had flash, you must control a creature with power 4 or greater only as you begin the casting process and put Dragon Grip on the stack. Losing control of that creature while casting Dragon Grip (perhaps because you sacrificed it to activate a mana ability), or in response to Dragon Grip won’t affect Dragon Grip on the stack."
+          "text": "If you're using Dragon Grip's ferocious ability to cast it as though it had flash, you must control a creature with power 4 or greater only as you begin the casting process and put Dragon Grip on the stack. Losing control of that creature while casting Dragon Grip (perhaps because you sacrificed it to activate a mana ability), or in response to Dragon Grip won't affect Dragon Grip on the stack."
         },
         {
           "date": "2014-09-20",
@@ -13325,7 +13329,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -13333,7 +13337,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -13559,11 +13563,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Turning Horde Ambusher face up after blockers have been declared won’t remove any creature from combat or change how any creature is blocking."
+          "text": "Turning Horde Ambusher face up after blockers have been declared won't remove any creature from combat or change how any creature is blocking."
         },
         {
           "date": "2014-09-20",
-          "text": "If a face-down Horde Ambusher blocks and is then turned face up, its first ability won’t trigger because it didn’t have that ability when it blocked."
+          "text": "If a face-down Horde Ambusher blocks and is then turned face up, its first ability won't trigger because it didn't have that ability when it blocked."
         },
         {
           "date": "2014-09-20",
@@ -13575,27 +13579,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -13819,7 +13823,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Howl of the Horde creates a delayed triggered ability that triggers when you cast your next instant or sorcery spell that turn. The raid ability creates a second, identical delayed triggered ability. Each of these will create a single copy of the next instant or sorcery spell you cast during that turn. If you don’t cast another instant or sorcery spell during that turn, both delayed triggered abilities will cease to exist."
+          "text": "Howl of the Horde creates a delayed triggered ability that triggers when you cast your next instant or sorcery spell that turn. The raid ability creates a second, identical delayed triggered ability. Each of these will create a single copy of the next instant or sorcery spell you cast during that turn. If you don't cast another instant or sorcery spell during that turn, both delayed triggered abilities will cease to exist."
         },
         {
           "date": "2014-09-20",
@@ -13827,27 +13831,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When either ability resolves, it creates a copy of the instant or sorcery spell. You control each copy. Each copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy or copies will then resolve like normal spells, after players get a chance to cast spells and activate abilities."
+          "text": "When either ability resolves, it creates a copy of the instant or sorcery spell. You control each copy. Each copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy or copies will then resolve like normal spells, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2014-09-20",
-          "text": "Each copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal). You can choose different targets for each copy."
+          "text": "Each copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal). You can choose different targets for each copy."
         },
         {
           "date": "2014-09-20",
-          "text": "If the spell being copied is modal (that is, it says “Choose one —” or the like), each copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell being copied is modal (that is, it says \"Choose one —\" or the like), each copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2014-09-20",
-          "text": "If the spell being copied has an X whose value was determined as it was cast (like Crater’s Claws has), each copy will have the same value of X."
+          "text": "If the spell being copied has an X whose value was determined as it was cast (like Crater's Claws has), each copy will have the same value of X."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nRaid — If you attacked with a creature this turn, when you cast your next instant or sorcery spell this turn, copy that spell an additional time. You may choose new targets for the copy.",
@@ -13960,11 +13964,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Jeering Instigator’s last ability can target any creature, even one that’s untapped or one you already control."
+          "text": "Jeering Instigator's last ability can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2014-09-20",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to that creature."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to that creature."
         },
         {
           "date": "2014-09-20",
@@ -13976,27 +13980,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -14118,7 +14122,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Activating Leaping Master’s ability after it’s been blocked won’t change or undo the block."
+          "text": "Activating Leaping Master's ability after it's been blocked won't change or undo the block."
         }
       ],
       "subtypes": [
@@ -14347,11 +14351,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -14470,15 +14474,15 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Mardu Warshrieker’s raid ability isn’t a mana ability even though it adds mana to your mana pool. It uses the stack and can be responded to."
+          "text": "Mardu Warshrieker's raid ability isn't a mana ability even though it adds mana to your mana pool. It uses the stack and can be responded to."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -14595,7 +14599,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2014-09-20",
@@ -14603,7 +14607,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -14719,19 +14723,19 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If Sarkhan, the Dragonspeaker becomes a creature due to his first ability, that doesn’t count as having a creature enter the battlefield. Sarkhan was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "If Sarkhan, the Dragonspeaker becomes a creature due to his first ability, that doesn't count as having a creature enter the battlefield. Sarkhan was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "Any loyalty counters on Sarkhan when his first ability resolves will remain on him while he’s a creature. Because he’s not a planeswalker at this time, damage dealt to him won’t cause those counters to be removed."
+          "text": "Any loyalty counters on Sarkhan when his first ability resolves will remain on him while he's a creature. Because he's not a planeswalker at this time, damage dealt to him won't cause those counters to be removed."
         },
         {
           "date": "2014-09-20",
-          "text": "After the first ability resolves, Sarkhan won’t be a planeswalker until the end of the turn. Later that turn, if you cast another Sarkhan, the Dragonspeaker, neither permanent will be put into its owner’s graveyard. The “legend rule” sees only the original Sarkhan and the “planeswalker uniqueness rule” sees only the new Sarkhan. However, if you activate the first ability of the new Sarkhan, you would then control two legendary permanents with the same name. You’d choose one to remain on the battlefield and the other would be put into its owner’s graveyard. If you don’t activate the first ability of the new Sarkhan, the original Sarkhan will return to being a planeswalker during the cleanup step. You would then control two planeswalkers with the same planeswalker type. You’d choose one to remain on the battlefield and the other would be put into its owner’s graveyard. There would then be another cleanup step before the turn ended."
+          "text": "After the first ability resolves, Sarkhan won't be a planeswalker until the end of the turn. Later that turn, if you cast another Sarkhan, the Dragonspeaker, neither permanent will be put into its owner's graveyard. The \"legend rule\" sees only the original Sarkhan and the \"planeswalker uniqueness rule\" sees only the new Sarkhan. However, if you activate the first ability of the new Sarkhan, you would then control two legendary permanents with the same name. You'd choose one to remain on the battlefield and the other would be put into its owner's graveyard. If you don't activate the first ability of the new Sarkhan, the original Sarkhan will return to being a planeswalker during the cleanup step. You would then control two planeswalkers with the same planeswalker type. You'd choose one to remain on the battlefield and the other would be put into its owner's graveyard. There would then be another cleanup step before the turn ended."
         },
         {
           "date": "2014-09-20",
-          "text": "If a permanent enters the battlefield as a copy of Sarkhan after his first ability has resolved, the copy will be a Sarkhan planeswalker. It will enter the battlefield with four loyalty counters, no matter how many loyalty counters are on the original Sarkhan. You’ll then find yourself in the same situation described above."
+          "text": "If a permanent enters the battlefield as a copy of Sarkhan after his first ability has resolved, the copy will be a Sarkhan planeswalker. It will enter the battlefield with four loyalty counters, no matter how many loyalty counters are on the original Sarkhan. You'll then find yourself in the same situation described above."
         }
       ],
       "subtypes": [
@@ -15097,7 +15101,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You can’t cast Swift Kick unless you target both a creature you control and a creature you don’t control."
+          "text": "You can't cast Swift Kick unless you target both a creature you control and a creature you don't control."
         },
         {
           "date": "2014-09-20",
@@ -15105,7 +15109,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "If just the creature you control is an illegal target when Swift Kick tries to resolve, it won’t get +1/+0 until end of turn. If the creature you control is a legal target but the creature you don’t control isn’t, the creature you control will get +1/+0 until end of turn."
+          "text": "If just the creature you control is an illegal target when Swift Kick tries to resolve, it won't get +1/+0 until end of turn. If the creature you control is a legal target but the creature you don't control isn't, the creature you control will get +1/+0 until end of turn."
         }
       ],
       "text": "Target creature you control gets +1/+0 until end of turn. It fights target creature you don't control.",
@@ -15231,7 +15235,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Because discarding a card is an additional cost, you can’t cast Tormenting Voice if you have no other cards in hand."
+          "text": "Because discarding a card is an additional cost, you can't cast Tormenting Voice if you have no other cards in hand."
         }
       ],
       "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
@@ -15350,7 +15354,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
@@ -15358,7 +15362,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you’ve declared attackers usually won’t do anything."
+          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you've declared attackers usually won't do anything."
         }
       ],
       "text": "Attacking creatures get +2/+0 until end of turn.",
@@ -15473,11 +15477,11 @@
         },
         {
           "date": "2014-09-20",
-          "text": "If, during your declare attackers step, Valley Dasher is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having Valley Dasher attack, you’re not forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Valley Dasher is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having Valley Dasher attack, you're not forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2014-09-20",
-          "text": "If Valley Dasher enters the battlefield before the combat phase, it will attack that turn if able. If it enters the battlefield after combat, it won’t attack that turn and will usually be available to block on the following turn."
+          "text": "If Valley Dasher enters the battlefield before the combat phase, it will attack that turn if able. If it enters the battlefield after combat, it won't attack that turn and will usually be available to block on the following turn."
         }
       ],
       "subtypes": [
@@ -15594,15 +15598,15 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Once a creature legally blocks War-Name Aspirant, changing that creature’s power to 1 or less won’t change or undo that block."
+          "text": "Once a creature legally blocks War-Name Aspirant, changing that creature's power to 1 or less won't change or undo that block."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities care only that you attacked with a creature. It doesn’t matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
+          "text": "Raid abilities care only that you attacked with a creature. It doesn't matter how many creatures you attacked with, or which opponent or planeswalker controlled by an opponent those creatures attacked."
         },
         {
           "date": "2014-09-20",
-          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn’t have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn’t have to still be in the game or on the battlefield, respectively."
+          "text": "Raid abilities evaluate the entire turn to see if you attacked with a creature. That creature doesn't have to still be on the battlefield. Similarly, the player or planeswalker it attacked doesn't have to still be in the game or on the battlefield, respectively."
         }
       ],
       "subtypes": [
@@ -16145,7 +16149,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Dragonscale Boon can target any creature, including one that’s already untapped."
+          "text": "Dragonscale Boon can target any creature, including one that's already untapped."
         }
       ],
       "text": "Put two +1/+1 counters on target creature and untap it.",
@@ -16255,11 +16259,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Some ferocious abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
+          "text": "Some ferocious abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
         },
         {
           "date": "2014-09-20",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” will provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" will provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "You gain 5 life.\nFerocious — You gain 10 life instead if you control a creature with power 4 or greater.",
@@ -16372,7 +16376,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "“Placed on a creature you control” includes that creature entering the battlefield with +1/+1 counters on it. If a creature would enter the battlefield with a number of +1/+1 counters on it while you control Hardened Scales, it enters with that many counters plus one."
+          "text": "\"Placed on a creature you control\" includes that creature entering the battlefield with +1/+1 counters on it. If a creature would enter the battlefield with a number of +1/+1 counters on it while you control Hardened Scales, it enters with that many counters plus one."
         },
         {
           "date": "2014-09-20",
@@ -16489,7 +16493,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Heir of the Wilds has a triggered ferocious ability with an intervening “if” clause. That ability will check if you control a creature with power 4 or greater whenever Heir of the Wilds attacks. If you don’t at that time, the ability won’t trigger at all. If it triggers, the ability will also check if you control a creature with power 4 or greater as it resolves. If you don’t at that time, the ability won’t do anything. Note that the creature with power 4 or greater you control as the ability triggers doesn’t necessarily have to be the same one you control as the ability resolves."
+          "text": "Heir of the Wilds has a triggered ferocious ability with an intervening \"if\" clause. That ability will check if you control a creature with power 4 or greater whenever Heir of the Wilds attacks. If you don't at that time, the ability won't trigger at all. If it triggers, the ability will also check if you control a creature with power 4 or greater as it resolves. If you don't at that time, the ability won't do anything. Note that the creature with power 4 or greater you control as the ability triggers doesn't necessarily have to be the same one you control as the ability resolves."
         }
       ],
       "subtypes": [
@@ -16718,11 +16722,11 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Hooded Hydra’s last ability isn’t a triggered ability. It’s a replacement ability that modifies how Hooded Hydra is turned face up. Players can’t respond to Hooded Hydra being turned face up and having five +1/+1 counters put on it."
+          "text": "Hooded Hydra's last ability isn't a triggered ability. It's a replacement ability that modifies how Hooded Hydra is turned face up. Players can't respond to Hooded Hydra being turned face up and having five +1/+1 counters put on it."
         },
         {
           "date": "2014-09-20",
-          "text": "If Hooded Hydra is face down and it’s turned face up some other way than by having its morph cost paid, the last ability will still apply."
+          "text": "If Hooded Hydra is face down and it's turned face up some other way than by having its morph cost paid, the last ability will still apply."
         },
         {
           "date": "2014-09-20",
@@ -16734,27 +16738,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -16875,23 +16879,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s cost. Exiling a card this way is simply another way to pay that cost."
+          "text": "The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell's cost. Exiling a card this way is simply another way to pay that cost."
         },
         {
           "date": "2014-09-20",
-          "text": "Delve doesn’t change a spell’s mana cost or converted mana cost. For example, Dead Drop’s converted mana cost is 10 even if you exiled three cards to cast it."
+          "text": "Delve doesn't change a spell's mana cost or converted mana cost. For example, Dead Drop's converted mana cost is 10 even if you exiled three cards to cast it."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile cards to pay for the colored mana requirements of a spell with delve."
+          "text": "You can't exile cards to pay for the colored mana requirements of a spell with delve."
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more than nine cards from your graveyard to cast Dead Drop."
+          "text": "You can't exile more cards than the generic mana requirement of a spell with delve. For example, you can't exile more than nine cards from your graveyard to cast Dead Drop."
         },
         {
           "date": "2014-09-20",
-          "text": "Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because delve isn't an alternative cost, it can be used in conjunction with alternative costs."
         }
       ],
       "subtypes": [
@@ -17140,27 +17144,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -17280,7 +17284,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -17400,11 +17404,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "As Meandering Towershell returns to the battlefield because of the delayed triggered ability, you choose which opponent or opposing planeswalker it’s attacking. It doesn’t have to attack the same opponent or opposing planeswalker that it was when it was exiled."
+          "text": "As Meandering Towershell returns to the battlefield because of the delayed triggered ability, you choose which opponent or opposing planeswalker it's attacking. It doesn't have to attack the same opponent or opposing planeswalker that it was when it was exiled."
         },
         {
           "date": "2014-09-20",
-          "text": "If Meandering Towershell enters the battlefield attacking, it wasn’t declared as an attacking creature that turn. Abilities that trigger when a creature attacks, including its own triggered ability, won’t trigger."
+          "text": "If Meandering Towershell enters the battlefield attacking, it wasn't declared as an attacking creature that turn. Abilities that trigger when a creature attacks, including its own triggered ability, won't trigger."
         },
         {
           "date": "2014-09-20",
@@ -17412,7 +17416,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "If you attack with a Meandering Towershell that you don’t own, you’ll control it when it returns to the battlefield."
+          "text": "If you attack with a Meandering Towershell that you don't own, you'll control it when it returns to the battlefield."
         }
       ],
       "subtypes": [
@@ -17667,7 +17671,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If a face-down creature other than Pine Walker is turned face up and the resulting permanent isn’t a creature, Pine Walker’s last ability won’t trigger."
+          "text": "If a face-down creature other than Pine Walker is turned face up and the resulting permanent isn't a creature, Pine Walker's last ability won't trigger."
         },
         {
           "date": "2014-09-20",
@@ -17679,27 +17683,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -17822,7 +17826,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Although turning a face-down creature with morph face up doesn’t use the stack, Rattleclaw Mystic’s triggered ability does use the stack, and players can respond to that ability. Notably, you can’t turn Rattleclaw Mystic face up while casting a spell or activating an ability. You’ll need to turn Rattleclaw Mystic face up and have its triggered ability resolve before you can spend that mana."
+          "text": "Although turning a face-down creature with morph face up doesn't use the stack, Rattleclaw Mystic's triggered ability does use the stack, and players can respond to that ability. Notably, you can't turn Rattleclaw Mystic face up while casting a spell or activating an ability. You'll need to turn Rattleclaw Mystic face up and have its triggered ability resolve before you can spend that mana."
         },
         {
           "date": "2014-09-20",
@@ -17834,27 +17838,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -17973,23 +17977,23 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Roar of Challenge doesn’t give any creatures the ability to block the target creature. It just forces those creatures that are already able to block the creature to do so."
+          "text": "Roar of Challenge doesn't give any creatures the ability to block the target creature. It just forces those creatures that are already able to block the creature to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "If, during the declare blockers step, a creature is tapped or is affected by a spell or ability that says it can’t block, then it doesn’t block. If there’s a cost associated with having that creature block, its controller isn’t forced to pay that cost. If the player doesn’t, the creature doesn’t block in that case either."
+          "text": "If, during the declare blockers step, a creature is tapped or is affected by a spell or ability that says it can't block, then it doesn't block. If there's a cost associated with having that creature block, its controller isn't forced to pay that cost. If the player doesn't, the creature doesn't block in that case either."
         },
         {
           "date": "2014-09-20",
-          "text": "If there are multiple combat phases, creatures that blocked the creature targeted by Roar of Challenge in the first combat aren’t required to block it again in subsequent combats."
+          "text": "If there are multiple combat phases, creatures that blocked the creature targeted by Roar of Challenge in the first combat aren't required to block it again in subsequent combats."
         },
         {
           "date": "2014-09-20",
-          "text": "Some ferocious abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
+          "text": "Some ferocious abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
         },
         {
           "date": "2014-09-20",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” will provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" will provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "All creatures able to block target creature this turn do so.\nFerocious — That creature gains indestructible until end of turn if you control a creature with power 4 or greater.",
@@ -18109,27 +18113,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -18248,7 +18252,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You can’t cast Savage Punch unless you target both a creature you control and a creature you don’t control."
+          "text": "You can't cast Savage Punch unless you target both a creature you control and a creature you don't control."
         },
         {
           "date": "2014-09-20",
@@ -18256,15 +18260,15 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Assuming the ferocious ability applies, if just the creature you control is an illegal target when Savage Punch tries to resolve, it won’t get +2/+2 until end of turn. If the creature you control is a legal target but the creature you don’t control isn’t, the creature you control will get +2/+2 until end of turn."
+          "text": "Assuming the ferocious ability applies, if just the creature you control is an illegal target when Savage Punch tries to resolve, it won't get +2/+2 until end of turn. If the creature you control is a legal target but the creature you don't control isn't, the creature you control will get +2/+2 until end of turn."
         },
         {
           "date": "2014-09-20",
-          "text": "Some ferocious abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
+          "text": "Some ferocious abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
         },
         {
           "date": "2014-09-20",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” will provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" will provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Target creature you control fights target creature you don't control.\nFerocious — The creature you control gets +2/+2 until end of turn before it fights if you control a creature with power 4 or greater.",
@@ -18483,7 +18487,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Because you’re not casting the creature cards, you can’t pay any additional or alternative costs. You can’t put the cards onto the battlefield face down."
+          "text": "Because you're not casting the creature cards, you can't pay any additional or alternative costs. You can't put the cards onto the battlefield face down."
         },
         {
           "date": "2014-09-20",
@@ -18491,11 +18495,11 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Some ferocious abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
+          "text": "Some ferocious abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect if you control a creature with power 4 or greater as they resolve. For these, you only get the upgraded effect, not both effects."
         },
         {
           "date": "2014-09-20",
-          "text": "Ferocious abilities of instants and sorceries that don’t use the word “instead” will provide an additional effect if you control a creature with power 4 or greater as they resolve."
+          "text": "Ferocious abilities of instants and sorceries that don't use the word \"instead\" will provide an additional effect if you control a creature with power 4 or greater as they resolve."
         }
       ],
       "text": "Reveal the top eight cards of your library. You may put a creature card from among them onto the battlefield. Put the rest into your graveyard.\nFerocious — If you control a creature with power 4 or greater, you may put two creature cards onto the battlefield instead of one.",
@@ -18723,11 +18727,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Smoke Teller’s ability lets you look at the creature as the ability resolves. It doesn’t let you look at it later, although you should be given a reasonable amount of time to look at it. In a multiplayer game, be sure not to reveal the card to other players."
+          "text": "Smoke Teller's ability lets you look at the creature as the ability resolves. It doesn't let you look at it later, although you should be given a reasonable amount of time to look at it. In a multiplayer game, be sure not to reveal the card to other players."
         },
         {
           "date": "2014-09-20",
-          "text": "You could target a creature you control with Smoke Teller’s ability, but there’s no benefit to doing so. Remember, you may look at face-down spells you control on the stack and face-down permanents you control at any time."
+          "text": "You could target a creature you control with Smoke Teller's ability, but there's no benefit to doing so. Remember, you may look at face-down spells you control on the stack and face-down permanents you control at any time."
         }
       ],
       "subtypes": [
@@ -18968,27 +18972,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -19320,7 +19324,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The cost to activate a creature’s outlast ability includes the tap symbol ({T}). A creature’s outlast ability can’t be activated unless that creature has been under your control continuously since the beginning of your turn."
+          "text": "The cost to activate a creature's outlast ability includes the tap symbol ({T}). A creature's outlast ability can't be activated unless that creature has been under your control continuously since the beginning of your turn."
         },
         {
           "date": "2014-09-20",
@@ -19557,27 +19561,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -19709,27 +19713,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -19961,7 +19965,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If you choose the third mode, you choose how the counters will be distributed as you cast the spell. Notably, if you choose to put one +1/+1 counter on each of two target creatures, and one of those creatures becomes an illegal target in response, the +1/+1 counter that would have been put on that creature is lost. It can’t be put on the remaining legal target."
+          "text": "If you choose the third mode, you choose how the counters will be distributed as you cast the spell. Notably, if you choose to put one +1/+1 counter on each of two target creatures, and one of those creatures becomes an illegal target in response, the +1/+1 counter that would have been put on that creature is lost. It can't be put on the remaining legal target."
         }
       ],
       "text": "Choose one —\n• Exile target creature with power 3 or greater.\n• You draw two cards and you lose 2 life.\n• Distribute two +1/+1 counters among one or two target creatures.",
@@ -20085,27 +20089,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -20231,19 +20235,19 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Anafenza’s first ability can target any tapped creature you control. That creature doesn’t necessarily have to be attacking."
+          "text": "Anafenza's first ability can target any tapped creature you control. That creature doesn't necessarily have to be attacking."
         },
         {
           "date": "2014-09-20",
-          "text": "While Anafenza is on the battlefield, abilities that trigger whenever a nontoken creature your opponent owns dies won’t trigger, as that card will never reach that player’s graveyard. (Token creatures will still go to the graveyard briefly before ceasing to exist.)"
+          "text": "While Anafenza is on the battlefield, abilities that trigger whenever a nontoken creature your opponent owns dies won't trigger, as that card will never reach that player's graveyard. (Token creatures will still go to the graveyard briefly before ceasing to exist.)"
         },
         {
           "date": "2014-09-20",
-          "text": "If your opponent discards a creature card while Anafenza is on the battlefield, abilities that function when a card is discarded (such as madness) still work, even though that card never reaches a graveyard. In addition, spells or abilities that check the characteristics of a discarded card (such as Chandra Ablaze’s first ability) can find that card in exile."
+          "text": "If your opponent discards a creature card while Anafenza is on the battlefield, abilities that function when a card is discarded (such as madness) still work, even though that card never reaches a graveyard. In addition, spells or abilities that check the characteristics of a discarded card (such as Chandra Ablaze's first ability) can find that card in exile."
         },
         {
           "date": "2014-09-20",
-          "text": "Anafenza’s last ability cares only what the card would be in the zone it’s moving from, not what it would be in the graveyard. For example, if a land card you control becomes a creature due to an effect and then dies, the land card will be exiled. But if a creature card with bestow is an Aura when it would be put into the graveyard, it ends up in the graveyard."
+          "text": "Anafenza's last ability cares only what the card would be in the zone it's moving from, not what it would be in the graveyard. For example, if a land card you control becomes a creature due to an effect and then dies, the land card will be exiled. But if a creature card with bestow is an Aura when it would be put into the graveyard, it ends up in the graveyard."
         }
       ],
       "subtypes": [
@@ -20489,7 +20493,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "You choose how the counters will be distributed as you put the ability on the stack. Notably, if you choose to put one +1/+1 counter on each of two target creatures, and one of those creatures becomes an illegal target in response, the +1/+1 counter that would’ve gone on that creature is lost. It can’t be put on the remaining legal target."
+          "text": "You choose how the counters will be distributed as you put the ability on the stack. Notably, if you choose to put one +1/+1 counter on each of two target creatures, and one of those creatures becomes an illegal target in response, the +1/+1 counter that would've gone on that creature is lost. It can't be put on the remaining legal target."
         }
       ],
       "subtypes": [
@@ -20612,11 +20616,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If the target creature can’t block Avalanche Tusker, but could block another attacking creature, it’s free to block that creature or block no creatures at all."
+          "text": "If the target creature can't block Avalanche Tusker, but could block another attacking creature, it's free to block that creature or block no creatures at all."
         },
         {
           "date": "2014-09-20",
-          "text": "If, during the declare blockers step, the target creature is tapped or is affected by a spell or ability that says it can’t block, then it doesn’t block. If there’s a cost associated with having that creature block, its controller isn’t forced to pay that cost. If the player doesn’t, the creature doesn’t block in that case either."
+          "text": "If, during the declare blockers step, the target creature is tapped or is affected by a spell or ability that says it can't block, then it doesn't block. If there's a cost associated with having that creature block, its controller isn't forced to pay that cost. If the player doesn't, the creature doesn't block in that case either."
         }
       ],
       "subtypes": [
@@ -21203,11 +21207,11 @@
         },
         {
           "date": "2014-09-20",
-          "text": "The sacrifice is not dependent on the damage being dealt. It doesn’t matter if that damage is prevented or redirected."
+          "text": "The sacrifice is not dependent on the damage being dealt. It doesn't matter if that damage is prevented or redirected."
         },
         {
           "date": "2014-09-20",
-          "text": "Crackling Doom doesn’t target any player or creature. For example, a creature with protection from black could be sacrificed."
+          "text": "Crackling Doom doesn't target any player or creature. For example, a creature with protection from black could be sacrificed."
         },
         {
           "date": "2014-09-20",
@@ -21328,7 +21332,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Only creatures on the battlefield when Death Frenzy resolves will get -2/-2. However, if a creature enters the battlefield and then dies later that turn, you’ll gain 1 life for it."
+          "text": "Only creatures on the battlefield when Death Frenzy resolves will get -2/-2. However, if a creature enters the battlefield and then dies later that turn, you'll gain 1 life for it."
         }
       ],
       "text": "All creatures get -2/-2 until end of turn. Whenever a creature dies this turn, you gain 1 life.",
@@ -21441,11 +21445,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Deflecting Palm doesn’t target any creature or player. You choose a source of damage as Deflecting Palm resolves."
+          "text": "Deflecting Palm doesn't target any creature or player. You choose a source of damage as Deflecting Palm resolves."
         },
         {
           "date": "2014-09-20",
-          "text": "If multiple prevention and/or replacement effects are trying to apply to the same damage, the player who would be dealt damage chooses the order in which to apply them. Notably, if noncombat damage would be dealt to you by a source controlled by an opponent, you choose the order in which to apply Deflecting Palm and the planeswalker redirection effect. If you apply Deflecting Palm first, the damage will be prevented (and damage will be dealt to the source’s controller) and the planeswalker redirection effect won’t apply."
+          "text": "If multiple prevention and/or replacement effects are trying to apply to the same damage, the player who would be dealt damage chooses the order in which to apply them. Notably, if noncombat damage would be dealt to you by a source controlled by an opponent, you choose the order in which to apply Deflecting Palm and the planeswalker redirection effect. If you apply Deflecting Palm first, the damage will be prevented (and damage will be dealt to the source's controller) and the planeswalker redirection effect won't apply."
         }
       ],
       "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. If damage is prevented this way, Deflecting Palm deals that much damage to that source's controller.",
@@ -21561,7 +21565,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You decide which creature to spare as Duneblast resolves. This choice doesn’t target the creature. If you don’t choose a creature, then all creatures will be destroyed."
+          "text": "You decide which creature to spare as Duneblast resolves. This choice doesn't target the creature. If you don't choose a creature, then all creatures will be destroyed."
         }
       ],
       "text": "Choose up to one creature. Destroy the rest.",
@@ -21684,27 +21688,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -22054,7 +22058,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If you control the only other creatures when Icefeather Aven is turned face up, you must target one of them. You choose whether that creature is returned to its owner’s hand as the ability resolves."
+          "text": "If you control the only other creatures when Icefeather Aven is turned face up, you must target one of them. You choose whether that creature is returned to its owner's hand as the ability resolves."
         },
         {
           "date": "2014-09-20",
@@ -22066,27 +22070,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -22213,15 +22217,15 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Each creature you control with a +1/+1 counter on it untaps at the same time as the active player’s permanents. You can’t choose to not untap them at that time."
+          "text": "Each creature you control with a +1/+1 counter on it untaps at the same time as the active player's permanents. You can't choose to not untap them at that time."
         },
         {
           "date": "2014-09-20",
-          "text": "Effects that state a creature you control doesn’t untap during your untap step won’t apply during another player’s untap step."
+          "text": "Effects that state a creature you control doesn't untap during your untap step won't apply during another player's untap step."
         },
         {
           "date": "2014-09-20",
-          "text": "Controlling more than one Ivorytusk Fortress doesn’t allow you to untap any creature more than once during a single untap step."
+          "text": "Controlling more than one Ivorytusk Fortress doesn't allow you to untap any creature more than once during a single untap step."
         }
       ],
       "subtypes": [
@@ -22562,27 +22566,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "The creature card returned to the battlefield is chosen at random as the ability resolves. If any player responds to the ability, that player won’t yet know what card will be returned."
+          "text": "The creature card returned to the battlefield is chosen at random as the ability resolves. If any player responds to the ability, that player won't yet know what card will be returned."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the ability doesn’t target any creature card, any creature card (including Kheru Lich Lord itself) put into the graveyard in response to that ability may be returned to the battlefield."
+          "text": "Because the ability doesn't target any creature card, any creature card (including Kheru Lich Lord itself) put into the graveyard in response to that ability may be returned to the battlefield."
         },
         {
           "date": "2014-09-20",
-          "text": "The ability that exiles the card at the beginning of your next end step is a delayed triggered ability. If the delayed triggered ability is countered, the creature will stay on the battlefield and the ability won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "The ability that exiles the card at the beginning of your next end step is a delayed triggered ability. If the delayed triggered ability is countered, the creature will stay on the battlefield and the ability won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2014-09-20",
-          "text": "Kheru Lich Lord grants flying, trample, and haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of your next end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Kheru Lich Lord grants flying, trample, and haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of your next end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2014-09-20",
-          "text": "If a creature card returned to the battlefield with Kheru Lich Lord would leave the battlefield for any reason, it’s exiled instead. However, if that creature is already being exiled, then the replacement effect won’t apply. If the spell or ability that exiles it later returns it to the battlefield (as Suspension Field might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The effects from Kheru Lich Lord will no longer apply to it."
+          "text": "If a creature card returned to the battlefield with Kheru Lich Lord would leave the battlefield for any reason, it's exiled instead. However, if that creature is already being exiled, then the replacement effect won't apply. If the spell or ability that exiles it later returns it to the battlefield (as Suspension Field might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The effects from Kheru Lich Lord will no longer apply to it."
         },
         {
           "date": "2014-09-20",
-          "text": "The exiled creature is never put into the graveyard. Any abilities the creature has that trigger when it dies won’t trigger."
+          "text": "The exiled creature is never put into the graveyard. Any abilities the creature has that trigger when it dies won't trigger."
         }
       ],
       "subtypes": [
@@ -22700,11 +22704,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The value of X is determined only once, as Kin-Tree Invocation resolves. The power and toughness of the Spirit Warrior token doesn’t later change if the greatest toughness among creatures you control changes."
+          "text": "The value of X is determined only once, as Kin-Tree Invocation resolves. The power and toughness of the Spirit Warrior token doesn't later change if the greatest toughness among creatures you control changes."
         },
         {
           "date": "2014-09-20",
-          "text": "If you control no creatures as Kin-Tree Invocation resolves, you’ll put a 0/0 token onto the battlefield. Unless something else is raising its toughness above 0, it will immediately be put into its owner’s graveyard and then cease to exist. Any abilities that trigger when a creature enters the battlefield or dies will trigger."
+          "text": "If you control no creatures as Kin-Tree Invocation resolves, you'll put a 0/0 token onto the battlefield. Unless something else is raising its toughness above 0, it will immediately be put into its owner's graveyard and then cease to exist. Any abilities that trigger when a creature enters the battlefield or dies will trigger."
         }
       ],
       "text": "Create an X/X black and green Spirit Warrior creature token, where X is the greatest toughness among creatures you control.",
@@ -22933,7 +22937,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "As the Goblin token enters the battlefield, you choose which opponent or opposing planeswalker it’s attacking. It doesn’t have to attack the same opponent or opposing planeswalker that the original creature is attacking."
+          "text": "As the Goblin token enters the battlefield, you choose which opponent or opposing planeswalker it's attacking. It doesn't have to attack the same opponent or opposing planeswalker that the original creature is attacking."
         },
         {
           "date": "2014-09-20",
@@ -23273,11 +23277,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Use the number of cards in your hand after you draw the card to determine how much damage Master the Way deals to the target creature or player. (Remember that Master the Way is not in your hand; it’s on the stack.)"
+          "text": "Use the number of cards in your hand after you draw the card to determine how much damage Master the Way deals to the target creature or player. (Remember that Master the Way is not in your hand; it's on the stack.)"
         },
         {
           "date": "2014-09-20",
-          "text": "If the creature or player is an illegal target as Master the Way tries to resolve, Master the Way will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the creature or player is an illegal target as Master the Way tries to resolve, Master the Way will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "text": "Draw a card. Master the Way deals damage to target creature or player equal to the number of cards in your hand.",
@@ -23389,7 +23393,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If the controller of the target spell pays {X}, the spell won’t be countered. Mindswipe will still deal damage to that player."
+          "text": "If the controller of the target spell pays {X}, the spell won't be countered. Mindswipe will still deal damage to that player."
         },
         {
           "date": "2014-09-20",
@@ -23512,11 +23516,11 @@
         },
         {
           "date": "2014-09-20",
-          "text": "You can’t play any land cards exiled with Narset."
+          "text": "You can't play any land cards exiled with Narset."
         },
         {
           "date": "2014-09-20",
-          "text": "Because you’re already casting the card using an alternative cost (by casting it without paying its mana cost), you can’t pay any other alternative costs for the card, including casting it face down using the morph ability. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
+          "text": "Because you're already casting the card using an alternative cost (by casting it without paying its mana cost), you can't pay any other alternative costs for the card, including casting it face down using the morph ability. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2014-09-20",
@@ -23524,7 +23528,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Any exiled cards you don’t cast remain in exile."
+          "text": "Any exiled cards you don't cast remain in exile."
         }
       ],
       "subtypes": [
@@ -23655,27 +23659,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -23915,11 +23919,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If a card is exiled “instead” of being put into a graveyard, Rakshasa Vizier’s ability won’t trigger."
+          "text": "If a card is exiled \"instead\" of being put into a graveyard, Rakshasa Vizier's ability won't trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "Exiling cards from your graveyard to pay the cost of a spell with delve is a single action. It will cause Rakshasa Vizier’s ability to trigger once, putting a number of +1/+1 counters on it equal to the number of cards you exiled."
+          "text": "Exiling cards from your graveyard to pay the cost of a spell with delve is a single action. It will cause Rakshasa Vizier's ability to trigger once, putting a number of +1/+1 counters on it equal to the number of cards you exiled."
         }
       ],
       "subtypes": [
@@ -24054,7 +24058,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "In some rare cases, the blocking creature wasn’t declared as a blocking creature that combat (for example, if it entered the battlefield blocking). In that case, the attacking creatures it was blocking won’t gain trample even though the blocking creature is destroyed."
+          "text": "In some rare cases, the blocking creature wasn't declared as a blocking creature that combat (for example, if it entered the battlefield blocking). In that case, the attacking creatures it was blocking won't gain trample even though the blocking creature is destroyed."
         }
       ],
       "text": "Destroy target blocking creature. Creatures that were blocked by that creature this combat gain trample until end of turn.",
@@ -24292,27 +24296,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -24661,11 +24665,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Sidisi’s last ability triggers any time creature cards are put into your graveyard from anywhere in your library, not just from the top."
+          "text": "Sidisi's last ability triggers any time creature cards are put into your graveyard from anywhere in your library, not just from the top."
         },
         {
           "date": "2014-09-20",
-          "text": "Any instruction, including Sidisi’s first ability, that tells you to put multiple cards from a library into a graveyard moves all the cards at the same time. For example, if Sidisi enters the battlefield and you put three creature cards into your graveyard, Sidisi’s last ability will trigger once and you’ll put one Zombie token onto the battlefield."
+          "text": "Any instruction, including Sidisi's first ability, that tells you to put multiple cards from a library into a graveyard moves all the cards at the same time. For example, if Sidisi enters the battlefield and you put three creature cards into your graveyard, Sidisi's last ability will trigger once and you'll put one Zombie token onto the battlefield."
         }
       ],
       "subtypes": [
@@ -24913,27 +24917,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -25059,7 +25063,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the emblem’s ability resolves, if the player controls no creatures, the player won’t sacrifice anything."
+          "text": "When the emblem's ability resolves, if the player controls no creatures, the player won't sacrifice anything."
         }
       ],
       "subtypes": [
@@ -25287,7 +25291,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "A monocolored creature is exactly one color. Colorless creatures aren’t monocolored."
+          "text": "A monocolored creature is exactly one color. Colorless creatures aren't monocolored."
         }
       ],
       "text": "Choose one —\n• Destroy target monocolored creature.\n• Destroy target artifact or enchantment.\n• Draw two cards, then discard a card.",
@@ -25519,7 +25523,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "A spell or ability that counters spells can still target a creature spell you control. When that spell or ability resolves, the creature spell won’t be countered, but any additional effects of that spell or ability will still happen."
+          "text": "A spell or ability that counters spells can still target a creature spell you control. When that spell or ability resolves, the creature spell won't be countered, but any additional effects of that spell or ability will still happen."
         }
       ],
       "subtypes": [
@@ -25750,7 +25754,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You can’t cast Temur Charm choosing the first mode unless you target both a creature you control and a creature you don’t control."
+          "text": "You can't cast Temur Charm choosing the first mode unless you target both a creature you control and a creature you don't control."
         },
         {
           "date": "2014-09-20",
@@ -25758,11 +25762,11 @@
         },
         {
           "date": "2014-09-20",
-          "text": "If the first mode was chosen and just the creature you control is an illegal target when Temur Charm tries to resolve, it won’t get +1/+1 until end of turn. If the creature you control is a legal target but the creature you don’t control isn’t, the creature you control will get +1/+1 until end of turn."
+          "text": "If the first mode was chosen and just the creature you control is an illegal target when Temur Charm tries to resolve, it won't get +1/+1 until end of turn. If the creature you control is a legal target but the creature you don't control isn't, the creature you control will get +1/+1 until end of turn."
         },
         {
           "date": "2014-09-20",
-          "text": "If the third mode was chosen, creatures with power 3 or less that enter the battlefield after Temur Charm resolves also can’t block. A creature whose power was 4 or greater when Temur Charm resolved but is 3 or less as the declare blockers step begins also can’t block."
+          "text": "If the third mode was chosen, creatures with power 3 or less that enter the battlefield after Temur Charm resolves also can't block. A creature whose power was 4 or greater when Temur Charm resolved but is 3 or less as the declare blockers step begins also can't block."
         }
       ],
       "text": "Choose one —\n• Target creature you control gets +1/+1 until end of turn. It fights target creature you don't control.\n• Counter target spell unless its controller pays {3}.\n• Creatures with power 3 or less can't block this turn.",
@@ -25878,7 +25882,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You don’t have to target a creature to cast Trap Essence, although you must target a creature spell on the stack."
+          "text": "You don't have to target a creature to cast Trap Essence, although you must target a creature spell on the stack."
         }
       ],
       "text": "Counter target creature spell. Put two +1/+1 counters on up to one target creature.",
@@ -26103,11 +26107,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You cast the cards one at a time as Villainous Wealth is resolving, choosing modes, targets, and so on. The last card you cast will be the first one to resolve. Ignore timing restrictions based on the cards’ types. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "You cast the cards one at a time as Villainous Wealth is resolving, choosing modes, targets, and so on. The last card you cast will be the first one to resolve. Ignore timing restrictions based on the cards' types. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2014-09-20",
-          "text": "Because you’re already casting the cards using an alternative cost (by casting them without paying their mana costs), you can’t pay any other alternative costs for the cards, including casting them face down using the morph ability. You can pay additional costs, such as kicker costs. If the cards have any mandatory additional costs, you must pay those."
+          "text": "Because you're already casting the cards using an alternative cost (by casting them without paying their mana costs), you can't pay any other alternative costs for the cards, including casting them face down using the morph ability. You can pay additional costs, such as kicker costs. If the cards have any mandatory additional costs, you must pay those."
         },
         {
           "date": "2014-09-20",
@@ -26115,7 +26119,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Any cards you don’t cast this way will remain in exile."
+          "text": "Any cards you don't cast this way will remain in exile."
         }
       ],
       "text": "Target opponent exiles the top X cards of his or her library. You may cast any number of nonland cards with converted mana cost X or less from among them without paying their mana costs.",
@@ -26343,7 +26347,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "You choose which mode you’re using—or that you’re using both modes—as you’re casting the spell. Once this choice is made, it can’t be changed later while the spell is on the stack."
+          "text": "You choose which mode you're using—or that you're using both modes—as you're casting the spell. Once this choice is made, it can't be changed later while the spell is on the stack."
         },
         {
           "date": "2014-09-20",
@@ -26351,7 +26355,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Winterflame won’t affect any target that’s illegal as it tries to resolve. If you choose to use both modes and both targets are illegal at that time, Winterflame will be countered."
+          "text": "Winterflame won't affect any target that's illegal as it tries to resolve. If you choose to use both modes and both targets are illegal at that time, Winterflame will be countered."
         }
       ],
       "text": "Choose one or both —\n• Tap target creature.\n• Winterflame deals 2 damage to target creature.",
@@ -26471,15 +26475,15 @@
         },
         {
           "date": "2014-09-20",
-          "text": "If, during your declare attackers step, Zurgo is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having Zurgo attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Zurgo is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having Zurgo attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2014-09-20",
-          "text": "If Zurgo enters the battlefield before the combat phase, it will attack that turn if able. If it enters the battlefield after combat, it won’t attack that turn and will usually be available to block on the following turn."
+          "text": "If Zurgo enters the battlefield before the combat phase, it will attack that turn if able. If it enters the battlefield after combat, it won't attack that turn and will usually be available to block on the following turn."
         },
         {
           "date": "2014-09-20",
-          "text": "Each time a creature dies, check whether Zurgo had dealt any damage to it at any time during that turn. If so, Zurgo’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it went to."
+          "text": "Each time a creature dies, check whether Zurgo had dealt any damage to it at any time during that turn. If so, Zurgo's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it went to."
         }
       ],
       "subtypes": [
@@ -26802,11 +26806,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Activating the ability targeting a creature that’s already attacking or blocking won’t remove it from combat or affect that attack or block."
+          "text": "Activating the ability targeting a creature that's already attacking or blocking won't remove it from combat or affect that attack or block."
         },
         {
           "date": "2014-09-20",
-          "text": "If Briber’s Purse has no gem counters on it, it remains on the battlefield, although you can’t activate its last ability."
+          "text": "If Briber's Purse has no gem counters on it, it remains on the battlefield, although you can't activate its last ability."
         }
       ],
       "text": "Briber's Purse enters the battlefield with X gem counters on it.\n{1}, {T}, Remove a gem counter from Briber's Purse: Target creature can't attack or block this turn.",
@@ -26910,7 +26914,7 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "If the player’s graveyard is empty, the player will shuffle his or her library, then you’ll draw a card."
+          "text": "If the player's graveyard is empty, the player will shuffle his or her library, then you'll draw a card."
         }
       ],
       "text": "{2}, Exile Cranial Archive: Target player shuffles his or her graveyard into his or her library. Draw a card.",
@@ -27015,7 +27019,11 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "The value of X is determined as the activated ability resolves. If the equipped creature isn’t on the battlefield at that time, use its power the last time it was on the battlefield to determine the value of X. If that power was negative, other creatures you control will lose power and toughness. For example, if the equipped creature was 2/2 and a spell gave it -5/-5 in response to Dragon Throne of Tarkir’s activated ability, other creatures you control would get -3/-3 until end of turn."
+          "text": "The value of X is determined as the activated ability resolves. If the equipped creature isn't on the battlefield at that time, use its power the last time it was on the battlefield to determine the value of X."
+        },
+        {
+          "date": "2017-06-27",
+          "text": "If the equipped creature's power is negative while resolving the activated ability it gains, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -27241,7 +27249,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "In some rare cases, a Heart-Piercer Bow you control may be attached to a creature that’s attacking you or a planeswalker you control. In that case, you choose the target of the triggered ability, but as you are the defending player, you must choose a creature you control as the target."
+          "text": "In some rare cases, a Heart-Piercer Bow you control may be attached to a creature that's attacking you or a planeswalker you control. In that case, you choose the target of the triggered ability, but as you are the defending player, you must choose a creature you control as the target."
         }
       ],
       "subtypes": [
@@ -27452,15 +27460,15 @@
       "rulings": [
         {
           "date": "2014-09-20",
-          "text": "Lens of Clarity lets you look at the top card of your library and at face-down creatures you don’t control whenever you want, even if you don’t have priority. This action doesn’t use the stack. Knowing what those cards are becomes part of the information you have access to, just like you can look at the cards in your hand."
+          "text": "Lens of Clarity lets you look at the top card of your library and at face-down creatures you don't control whenever you want, even if you don't have priority. This action doesn't use the stack. Knowing what those cards are becomes part of the information you have access to, just like you can look at the cards in your hand."
         },
         {
           "date": "2014-09-20",
-          "text": "Lens of Clarity doesn’t stop your opponents from looking at face-down creatures they control."
+          "text": "Lens of Clarity doesn't stop your opponents from looking at face-down creatures they control."
         },
         {
           "date": "2014-09-20",
-          "text": "Lens of Clarity doesn’t let you look at face-down spells you don’t control on the stack."
+          "text": "Lens of Clarity doesn't let you look at face-down spells you don't control on the stack."
         }
       ],
       "text": "You may look at the top card of your library and at face-down creatures you don't control. (You may do this at any time.)",
@@ -27873,6 +27881,16 @@
         "KTK"
       ],
       "rarity": "Mythic Rare",
+      "rulings": [
+        {
+          "date": "2014-09-20",
+          "text": "An \"extra turn\" is any turn created by a spell or ability. Notably, it doesn't include additional turns taken in tournaments after time expires for a round."
+        },
+        {
+          "date": "2014-09-20",
+          "text": "Extra turns can still be created while Ugin's Nexus is on the battlefield. They're not skipped until they would begin, so if Ugin's Nexus leaves the battlefield before that happens, the extra turns will be unaffected. Notably, if you control more than one Ugin's Nexus, all but one will be exiled and an extra turn created for each. If the Ugin's Nexus that remains on the battlefield isn't on the battlefield when each of those extra turns would begin, you can take those turns."
+        }
+      ],
       "supertypes": [
         "Legendary"
       ],
@@ -27986,27 +28004,27 @@
         },
         {
           "date": "2014-09-20",
-          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It’s colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
+          "text": "When the spell resolves, it enters the battlefield as a 2/2 creature with no name, mana cost, creature types, or abilities. It's colorless and has a converted mana cost of 0. Other effects that apply to the creature can still grant it any of these characteristics."
         },
         {
           "date": "2014-09-20",
-          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn’t use the stack and can’t be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+          "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its morph cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
         },
         {
           "date": "2014-09-20",
-          "text": "Because the permanent is on the battlefield both before and after it’s turned face up, turning a permanent face up doesn’t cause any enters-the-battlefield abilities to trigger."
+          "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
         },
         {
           "date": "2014-09-20",
-          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren’t affected."
+          "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent, as well as Auras and Equipment that were attached to the permanent, aren't affected."
         },
         {
           "date": "2014-09-20",
-          "text": "At any time, you can look at a face-down spell or permanent you control. You can’t look at face-down spells or permanents you don’t control unless an effect instructs you to do so."
+          "text": "At any time, you can look at a face-down spell or permanent you control. You can't look at face-down spells or permanents you don't control unless an effect instructs you to do so."
         },
         {
           "date": "2014-09-20",
-          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You’re not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
+          "text": "You must ensure that your face-down spells and permanents can easily be differentiated from each other. You're not allowed to mix up the cards that represent them on the battlefield in order to confuse other players. The order they entered the battlefield should remain clear. Common methods for doing this include using markers or dice, or simply placing them in order on the battlefield."
         },
         {
           "date": "2014-09-20",
@@ -30191,11 +30209,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "平原",
-          "multiverseid": 386892
-        },
-        {
           "language": "Chinese Traditional",
           "name": "平原",
           "multiverseid": 387161
@@ -30281,21 +30294,6 @@
           "multiverseid": 388237
         },
         {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 388238
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 388239
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 388240
-        },
-        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 388506
@@ -30314,6 +30312,26 @@
           "language": "Korean",
           "name": "들",
           "multiverseid": 388509
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 389313
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 389314
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 389315
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 389316
         }
       ],
       "id": "330019c706ac96ce9b51d720751a721060068e7b",
@@ -30953,11 +30971,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "平原",
-          "multiverseid": 386892
-        },
-        {
           "language": "Chinese Traditional",
           "name": "平原",
           "multiverseid": 387161
@@ -31043,21 +31056,6 @@
           "multiverseid": 388237
         },
         {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 388238
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 388239
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 388240
-        },
-        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 388506
@@ -31076,6 +31074,26 @@
           "language": "Korean",
           "name": "들",
           "multiverseid": 388509
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 389313
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 389314
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 389315
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 389316
         }
       ],
       "id": "77fedbfe536c9dbd7d31b88805cc10353850e272",
@@ -31740,21 +31758,6 @@
           "multiverseid": 387641
         },
         {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 387642
-        },
-        {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 387643
-        },
-        {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 387644
-        },
-        {
           "language": "German",
           "name": "Insel",
           "multiverseid": 387372
@@ -31835,9 +31838,24 @@
           "multiverseid": 388451
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Ilha",
-          "multiverseid": 388717
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389255
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389256
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389257
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389258
         }
       ],
       "id": "5d9a574266b76b50fc80b6ac556e2c55dd30df7c",
@@ -32119,21 +32137,6 @@
           "multiverseid": 387641
         },
         {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 387642
-        },
-        {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 387643
-        },
-        {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 387644
-        },
-        {
           "language": "German",
           "name": "Insel",
           "multiverseid": 387372
@@ -32214,9 +32217,24 @@
           "multiverseid": 388451
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Ilha",
-          "multiverseid": 388717
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389255
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389256
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389257
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389258
         }
       ],
       "id": "8f6815ea513561c635dd511bc7660ce2d6e46529",
@@ -32877,21 +32895,6 @@
           "multiverseid": 387641
         },
         {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 387642
-        },
-        {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 387643
-        },
-        {
-          "language": "French",
-          "name": "Île",
-          "multiverseid": 387644
-        },
-        {
           "language": "German",
           "name": "Insel",
           "multiverseid": 387372
@@ -32972,9 +32975,24 @@
           "multiverseid": 388451
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Ilha",
-          "multiverseid": 388717
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389255
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389256
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389257
+        },
+        {
+          "language": "Spanish",
+          "name": "Isla",
+          "multiverseid": 389258
         }
       ],
       "id": "339cdb45881646dddc698389589f7ba468dc2231",
@@ -35537,11 +35555,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "山脉",
-          "multiverseid": 386878
-        },
-        {
           "language": "Chinese Traditional",
           "name": "山脈",
           "multiverseid": 387147
@@ -35565,21 +35578,6 @@
           "language": "French",
           "name": "Montagne",
           "multiverseid": 387685
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 387686
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 387687
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 387688
         },
         {
           "language": "German",
@@ -35660,6 +35658,26 @@
           "language": "Korean",
           "name": "산",
           "multiverseid": 388495
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 389299
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 389300
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 389301
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 389302
         }
       ],
       "id": "408c5d93a9f590d9706cc6362927fc04e40d2c4f",
@@ -35922,11 +35940,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "山脉",
-          "multiverseid": 386878
-        },
-        {
           "language": "Chinese Traditional",
           "name": "山脈",
           "multiverseid": 387147
@@ -35950,21 +35963,6 @@
           "language": "French",
           "name": "Montagne",
           "multiverseid": 387685
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 387686
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 387687
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 387688
         },
         {
           "language": "German",
@@ -36045,6 +36043,26 @@
           "language": "Korean",
           "name": "산",
           "multiverseid": 388495
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 389299
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 389300
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 389301
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 389302
         }
       ],
       "id": "a0d1dc488d3fc67e33d48e83fcfe08942c25e463",
@@ -36427,9 +36445,9 @@
           "multiverseid": 388426
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 389230
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 388961
         }
       ],
       "id": "a873d16e1982fb5e08d35b371202db04e419e760",
@@ -36810,9 +36828,9 @@
           "multiverseid": 388426
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 389230
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 388961
         }
       ],
       "id": "2bf7d91137da565b8432fa6575412021097048b1",
@@ -37158,21 +37176,6 @@
           "multiverseid": 388154
         },
         {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 388155
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 388156
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 388157
-        },
-        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 388423
@@ -37196,6 +37199,21 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 389230
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 389231
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 389232
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 389233
         }
       ],
       "id": "c91872300d94efa5a444c0fad8c755c2f9abc1f9",
@@ -37576,9 +37594,9 @@
           "multiverseid": 388426
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 389230
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 388961
         }
       ],
       "id": "4cca0916e7f6c8a101cac472376342a046470ce7",

--- a/json/LEA.json
+++ b/json/LEA.json
@@ -194,11 +194,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that’s already a creature, it won’t change its power and toughness."
+          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that's already a creature, it won't change its power and toughness."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -264,7 +264,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -272,11 +272,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -395,7 +395,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -454,7 +454,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -626,7 +627,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land type changing effects that change a dual land’s land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
+          "text": "Land type changing effects that change a dual land's land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
         },
         {
           "date": "2004-10-04",
@@ -638,7 +639,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -705,7 +706,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Balance doesn’t have targets, so permanents that can’t be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
+          "text": "Balance doesn't have targets, so permanents that can't be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
         },
         {
           "date": "2016-06-08",
@@ -817,7 +818,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -879,7 +880,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1187,7 +1188,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "text": "As Black Vise enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, Black Vise deals X damage to that player, where X is the number of cards in his or her hand minus 4.",
@@ -1296,7 +1297,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Blaze of Glory only during combat before blockers are declared.\nTarget creature defending player controls can block any number of creatures this turn. It blocks each attacking creature this turn if able.",
@@ -1408,7 +1409,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         }
       ],
       "text": "Choose one —\n• Counter target red spell.\n• Destroy target red permanent.",
@@ -1825,7 +1826,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life you don’t have. In other words, you can’t Channel yourself below zero life."
+          "text": "You can't pay life you don't have. In other words, you can't Channel yourself below zero life."
         }
       ],
       "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
@@ -1872,15 +1873,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Chaos Orb can only affect permanents. Cards that are in the game but not on the battlefield, such as those in the Library and Graveyard, can’t be affected."
+          "text": "Chaos Orb can only affect permanents. Cards that are in the game but not on the battlefield, such as those in the Library and Graveyard, can't be affected."
         },
         {
           "date": "2004-10-04",
-          "text": "You can arrange your cards any time before the Orb is put onto the battlefield, but not after. In general, you should not stack cards or put them in places where your opponent can’t read the names of all of them or count them. This is recommended good gaming practice."
+          "text": "You can arrange your cards any time before the Orb is put onto the battlefield, but not after. In general, you should not stack cards or put them in places where your opponent can't read the names of all of them or count them. This is recommended good gaming practice."
         },
         {
           "date": "2004-10-04",
-          "text": "It must flip 360 degrees (that’s what “flip” means). And this flip must be in the air and not in your hand."
+          "text": "It must flip 360 degrees (that's what \"flip\" means). And this flip must be in the air and not in your hand."
         },
         {
           "date": "2004-10-04",
@@ -1892,7 +1893,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t interfere in any physical way with the casting of this card."
+          "text": "You can't interfere in any physical way with the casting of this card."
         }
       ],
       "text": "{1}, {T}: If Chaos Orb is on the battlefield, flip Chaos Orb onto the battlefield from a height of at least one foot. If Chaos Orb turns over completely at least once during the flip, destroy all nontoken permanents it touches. Then destroy Chaos Orb.",
@@ -2012,7 +2013,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2088,7 +2089,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2168,7 +2169,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2244,7 +2245,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2318,7 +2319,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Clockwork Beast’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "Clockwork Beast's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         }
       ],
       "subtypes": [
@@ -2401,7 +2402,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -2409,11 +2410,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -2421,7 +2422,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -2559,11 +2560,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Consecrate Land enters the battlefield attached to a land that’s enchanted by other Auras, those Auras are put into their owners’ graveyards."
+          "text": "If Consecrate Land enters the battlefield attached to a land that's enchanted by other Auras, those Auras are put into their owners' graveyards."
         },
         {
           "date": "2013-07-01",
-          "text": "A permanent with indestructible can’t be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
+          "text": "A permanent with indestructible can't be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
         }
       ],
       "subtypes": [
@@ -2717,7 +2718,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -3285,7 +3286,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "After leaving the battlefield, the ability triggers during each of your upkeeps for the rest of the game. As it resolves, you must remove a mire counter from a land that had a mire counter put on it by that instance of Cyclopean Tomb, but it doesn’t matter where the mire counter you remove came from. For instance, you could remove mire counters that were put on the land by Gilder Bairn."
+          "text": "After leaving the battlefield, the ability triggers during each of your upkeeps for the rest of the game. As it resolves, you must remove a mire counter from a land that had a mire counter put on it by that instance of Cyclopean Tomb, but it doesn't matter where the mire counter you remove came from. For instance, you could remove mire counters that were put on the land by Gilder Bairn."
         },
         {
           "date": "2008-08-01",
@@ -3745,7 +3746,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t reveal the card to your opponent."
+          "text": "You don't reveal the card to your opponent."
         },
         {
           "date": "2004-10-04",
@@ -3967,7 +3968,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “can’t regenerate” is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
+          "text": "The \"can't regenerate\" is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
         },
         {
           "date": "2004-10-04",
@@ -4099,11 +4100,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -4241,7 +4242,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "text": "Target player activates a mana ability of each land he or she controls. Then put all mana from that player's mana pool into yours.",
@@ -4423,11 +4424,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can’t be unblocked."
+          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can't be unblocked."
         },
         {
           "date": "2004-10-04",
-          "text": "If you increase the power of the targeted creature after the ability resolves, it still can’t be blocked that turn."
+          "text": "If you increase the power of the targeted creature after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -4739,7 +4740,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability “{T}: Add {B} to your mana pool.” Evil Presence doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability \"{T}: Add {B} to your mana pool.\" Evil Presence doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         }
       ],
       "subtypes": [
@@ -4901,11 +4902,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You take damage when you play a land using the “play a land” action. Such an action can be your regular “play a land”, one enabled by Fastbond, or ones enabled through other effects."
+          "text": "You take damage when you play a land using the \"play a land\" action. Such an action can be your regular \"play a land\", one enabled by Fastbond, or ones enabled through other effects."
         },
         {
           "date": "2004-10-04",
-          "text": "You do not take damage when you “put a land onto the battlefield” through the effect of a spell or ability."
+          "text": "You do not take damage when you \"put a land onto the battlefield\" through the effect of a spell or ability."
         }
       ],
       "text": "You may play any number of lands on each of your turns.\nWhenever you play a land, if it wasn't the first land you played this turn, Fastbond deals 1 damage to you.",
@@ -5165,7 +5166,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -5177,7 +5178,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -5251,7 +5252,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -5556,7 +5557,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This can’t be used to prevent damage caused by a blocked creature with Trample ability."
+          "text": "This can't be used to prevent damage caused by a blocked creature with Trample ability."
         }
       ],
       "text": "{1}: The next time an unblocked creature of your choice would deal combat damage to you this turn, prevent all but 1 of that damage.",
@@ -6115,7 +6116,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When a spell with additional costs is copied, you don’t have to pay those costs again."
+          "text": "When a spell with additional costs is copied, you don't have to pay those costs again."
         },
         {
           "date": "2004-10-04",
@@ -6143,7 +6144,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy’s target will be illegal when it resolves."
+          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy's target will be illegal when it resolves."
         },
         {
           "date": "2004-10-04",
@@ -6151,7 +6152,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The copy that is placed on the stack is not considered to have been “cast”."
+          "text": "The copy that is placed on the stack is not considered to have been \"cast\"."
         },
         {
           "date": "2004-10-04",
@@ -6357,11 +6358,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When being declared as an attacker, use the “not attacking” power and toughness. It only changes after declaration is complete."
+          "text": "When being declared as an attacker, use the \"not attacking\" power and toughness. It only changes after declaration is complete."
         },
         {
           "date": "2006-09-25",
-          "text": "The activated ability doesn’t affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability “{T}: Add {G} to your mana pool.”"
+          "text": "The activated ability doesn't affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability \"{T}: Add {G} to your mana pool.\""
         },
         {
           "date": "2006-10-15",
@@ -6547,6 +6548,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -6704,7 +6709,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "White spells cost {3} more to cast.\nActivated abilities of white enchantments cost {3} more to activate.",
@@ -6772,7 +6777,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade’s ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
         }
       ],
       "subtypes": [
@@ -7240,7 +7245,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -7751,7 +7756,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers even if the Specter’s damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
+          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
         }
       ],
       "subtypes": [
@@ -7868,19 +7873,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player’s pool."
+          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player's pool."
         },
         {
           "date": "2004-10-04",
-          "text": "Icy Manipulator can’t be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
+          "text": "Icy Manipulator can't be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger “if the card becomes tapped” effects."
+          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger \"if the card becomes tapped\" effects."
         },
         {
           "date": "2004-10-04",
-          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use the Icy Manipulator."
+          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use the Icy Manipulator."
         },
         {
           "date": "2004-10-04",
@@ -7932,11 +7937,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature enters the battlefield face down, so none of its “enters the battlefield” abilities will trigger or have any effect. Also none of its “As this enters the battlefield” abilities apply."
+          "text": "The creature enters the battlefield face down, so none of its \"enters the battlefield\" abilities will trigger or have any effect. Also none of its \"As this enters the battlefield\" abilities apply."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature’s “enters the battlefield” abilities (and any other abilities relating to the creature entering the battlefield) do not trigger when it turns face up."
+          "text": "The creature's \"enters the battlefield\" abilities (and any other abilities relating to the creature entering the battlefield) do not trigger when it turns face up."
         },
         {
           "date": "2004-10-04",
@@ -7944,11 +7949,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the ability to cast a creature card face down, you must keep track of the amount and types of mana you spent on {X}. If that creature spell is moved from the stack to anywhere other than the battlefield, the resulting creature leaves the battlefield, or the game ends, the face-down card is revealed. If its mana cost couldn’t be paid by some amount of, or all of, the mana you spent on {X}, all applicable penalties for casting a card illegally are assessed."
+          "text": "If you use the ability to cast a creature card face down, you must keep track of the amount and types of mana you spent on {X}. If that creature spell is moved from the stack to anywhere other than the battlefield, the resulting creature leaves the battlefield, or the game ends, the face-down card is revealed. If its mana cost couldn't be paid by some amount of, or all of, the mana you spent on {X}, all applicable penalties for casting a card illegally are assessed."
         },
         {
           "date": "2009-10-01",
@@ -7956,19 +7961,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect that turns it face-up is a replacement effect. It doesn’t use the stack and can’t be responded to."
+          "text": "The effect that turns it face-up is a replacement effect. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2009-10-01",
-          "text": "You may not turn a face-down spell face up. You may not turn a face-down permanent face up unless it would have morph while face up or an effect specifically allows you to turn it face up. Illusionary Mask’s ability has you turn a face-down creature face up if it would assign damage, deal damage, be dealt damage, or become tapped, but not for any other reason. For example, if you use Illusionary Mask’s ability to cast a black creature face down, you can’t turn it face up just because it’s being targeted by Terror."
+          "text": "You may not turn a face-down spell face up. You may not turn a face-down permanent face up unless it would have morph while face up or an effect specifically allows you to turn it face up. Illusionary Mask's ability has you turn a face-down creature face up if it would assign damage, deal damage, be dealt damage, or become tapped, but not for any other reason. For example, if you use Illusionary Mask's ability to cast a black creature face down, you can't turn it face up just because it's being targeted by Terror."
         },
         {
           "date": "2009-10-01",
-          "text": "Both the amount and types of mana you spend on {X} are taken into account while you’re choosing a creature card from your hand. For example, if you spent {U}{U} on {X}, you can choose a creature card with mana cost {U}{U}, {1}{U}, {2}, or {W/U}{W/U}, among other possibilities, but not one that costs {2}{U} or one that costs {G}."
+          "text": "Both the amount and types of mana you spend on {X} are taken into account while you're choosing a creature card from your hand. For example, if you spent {U}{U} on {X}, you can choose a creature card with mana cost {U}{U}, {1}{U}, {2}, or {W/U}{W/U}, among other possibilities, but not one that costs {2}{U} or one that costs {G}."
         },
         {
           "date": "2009-10-01",
-          "text": "While the creature card is face down, it’s a 2/2 creature with no name, mana cost, color, creature type, abilities, or expansion symbol. Since it has no mana cost, its converted mana cost is 0."
+          "text": "While the creature card is face down, it's a 2/2 creature with no name, mana cost, color, creature type, abilities, or expansion symbol. Since it has no mana cost, its converted mana cost is 0."
         },
         {
           "date": "2009-10-01",
@@ -7976,11 +7981,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You can turn a face-down permanent face up if it would have morph while face up. This applies to creatures you cast face down as a result of Illusionary Mask’s effect. The rest of Illusionary Mask’s effect applies to it as well."
+          "text": "You can turn a face-down permanent face up if it would have morph while face up. This applies to creatures you cast face down as a result of Illusionary Mask's effect. The rest of Illusionary Mask's effect applies to it as well."
         },
         {
           "date": "2009-10-01",
-          "text": "Illusionary Mask’s ability will continue to apply to creatures cast face down with it, even if Illusionary Mask has left the battlefield."
+          "text": "Illusionary Mask's ability will continue to apply to creatures cast face down with it, even if Illusionary Mask has left the battlefield."
         }
       ],
       "text": "{X}: You may choose a creature card in your hand whose mana cost could be paid by some amount of, or all of, the mana you spent on {X}. If you do, you may cast that card face down as a 2/2 creature spell without paying its mana cost. If the creature that spell becomes as it resolves has not been turned face up and would assign or deal damage, be dealt damage, or become tapped, instead it's turned face up and assigns or deals damage, is dealt damage, or becomes tapped. Activate this ability only any time you could cast a sorcery.",
@@ -8036,15 +8041,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If attached to an opponent’s creature, you can untap their creature during your turn."
+          "text": "If attached to an opponent's creature, you can untap their creature during your turn."
         },
         {
           "date": "2004-10-04",
-          "text": "Instill Energy’s untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
+          "text": "Instill Energy's untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
         },
         {
           "date": "2005-08-01",
-          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card’s ability to untap once during the turn."
+          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card's ability to untap once during the turn."
         }
       ],
       "subtypes": [
@@ -8822,7 +8827,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Since the draw is replaced, you can’t use the same draw to do other things."
+          "text": "Since the draw is replaced, you can't use the same draw to do other things."
         }
       ],
       "text": "If you would draw a card during your draw step, instead you may skip that draw. If you do, until your next turn, you can't be attacked except by creatures with flying and/or islandwalk.",
@@ -8973,19 +8978,19 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A delayed triggered ability that refers to Jade Statue still affects it even if it’s no longer a creature. For example, if Jade Statue blocks the Kashi-Tribe Warriors (“Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn’t untap during its controller’s next untap step.”), the Warriors’ effect stops Jade Statue from untapping."
+          "text": "A delayed triggered ability that refers to Jade Statue still affects it even if it's no longer a creature. For example, if Jade Statue blocks the Kashi-Tribe Warriors (\"Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.\"), the Warriors' effect stops Jade Statue from untapping."
         },
         {
           "date": "2005-08-01",
-          "text": "If Jade Statue’s ability has been activated, abilities that trigger “at end of combat” will see Jade Statue as an artifact creature."
+          "text": "If Jade Statue's ability has been activated, abilities that trigger \"at end of combat\" will see Jade Statue as an artifact creature."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-09-20",
-          "text": "If Jade Statue is animated by some other effect, you get an artifact creature with whatever power, toughness, and creature types (if any) are specified by that effect. If you subsequently use Jade Statue’s ability during combat, it will become 3/6 and gain the creature type Golem in addition to those creature types until end of combat."
+          "text": "If Jade Statue is animated by some other effect, you get an artifact creature with whatever power, toughness, and creature types (if any) are specified by that effect. If you subsequently use Jade Statue's ability during combat, it will become 3/6 and gain the creature type Golem in addition to those creature types until end of combat."
         }
       ],
       "text": "{2}: Jade Statue becomes a 3/6 Golem artifact creature until end of combat. Activate this ability only during combat.",
@@ -9106,11 +9111,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -9174,7 +9179,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         }
       ],
       "text": "Target creature gains flying until end of turn.",
@@ -9291,7 +9296,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never “locked in”."
+          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never \"locked in\"."
         }
       ],
       "subtypes": [
@@ -9353,7 +9358,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Swamps are 1/1 black creatures that are still lands.",
@@ -9408,7 +9413,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can move it to any other player’s land whenever you get to move it."
+          "text": "You can move it to any other player's land whenever you get to move it."
         },
         {
           "date": "2005-08-01",
@@ -9420,7 +9425,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Because the ability isn’t targeted, the controller of the destroyed land may attach it to a land that can’t be the target of abilities."
+          "text": "Because the ability isn't targeted, the controller of the destroyed land may attach it to a land that can't be the target of abilities."
         }
       ],
       "subtypes": [
@@ -9535,7 +9540,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can’t be used at times that only mana abilities can be used."
+          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can't be used at times that only mana abilities can be used."
         }
       ],
       "subtypes": [
@@ -9590,11 +9595,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not “discarded”."
+          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not \"discarded\"."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren’t effects."
+          "text": "You can't use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren't effects."
         },
         {
           "date": "2004-10-04",
@@ -9622,7 +9627,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\nIf an effect causes you to discard a card, discard it, but you may put it on top of your library instead of into your graveyard.",
@@ -9684,15 +9689,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life, just like any player at less than one life can’t pay life. You can pay zero life if you want."
+          "text": "You can't pay life, just like any player at less than one life can't pay life. You can pay zero life if you want."
         },
         {
           "date": "2004-10-04",
-          "text": "If an opponent steals control of Lich and no other effect prevents you from losing with a life total of zero, you will lose the game due to a zero life total as a State-Based Action before you can take any actions. The last sentence doesn’t apply in this case since the Lich didn’t leave the battlefield."
+          "text": "If an opponent steals control of Lich and no other effect prevents you from losing with a life total of zero, you will lose the game due to a zero life total as a State-Based Action before you can take any actions. The last sentence doesn't apply in this case since the Lich didn't leave the battlefield."
         },
         {
           "date": "2004-10-04",
-          "text": "If an opponent steals control of Lich, their life total does not change. The life total changes for a player only when it enters the battlefield under that player’s control."
+          "text": "If an opponent steals control of Lich, their life total does not change. The life total changes for a player only when it enters the battlefield under that player's control."
         },
         {
           "date": "2004-10-04",
@@ -9700,7 +9705,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich leaves the battlefield or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can’t lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
+          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich leaves the battlefield or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can't lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
         },
         {
           "date": "2010-08-15",
@@ -9708,7 +9713,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich is put into the graveyard or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can’t lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
+          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich is put into the graveyard or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can't lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
         }
       ],
       "text": "As Lich enters the battlefield, you lose life equal to your life total.\nYou don't lose the game for having 0 or less life.\nIf you would gain life, draw that many cards instead.\nWhenever you're dealt damage, sacrifice that many nontoken permanents. If you can't, you lose the game.\nWhen Lich is put into a graveyard from the battlefield, you lose the game.",
@@ -9982,7 +9987,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can cast it targeting your opponent’s artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
+          "text": "You can cast it targeting your opponent's artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
         },
         {
           "date": "2004-10-04",
@@ -10046,7 +10051,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Forests are 1/1 creatures that are still lands.",
@@ -10468,7 +10473,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -10480,7 +10485,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
@@ -10492,7 +10497,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target spell or permanent by replacing all instances of one basic land type with another. (For example, you may change \"swampwalk\" to \"plainswalk.\" This effect lasts indefinitely.)",
@@ -10615,7 +10620,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare’s ability."
+          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare's ability."
         },
         {
           "date": "2004-10-04",
@@ -10623,7 +10628,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can’t give a mana of a color that wasn’t produced."
+          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can't give a mana of a color that wasn't produced."
         },
         {
           "date": "2004-10-04",
@@ -10639,7 +10644,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Does not copy any restrictions on the mana, such as with Mishra’s Workshop or Pillar of the Paruns."
+          "text": "Does not copy any restrictions on the mana, such as with Mishra's Workshop or Pillar of the Paruns."
         },
         {
           "date": "2007-09-16",
@@ -10828,7 +10833,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -11003,7 +11008,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -11969,7 +11974,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can’t be countered with something that counters spells."
+          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can't be countered with something that counters spells."
         },
         {
           "date": "2004-10-04",
@@ -11977,7 +11982,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "A card is “above” another card in your graveyard if it was put into that graveyard later."
+          "text": "A card is \"above\" another card in your graveyard if it was put into that graveyard later."
         },
         {
           "date": "2008-10-01",
@@ -11989,11 +11994,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -12055,11 +12060,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can use this effect on a creature you know won’t be able to attack. For example, you can use it on a tapped creature."
+          "text": "You can use this effect on a creature you know won't be able to attack. For example, you can use it on a tapped creature."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2013-09-20",
@@ -12124,7 +12129,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -12200,19 +12205,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -12545,7 +12550,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' ‘Well, now that we have seen each other,' said the Unicorn, ‘if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
+      "flavor": "\"'Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' 'Well, now that we have seen each other,' said the Unicorn, 'if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
       "id": "e0b7e7fb6d214b4557a7dc8c7d8c44815728f662",
       "imageName": "pearled unicorn",
       "layout": "normal",
@@ -12643,7 +12648,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent’s Incarnation you can let it die to make them lose life."
+          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent's Incarnation you can let it die to make them lose life."
         },
         {
           "date": "2007-02-01",
@@ -12718,7 +12723,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -13577,7 +13582,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -13716,7 +13721,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -14145,7 +14150,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -14550,7 +14555,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -14673,7 +14678,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If damage that would be dealt to Rock Hydra can’t be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
+          "text": "If damage that would be dealt to Rock Hydra can't be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
         }
       ],
       "subtypes": [
@@ -14801,11 +14806,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -14995,7 +15000,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -15240,7 +15245,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -15497,15 +15502,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -15874,7 +15879,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t use Simulacrum on Loss of Life, just damage."
+          "text": "You can't use Simulacrum on Loss of Life, just damage."
         },
         {
           "date": "2004-10-04",
@@ -15882,7 +15887,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage’s source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
+          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage's source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
         }
       ],
       "text": "You gain life equal to the damage dealt to you this turn. Simulacrum deals damage to target creature you control equal to the damage dealt to you this turn.",
@@ -15985,15 +15990,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It will require creatures with Haste to attack since they are able, but it won’t destroy them if they don’t for some reason."
+          "text": "It will require creatures with Haste to attack since they are able, but it won't destroy them if they don't for some reason."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2009-02-01",
-          "text": "This will destroy creatures that weren’t able to attack because they had been previously tapped."
+          "text": "This will destroy creatures that weren't able to attack because they had been previously tapped."
         },
         {
           "date": "2013-09-20",
@@ -16057,7 +16062,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t Sleight proper nouns (i.e. card names). This means that you can’t affect a “Black Vise”."
+          "text": "You can't Sleight proper nouns (i.e. card names). This means that you can't affect a \"Black Vise\"."
         },
         {
           "date": "2004-10-04",
@@ -16065,7 +16070,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Can’t change a color word to the same color word. It must be a different word."
+          "text": "Can't change a color word to the same color word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -16077,7 +16082,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -16320,11 +16325,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -16380,7 +16385,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since there is no untap step, Phasing in/out won’t happen."
+          "text": "Since there is no untap step, Phasing in/out won't happen."
         },
         {
           "date": "2004-10-04",
@@ -16512,19 +16517,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the Giant’s power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
+          "text": "If the Giant's power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
         },
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stone Giant’s ability is activated during a turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. The targeted creature will be destroyed at that time."
+          "text": "If Stone Giant's ability is activated during a turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. The targeted creature will be destroyed at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it’s no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant’s power at that time."
+          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it's no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant's power at that time."
         }
       ],
       "subtypes": [
@@ -17297,7 +17302,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -17354,7 +17359,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -17536,7 +17541,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Protection from Green does not stop the Basilisk’s ability because the ability is not targeted."
+          "text": "Protection from Green does not stop the Basilisk's ability because the ability is not targeted."
         },
         {
           "date": "2004-10-04",
@@ -17698,7 +17703,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -17763,7 +17768,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         },
         {
           "date": "2008-10-01",
@@ -17825,7 +17830,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one.",
@@ -17879,7 +17884,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. (Then put Timetwister into its owner's graveyard.)",
@@ -18004,7 +18009,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18115,7 +18120,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18344,7 +18349,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18436,6 +18441,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -18693,23 +18702,23 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
+          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
         },
         {
           "date": "2007-09-16",
-          "text": "When Vesuvan Doppelganger’s triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
+          "text": "When Vesuvan Doppelganger's triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger copies the mana cost of the creature it’s copying but doesn’t copy its color."
+          "text": "Vesuvan Doppelganger copies the mana cost of the creature it's copying but doesn't copy its color."
         },
         {
           "date": "2007-09-16",
-          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger’s color, and will gain Vesuvan Doppelganger’s triggered ability."
+          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger's color, and will gain Vesuvan Doppelganger's triggered ability."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger’s triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller’s upkeep. They’ll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger’s characteristics for the rest of the turn."
+          "text": "Vesuvan Doppelganger's triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller's upkeep. They'll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger's characteristics for the rest of the turn."
         },
         {
           "date": "2007-09-16",
@@ -18717,7 +18726,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Although Vesuvan Doppelganger’s triggered ability is targeted, its “as enters the battlefield” ability is not."
+          "text": "Although Vesuvan Doppelganger's triggered ability is targeted, its \"as enters the battlefield\" ability is not."
         }
       ],
       "subtypes": [
@@ -18778,7 +18787,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can’t be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
+          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can't be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
         },
         {
           "date": "2004-10-04",
@@ -18862,7 +18871,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"This ‘standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
+      "flavor": "\"This 'standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
       "id": "001ca412629180934cffd4b493d55a5c1e5f311c",
       "imageName": "wall of air",
       "layout": "normal",
@@ -18991,7 +19000,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"What else, when chaos draws all forces inward to shape a single leaf.\"\n —Conrad Aiken",
+      "flavor": "\"What else, when chaos draws all forces inward to shape a single leaf.\"\n—Conrad Aiken",
       "id": "ba1fa70fbb5179ba5022ef155cddf59825de473a",
       "imageName": "wall of brambles",
       "layout": "normal",
@@ -20070,11 +20079,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All permanents untap during a player’s untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
+          "text": "All permanents untap during a player's untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
+          "text": "You can't tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
         }
       ],
       "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",
@@ -20178,7 +20187,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2009-10-01",
@@ -20186,15 +20195,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Word of Command can’t be used to force a player to play a card that isn’t in his or her hand."
+          "text": "Word of Command can't be used to force a player to play a card that isn't in his or her hand."
         },
         {
           "date": "2011-01-01",
-          "text": "You control the player while this spell is resolving, which means you get to see anything he or she can see. If that player is required to search his or her library as part of playing the card or as part of its resolution if it’s cast as a spell, then you can see the cards in that player’s library as well."
+          "text": "You control the player while this spell is resolving, which means you get to see anything he or she can see. If that player is required to search his or her library as part of playing the card or as part of its resolution if it's cast as a spell, then you can see the cards in that player's library as well."
         },
         {
           "date": "2011-01-01",
-          "text": "Your opponent can’t counter the Word of Command after letting you look at his or her hand, but they can attempt to counter the spell you force them to cast."
+          "text": "Your opponent can't counter the Word of Command after letting you look at his or her hand, but they can attempt to counter the spell you force them to cast."
         },
         {
           "date": "2011-01-01",
@@ -20210,7 +20219,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Since this spell is an instant, your opponent gets a chance to respond to it as normal. Once this spell resolves, you look at your opponent’s hand and choose a card. Note that it is common practice to respond to Word of Command by using up any spells or mana you have prior to letting it resolve."
+          "text": "Since this spell is an instant, your opponent gets a chance to respond to it as normal. Once this spell resolves, you look at your opponent's hand and choose a card. Note that it is common practice to respond to Word of Command by using up any spells or mana you have prior to letting it resolve."
         },
         {
           "date": "2011-01-01",
@@ -20218,11 +20227,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "text": "Look at target opponent's hand and choose a card from it. You control that player until Word of Command finishes resolving. The player plays that card if able. While doing so, the player can activate mana abilities only if they're from lands he or she controls and only if mana they produce is spent to activate other mana abilities of lands he or she controls and/or play that card. If the chosen card is cast as a spell, you control the player while that spell is resolving.",

--- a/json/LEB.json
+++ b/json/LEB.json
@@ -194,11 +194,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that’s already a creature, it won’t change its power and toughness."
+          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that's already a creature, it won't change its power and toughness."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -264,7 +264,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -272,11 +272,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -395,7 +395,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -454,7 +454,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -626,7 +627,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land type changing effects that change a dual land’s land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
+          "text": "Land type changing effects that change a dual land's land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
         },
         {
           "date": "2004-10-04",
@@ -638,7 +639,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -705,7 +706,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Balance doesn’t have targets, so permanents that can’t be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
+          "text": "Balance doesn't have targets, so permanents that can't be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
         },
         {
           "date": "2016-06-08",
@@ -817,7 +818,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -879,7 +880,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1187,7 +1188,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "text": "As Black Vise enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, Black Vise deals X damage to that player, where X is the number of cards in his or her hand minus 4.",
@@ -1296,7 +1297,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Blaze of Glory only during combat before blockers are declared.\nTarget creature defending player controls can block any number of creatures this turn. It blocks each attacking creature this turn if able.",
@@ -1408,7 +1409,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         }
       ],
       "text": "Choose one —\n• Counter target red spell.\n• Destroy target red permanent.",
@@ -1825,7 +1826,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life you don’t have. In other words, you can’t Channel yourself below zero life."
+          "text": "You can't pay life you don't have. In other words, you can't Channel yourself below zero life."
         }
       ],
       "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
@@ -1872,15 +1873,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Chaos Orb can only affect permanents. Cards that are in the game but not on the battlefield, such as those in the Library and Graveyard, can’t be affected."
+          "text": "Chaos Orb can only affect permanents. Cards that are in the game but not on the battlefield, such as those in the Library and Graveyard, can't be affected."
         },
         {
           "date": "2004-10-04",
-          "text": "You can arrange your cards any time before the Orb is put onto the battlefield, but not after. In general, you should not stack cards or put them in places where your opponent can’t read the names of all of them or count them. This is recommended good gaming practice."
+          "text": "You can arrange your cards any time before the Orb is put onto the battlefield, but not after. In general, you should not stack cards or put them in places where your opponent can't read the names of all of them or count them. This is recommended good gaming practice."
         },
         {
           "date": "2004-10-04",
-          "text": "It must flip 360 degrees (that’s what “flip” means). And this flip must be in the air and not in your hand."
+          "text": "It must flip 360 degrees (that's what \"flip\" means). And this flip must be in the air and not in your hand."
         },
         {
           "date": "2004-10-04",
@@ -1892,7 +1893,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t interfere in any physical way with the casting of this card."
+          "text": "You can't interfere in any physical way with the casting of this card."
         }
       ],
       "text": "{1}, {T}: If Chaos Orb is on the battlefield, flip Chaos Orb onto the battlefield from a height of at least one foot. If Chaos Orb turns over completely at least once during the flip, destroy all nontoken permanents it touches. Then destroy Chaos Orb.",
@@ -2014,7 +2015,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2090,7 +2091,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2166,7 +2167,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2246,7 +2247,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2322,7 +2323,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2396,7 +2397,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Clockwork Beast’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "Clockwork Beast's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         }
       ],
       "subtypes": [
@@ -2479,7 +2480,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -2487,11 +2488,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -2499,7 +2500,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -2637,11 +2638,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Consecrate Land enters the battlefield attached to a land that’s enchanted by other Auras, those Auras are put into their owners’ graveyards."
+          "text": "If Consecrate Land enters the battlefield attached to a land that's enchanted by other Auras, those Auras are put into their owners' graveyards."
         },
         {
           "date": "2013-07-01",
-          "text": "A permanent with indestructible can’t be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
+          "text": "A permanent with indestructible can't be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
         }
       ],
       "subtypes": [
@@ -2795,7 +2796,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -3363,7 +3364,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "After leaving the battlefield, the ability triggers during each of your upkeeps for the rest of the game. As it resolves, you must remove a mire counter from a land that had a mire counter put on it by that instance of Cyclopean Tomb, but it doesn’t matter where the mire counter you remove came from. For instance, you could remove mire counters that were put on the land by Gilder Bairn."
+          "text": "After leaving the battlefield, the ability triggers during each of your upkeeps for the rest of the game. As it resolves, you must remove a mire counter from a land that had a mire counter put on it by that instance of Cyclopean Tomb, but it doesn't matter where the mire counter you remove came from. For instance, you could remove mire counters that were put on the land by Gilder Bairn."
         },
         {
           "date": "2008-08-01",
@@ -3823,7 +3824,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t reveal the card to your opponent."
+          "text": "You don't reveal the card to your opponent."
         },
         {
           "date": "2004-10-04",
@@ -4045,7 +4046,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “can’t regenerate” is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
+          "text": "The \"can't regenerate\" is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
         },
         {
           "date": "2004-10-04",
@@ -4177,11 +4178,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -4319,7 +4320,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "text": "Target player activates a mana ability of each land he or she controls. Then put all mana from that player's mana pool into yours.",
@@ -4501,11 +4502,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can’t be unblocked."
+          "text": "The ability can be activated after a creature is blocked, but it has no effect. Once a creature is blocked, it can't be unblocked."
         },
         {
           "date": "2004-10-04",
-          "text": "If you increase the power of the targeted creature after the ability resolves, it still can’t be blocked that turn."
+          "text": "If you increase the power of the targeted creature after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -4817,7 +4818,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability “{T}: Add {B} to your mana pool.” Evil Presence doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability \"{T}: Add {B} to your mana pool.\" Evil Presence doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         }
       ],
       "subtypes": [
@@ -4979,11 +4980,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You take damage when you play a land using the “play a land” action. Such an action can be your regular “play a land”, one enabled by Fastbond, or ones enabled through other effects."
+          "text": "You take damage when you play a land using the \"play a land\" action. Such an action can be your regular \"play a land\", one enabled by Fastbond, or ones enabled through other effects."
         },
         {
           "date": "2004-10-04",
-          "text": "You do not take damage when you “put a land onto the battlefield” through the effect of a spell or ability."
+          "text": "You do not take damage when you \"put a land onto the battlefield\" through the effect of a spell or ability."
         }
       ],
       "text": "You may play any number of lands on each of your turns.\nWhenever you play a land, if it wasn't the first land you played this turn, Fastbond deals 1 damage to you.",
@@ -5243,7 +5244,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -5255,7 +5256,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -5329,7 +5330,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -5634,7 +5635,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This can’t be used to prevent damage caused by a blocked creature with Trample ability."
+          "text": "This can't be used to prevent damage caused by a blocked creature with Trample ability."
         }
       ],
       "text": "{1}: The next time an unblocked creature of your choice would deal combat damage to you this turn, prevent all but 1 of that damage.",
@@ -6448,7 +6449,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When a spell with additional costs is copied, you don’t have to pay those costs again."
+          "text": "When a spell with additional costs is copied, you don't have to pay those costs again."
         },
         {
           "date": "2004-10-04",
@@ -6476,7 +6477,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy’s target will be illegal when it resolves."
+          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy's target will be illegal when it resolves."
         },
         {
           "date": "2004-10-04",
@@ -6484,7 +6485,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The copy that is placed on the stack is not considered to have been “cast”."
+          "text": "The copy that is placed on the stack is not considered to have been \"cast\"."
         },
         {
           "date": "2004-10-04",
@@ -6690,11 +6691,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When being declared as an attacker, use the “not attacking” power and toughness. It only changes after declaration is complete."
+          "text": "When being declared as an attacker, use the \"not attacking\" power and toughness. It only changes after declaration is complete."
         },
         {
           "date": "2006-09-25",
-          "text": "The activated ability doesn’t affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability “{T}: Add {G} to your mana pool.”"
+          "text": "The activated ability doesn't affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability \"{T}: Add {G} to your mana pool.\""
         },
         {
           "date": "2006-10-15",
@@ -6880,6 +6881,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -7037,7 +7042,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "White spells cost {3} more to cast.\nActivated abilities of white enchantments cost {3} more to activate.",
@@ -7105,7 +7110,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade’s ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
         }
       ],
       "subtypes": [
@@ -7573,7 +7578,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -8084,7 +8089,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers even if the Specter’s damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
+          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
         }
       ],
       "subtypes": [
@@ -8201,19 +8206,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player’s pool."
+          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player's pool."
         },
         {
           "date": "2004-10-04",
-          "text": "Icy Manipulator can’t be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
+          "text": "Icy Manipulator can't be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger “if the card becomes tapped” effects."
+          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger \"if the card becomes tapped\" effects."
         },
         {
           "date": "2004-10-04",
-          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use the Icy Manipulator."
+          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use the Icy Manipulator."
         },
         {
           "date": "2004-10-04",
@@ -8265,11 +8270,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature enters the battlefield face down, so none of its “enters the battlefield” abilities will trigger or have any effect. Also none of its “As this enters the battlefield” abilities apply."
+          "text": "The creature enters the battlefield face down, so none of its \"enters the battlefield\" abilities will trigger or have any effect. Also none of its \"As this enters the battlefield\" abilities apply."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature’s “enters the battlefield” abilities (and any other abilities relating to the creature entering the battlefield) do not trigger when it turns face up."
+          "text": "The creature's \"enters the battlefield\" abilities (and any other abilities relating to the creature entering the battlefield) do not trigger when it turns face up."
         },
         {
           "date": "2004-10-04",
@@ -8277,11 +8282,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the ability to cast a creature card face down, you must keep track of the amount and types of mana you spent on {X}. If that creature spell is moved from the stack to anywhere other than the battlefield, the resulting creature leaves the battlefield, or the game ends, the face-down card is revealed. If its mana cost couldn’t be paid by some amount of, or all of, the mana you spent on {X}, all applicable penalties for casting a card illegally are assessed."
+          "text": "If you use the ability to cast a creature card face down, you must keep track of the amount and types of mana you spent on {X}. If that creature spell is moved from the stack to anywhere other than the battlefield, the resulting creature leaves the battlefield, or the game ends, the face-down card is revealed. If its mana cost couldn't be paid by some amount of, or all of, the mana you spent on {X}, all applicable penalties for casting a card illegally are assessed."
         },
         {
           "date": "2009-10-01",
@@ -8289,19 +8294,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect that turns it face-up is a replacement effect. It doesn’t use the stack and can’t be responded to."
+          "text": "The effect that turns it face-up is a replacement effect. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2009-10-01",
-          "text": "You may not turn a face-down spell face up. You may not turn a face-down permanent face up unless it would have morph while face up or an effect specifically allows you to turn it face up. Illusionary Mask’s ability has you turn a face-down creature face up if it would assign damage, deal damage, be dealt damage, or become tapped, but not for any other reason. For example, if you use Illusionary Mask’s ability to cast a black creature face down, you can’t turn it face up just because it’s being targeted by Terror."
+          "text": "You may not turn a face-down spell face up. You may not turn a face-down permanent face up unless it would have morph while face up or an effect specifically allows you to turn it face up. Illusionary Mask's ability has you turn a face-down creature face up if it would assign damage, deal damage, be dealt damage, or become tapped, but not for any other reason. For example, if you use Illusionary Mask's ability to cast a black creature face down, you can't turn it face up just because it's being targeted by Terror."
         },
         {
           "date": "2009-10-01",
-          "text": "Both the amount and types of mana you spend on {X} are taken into account while you’re choosing a creature card from your hand. For example, if you spent {U}{U} on {X}, you can choose a creature card with mana cost {U}{U}, {1}{U}, {2}, or {W/U}{W/U}, among other possibilities, but not one that costs {2}{U} or one that costs {G}."
+          "text": "Both the amount and types of mana you spend on {X} are taken into account while you're choosing a creature card from your hand. For example, if you spent {U}{U} on {X}, you can choose a creature card with mana cost {U}{U}, {1}{U}, {2}, or {W/U}{W/U}, among other possibilities, but not one that costs {2}{U} or one that costs {G}."
         },
         {
           "date": "2009-10-01",
-          "text": "While the creature card is face down, it’s a 2/2 creature with no name, mana cost, color, creature type, abilities, or expansion symbol. Since it has no mana cost, its converted mana cost is 0."
+          "text": "While the creature card is face down, it's a 2/2 creature with no name, mana cost, color, creature type, abilities, or expansion symbol. Since it has no mana cost, its converted mana cost is 0."
         },
         {
           "date": "2009-10-01",
@@ -8309,11 +8314,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You can turn a face-down permanent face up if it would have morph while face up. This applies to creatures you cast face down as a result of Illusionary Mask’s effect. The rest of Illusionary Mask’s effect applies to it as well."
+          "text": "You can turn a face-down permanent face up if it would have morph while face up. This applies to creatures you cast face down as a result of Illusionary Mask's effect. The rest of Illusionary Mask's effect applies to it as well."
         },
         {
           "date": "2009-10-01",
-          "text": "Illusionary Mask’s ability will continue to apply to creatures cast face down with it, even if Illusionary Mask has left the battlefield."
+          "text": "Illusionary Mask's ability will continue to apply to creatures cast face down with it, even if Illusionary Mask has left the battlefield."
         }
       ],
       "text": "{X}: You may choose a creature card in your hand whose mana cost could be paid by some amount of, or all of, the mana you spent on {X}. If you do, you may cast that card face down as a 2/2 creature spell without paying its mana cost. If the creature that spell becomes as it resolves has not been turned face up and would assign or deal damage, be dealt damage, or become tapped, instead it's turned face up and assigns or deals damage, is dealt damage, or becomes tapped. Activate this ability only any time you could cast a sorcery.",
@@ -8369,15 +8374,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If attached to an opponent’s creature, you can untap their creature during your turn."
+          "text": "If attached to an opponent's creature, you can untap their creature during your turn."
         },
         {
           "date": "2004-10-04",
-          "text": "Instill Energy’s untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
+          "text": "Instill Energy's untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
         },
         {
           "date": "2005-08-01",
-          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card’s ability to untap once during the turn."
+          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card's ability to untap once during the turn."
         }
       ],
       "subtypes": [
@@ -9406,7 +9411,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Since the draw is replaced, you can’t use the same draw to do other things."
+          "text": "Since the draw is replaced, you can't use the same draw to do other things."
         }
       ],
       "text": "If you would draw a card during your draw step, instead you may skip that draw. If you do, until your next turn, you can't be attacked except by creatures with flying and/or islandwalk.",
@@ -9557,19 +9562,19 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A delayed triggered ability that refers to Jade Statue still affects it even if it’s no longer a creature. For example, if Jade Statue blocks the Kashi-Tribe Warriors (“Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn’t untap during its controller’s next untap step.”), the Warriors’ effect stops Jade Statue from untapping."
+          "text": "A delayed triggered ability that refers to Jade Statue still affects it even if it's no longer a creature. For example, if Jade Statue blocks the Kashi-Tribe Warriors (\"Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.\"), the Warriors' effect stops Jade Statue from untapping."
         },
         {
           "date": "2005-08-01",
-          "text": "If Jade Statue’s ability has been activated, abilities that trigger “at end of combat” will see Jade Statue as an artifact creature."
+          "text": "If Jade Statue's ability has been activated, abilities that trigger \"at end of combat\" will see Jade Statue as an artifact creature."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-09-20",
-          "text": "If Jade Statue is animated by some other effect, you get an artifact creature with whatever power, toughness, and creature types (if any) are specified by that effect. If you subsequently use Jade Statue’s ability during combat, it will become 3/6 and gain the creature type Golem in addition to those creature types until end of combat."
+          "text": "If Jade Statue is animated by some other effect, you get an artifact creature with whatever power, toughness, and creature types (if any) are specified by that effect. If you subsequently use Jade Statue's ability during combat, it will become 3/6 and gain the creature type Golem in addition to those creature types until end of combat."
         }
       ],
       "text": "{2}: Jade Statue becomes a 3/6 Golem artifact creature until end of combat. Activate this ability only during combat.",
@@ -9690,11 +9695,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -9758,7 +9763,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         }
       ],
       "text": "Target creature gains flying until end of turn.",
@@ -9875,7 +9880,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never “locked in”."
+          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never \"locked in\"."
         }
       ],
       "subtypes": [
@@ -9937,7 +9942,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Swamps are 1/1 black creatures that are still lands.",
@@ -9992,7 +9997,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can move it to any other player’s land whenever you get to move it."
+          "text": "You can move it to any other player's land whenever you get to move it."
         },
         {
           "date": "2005-08-01",
@@ -10004,7 +10009,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Because the ability isn’t targeted, the controller of the destroyed land may attach it to a land that can’t be the target of abilities."
+          "text": "Because the ability isn't targeted, the controller of the destroyed land may attach it to a land that can't be the target of abilities."
         }
       ],
       "subtypes": [
@@ -10119,7 +10124,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can’t be used at times that only mana abilities can be used."
+          "text": "The land is untapped as a normal ability that goes on the stack. It is not a mana ability, so it can't be used at times that only mana abilities can be used."
         }
       ],
       "subtypes": [
@@ -10174,11 +10179,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not “discarded”."
+          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not \"discarded\"."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren’t effects."
+          "text": "You can't use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren't effects."
         },
         {
           "date": "2004-10-04",
@@ -10206,7 +10211,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\nIf an effect causes you to discard a card, discard it, but you may put it on top of your library instead of into your graveyard.",
@@ -10268,15 +10273,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life, just like any player at less than one life can’t pay life. You can pay zero life if you want."
+          "text": "You can't pay life, just like any player at less than one life can't pay life. You can pay zero life if you want."
         },
         {
           "date": "2004-10-04",
-          "text": "If an opponent steals control of Lich and no other effect prevents you from losing with a life total of zero, you will lose the game due to a zero life total as a State-Based Action before you can take any actions. The last sentence doesn’t apply in this case since the Lich didn’t leave the battlefield."
+          "text": "If an opponent steals control of Lich and no other effect prevents you from losing with a life total of zero, you will lose the game due to a zero life total as a State-Based Action before you can take any actions. The last sentence doesn't apply in this case since the Lich didn't leave the battlefield."
         },
         {
           "date": "2004-10-04",
-          "text": "If an opponent steals control of Lich, their life total does not change. The life total changes for a player only when it enters the battlefield under that player’s control."
+          "text": "If an opponent steals control of Lich, their life total does not change. The life total changes for a player only when it enters the battlefield under that player's control."
         },
         {
           "date": "2004-10-04",
@@ -10284,7 +10289,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich leaves the battlefield or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can’t lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
+          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich leaves the battlefield or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can't lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
         },
         {
           "date": "2010-08-15",
@@ -10292,7 +10297,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich is put into the graveyard or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can’t lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
+          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich is put into the graveyard or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can't lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
         }
       ],
       "text": "As Lich enters the battlefield, you lose life equal to your life total.\nYou don't lose the game for having 0 or less life.\nIf you would gain life, draw that many cards instead.\nWhenever you're dealt damage, sacrifice that many nontoken permanents. If you can't, you lose the game.\nWhen Lich is put into a graveyard from the battlefield, you lose the game.",
@@ -10566,7 +10571,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can cast it targeting your opponent’s artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
+          "text": "You can cast it targeting your opponent's artifacts. The controller of the Aura (not the controller of the artifact) controls the Living Artifact ability."
         },
         {
           "date": "2004-10-04",
@@ -10630,7 +10635,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Forests are 1/1 creatures that are still lands.",
@@ -11052,7 +11057,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -11064,7 +11069,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
@@ -11076,7 +11081,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target spell or permanent by replacing all instances of one basic land type with another. (For example, you may change \"swampwalk\" to \"plainswalk.\" This effect lasts indefinitely.)",
@@ -11199,7 +11204,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare’s ability."
+          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare's ability."
         },
         {
           "date": "2004-10-04",
@@ -11207,7 +11212,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can’t give a mana of a color that wasn’t produced."
+          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can't give a mana of a color that wasn't produced."
         },
         {
           "date": "2004-10-04",
@@ -11223,7 +11228,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Does not copy any restrictions on the mana, such as with Mishra’s Workshop or Pillar of the Paruns."
+          "text": "Does not copy any restrictions on the mana, such as with Mishra's Workshop or Pillar of the Paruns."
         },
         {
           "date": "2007-09-16",
@@ -11412,7 +11417,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -11587,7 +11592,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -12810,7 +12815,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can’t be countered with something that counters spells."
+          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can't be countered with something that counters spells."
         },
         {
           "date": "2004-10-04",
@@ -12818,7 +12823,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "A card is “above” another card in your graveyard if it was put into that graveyard later."
+          "text": "A card is \"above\" another card in your graveyard if it was put into that graveyard later."
         },
         {
           "date": "2008-10-01",
@@ -12830,11 +12835,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -12896,11 +12901,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can use this effect on a creature you know won’t be able to attack. For example, you can use it on a tapped creature."
+          "text": "You can use this effect on a creature you know won't be able to attack. For example, you can use it on a tapped creature."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2013-09-20",
@@ -12965,7 +12970,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -13041,19 +13046,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -13386,7 +13391,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' ‘Well, now that we have seen each other,' said the Unicorn, ‘if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
+      "flavor": "\"'Do you know, I always thought Unicorns were fabulous monsters, too? I never saw one alive before!' 'Well, now that we have seen each other,' said the Unicorn, 'if you'll believe in me, I'll believe in you.'\" —Lewis Carroll",
       "id": "5c659095808367756d35a25414872077aedc15ca",
       "imageName": "pearled unicorn",
       "layout": "normal",
@@ -13484,7 +13489,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent’s Incarnation you can let it die to make them lose life."
+          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent's Incarnation you can let it die to make them lose life."
         },
         {
           "date": "2007-02-01",
@@ -13559,7 +13564,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -14671,7 +14676,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -14810,7 +14815,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -15239,7 +15244,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -15644,7 +15649,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -15767,7 +15772,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If damage that would be dealt to Rock Hydra can’t be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
+          "text": "If damage that would be dealt to Rock Hydra can't be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
         }
       ],
       "subtypes": [
@@ -15895,11 +15900,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -16089,7 +16094,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -16334,7 +16339,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -16591,15 +16596,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -16968,7 +16973,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t use Simulacrum on Loss of Life, just damage."
+          "text": "You can't use Simulacrum on Loss of Life, just damage."
         },
         {
           "date": "2004-10-04",
@@ -16976,7 +16981,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage’s source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
+          "text": "Simulacrum is the source of the damage. If an effect needs to know a characteristic of the damage's source (Protection from Black, for instance), it will see the damage coming from Simulacrum."
         }
       ],
       "text": "You gain life equal to the damage dealt to you this turn. Simulacrum deals damage to target creature you control equal to the damage dealt to you this turn.",
@@ -17079,15 +17084,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It will require creatures with Haste to attack since they are able, but it won’t destroy them if they don’t for some reason."
+          "text": "It will require creatures with Haste to attack since they are able, but it won't destroy them if they don't for some reason."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature is destroyed if it does not attack because it simply can’t do so legally."
+          "text": "The creature is destroyed if it does not attack because it simply can't do so legally."
         },
         {
           "date": "2009-02-01",
-          "text": "This will destroy creatures that weren’t able to attack because they had been previously tapped."
+          "text": "This will destroy creatures that weren't able to attack because they had been previously tapped."
         },
         {
           "date": "2013-09-20",
@@ -17151,7 +17156,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t Sleight proper nouns (i.e. card names). This means that you can’t affect a “Black Vise”."
+          "text": "You can't Sleight proper nouns (i.e. card names). This means that you can't affect a \"Black Vise\"."
         },
         {
           "date": "2004-10-04",
@@ -17159,7 +17164,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Can’t change a color word to the same color word. It must be a different word."
+          "text": "Can't change a color word to the same color word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -17171,7 +17176,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -17414,11 +17419,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -17474,7 +17479,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since there is no untap step, Phasing in/out won’t happen."
+          "text": "Since there is no untap step, Phasing in/out won't happen."
         },
         {
           "date": "2004-10-04",
@@ -17606,19 +17611,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the Giant’s power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
+          "text": "If the Giant's power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
         },
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stone Giant’s ability is activated during a turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. The targeted creature will be destroyed at that time."
+          "text": "If Stone Giant's ability is activated during a turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. The targeted creature will be destroyed at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it’s no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant’s power at that time."
+          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it's no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant's power at that time."
         }
       ],
       "subtypes": [
@@ -18647,7 +18652,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -18704,7 +18709,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18886,7 +18891,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Protection from Green does not stop the Basilisk’s ability because the ability is not targeted."
+          "text": "Protection from Green does not stop the Basilisk's ability because the ability is not targeted."
         },
         {
           "date": "2004-10-04",
@@ -19048,7 +19053,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -19113,7 +19118,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         },
         {
           "date": "2008-10-01",
@@ -19175,7 +19180,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one.",
@@ -19229,7 +19234,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. (Then put Timetwister into its owner's graveyard.)",
@@ -19354,7 +19359,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -19465,7 +19470,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -19694,7 +19699,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -19786,6 +19791,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -20043,23 +20052,23 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
+          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
         },
         {
           "date": "2007-09-16",
-          "text": "When Vesuvan Doppelganger’s triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
+          "text": "When Vesuvan Doppelganger's triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger copies the mana cost of the creature it’s copying but doesn’t copy its color."
+          "text": "Vesuvan Doppelganger copies the mana cost of the creature it's copying but doesn't copy its color."
         },
         {
           "date": "2007-09-16",
-          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger’s color, and will gain Vesuvan Doppelganger’s triggered ability."
+          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger's color, and will gain Vesuvan Doppelganger's triggered ability."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger’s triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller’s upkeep. They’ll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger’s characteristics for the rest of the turn."
+          "text": "Vesuvan Doppelganger's triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller's upkeep. They'll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger's characteristics for the rest of the turn."
         },
         {
           "date": "2007-09-16",
@@ -20067,7 +20076,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Although Vesuvan Doppelganger’s triggered ability is targeted, its “as enters the battlefield” ability is not."
+          "text": "Although Vesuvan Doppelganger's triggered ability is targeted, its \"as enters the battlefield\" ability is not."
         }
       ],
       "subtypes": [
@@ -20128,7 +20137,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can’t be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
+          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can't be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
         },
         {
           "date": "2004-10-04",
@@ -20250,7 +20259,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -20272,7 +20281,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"This ‘standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
+      "flavor": "\"This 'standing windstorm' can hold us off indefinitely? Ridiculous!\" Saying nothing, she put a pinch of salt on the table. With a bang she clapped her hands, and the salt disappeared, blown away.",
       "id": "69a0597db7e4ced17662ef87aae1008debce288c",
       "imageName": "wall of air",
       "layout": "normal",
@@ -20401,7 +20410,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"What else, when chaos draws all forces inward to shape a single leaf.\"\n —Conrad Aiken",
+      "flavor": "\"What else, when chaos draws all forces inward to shape a single leaf.\"\n—Conrad Aiken",
       "id": "fea92cc9701626198a29e4054993095586d411b9",
       "imageName": "wall of brambles",
       "layout": "normal",
@@ -21480,11 +21489,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All permanents untap during a player’s untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
+          "text": "All permanents untap during a player's untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
+          "text": "You can't tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
         }
       ],
       "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",
@@ -21588,7 +21597,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2009-10-01",
@@ -21596,15 +21605,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Word of Command can’t be used to force a player to play a card that isn’t in his or her hand."
+          "text": "Word of Command can't be used to force a player to play a card that isn't in his or her hand."
         },
         {
           "date": "2011-01-01",
-          "text": "You control the player while this spell is resolving, which means you get to see anything he or she can see. If that player is required to search his or her library as part of playing the card or as part of its resolution if it’s cast as a spell, then you can see the cards in that player’s library as well."
+          "text": "You control the player while this spell is resolving, which means you get to see anything he or she can see. If that player is required to search his or her library as part of playing the card or as part of its resolution if it's cast as a spell, then you can see the cards in that player's library as well."
         },
         {
           "date": "2011-01-01",
-          "text": "Your opponent can’t counter the Word of Command after letting you look at his or her hand, but they can attempt to counter the spell you force them to cast."
+          "text": "Your opponent can't counter the Word of Command after letting you look at his or her hand, but they can attempt to counter the spell you force them to cast."
         },
         {
           "date": "2011-01-01",
@@ -21620,7 +21629,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Since this spell is an instant, your opponent gets a chance to respond to it as normal. Once this spell resolves, you look at your opponent’s hand and choose a card. Note that it is common practice to respond to Word of Command by using up any spells or mana you have prior to letting it resolve."
+          "text": "Since this spell is an instant, your opponent gets a chance to respond to it as normal. Once this spell resolves, you look at your opponent's hand and choose a card. Note that it is common practice to respond to Word of Command by using up any spells or mana you have prior to letting it resolve."
         },
         {
           "date": "2011-01-01",
@@ -21628,11 +21637,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "text": "Look at target opponent's hand and choose a card from it. You control that player until Word of Command finishes resolving. The player plays that card if able. While doing so, the player can activate mana abilities only if they're from lands he or she controls and only if mana they produce is spent to activate other mana abilities of lands he or she controls and/or play that card. If the chosen card is cast as a spell, you control the player while that spell is resolving.",

--- a/json/LEG.json
+++ b/json/LEG.json
@@ -218,7 +218,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -309,7 +309,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "There is a typographical error in the title of the card so that the “Ae” does not appear."
+          "text": "There is a typographical error in the title of the card so that the \"Ae\" does not appear."
         }
       ],
       "subtypes": [
@@ -607,27 +607,27 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since you can respond to triggered abilities, it is legal to sacrifice creatures using some spell or ability prior to resolving the ability that removes the final counter from All Hallow’s Eve."
+          "text": "Since you can respond to triggered abilities, it is legal to sacrifice creatures using some spell or ability prior to resolving the ability that removes the final counter from All Hallow's Eve."
         },
         {
           "date": "2007-02-01",
-          "text": "This card is once again a sorcery, and its ability looks very much like suspend (although it doesn’t have the suspend ability."
+          "text": "This card is once again a sorcery, and its ability looks very much like suspend (although it doesn't have the suspend ability."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "The only thing that happens when All Hallow’s Eve resolves is that it’s exiled with two scream counters on it."
+          "text": "The only thing that happens when All Hallow's Eve resolves is that it's exiled with two scream counters on it."
         },
         {
           "date": "2009-10-01",
-          "text": "All Hallow’s Eve’s triggered ability functions from the exile zone. This ability has an “intervening ‘if’ clause.” It won’t trigger at all unless All Hallow’s Eve is exiled and has a scream counter on it (which can happen only if it resolves as a spell)."
+          "text": "All Hallow's Eve's triggered ability functions from the exile zone. This ability has an \"intervening 'if' clause.\" It won't trigger at all unless All Hallow's Eve is exiled and has a scream counter on it (which can happen only if it resolves as a spell)."
         },
         {
           "date": "2009-10-01",
-          "text": "Each creature returned to the battlefield by All Hallow’s Eve enters the battlefield under its owner’s control."
+          "text": "Each creature returned to the battlefield by All Hallow's Eve enters the battlefield under its owner's control."
         }
       ],
       "text": "Exile All Hallow's Eve with two scream counters on it.\nAt the beginning of your upkeep, if All Hallow's Eve is exiled with a scream counter on it, remove a scream counter from it. If there are no more scream counters on it, put it into your graveyard and each player returns all creature cards from his or her graveyard to the battlefield.",
@@ -679,7 +679,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A creature with power 3 or greater can’t be declared as a blocker for Amrou Kithkin. If the power of a creature that’s already blocking Amrou Kithkin is increased to 3 or greater, it will continue to block Amrou Kithkin."
+          "text": "A creature with power 3 or greater can't be declared as a blocker for Amrou Kithkin. If the power of a creature that's already blocking Amrou Kithkin is increased to 3 or greater, it will continue to block Amrou Kithkin."
         }
       ],
       "subtypes": [
@@ -890,19 +890,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
-          "text": "Arboria doesn’t stop creatures from attacking planeswalkers, regardless of what their controllers did or didn’t do during their last turns."
+          "text": "Arboria doesn't stop creatures from attacking planeswalkers, regardless of what their controllers did or didn't do during their last turns."
         },
         {
           "date": "2009-10-01",
-          "text": "Arboria’s effect cares whether a player put a nontoken permanent onto the battlefield. It’s unusual for an ability to care who did the putting (as opposed to whose control the permanent entered the battlefield under), and requires careful reading of spells and abilities to see which player is instructed to put something onto the battlefield. For example, Exhume causes each player to return a creature card from his or her graveyard to the battlefield. If Exhume’s controller has no creature cards in his or her graveyard, but another player does, only that other player puts a permanent onto the battlefield. It doesn’t matter who controls the effect."
+          "text": "Arboria's effect cares whether a player put a nontoken permanent onto the battlefield. It's unusual for an ability to care who did the putting (as opposed to whose control the permanent entered the battlefield under), and requires careful reading of spells and abilities to see which player is instructed to put something onto the battlefield. For example, Exhume causes each player to return a creature card from his or her graveyard to the battlefield. If Exhume's controller has no creature cards in his or her graveyard, but another player does, only that other player puts a permanent onto the battlefield. It doesn't matter who controls the effect."
         },
         {
           "date": "2009-10-01",
-          "text": "Arboria’s effect cares about the actions taken by players, not their results. If a player cast a spell during his or her last turn but that spell was countered, that player may still be attacked. The same is true if a player put a nontoken permanent onto the battlefield during his or her last turn, even if it’s no longer on the battlefield by the time that player is attacked."
+          "text": "Arboria's effect cares about the actions taken by players, not their results. If a player cast a spell during his or her last turn but that spell was countered, that player may still be attacked. The same is true if a player put a nontoken permanent onto the battlefield during his or her last turn, even if it's no longer on the battlefield by the time that player is attacked."
         }
       ],
       "supertypes": [
@@ -960,7 +960,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As long as Arcades Sabboth is untapped and isn’t attacking, it’ll get +0/+2 from its own third ability."
+          "text": "As long as Arcades Sabboth is untapped and isn't attacking, it'll get +0/+2 from its own third ability."
         }
       ],
       "subtypes": [
@@ -1063,7 +1063,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Avoid Fate must target an instant spell or an Aura spell as it’s cast, and it must be targeting an instant or an Aura spell at the time it resolves. It will still resolve if it starts out targeting a spell of one type but the target changes to a spell of the other type (thanks to Shunt, for instance) before it resolves."
+          "text": "Avoid Fate must target an instant spell or an Aura spell as it's cast, and it must be targeting an instant or an Aura spell at the time it resolves. It will still resolve if it starts out targeting a spell of one type but the target changes to a spell of the other type (thanks to Shunt, for instance) before it resolves."
         }
       ],
       "text": "Counter target instant or Aura spell that targets a permanent you control.",
@@ -1116,15 +1116,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Each time a creature is put into a graveyard from play, check whether Axelrod Gunnarson had dealt any damage to it at any time during that turn. (This includes combat damage.) If so, Axelrod Gunnarson’s second ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from play, check whether Axelrod Gunnarson had dealt any damage to it at any time during that turn. (This includes combat damage.) If so, Axelrod Gunnarson's second ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2009-10-01",
-          "text": "If Axelrod Gunnarson and a creature it dealt damage to are both put into a graveyard at the same time, Axelrod Gunnarson’s second ability will trigger."
+          "text": "If Axelrod Gunnarson and a creature it dealt damage to are both put into a graveyard at the same time, Axelrod Gunnarson's second ability will trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "The player you target with Axelrod Gunnarson’s ability doesn’t have to be the player that controlled the creature that was put into a graveyard."
+          "text": "The player you target with Axelrod Gunnarson's ability doesn't have to be the player that controlled the creature that was put into a graveyard."
         }
       ],
       "subtypes": [
@@ -1183,7 +1183,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1199,7 +1199,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -1511,7 +1511,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This card can be enchanted by moving Auras onto it. The “can’t be the target” text is different from “can’t be enchanted” in that it only applies to Aura spells when they are being cast."
+          "text": "This card can be enchanted by moving Auras onto it. The \"can't be the target\" text is different from \"can't be enchanted\" in that it only applies to Aura spells when they are being cast."
         }
       ],
       "subtypes": [
@@ -2039,7 +2039,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"‘War is no picnic,' my father liked to say. But the Ants seemed to disagree.\" —General Chanek Valteroth",
+      "flavor": "\"'War is no picnic,' my father liked to say. But the Ants seemed to disagree.\" —General Chanek Valteroth",
       "id": "a8e11b8897a19ec642a9b27f0d754f79df2c8b3a",
       "imageName": "carrion ants",
       "layout": "normal",
@@ -2207,7 +2207,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -2275,7 +2275,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who’s copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
+          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who's copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
         },
         {
           "date": "2016-06-08",
@@ -2283,11 +2283,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The copy of Chain Lightning is created on the stack, so it’s not cast. Abilities that trigger when a player casts a spell won’t trigger. Players may respond to that spell before it resolves."
+          "text": "The copy of Chain Lightning is created on the stack, so it's not cast. Abilities that trigger when a player casts a spell won't trigger. Players may respond to that spell before it resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can’t be copied."
+          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can't be copied."
         }
       ],
       "text": "Chain Lightning deals 3 damage to target creature or player. Then that player or that creature's controller may pay {R}{R}. If the player does, he or she may copy this spell and may choose a new target for that copy.",
@@ -2337,7 +2337,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The effect is cumulative. If there are two of these on the battlefield, each of them will modify each draw (after the first one if during the draw step), and will cause the player to discard or to “mill” a card from their library. As they resolve in order, the player must discard if possible. Once the player fails to discard and instead “mills” a card, all further effects of additional Chains of Mephistopheles will not do anything. This is because the “mill” also replaces the draw effect and the player is no longer drawing a card. You handle them in order. Each one makes you discard first and then continue or else mill a card and lose the draw."
+          "text": "The effect is cumulative. If there are two of these on the battlefield, each of them will modify each draw (after the first one if during the draw step), and will cause the player to discard or to \"mill\" a card from their library. As they resolve in order, the player must discard if possible. Once the player fails to discard and instead \"mills\" a card, all further effects of additional Chains of Mephistopheles will not do anything. This is because the \"mill\" also replaces the draw effect and the player is no longer drawing a card. You handle them in order. Each one makes you discard first and then continue or else mill a card and lose the draw."
         },
         {
           "date": "2004-10-04",
@@ -2345,15 +2345,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If a spell or ability would cause a player to draw multiple cards, this is treated as a number of individual “draw one card” actions. Apply the effect of Chains of Mephistopheles to each one."
+          "text": "If a spell or ability would cause a player to draw multiple cards, this is treated as a number of individual \"draw one card\" actions. Apply the effect of Chains of Mephistopheles to each one."
         },
         {
           "date": "2007-09-16",
-          "text": "A player’s normal card draw on his or her turn is exempt from this effect. All other draws will be affected."
+          "text": "A player's normal card draw on his or her turn is exempt from this effect. All other draws will be affected."
         },
         {
           "date": "2007-09-16",
-          "text": "Here’s what happens when Chains of Mephistopheles replaces a player’s draw: — If that player has at least one card in his or her hand, he or she discards a card and then draws a card. — If that player’s hand is empty, he or she puts the top card of his or her library into his or her graveyard. The player doesn’t draw a card at all."
+          "text": "Here's what happens when Chains of Mephistopheles replaces a player's draw: — If that player has at least one card in his or her hand, he or she discards a card and then draws a card. — If that player's hand is empty, he or she puts the top card of his or her library into his or her graveyard. The player doesn't draw a card at all."
         }
       ],
       "text": "If a player would draw a card except the first one he or she draws in his or her draw step each turn, that player discards a card instead. If the player discards a card this way, he or she draws a card. If the player doesn't discard a card this way, he or she puts the top card of his or her library into his or her graveyard.",
@@ -2613,7 +2613,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
@@ -2672,7 +2672,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you choose not to pay Cosmic Horror’s upkeep cost, it deals 7 damage to you only if it’s actually destroyed. If it regenerates or an effect has given it indestructible, it deals no damage."
+          "text": "If you choose not to pay Cosmic Horror's upkeep cost, it deals 7 damage to you only if it's actually destroyed. If it regenerates or an effect has given it indestructible, it deals no damage."
         }
       ],
       "subtypes": [
@@ -2828,7 +2828,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -2933,7 +2933,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -3361,11 +3361,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you cast Disharmony during an opponent’s turn, you may then block with the creature you gain control of (assuming there’s an attacking creature it can block)."
+          "text": "If you cast Disharmony during an opponent's turn, you may then block with the creature you gain control of (assuming there's an attacking creature it can block)."
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Disharmony only during combat before blockers are declared.\nUntap target attacking creature and remove it from combat. Gain control of that creature until end of turn.",
@@ -3415,15 +3415,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "When Divine Intervention’s third ability resolves, the game ends immediately. The game is a draw, meaning neither player wins and neither player loses."
+          "text": "When Divine Intervention's third ability resolves, the game ends immediately. The game is a draw, meaning neither player wins and neither player loses."
         },
         {
           "date": "2009-10-01",
-          "text": "Divine Intervention’s third ability triggers only if its controller removes the last intervention counter from it. It doesn’t matter how that happens. For example, if you control Divine Intervention and the last intervention counter is removed as a result of a Clockspinning you control, the ability will trigger. On the other hand, if the last intervention counter is removed as a result of a Clockspinning another player controls, the ability won’t trigger (and won’t ever be able to)."
+          "text": "Divine Intervention's third ability triggers only if its controller removes the last intervention counter from it. It doesn't matter how that happens. For example, if you control Divine Intervention and the last intervention counter is removed as a result of a Clockspinning you control, the ability will trigger. On the other hand, if the last intervention counter is removed as a result of a Clockspinning another player controls, the ability won't trigger (and won't ever be able to)."
         },
         {
           "date": "2009-10-01",
-          "text": "In a multiplayer game played with the limited range of influence option, Divine Intervention won’t necessarily end the entire game when its third ability resolves. All players within range of Divine Intervention will leave the game. They’ll neither win nor lose; as far as they’re concerned, the result of the game is a draw. All other players will continue playing."
+          "text": "In a multiplayer game played with the limited range of influence option, Divine Intervention won't necessarily end the entire game when its third ability resolves. All players within range of Divine Intervention will leave the game. They'll neither win nor lose; as far as they're concerned, the result of the game is a draw. All other players will continue playing."
         }
       ],
       "text": "Divine Intervention enters the battlefield with two intervention counters on it.\nAt the beginning of your upkeep, remove an intervention counter from Divine Intervention.\nWhen you remove the last intervention counter from Divine Intervention, the game is a draw.",
@@ -3493,7 +3493,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you’ll still gain the life."
+          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you'll still gain the life."
         }
       ],
       "text": "Destroy target artifact. You gain life equal to its converted mana cost.",
@@ -3870,7 +3870,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -4024,7 +4024,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "If you change this card’s target, you can change which Aura is targeted, but you can’t choose where that Aura will be moved."
+          "text": "If you change this card's target, you can change which Aura is targeted, but you can't choose where that Aura will be moved."
         },
         {
           "date": "2005-08-01",
@@ -4135,7 +4135,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Equinox will not counter a spell that deals damage to an animated land, even if it would deal more damage than the land’s toughness. This is because the spell itself does not destroy the land directly. The land is destroyed by a game rule."
+          "text": "Equinox will not counter a spell that deals damage to an animated land, even if it would deal more damage than the land's toughness. This is because the spell itself does not destroy the land directly. The land is destroyed by a game rule."
         },
         {
           "date": "2008-10-01",
@@ -4245,11 +4245,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The cards are put onto the battlefield and will not trigger effects which trigger on such cards being “cast” or “played”."
+          "text": "The cards are put onto the battlefield and will not trigger effects which trigger on such cards being \"cast\" or \"played\"."
         },
         {
           "date": "2004-10-04",
-          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn’t end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
+          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn't end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
         },
         {
           "date": "2004-10-04",
@@ -4261,7 +4261,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "A “permanent card” is a card that would be a permanent once it’s on the battlefield. Specifically, it’s an artifact, creature, enchantment, land, or planeswalker card."
+          "text": "A \"permanent card\" is a card that would be a permanent once it's on the battlefield. Specifically, it's an artifact, creature, enchantment, land, or planeswalker card."
         }
       ],
       "text": "Starting with you, each player may put a permanent card from his or her hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.",
@@ -4532,15 +4532,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -4652,11 +4652,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The “rebirth” is a replacement effect."
+          "text": "The \"rebirth\" is a replacement effect."
         },
         {
           "date": "2009-10-01",
-          "text": "The Firestorm Phoenix you return to your hand is tracked by its ability. As long as it remains in your hand, that particular card can’t be played before your next turn begins, but a different Firestorm Phoenix in your hand can."
+          "text": "The Firestorm Phoenix you return to your hand is tracked by its ability. As long as it remains in your hand, that particular card can't be played before your next turn begins, but a different Firestorm Phoenix in your hand can."
         }
       ],
       "subtypes": [
@@ -4678,7 +4678,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"She grinned at me—a wicked grin. ‘I hope you weren't relying too heavily on that, my dear.'\" —Medryn Silverwand, Diary",
+      "flavor": "\"She grinned at me—a wicked grin. 'I hope you weren't relying too heavily on that, my dear.'\" —Medryn Silverwand, Diary",
       "id": "5201430c015bb714737357bed01bb7a3e74ec742",
       "imageName": "flash counter",
       "layout": "normal",
@@ -4802,7 +4802,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -5162,11 +5162,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As you activate the ability, the targets you choose must be two artifacts, two creatures, or two lands. As the ability resolves, both targets will be legal only if they are two artifacts, two creatures, or two lands at that time as well, though they may be a different type than they were at the time the ability was activated. For example, if the targets were a creature and an artifact creature when the ability was activated, but the first target became a noncreature artifact by the time the ability resolves, both targets will still be legal (since they’re both artifacts)."
+          "text": "As you activate the ability, the targets you choose must be two artifacts, two creatures, or two lands. As the ability resolves, both targets will be legal only if they are two artifacts, two creatures, or two lands at that time as well, though they may be a different type than they were at the time the ability was activated. For example, if the targets were a creature and an artifact creature when the ability was activated, but the first target became a noncreature artifact by the time the ability resolves, both targets will still be legal (since they're both artifacts)."
         },
         {
           "date": "2009-10-01",
-          "text": "If one of the targets is illegal by the time the ability resolves (because the wrong player controls it, or it’s the wrong card type, or for any other reason), the exchange doesn’t happen. The target that’s still legal will remain under its controller’s control. Since the exchange doesn’t happen, no Auras are destroyed. (If both targets are illegal, the ability is countered.)"
+          "text": "If one of the targets is illegal by the time the ability resolves (because the wrong player controls it, or it's the wrong card type, or for any other reason), the exchange doesn't happen. The target that's still legal will remain under its controller's control. Since the exchange doesn't happen, no Auras are destroyed. (If both targets are illegal, the ability is countered.)"
         }
       ],
       "text": "{5}, Sacrifice Gauntlets of Chaos: Exchange control of target artifact, creature, or land you control and target permanent an opponent controls that shares one of those types with it. If those permanents are exchanged this way, destroy all Auras attached to them.",
@@ -5265,7 +5265,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the Slug changes controllers after the mana is spent, the player who activates this ability selects a landwalk during their next upkeep even if they don’t control it at the time."
+          "text": "If the Slug changes controllers after the mana is spent, the player who activates this ability selects a landwalk during their next upkeep even if they don't control it at the time."
         },
         {
           "date": "2004-10-04",
@@ -5378,7 +5378,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It only cares if it attacked on _your_ last turn, and not your opponent’s. This makes a difference if you take control of the Turtle during your opponent’s turn after it attacks. You can use it on your turn because it began your turn on the battlefield and because you did not attack with it last turn."
+          "text": "It only cares if it attacked on _your_ last turn, and not your opponent's. This makes a difference if you take control of the Turtle during your opponent's turn after it attacks. You can use it on your turn because it began your turn on the battlefield and because you did not attack with it last turn."
         }
       ],
       "subtypes": [
@@ -5564,7 +5564,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can cast this targeting your opponent’s walls to good effect."
+          "text": "You can cast this targeting your opponent's walls to good effect."
         },
         {
           "date": "2004-10-04",
@@ -5616,15 +5616,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "First place all the affected creatures in the graveyard, then choose the appropriate number of creatures from the attacker’s graveyard and put them onto the battlefield. Some or all of them may be the same creatures which were just destroyed."
+          "text": "First place all the affected creatures in the graveyard, then choose the appropriate number of creatures from the attacker's graveyard and put them onto the battlefield. Some or all of them may be the same creatures which were just destroyed."
         },
         {
           "date": "2004-10-04",
-          "text": "Yes, you can cast this targeting your opponent’s Walls to good effect."
+          "text": "Yes, you can cast this targeting your opponent's Walls to good effect."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Cast Glyph of Reincarnation only after combat.\nDestroy all creatures that were blocked by target Wall this turn. They can't be regenerated. For each creature that died this way, put a creature card from the graveyard of the player who controlled that creature the last time it became blocked by that Wall onto the battlefield under its owner's control.",
@@ -5732,7 +5732,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -6070,11 +6070,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         },
         {
           "date": "2009-10-01",
-          "text": "Note that the duration of Halfdane’s ability is until the end of your next upkeep. If Halfdane’s ability doesn’t get a chance to resolve (because there are no legal targets when it triggers, or because it’s countered), then the effect from the previous turn’s ability will continue to work through the rest of that upkeep step. Then that effect will wear off, and Halfdane will revert to being 3/3, its printed power and toughness (unless some other effect is modifying what its power and toughness is)."
+          "text": "Note that the duration of Halfdane's ability is until the end of your next upkeep. If Halfdane's ability doesn't get a chance to resolve (because there are no legal targets when it triggers, or because it's countered), then the effect from the previous turn's ability will continue to work through the rest of that upkeep step. Then that effect will wear off, and Halfdane will revert to being 3/3, its printed power and toughness (unless some other effect is modifying what its power and toughness is)."
         }
       ],
       "subtypes": [
@@ -6095,7 +6095,7 @@
       "colorIdentity": [
         "R"
       ],
-      "flavor": "\"‘Tis distance lends enchantment to the view,/ And robes the mountain in its azure hue.\" —Thomas Campbell, \"Pleasures of Hope\"",
+      "flavor": "\"'Tis distance lends enchantment to the view,/ And robes the mountain in its azure hue.\" —Thomas Campbell, \"Pleasures of Hope\"",
       "id": "85de9c1f8cb861fac52ea6a4609c69de283fe664",
       "imageName": "hammerheim",
       "layout": "normal",
@@ -6130,7 +6130,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Causing a creature to lose landwalk abilities is useful only during the declare attackers step or earlier. Once the declare blockers step begins, it’s too late to block the creature."
+          "text": "Causing a creature to lose landwalk abilities is useful only during the declare attackers step or earlier. Once the declare blockers step begins, it's too late to block the creature."
         }
       ],
       "supertypes": [
@@ -6188,11 +6188,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "When Hazezon Tamar’s second ability resolves, all permanents with both the Sand and Warrior creature types are exiled, not just the Sand Warrior creature tokens it created. Permanents that have just one of those types are unaffected."
+          "text": "When Hazezon Tamar's second ability resolves, all permanents with both the Sand and Warrior creature types are exiled, not just the Sand Warrior creature tokens it created. Permanents that have just one of those types are unaffected."
         },
         {
           "date": "2009-10-01",
-          "text": "The first ability creates a delayed triggered ability that triggers at the beginning of your next upkeep. It doesn’t matter who controls Hazezon Tamar at that time, or even if it’s on the battlefield. The player who put Hazezon onto the battlefield gets the Sand Warriors."
+          "text": "The first ability creates a delayed triggered ability that triggers at the beginning of your next upkeep. It doesn't matter who controls Hazezon Tamar at that time, or even if it's on the battlefield. The player who put Hazezon onto the battlefield gets the Sand Warriors."
         },
         {
           "date": "2009-10-01",
@@ -6410,7 +6410,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -6465,15 +6465,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Hellfire checks the number of creatures put into graveyards as the result of its effect, not the number of creatures destroyed as a result of its effect. For example, a replacement effect that says “If a creature would be put into a graveyard from the battlefield, exile it instead” won’t affect whether a creature is destroyed or not, but will affect whether it’s put into a graveyard or not."
+          "text": "Hellfire checks the number of creatures put into graveyards as the result of its effect, not the number of creatures destroyed as a result of its effect. For example, a replacement effect that says \"If a creature would be put into a graveyard from the battlefield, exile it instead\" won't affect whether a creature is destroyed or not, but will affect whether it's put into a graveyard or not."
         },
         {
           "date": "2009-10-01",
-          "text": "A creature that regenerates instead of being destroyed doesn’t leave the battlefield, so it’s not put into a graveyard."
+          "text": "A creature that regenerates instead of being destroyed doesn't leave the battlefield, so it's not put into a graveyard."
         },
         {
           "date": "2009-10-01",
-          "text": "A token creature that’s destroyed is put into its owner’s graveyard, and will be counted by Hellfire’s effect. (Immediately after Hellfire finishes resolving, the token will cease to exist.)"
+          "text": "A token creature that's destroyed is put into its owner's graveyard, and will be counted by Hellfire's effect. (Immediately after Hellfire finishes resolving, the token will cease to exist.)"
         }
       ],
       "text": "Destroy all nonblack creatures. Hellfire deals X plus 3 damage to you, where X is the number of creatures that died this way.",
@@ -6927,7 +6927,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "subtypes": [
@@ -6984,7 +6984,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -7037,7 +7037,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Despite the name, this card only prevents damage and not destroy effects. It’s also not an Aura."
+          "text": "Despite the name, this card only prevents damage and not destroy effects. It's also not an Aura."
         }
       ],
       "text": "Prevent all damage that would be dealt to target creature this turn.",
@@ -7641,7 +7641,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "First creatures are exchanged, then artifacts are exchanged. It’s possible that the same artifact creature may be involved in both exchanges."
+          "text": "First creatures are exchanged, then artifacts are exchanged. It's possible that the same artifact creature may be involved in both exchanges."
         },
         {
           "date": "2007-09-16",
@@ -7649,7 +7649,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If one of the players doesn’t control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn’t control an artifact at the time the exchange would be made, that part of the effect does nothing."
+          "text": "If one of the players doesn't control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn't control an artifact at the time the exchange would be made, that part of the effect does nothing."
         }
       ],
       "text": "You and target player exchange control of the creature you each control with the highest converted mana cost. Then exchange control of artifacts the same way. If two or more permanents a player controls are tied for highest cost, their controller chooses one of them.",
@@ -7962,7 +7962,7 @@
           "text": "Does not affect cards that phase in."
         }
       ],
-      "text": "Artifacts, creatures, and lands played by your opponents enter the battlefield tapped.",
+      "text": "Artifacts, creatures, and lands your opponents control enter the battlefield tapped.",
       "type": "Enchantment",
       "types": [
         "Enchantment"
@@ -8007,11 +8007,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You don’t get to look at the cards exiled with Knowledge Vault."
+          "text": "You don't get to look at the cards exiled with Knowledge Vault."
         },
         {
           "date": "2009-10-01",
-          "text": "If you activate Knowledge Vault’s second ability, all that happens at that time is that you pay a cost of {0}. As the ability resolves, you must sacrifice Knowledge Vault. This is mandatory. If you are able to do so, you discard your hand and put all cards exiled with Knowledge Vault into their owners’ hands. If you aren’t able to do so because Knowledge Vault left the battlefield or changed controllers before the ability resolves, nothing happens."
+          "text": "If you activate Knowledge Vault's second ability, all that happens at that time is that you pay a cost of {0}. As the ability resolves, you must sacrifice Knowledge Vault. This is mandatory. If you are able to do so, you discard your hand and put all cards exiled with Knowledge Vault into their owners' hands. If you aren't able to do so because Knowledge Vault left the battlefield or changed controllers before the ability resolves, nothing happens."
         }
       ],
       "text": "{2}, {T}: Exile the top card of your library face down.\n{0}: Sacrifice Knowledge Vault. If you do, discard your hand, then put all cards exiled with Knowledge Vault into their owner's hand.\nWhen Knowledge Vault leaves the battlefield, put all cards exiled with Knowledge Vault into their owner's graveyard.",
@@ -8220,7 +8220,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -8475,15 +8475,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This effect applies no matter how the land would enter the battlefield: because an opponent plays it, or because a spell or ability allows that opponent to put it onto the battlefield. Note that it doesn’t matter whose control the land enters the battlefield under. If the opponent would put the land onto the battlefield under someone else’s control (as a result of Yavimaya Dryad’s ability, for example), that opponent will still have to sacrifice a land."
+          "text": "This effect applies no matter how the land would enter the battlefield: because an opponent plays it, or because a spell or ability allows that opponent to put it onto the battlefield. Note that it doesn't matter whose control the land enters the battlefield under. If the opponent would put the land onto the battlefield under someone else's control (as a result of Yavimaya Dryad's ability, for example), that opponent will still have to sacrifice a land."
         },
         {
           "date": "2009-10-01",
-          "text": "If an opponent puts a land onto the battlefield under his or her own control, he or she may sacrifice that same land. The player won’t be able to tap that land for mana before sacrificing it."
+          "text": "If an opponent puts a land onto the battlefield under his or her own control, he or she may sacrifice that same land. The player won't be able to tap that land for mana before sacrificing it."
         },
         {
           "date": "2009-10-01",
-          "text": "If a land that would enter the battlefield has its own “If [this land] would enter the battlefield” replacement effect, the player who will control that land chooses which replacement effect to apply. After applying one, if the other one would still be applicable, it’s then applied."
+          "text": "If a land that would enter the battlefield has its own \"If [this land] would enter the battlefield\" replacement effect, the player who will control that land chooses which replacement effect to apply. After applying one, if the other one would still be applicable, it's then applied."
         }
       ],
       "text": "If an opponent who controls at least as many lands as you do would put a land onto the battlefield, that player instead puts that land onto the battlefield then sacrifices a land.",
@@ -8535,15 +8535,15 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "You can fetch any of the “Snow-Covered” lands, since they all also have the supertype basic."
+          "text": "You can fetch any of the \"Snow-Covered\" lands, since they all also have the supertype basic."
         },
         {
           "date": "2009-10-01",
-          "text": "This ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
+          "text": "This ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "You shuffle your library if you search, even if you don’t put any basic land cards into your hand."
+          "text": "You shuffle your library if you search, even if you don't put any basic land cards into your hand."
         }
       ],
       "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, and put them into your hand. If you do, shuffle your library.",
@@ -8592,11 +8592,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The damage done when you discard a land only applies to lands which are discarded by choice using the Land’s Edge ability. It does not work on forced discards of any type."
+          "text": "The damage done when you discard a land only applies to lands which are discarded by choice using the Land's Edge ability. It does not work on forced discards of any type."
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -8649,7 +8649,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may activate Lesser Werewolf’s ability no matter what its power is. However, if Lesser Werewolf’s power is 0 or less at the time the ability resolves, the ability won’t do anything."
+          "text": "You may activate Lesser Werewolf's ability no matter what its power is. However, if Lesser Werewolf's power is 0 or less at the time the ability resolves, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -8833,11 +8833,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         }
       ],
       "supertypes": [
@@ -8894,7 +8894,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "“Legendary landwalk” means “This creature is can’t be blocked as long as defending player controls a legendary land.”"
+          "text": "\"Legendary landwalk\" means \"This creature is can't be blocked as long as defending player controls a legendary land.\""
         }
       ],
       "subtypes": [
@@ -9066,15 +9066,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell “can’t be countered,” it remains on the stack. Mana Drain continues to resolve. At the beginning of your next main phase, the delayed triggered ability will still add the mana to your mana pool."
+          "text": "If the targeted spell \"can't be countered,\" it remains on the stack. Mana Drain continues to resolve. At the beginning of your next main phase, the delayed triggered ability will still add the mana to your mana pool."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell is an illegal target by the time Mana Drain resolves, Mana Drain is countered. You won’t get any mana later."
+          "text": "If the targeted spell is an illegal target by the time Mana Drain resolves, Mana Drain is countered. You won't get any mana later."
         },
         {
           "date": "2009-10-01",
-          "text": "Mana Drain’s delayed triggered ability will usually trigger at the beginning of your precombat main phase. However, if you cast Mana Drain during your precombat main phase or during your combat phase, its delayed triggered ability will trigger at the beginning of that turn’s postcombat main phase."
+          "text": "Mana Drain's delayed triggered ability will usually trigger at the beginning of your precombat main phase. However, if you cast Mana Drain during your precombat main phase or during your combat phase, its delayed triggered ability will trigger at the beginning of that turn's postcombat main phase."
         }
       ],
       "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} to your mana pool equal to that spell's converted mana cost.",
@@ -9130,7 +9130,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Only reduces the generic mana portion of a spell’s cost. If the cost does not include generic mana or includes less than {2}, you get a reduced or null effect from this card."
+          "text": "Only reduces the generic mana portion of a spell's cost. If the cost does not include generic mana or includes less than {2}, you get a reduced or null effect from this card."
         }
       ],
       "text": "Instant and enchantment spells you cast cost up to {2} less to cast.",
@@ -9326,11 +9326,11 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player’s previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
+          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player's previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says that a player can’t lose life, that player can’t exchange life totals with a player who has a lower life total; in that case, the exchange won’t happen."
+          "text": "If an effect says that a player can't lose life, that player can't exchange life totals with a player who has a lower life total; in that case, the exchange won't happen."
         }
       ],
       "text": "{T}, Sacrifice Mirror Universe: Exchange life totals with target opponent. Activate this ability only during your upkeep.",
@@ -9618,11 +9618,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t name a card until the ability resolves. Once you name a card, it’s too late for the targeted opponent to respond."
+          "text": "You don't name a card until the ability resolves. Once you name a card, it's too late for the targeted opponent to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "You may activate the ability only during your turn, but you may do so any time you have priority. (In other words, it’s not restricted to only the times you could cast a sorcery.)"
+          "text": "You may activate the ability only during your turn, but you may do so any time you have priority. (In other words, it's not restricted to only the times you could cast a sorcery.)"
         }
       ],
       "subtypes": [
@@ -9685,7 +9685,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
@@ -9757,7 +9757,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Nicol Bolas’s third ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Nicol Bolas's third ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -9850,7 +9850,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "As you activate the ability, you choose an opponent, then that opponent chooses a creature for the ability to target. It doesn’t have to be a creature that opponent controls. If there are no creatures that can be targeted with the ability, it can’t be activated."
+          "text": "As you activate the ability, you choose an opponent, then that opponent chooses a creature for the ability to target. It doesn't have to be a creature that opponent controls. If there are no creatures that can be targeted with the ability, it can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -9858,7 +9858,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The next time damage from the chosen source would be dealt to you this turn, that damage is dealt to the targeted creature instead. Whether it’s still a legal target is not checked at this time. However, if it’s not able to be dealt damage because it’s neither a creature nor a planeswalker, or it’s no longer on the battlefield, then the damage is not redirected and is dealt to you as normal."
+          "text": "The next time damage from the chosen source would be dealt to you this turn, that damage is dealt to the targeted creature instead. Whether it's still a legal target is not checked at this time. However, if it's not able to be dealt damage because it's neither a creature nor a planeswalker, or it's no longer on the battlefield, then the damage is not redirected and is dealt to you as normal."
         }
       ],
       "text": "{3}, {T}: The next time a source of your choice would deal damage to you this turn, that damage is dealt to target creature of an opponent's choice instead.",
@@ -10178,7 +10178,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the targeted player’s library is empty, that player still names a card, but nothing further happens. That player will not lose the game."
+          "text": "If the targeted player's library is empty, that player still names a card, but nothing further happens. That player will not lose the game."
         }
       ],
       "subtypes": [
@@ -10333,7 +10333,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Only reduces the generic mana portion of a spell’s cost. If the cost does not include generic mana or includes less than {2}, you get a reduced or null effect from this card."
+          "text": "Only reduces the generic mana portion of a spell's cost. If the cost does not include generic mana or includes less than {2}, you get a reduced or null effect from this card."
         },
         {
           "date": "2008-04-01",
@@ -10659,7 +10659,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The loss of life can’t be prevented by any means. It is not damage."
+          "text": "The loss of life can't be prevented by any means. It is not damage."
         },
         {
           "date": "2004-10-04",
@@ -10712,7 +10712,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You only get the opportunity to pay {U}{U}{U} (and thus to return Puppet Master to its owner’s hand) if the creature card actually gets returned to its owner’s hand. If it isn’t (for instance, if it was removed from the graveyard prior to this ability resolving), you don’t get the option to pay."
+          "text": "You only get the opportunity to pay {U}{U}{U} (and thus to return Puppet Master to its owner's hand) if the creature card actually gets returned to its owner's hand. If it isn't (for instance, if it was removed from the graveyard prior to this ability resolving), you don't get the option to pay."
         }
       ],
       "subtypes": [
@@ -10786,15 +10786,15 @@
         },
         {
           "date": "2014-11-24",
-          "text": "If some but not all of Pyrotechnics’s targets become illegal, you can’t change the division of damage. Damage that would have been dealt to illegal targets simply isn’t dealt."
+          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2014-11-24",
-          "text": "You can’t deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can’t deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
         },
         {
           "date": "2014-11-24",
-          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can’t be changed. The effect that creates the copy may allow you to change the targets, however."
+          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
         }
       ],
       "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
@@ -11216,7 +11216,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "A creature is “enchanted” if it has any Auras attached to it."
+          "text": "A creature is \"enchanted\" if it has any Auras attached to it."
         }
       ],
       "subtypes": [
@@ -11326,7 +11326,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The fourth ability has an “intervening ‘if’ clause,” so it won’t trigger at all unless Rasputin Dreamweaver started the turn untapped."
+          "text": "The fourth ability has an \"intervening 'if' clause,\" so it won't trigger at all unless Rasputin Dreamweaver started the turn untapped."
         },
         {
           "date": "2009-10-01",
@@ -11437,11 +11437,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t discard cards until Recall resolves. If you don’t have X cards in your hand at that time, you discard all the cards in your hand."
+          "text": "You don't discard cards until Recall resolves. If you don't have X cards in your hand at that time, you discard all the cards in your hand."
         },
         {
           "date": "2009-10-01",
-          "text": "You don’t choose which cards in your graveyard you’ll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
+          "text": "You don't choose which cards in your graveyard you'll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
         }
       ],
       "text": "Discard X cards, then return a card from your graveyard to your hand for each card discarded this way. Exile Recall.",
@@ -11537,19 +11537,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "All Reincarnation does when it resolves is set up a delayed triggered ability. If the targeted creature isn’t put into a graveyard this turn, that ability never triggers. If the targeted creature is put into a graveyard this turn, that ability triggers and resolves like any other triggered ability."
+          "text": "All Reincarnation does when it resolves is set up a delayed triggered ability. If the targeted creature isn't put into a graveyard this turn, that ability never triggers. If the targeted creature is put into a graveyard this turn, that ability triggers and resolves like any other triggered ability."
         },
         {
           "date": "2009-10-01",
-          "text": "The creature card that will be returned to the battlefield isn’t chosen until the delayed triggered ability resolves. The player who chooses is the player who controlled Reincarnation. The player under whose control the chosen creature card enters the battlefield is the player who owned the targeted creature (in other words, the player into whose graveyard it went), not necessarily the controller of that creature."
+          "text": "The creature card that will be returned to the battlefield isn't chosen until the delayed triggered ability resolves. The player who chooses is the player who controlled Reincarnation. The player under whose control the chosen creature card enters the battlefield is the player who owned the targeted creature (in other words, the player into whose graveyard it went), not necessarily the controller of that creature."
         },
         {
           "date": "2009-10-01",
-          "text": "The creature that’s returned to the battlefield may be the same one that was put into the graveyard (assuming it’s still in the graveyard when the delayed triggered ability resolves). If so, it returns to the battlefield as a brand-new creature."
+          "text": "The creature that's returned to the battlefield may be the same one that was put into the graveyard (assuming it's still in the graveyard when the delayed triggered ability resolves). If so, it returns to the battlefield as a brand-new creature."
         }
       ],
       "text": "Choose target creature. When that creature dies this turn, return a creature card from its owner's graveyard to the battlefield under the control of that creature's owner.",
@@ -11751,7 +11751,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -11844,7 +11844,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -12091,11 +12091,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rohgahh’s first ability isn’t targeted. You don’t choose the opponent that will gain control of the creatures until the ability resolves."
+          "text": "Rohgahh's first ability isn't targeted. You don't choose the opponent that will gain control of the creatures until the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "If you don’t pay {R}{R}{R} as the first ability resolves, all creatures named Kobolds of Kher Keep become tapped (even the ones you don’t control), as does Rohgahh. The chosen opponent gains control of Rohgahh and all creatures named Kobolds of Kher Keep regardless of whether you control them or whether they were tapped by the ability."
+          "text": "If you don't pay {R}{R}{R} as the first ability resolves, all creatures named Kobolds of Kher Keep become tapped (even the ones you don't control), as does Rohgahh. The chosen opponent gains control of Rohgahh and all creatures named Kobolds of Kher Keep regardless of whether you control them or whether they were tapped by the ability."
         }
       ],
       "subtypes": [
@@ -12163,11 +12163,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won’t gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
+          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won't gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the targeted permanent remains a legal target for the ability, only that it’s on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
+          "text": "Once the ability resolves, it doesn't care whether the targeted permanent remains a legal target for the ability, only that it's on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
         }
       ],
       "subtypes": [
@@ -12223,11 +12223,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t be used on mana abilities because they don’t use the stack. They’ve already resolved by the time you get priority."
+          "text": "Can't be used on mana abilities because they don't use the stack. They've already resolved by the time you get priority."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Counter target activated ability from an artifact source. (Mana abilities can't be targeted.)",
@@ -12450,7 +12450,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -12544,7 +12544,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can only remove “bands with other” and not normal “banding” ability."
+          "text": "Can only remove \"bands with other\" and not normal \"banding\" ability."
         }
       ],
       "subtypes": [
@@ -12611,7 +12611,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"‘Tis now the very witching time of night,/ When churchyards yawn and hell itself breathes out/ Contagion to this world.\" —William Shakespeare, Hamlet",
+      "flavor": "\"'Tis now the very witching time of night,/ When churchyards yawn and hell itself breathes out/ Contagion to this world.\" —William Shakespeare, Hamlet",
       "id": "98fc5e182910356e13fe1827991c97a24b3a3f71",
       "imageName": "shimian night stalker",
       "layout": "normal",
@@ -12644,7 +12644,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can redirect damage from combat and from abilities, but the creature must be attacking before you can use this card’s ability."
+          "text": "Can redirect damage from combat and from abilities, but the creature must be attacking before you can use this card's ability."
         }
       ],
       "subtypes": [
@@ -13087,7 +13087,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Spirit Shackle’s ability triggers only when the enchanted creature changes from untapped to tapped. If Spirit Shackle enters the battlefield attached to an already tapped creature, it won’t do anything (until that creature untaps and becomes tapped again, that is)."
+          "text": "Spirit Shackle's ability triggers only when the enchanted creature changes from untapped to tapped. If Spirit Shackle enters the battlefield attached to an already tapped creature, it won't do anything (until that creature untaps and becomes tapped again, that is)."
         }
       ],
       "subtypes": [
@@ -13186,11 +13186,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Stangg’s delayed triggered abilities track only the token created by that particular Stangg."
+          "text": "Stangg's delayed triggered abilities track only the token created by that particular Stangg."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stangg leaves the battlefield before its ability has resolved, that ability will still create a Stangg Twin token, but its delayed triggered abilities will never have a chance to trigger. That token will remain on the battlefield indefinitely (until it’s dealt lethal damage, or anything else causes it to leave the battlefield)."
+          "text": "If Stangg leaves the battlefield before its ability has resolved, that ability will still create a Stangg Twin token, but its delayed triggered abilities will never have a chance to trigger. That token will remain on the battlefield indefinitely (until it's dealt lethal damage, or anything else causes it to leave the battlefield)."
         }
       ],
       "subtypes": [
@@ -13292,11 +13292,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
-          "text": "If the player whose turn it is has four or more cards in his or her hand as Storm World’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the player whose turn it is has four or more cards in his or her hand as Storm World's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "supertypes": [
@@ -13494,19 +13494,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player’s draw step."
+          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player's draw step."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library’s ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
+          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library's ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
         },
         {
           "date": "2016-06-08",
-          "text": "Any cards drawn prior to Sylvan Library’s ability resolving, including in your upkeep or in response to Sylvan Library’s triggered ability, can be chosen to be put back using this effect. Sylvan Library’s controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
+          "text": "Any cards drawn prior to Sylvan Library's ability resolving, including in your upkeep or in response to Sylvan Library's triggered ability, can be chosen to be put back using this effect. Sylvan Library's controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don’t get to draw all the cards at once and then put them all back at once."
+          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don't get to draw all the cards at once and then put them all back at once."
         },
         {
           "date": "2016-06-08",
@@ -13514,11 +13514,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library’s ability still happens. If you’ve actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven’t actually drawn any cards that turn, the rest of the ability has no effect."
+          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library's ability still happens. If you've actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven't actually drawn any cards that turn, the rest of the ability has no effect."
         },
         {
           "date": "2016-06-08",
-          "text": "It’s not possible to take any actions between drawing the cards and choosing two cards. You can’t cast the cards you drew to avoid having two cards to choose."
+          "text": "It's not possible to take any actions between drawing the cards and choosing two cards. You can't cast the cards you drew to avoid having two cards to choose."
         }
       ],
       "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
@@ -13668,19 +13668,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the creature leaves the battlefield without going to the graveyard, Takklemaggot is simply put into its owner’s graveyard."
+          "text": "If the creature leaves the battlefield without going to the graveyard, Takklemaggot is simply put into its owner's graveyard."
         },
         {
           "date": "2008-05-01",
-          "text": "Takklemaggot’s controller no longer changes as it returns to the battlefield. The player who controlled it when it left the battlefield is the same player that controls it when it returns to the battlefield, even though a different player may be choosing what it will be attached to after returning onto the battlefield."
+          "text": "Takklemaggot's controller no longer changes as it returns to the battlefield. The player who controlled it when it left the battlefield is the same player that controls it when it returns to the battlefield, even though a different player may be choosing what it will be attached to after returning onto the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "When the enchanted creature is put into a graveyard, Takklemaggot’s second ability triggers, then Takklemaggot is put into its owner’s graveyard as a state-based action. When the ability resolves, if Takklemaggot is still in that graveyard, it’s returned to the battlefield."
+          "text": "When the enchanted creature is put into a graveyard, Takklemaggot's second ability triggers, then Takklemaggot is put into its owner's graveyard as a state-based action. When the ability resolves, if Takklemaggot is still in that graveyard, it's returned to the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "The player who controlled the creature that went to the graveyard (and caused Takklemaggot’s second ability to trigger) chooses what creature Takklemaggot will return to the battlefield attached to. The creature isn’t chosen until the ability resolves, so no player can respond between the time the creature is chosen and the time Takklemaggot returns to the battlefield attached to it. The ability doesn’t target a creature, so a creature with shroud, for example, can be chosen. However, only a creature that can be legally enchanted by Takklemaggot can be chosen, so a creature with protection from black, for example, can’t be chosen. If the player can choose a creature, he or she must do so, no matter who controls it. If the player can’t choose a creature, Takklemaggot returns to the battlefield as a non-Aura enchantment, and that player is the player that Takklemaggot will deal damage to."
+          "text": "The player who controlled the creature that went to the graveyard (and caused Takklemaggot's second ability to trigger) chooses what creature Takklemaggot will return to the battlefield attached to. The creature isn't chosen until the ability resolves, so no player can respond between the time the creature is chosen and the time Takklemaggot returns to the battlefield attached to it. The ability doesn't target a creature, so a creature with shroud, for example, can be chosen. However, only a creature that can be legally enchanted by Takklemaggot can be chosen, so a creature with protection from black, for example, can't be chosen. If the player can choose a creature, he or she must do so, no matter who controls it. If the player can't choose a creature, Takklemaggot returns to the battlefield as a non-Aura enchantment, and that player is the player that Takklemaggot will deal damage to."
         }
       ],
       "subtypes": [
@@ -13733,7 +13733,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "Telekinesis’ ability doesn’t lock in who the creature’s controller is when it resolves. If the creature changes controllers, it won’t untap during its controller’s untap step until it has not done so twice, regardless of who its controller was during any of those untap steps."
+          "text": "Telekinesis' ability doesn't lock in who the creature's controller is when it resolves. If the creature changes controllers, it won't untap during its controller's untap step until it has not done so twice, regardless of who its controller was during any of those untap steps."
         }
       ],
       "text": "Tap target creature. Prevent all combat damage that would be dealt by that creature this turn. It doesn't untap during its controller's next two untap steps.",
@@ -13879,7 +13879,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card can be enchanted by moving Auras onto it. The “can’t be the target” text is different from “can’t be enchanted” in that it only applies to Aura spells when they are being cast."
+          "text": "This card can be enchanted by moving Auras onto it. The \"can't be the target\" text is different from \"can't be enchanted\" in that it only applies to Aura spells when they are being cast."
         },
         {
           "date": "2009-10-01",
@@ -13946,7 +13946,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -14144,15 +14144,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Any blocking creatures that regenerated during combat will have been removed from combat. Since such creatures are no longer in combat, they cannot be blocking The Wretched, which means you won’t be able to gain control of them."
+          "text": "Any blocking creatures that regenerated during combat will have been removed from combat. Since such creatures are no longer in combat, they cannot be blocking The Wretched, which means you won't be able to gain control of them."
         },
         {
           "date": "2009-05-01",
-          "text": "If The Wretched itself regenerated during combat, then it will have been removed from combat. Since it is no longer in combat, there cannot be any creatures blocking it, which means you won’t be able to gain control of any creatures."
+          "text": "If The Wretched itself regenerated during combat, then it will have been removed from combat. Since it is no longer in combat, there cannot be any creatures blocking it, which means you won't be able to gain control of any creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "The Wretched’s ability triggers only if it’s still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it’s blocked by a 7/7 creature and is destroyed, its ability won’t trigger at all."
+          "text": "The Wretched's ability triggers only if it's still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it's blocked by a 7/7 creature and is destroyed, its ability won't trigger at all."
         },
         {
           "date": "2009-10-01",
@@ -14160,11 +14160,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you lose control of The Wretched before its ability resolves, you won’t gain control of the creatures blocking it at all."
+          "text": "If you lose control of The Wretched before its ability resolves, you won't gain control of the creatures blocking it at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the permanents you gained control of remain creatures, only that they remain on the battlefield."
+          "text": "Once the ability resolves, it doesn't care whether the permanents you gained control of remain creatures, only that they remain on the battlefield."
         }
       ],
       "subtypes": [
@@ -14275,11 +14275,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A “permanent that isn’t enchanted” is a permanent with no Auras on it."
+          "text": "A \"permanent that isn't enchanted\" is a permanent with no Auras on it."
         },
         {
           "date": "2007-09-16",
-          "text": "If Time Elemental attacks or blocks, but you no longer control it at end of combat, you can’t sacrifice it. However, it will still deal 5 damage to you."
+          "text": "If Time Elemental attacks or blocks, but you no longer control it at end of combat, you can't sacrifice it. However, it will still deal 5 damage to you."
         }
       ],
       "subtypes": [
@@ -14585,7 +14585,7 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Note that the wording “Effects that alter the creature’s power alter its toughness instead, and vice versa, this turn” has been removed."
+          "text": "Note that the wording \"Effects that alter the creature's power alter its toughness instead, and vice versa, this turn\" has been removed."
         },
         {
           "date": "2013-04-15",
@@ -14593,7 +14593,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "text": "Switch target creature's power and toughness until end of turn.",
@@ -14641,7 +14641,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "{3}, {T}: Put a hatchling counter on Triassic Egg.\nSacrifice Triassic Egg: Choose one —\n• You may put a creature card from your hand onto the battlefield. Activate this ability only if two or more hatchling counters are on Triassic Egg.\n• Return target creature card from your graveyard to the battlefield. Activate this ability only if two or more hatchling counters are on Triassic Egg.",
@@ -15000,7 +15000,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2006-10-15",
@@ -15112,7 +15112,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If a creature loses first strike after first strike combat damage has been assigned, it won’t deal damage during the second combat damage step."
+          "text": "If a creature loses first strike after first strike combat damage has been assigned, it won't deal damage during the second combat damage step."
         },
         {
           "date": "2009-10-01",
@@ -15120,11 +15120,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Causing a creature to lose swampwalk is useful only during the declare attackers step or earlier. Once the declare blockers step begins, it’s too late to block the creature."
+          "text": "Causing a creature to lose swampwalk is useful only during the declare attackers step or earlier. Once the declare blockers step begins, it's too late to block the creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Urborg’s second ability affects only the first strike ability, not the part of the double strike ability that acts like first strike."
+          "text": "Urborg's second ability affects only the first strike ability, not the part of the double strike ability that acts like first strike."
         }
       ],
       "supertypes": [
@@ -15344,7 +15344,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t rearrange the cards. You put them back in the same order or have the whole library shuffled."
+          "text": "You can't rearrange the cards. You put them back in the same order or have the whole library shuffled."
         },
         {
           "date": "2004-10-04",
@@ -15396,15 +15396,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Voodoo Doll’s second ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless Voodoo Doll is untapped, and (2) the ability will do nothing if Voodoo Doll is tapped by the time it resolves. If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see if it was tapped or untapped."
+          "text": "Voodoo Doll's second ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless Voodoo Doll is untapped, and (2) the ability will do nothing if Voodoo Doll is tapped by the time it resolves. If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see if it was tapped or untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Each X in the cost of Voodoo Doll’s third ability is the number of pin counters on Voodoo Doll at the time you activate the ability. The X in the ability’s effect is the number of pin counters on Voodoo Doll at the time it resolves, which may not be the same number (if a spell or ability put counters on it or removed counters from it in the meantime). If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see how many pin counters were on it."
+          "text": "Each X in the cost of Voodoo Doll's third ability is the number of pin counters on Voodoo Doll at the time you activate the ability. The X in the ability's effect is the number of pin counters on Voodoo Doll at the time it resolves, which may not be the same number (if a spell or ability put counters on it or removed counters from it in the meantime). If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see how many pin counters were on it."
         },
         {
           "date": "2011-01-01",
-          "text": "Voodoo Doll’s second ability causes it to be destroyed regardless of whether it actually deals damage to you or not. Voodoo Doll is destroyed even if all the damage is prevented or redirected."
+          "text": "Voodoo Doll's second ability causes it to be destroyed regardless of whether it actually deals damage to you or not. Voodoo Doll is destroyed even if all the damage is prevented or redirected."
         }
       ],
       "text": "At the beginning of your upkeep, put a pin counter on Voodoo Doll.\nAt the beginning of your end step, if Voodoo Doll is untapped, destroy Voodoo Doll and it deals damage to you equal to the number of pin counters on it.\n{X}{X}, {T}: Voodoo Doll deals damage equal to the number of pin counters on it to target creature or player. X is the number of pin counters on Voodoo Doll.",
@@ -15798,7 +15798,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "The term “enchanted creatures” means “creatures with an Aura on them”."
+          "text": "The term \"enchanted creatures\" means \"creatures with an Aura on them\"."
         }
       ],
       "subtypes": [
@@ -15852,7 +15852,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can be targeted by a modal spell that can target a non-Wall in one of its modes, even if it has a mode that targets only Walls. That spell can, in theory, target a non-Wall, so it is not a “spell that can target only Walls”."
+          "text": "Can be targeted by a modal spell that can target a non-Wall in one of its modes, even if it has a mode that targets only Walls. That spell can, in theory, target a non-Wall, so it is not a \"spell that can target only Walls\"."
         }
       ],
       "subtypes": [
@@ -15905,11 +15905,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -16187,11 +16187,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Willow Satyr stops being tapped before its ability resolves — even if it becomes tapped again right away — you won’t gain control of the targeted creature at all. The same is true if you lose control of Willow Satyr before the ability resolves."
+          "text": "If Willow Satyr stops being tapped before its ability resolves — even if it becomes tapped again right away — you won't gain control of the targeted creature at all. The same is true if you lose control of Willow Satyr before the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the targeted permanent remains a legal target for the ability, only that it’s on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, stops being legendary, or would no longer be a legal target for any other reason."
+          "text": "Once the ability resolves, it doesn't care whether the targeted permanent remains a legal target for the ability, only that it's on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, stops being legendary, or would no longer be a legal target for any other reason."
         }
       ],
       "subtypes": [
@@ -16213,7 +16213,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"‘Tis the set of sails, and not the gales,/ Which tells us the way to go.\" —Ella Wheeler Wilcox",
+      "flavor": "\"'Tis the set of sails, and not the gales,/ Which tells us the way to go.\" —Ella Wheeler Wilcox",
       "id": "479ff2086dae100a6639625b600a874098fb161a",
       "imageName": "winds of change",
       "layout": "normal",
@@ -16306,7 +16306,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Checks if the creatures are Flying on resolution and not on announcement. It’s not a targeting restriction."
+          "text": "Checks if the creatures are Flying on resolution and not on announcement. It's not a targeting restriction."
         }
       ],
       "text": "Tap X target creatures. Winter Blast deals 2 damage to each of those creatures with flying.",

--- a/json/LGN.json
+++ b/json/LGN.json
@@ -1122,11 +1122,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1220,7 +1220,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -1555,7 +1555,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "All “enters the battlefield” abilities trigger as normal."
+          "text": "All \"enters the battlefield\" abilities trigger as normal."
         },
         {
           "date": "2004-10-04",
@@ -1567,7 +1567,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "When the creatures leave the battlefield, all Auras on them go to their owners’ graveyards, any counters on them are removed, and effects on them end. Token creatures do not return to the battlefield."
+          "text": "When the creatures leave the battlefield, all Auras on them go to their owners' graveyards, any counters on them are removed, and effects on them end. Token creatures do not return to the battlefield."
         }
       ],
       "subtypes": [
@@ -1654,11 +1654,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -2153,11 +2153,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -2444,7 +2444,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -2791,7 +2791,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The creatures can’t attack until you start a turn with them under your control. So you can’t swap and then attack."
+          "text": "The creatures can't attack until you start a turn with them under your control. So you can't swap and then attack."
         },
         {
           "date": "2004-10-04",
@@ -3395,7 +3395,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -3992,11 +3992,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -4092,7 +4092,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The type “Illusion” is printed on the card’s type line purely for flavor. The Ultimus has every other creature type as well."
+          "text": "The type \"Illusion\" is printed on the card's type line purely for flavor. The Ultimus has every other creature type as well."
         },
         {
           "date": "2006-09-25",
@@ -4100,7 +4100,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Mistform Ultimus has all creature types even if an effect removes its ability. Type-changing static abilities will apply in layer 4 before effects such as Sudden Spoiling’s remove them in layer 6."
+          "text": "Mistform Ultimus has all creature types even if an effect removes its ability. Type-changing static abilities will apply in layer 4 before effects such as Sudden Spoiling's remove them in layer 6."
         }
       ],
       "subtypes": [
@@ -4436,11 +4436,11 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "The activated ability overwrites all previous effects that set Riptide Mangler’s base power to specific a value (such as previous activations of the ability). Other effects that set its base power that start to apply after Riptide Mangler’s ability resolves will overwrite this effect."
+          "text": "The activated ability overwrites all previous effects that set Riptide Mangler's base power to specific a value (such as previous activations of the ability). Other effects that set its base power that start to apply after Riptide Mangler's ability resolves will overwrite this effect."
         },
         {
           "date": "2015-02-25",
-          "text": "Effects that modify Riptide Mangler’s power, such as the effect of Giant Growth or Glorious Anthem, will apply to Riptide Mangler no matter when they started applying. The same is true for counters that affect Riptide Mangler’s power and effects that switch its power and toughness."
+          "text": "Effects that modify Riptide Mangler's power, such as the effect of Giant Growth or Glorious Anthem, will apply to Riptide Mangler no matter when they started applying. The same is true for counters that affect Riptide Mangler's power and effects that switch its power and toughness."
         }
       ],
       "subtypes": [
@@ -4526,11 +4526,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -4616,11 +4616,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -4879,7 +4879,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "On your turn, an opponent can cycle a card that has a cycling triggered ability and target this card with that ability. This works on your turn because your triggered abilities go on the stack first, so your opponent’s ability will resolve before yours. This situation is reversed on your opponent’s turn."
+          "text": "On your turn, an opponent can cycle a card that has a cycling triggered ability and target this card with that ability. This works on your turn because your triggered abilities go on the stack first, so your opponent's ability will resolve before yours. This situation is reversed on your opponent's turn."
         }
       ],
       "subtypes": [
@@ -5500,11 +5500,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -6095,11 +6095,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -6432,7 +6432,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All creatures on the battlefield when Havoc Demon’s triggered ability resolves are affected. Ones that enter the battlefield or become creatures later in the turn are not."
+          "text": "All creatures on the battlefield when Havoc Demon's triggered ability resolves are affected. Ones that enter the battlefield or become creatures later in the turn are not."
         }
       ],
       "subtypes": [
@@ -6779,7 +6779,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is only considered “cast from your hand” if you cast it as a spell from your hand. Putting it onto the battlefield from your hand using a spell or ability will cause you to lose the game."
+          "text": "It is only considered \"cast from your hand\" if you cast it as a spell from your hand. Putting it onto the battlefield from your hand using a spell or ability will cause you to lose the game."
         },
         {
           "date": "2013-07-01",
@@ -7210,11 +7210,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -7301,11 +7301,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -7644,11 +7644,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -8155,7 +8155,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The target of the ability can’t be a creature with Protection from Creatures, with Protection from Goblins, or with Protection from Red."
+          "text": "The target of the ability can't be a creature with Protection from Creatures, with Protection from Goblins, or with Protection from Red."
         },
         {
           "date": "2008-10-01",
@@ -8167,11 +8167,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -8833,11 +8833,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -9272,11 +9272,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -10360,15 +10360,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card’s controller controls the triggered ability, but the controller of the Sliver that deals damage to a player decides whether or not to put the token onto the battlefield under their control."
+          "text": "This card's controller controls the triggered ability, but the controller of the Sliver that deals damage to a player decides whether or not to put the token onto the battlefield under their control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -10955,11 +10955,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "subtypes": [
@@ -11718,11 +11718,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -11812,15 +11812,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The addition of “by spells or abilities” to the second ability is so that tribal instant or sorcery spells that happen to be Slivers (such as Crib Swap) can be countered by the rules if all of their targets become illegal."
+          "text": "The addition of \"by spells or abilities\" to the second ability is so that tribal instant or sorcery spells that happen to be Slivers (such as Crib Swap) can be countered by the rules if all of their targets become illegal."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -11912,11 +11912,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Other effects can prevent a permanent from untapping during an untap step. You do need to look carefully, however, as many effects say that the permanent does not untap during its controller’s untap step, and this card’s ability occurs during other players’ untap steps. If a card does say this, then Seedborn Muse can untap it. But some other abilities are not written this way and can still prevent a card from untapping."
+          "text": "Other effects can prevent a permanent from untapping during an untap step. You do need to look carefully, however, as many effects say that the permanent does not untap during its controller's untap step, and this card's ability occurs during other players' untap steps. If a card does say this, then Seedborn Muse can untap it. But some other abilities are not written this way and can still prevent a card from untapping."
         },
         {
           "date": "2007-07-15",
-          "text": "All your permanents untap during each other player’s untap step. You have no choice about what untaps."
+          "text": "All your permanents untap during each other player's untap step. You have no choice about what untaps."
         }
       ],
       "subtypes": [
@@ -12090,7 +12090,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf’s ability resolves. If Timberwatch Elf is still on the battlefield, it’ll count itself."
+          "text": "The number of Elves on the battlefield is counted only as Timberwatch Elf's ability resolves. If Timberwatch Elf is still on the battlefield, it'll count itself."
         }
       ],
       "subtypes": [

--- a/json/LRW.json
+++ b/json/LRW.json
@@ -256,7 +256,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "In other multiplayer formats, each player’s life total is set to the highest life total within his or her range of influence. These changes happen at the same time. For example, if each player has a range of influence of one, and the players in the game are Alice (4 life), Barry (8 life), Carrie (11 life), and Doug (7 life), in that order, then Alice’s life total will become 8 and Barry and Doug’s life totals will each become 11."
+          "text": "In other multiplayer formats, each player's life total is set to the highest life total within his or her range of influence. These changes happen at the same time. For example, if each player has a range of influence of one, and the players in the game are Alice (4 life), Barry (8 life), Carrie (11 life), and Doug (7 life), in that order, then Alice's life total will become 8 and Barry and Doug's life totals will each become 11."
         },
         {
           "date": "2010-06-15",
@@ -588,7 +588,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If a creature loses double strike after dealing combat damage in the first combat damage step, it won’t assign combat damage in the second one."
+          "text": "If a creature loses double strike after dealing combat damage in the first combat damage step, it won't assign combat damage in the second one."
         }
       ],
       "subtypes": [
@@ -806,7 +806,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If the red source you chose changes colors before the damage is dealt, the damage-prevention effect doesn’t apply."
+          "text": "If the red source you chose changes colors before the damage is dealt, the damage-prevention effect doesn't apply."
         }
       ],
       "subtypes": [
@@ -1440,7 +1440,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If you clash because of a spell or ability an opponent controls, the ability will still trigger. Likewise, you can still win the clash even if you weren’t the player to initiate it."
+          "text": "If you clash because of a spell or ability an opponent controls, the ability will still trigger. Likewise, you can still win the clash even if you weren't the player to initiate it."
         }
       ],
       "text": "Whenever you clash, tap target creature an opponent controls. If you won, that creature doesn't untap during its controller's next untap step. (This ability triggers after the clash ends.)",
@@ -1545,7 +1545,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If there’s a tie for highest converted mana cost, all of those creatures have protection from all colors."
+          "text": "If there's a tie for highest converted mana cost, all of those creatures have protection from all colors."
         },
         {
           "date": "2007-10-01",
@@ -1553,7 +1553,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a creature has X in its mana cost, that X is treated as 0 for the purposes of this effect. It doesn’t matter what the value of X was while the creature was on the stack."
+          "text": "If a creature has X in its mana cost, that X is treated as 0 for the purposes of this effect. It doesn't matter what the value of X was while the creature was on the stack."
         }
       ],
       "subtypes": [
@@ -1663,7 +1663,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Galepowder Mage’s ability can target a creature controlled by any player. It’s not optional."
+          "text": "Galepowder Mage's ability can target a creature controlled by any player. It's not optional."
         },
         {
           "date": "2007-10-01",
@@ -1782,7 +1782,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "After Goldmeadow Dodger becomes blocked, increasing the blocking creature’s power to 4 or greater has no effect on the block."
+          "text": "After Goldmeadow Dodger becomes blocked, increasing the blocking creature's power to 4 or greater has no effect on the block."
         }
       ],
       "subtypes": [
@@ -2314,7 +2314,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If a spell or ability has you draw multiple cards, Hoofprints of the Stag’s ability triggers that many times."
+          "text": "If a spell or ability has you draw multiple cards, Hoofprints of the Stag's ability triggers that many times."
         }
       ],
       "subtypes": [
@@ -2424,11 +2424,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "This is a triggered ability, not an activated ability. It doesn’t allow you to tap the creature whenever you want; rather, you need some other way of tapping it, such as by attacking with the creature."
+          "text": "This is a triggered ability, not an activated ability. It doesn't allow you to tap the creature whenever you want; rather, you need some other way of tapping it, such as by attacking with the creature."
         },
         {
           "date": "2007-10-01",
-          "text": "For the ability to trigger, the creature has to actually change from untapped to tapped. If an effect attempts to tap the creature, but it was already tapped at the time, this ability won’t trigger."
+          "text": "For the ability to trigger, the creature has to actually change from untapped to tapped. If an effect attempts to tap the creature, but it was already tapped at the time, this ability won't trigger."
         }
       ],
       "subtypes": [
@@ -2752,7 +2752,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If, after dealing first-strike combat damage, Kithkin Greatheart loses first strike (perhaps because the Giant you controlled was destroyed by first-strike combat damage), it won’t deal regular combat damage."
+          "text": "If, after dealing first-strike combat damage, Kithkin Greatheart loses first strike (perhaps because the Giant you controlled was destroyed by first-strike combat damage), it won't deal regular combat damage."
         }
       ],
       "subtypes": [
@@ -3179,7 +3179,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Lairwatch Giant’s second ability triggers if it blocks at least two creatures when blockers are declared. It will also trigger if it blocks fewer than two creatures when blockers are declared and effects then cause it to block more creatures. However, if Lairwatch Giant is already blocking two or more creatures, and effects then cause it to block more creatures, the ability won’t trigger again."
+          "text": "Lairwatch Giant's second ability triggers if it blocks at least two creatures when blockers are declared. It will also trigger if it blocks fewer than two creatures when blockers are declared and effects then cause it to block more creatures. However, if Lairwatch Giant is already blocking two or more creatures, and effects then cause it to block more creatures, the ability won't trigger again."
         }
       ],
       "subtypes": [
@@ -3289,11 +3289,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The token enters the battlefield attacking. It doesn’t trigger “when a creature attacks” triggers and is not subject to restrictions on declaring attackers."
+          "text": "The token enters the battlefield attacking. It doesn't trigger \"when a creature attacks\" triggers and is not subject to restrictions on declaring attackers."
         },
         {
           "date": "2007-10-01",
-          "text": "You choose which player or planeswalker the token is attacking. It doesn’t have to attack the same player or planeswalker as the creature that caused the ability to trigger."
+          "text": "You choose which player or planeswalker the token is attacking. It doesn't have to attack the same player or planeswalker as the creature that caused the ability to trigger."
         }
       ],
       "subtypes": [
@@ -3415,7 +3415,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         },
         {
           "date": "2013-07-01",
@@ -3753,11 +3753,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -4067,19 +4067,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -5025,11 +5025,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "This is a triggered ability, not an activated ability. It doesn’t allow you to tap the creature whenever you want; rather, you need some other way of tapping it, such as by attacking with the creature."
+          "text": "This is a triggered ability, not an activated ability. It doesn't allow you to tap the creature whenever you want; rather, you need some other way of tapping it, such as by attacking with the creature."
         },
         {
           "date": "2007-10-01",
-          "text": "For the ability to trigger, the creature has to actually change from untapped to tapped. If an effect attempts to tap the creature, but it was already tapped at the time, this ability won’t trigger."
+          "text": "For the ability to trigger, the creature has to actually change from untapped to tapped. If an effect attempts to tap the creature, but it was already tapped at the time, this ability won't trigger."
         }
       ],
       "subtypes": [
@@ -5140,11 +5140,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The targeted creature must be tapped when the ability is activated and when it resolves. It doesn’t need to remain tapped in between."
+          "text": "The targeted creature must be tapped when the ability is activated and when it resolves. It doesn't need to remain tapped in between."
         },
         {
           "date": "2007-10-01",
-          "text": "Once the ability has resolved, all damage that would be dealt to that creature for the rest of the turn will be prevented, regardless of whether it’s tapped or untapped at the time that damage would be dealt."
+          "text": "Once the ability has resolved, all damage that would be dealt to that creature for the rest of the turn will be prevented, regardless of whether it's tapped or untapped at the time that damage would be dealt."
         }
       ],
       "subtypes": [
@@ -5900,7 +5900,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The opponent you clash with doesn’t have to be the controller of the targeted spell."
+          "text": "The opponent you clash with doesn't have to be the controller of the targeted spell."
         },
         {
           "date": "2007-10-01",
@@ -6008,19 +6008,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The ability triggers at the end of Captivating Glance’s controller’s turn. “You” refers to the controller of Captivating Glance, not the controller of the enchanted creature."
+          "text": "The ability triggers at the end of Captivating Glance's controller's turn. \"You\" refers to the controller of Captivating Glance, not the controller of the enchanted creature."
         },
         {
           "date": "2007-10-01",
-          "text": "The opponent you clash with doesn’t have to be the controller of the enchanted creature."
+          "text": "The opponent you clash with doesn't have to be the controller of the enchanted creature."
         },
         {
           "date": "2007-10-01",
-          "text": "If you win the clash, you gain control of the enchanted creature. If you don’t win the clash, the other player gains control of the enchanted creature (even if that player didn’t win the clash either)."
+          "text": "If you win the clash, you gain control of the enchanted creature. If you don't win the clash, the other player gains control of the enchanted creature (even if that player didn't win the clash either)."
         },
         {
           "date": "2007-10-01",
-          "text": "Captivating Glance’s controller never changes as a result of this card."
+          "text": "Captivating Glance's controller never changes as a result of this card."
         },
         {
           "date": "2007-10-01",
@@ -6028,7 +6028,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "Captivating Glance’s control-change effect continues to apply even if Captivating Glance leaves the battlefield."
+          "text": "Captivating Glance's control-change effect continues to apply even if Captivating Glance leaves the battlefield."
         }
       ],
       "subtypes": [
@@ -6143,7 +6143,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Look at both chosen modes to determine how many targets Cryptic Command has, if any. If it has at least one target, and all its targets are illegal when it tries to resolve, then it will be countered and none of its effects will happen. For example, if you choose the second and fourth modes, and the permanent is an illegal target when Cryptic Command tries to resolve, you won’t draw a card."
+          "text": "Look at both chosen modes to determine how many targets Cryptic Command has, if any. If it has at least one target, and all its targets are illegal when it tries to resolve, then it will be countered and none of its effects will happen. For example, if you choose the second and fourth modes, and the permanent is an illegal target when Cryptic Command tries to resolve, you won't draw a card."
         }
       ],
       "text": "Choose two —\n• Counter target spell.\n• Return target permanent to its owner's hand.\n• Tap all creatures your opponents control.\n• Draw a card.",
@@ -6889,11 +6889,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "This is a triggered ability, not an activated ability. It doesn’t allow you to tap the creature whenever you want; rather, you need some other way of tapping it, such as by attacking with the creature."
+          "text": "This is a triggered ability, not an activated ability. It doesn't allow you to tap the creature whenever you want; rather, you need some other way of tapping it, such as by attacking with the creature."
         },
         {
           "date": "2007-10-01",
-          "text": "For the ability to trigger, the creature has to actually change from untapped to tapped. If an effect attempts to tap the creature, but it was already tapped at the time, this ability won’t trigger."
+          "text": "For the ability to trigger, the creature has to actually change from untapped to tapped. If an effect attempts to tap the creature, but it was already tapped at the time, this ability won't trigger."
         }
       ],
       "subtypes": [
@@ -7004,7 +7004,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Familiar’s Ruse can’t be cast without a target spell. It can’t target itself."
+          "text": "Familiar's Ruse can't be cast without a target spell. It can't target itself."
         }
       ],
       "text": "As an additional cost to cast Familiar's Ruse, return a creature you control to its owner's hand.\nCounter target spell.",
@@ -7213,7 +7213,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Yes, the opponent draws seven cards. It’s not optional."
+          "text": "Yes, the opponent draws seven cards. It's not optional."
         }
       ],
       "text": "Whenever an opponent casts a spell, that player draws seven cards.",
@@ -7431,7 +7431,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If the enchanted creature becomes untapped, Glimmerdust Nap is put into its owner’s graveyard as a state-based action."
+          "text": "If the enchanted creature becomes untapped, Glimmerdust Nap is put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -7542,7 +7542,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Guile’s second ability replaces “counter [a certain spell]” with “exile [a certain spell] and you may cast it without paying its mana cost.” You have the option to cast it immediately upon its exile. If you choose not to, it remains exiled and you don’t get another chance to cast it. If the spell or ability that tried to counter the spell has additional effects, it then continues to resolve."
+          "text": "Guile's second ability replaces \"counter [a certain spell]\" with \"exile [a certain spell] and you may cast it without paying its mana cost.\" You have the option to cast it immediately upon its exile. If you choose not to, it remains exiled and you don't get another chance to cast it. If the spell or ability that tried to counter the spell has additional effects, it then continues to resolve."
         },
         {
           "date": "2007-10-01",
@@ -7554,23 +7554,23 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a spell or ability you control attempts to counter a spell that can’t be countered, it doesn’t. Since the spell wouldn’t be countered, Guile’s ability has no effect on it. The spell will continue to resolve normally."
+          "text": "If a spell or ability you control attempts to counter a spell that can't be countered, it doesn't. Since the spell wouldn't be countered, Guile's ability has no effect on it. The spell will continue to resolve normally."
         },
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -7790,7 +7790,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than twenty cards in the targeted player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than twenty cards in the targeted player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "subtypes": [
@@ -8956,11 +8956,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "You decide whether or not to add that much {C} to your mana pool as the delayed triggered ability resolves at the beginning of your next main phase. You don’t decide before then."
+          "text": "You decide whether or not to add that much {C} to your mana pool as the delayed triggered ability resolves at the beginning of your next main phase. You don't decide before then."
         },
         {
           "date": "2007-10-01",
-          "text": "You can’t add just some of the mana to your mana pool. You either add all the mana to your mana pool or none of it."
+          "text": "You can't add just some of the mana to your mana pool. You either add all the mana to your mana pool or none of it."
         }
       ],
       "text": "Counter target spell. Clash with an opponent. If you win, at the beginning of your next main phase, you may add an amount of {C} to your mana pool equal to that spell's converted mana cost. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -9276,19 +9276,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If the targeted Shapeshifter becomes an illegal target but the targeted creature doesn’t, the ability will resolve but have no effect."
+          "text": "If the targeted Shapeshifter becomes an illegal target but the targeted creature doesn't, the ability will resolve but have no effect."
         },
         {
           "date": "2007-10-01",
-          "text": "If the targeted creature becomes an illegal target but the targeted Shapeshifter doesn’t, the Shapeshifter will still become a copy of the object. The effect will use the illegal target’s current copiable characteristics if it’s still on the battlefield, or its last known copiable characteristics if it has left the battlefield."
+          "text": "If the targeted creature becomes an illegal target but the targeted Shapeshifter doesn't, the Shapeshifter will still become a copy of the object. The effect will use the illegal target's current copiable characteristics if it's still on the battlefield, or its last known copiable characteristics if it has left the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "The copy effect doesn’t wear off until just before your next untap step (even if an effect will cause that untap step to be skipped)."
+          "text": "The copy effect doesn't wear off until just before your next untap step (even if an effect will cause that untap step to be skipped)."
         },
         {
           "date": "2007-10-01",
-          "text": "If Shapesharer itself becomes a copy of another creature, it loses both changeling and its activated ability (unless it’s copying another creature with changeling and/or another Shapesharer, of course)."
+          "text": "If Shapesharer itself becomes a copy of another creature, it loses both changeling and its activated ability (unless it's copying another creature with changeling and/or another Shapesharer, of course)."
         },
         {
           "date": "2007-10-01",
@@ -9296,15 +9296,15 @@
         },
         {
           "date": "2007-10-01",
-          "text": "The targeted Shapeshifter copies the printed values of the targeted creature, plus any copy effects that have been applied to it. It won’t copy counters on that creature. It won’t copy effects that have changed the creature’s power, toughness, types, color, and so on."
+          "text": "The targeted Shapeshifter copies the printed values of the targeted creature, plus any copy effects that have been applied to it. It won't copy counters on that creature. It won't copy effects that have changed the creature's power, toughness, types, color, and so on."
         },
         {
           "date": "2007-10-01",
-          "text": "If the targeted Shapeshifter copies a creature that’s copying a creature, it will become whatever the chosen creature is copying."
+          "text": "If the targeted Shapeshifter copies a creature that's copying a creature, it will become whatever the chosen creature is copying."
         },
         {
           "date": "2007-10-01",
-          "text": "If the targeted Shapeshifter becomes a copy of a face-down creature, it will become a 2/2 creature with no name, creature type, abilities, mana cost, or color. It will not become face down and thus can’t be turned face up."
+          "text": "If the targeted Shapeshifter becomes a copy of a face-down creature, it will become a 2/2 creature with no name, creature type, abilities, mana cost, or color. It will not become face down and thus can't be turned face up."
         },
         {
           "date": "2007-10-01",
@@ -9523,11 +9523,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "A permanent that’s both a Merfolk and a Faerie is counted only once when determining X."
+          "text": "A permanent that's both a Merfolk and a Faerie is counted only once when determining X."
         },
         {
           "date": "2007-10-01",
-          "text": "The value of X is determined when Silvergill Douser’s ability resolves. It won’t change later, even if the number of Merfolk and/or Faeries you control changes."
+          "text": "The value of X is determined when Silvergill Douser's ability resolves. It won't change later, even if the number of Merfolk and/or Faeries you control changes."
         }
       ],
       "subtypes": [
@@ -9754,7 +9754,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The value of X needs to be determined both when the ability triggers (so you can choose a target) and again when the ability resolves (to check if that target is still legal). If the number of Faeries you control has decreased enough in that time to make the target illegal, Spellstutter Sprite’s ability will be countered (and the targeted spell will resolve as normal)."
+          "text": "The value of X needs to be determined both when the ability triggers (so you can choose a target) and again when the ability resolves (to check if that target is still legal). If the number of Faeries you control has decreased enough in that time to make the target illegal, Spellstutter Sprite's ability will be countered (and the targeted spell will resolve as normal)."
         }
       ],
       "subtypes": [
@@ -10075,11 +10075,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "This is a triggered ability, not an activated ability. It doesn’t allow you to tap the creature whenever you want; rather, you need some other way of tapping it, such as by attacking with the creature."
+          "text": "This is a triggered ability, not an activated ability. It doesn't allow you to tap the creature whenever you want; rather, you need some other way of tapping it, such as by attacking with the creature."
         },
         {
           "date": "2007-10-01",
-          "text": "For the ability to trigger, the creature has to actually change from untapped to tapped. If an effect attempts to tap the creature, but it was already tapped at the time, this ability won’t trigger."
+          "text": "For the ability to trigger, the creature has to actually change from untapped to tapped. If an effect attempts to tap the creature, but it was already tapped at the time, this ability won't trigger."
         }
       ],
       "subtypes": [
@@ -10299,7 +10299,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -10516,11 +10516,11 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If you don’t win the clash, the targeted creature always goes to its owner’s hand. If you win the clash, you choose whether the creature goes to its owner’s hand or the top of its owner’s library."
+          "text": "If you don't win the clash, the targeted creature always goes to its owner's hand. If you win the clash, you choose whether the creature goes to its owner's hand or the top of its owner's library."
         },
         {
           "date": "2007-10-01",
-          "text": "If you clash with the owner of the targeted creature and win, the owner of the creature decides where to put to card revealed during the clash before you decide whether to put the creature on top of that library. You know the player’s decision before you make your decision."
+          "text": "If you clash with the owner of the targeted creature and win, the owner of the creature decides where to put to card revealed during the clash before you decide whether to put the creature on top of that library. You know the player's decision before you make your decision."
         }
       ],
       "text": "Clash with an opponent, then return target creature to its owner's hand. If you win, you may put that creature on top of its owner's library instead. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -11462,7 +11462,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Cairn Wanderer’s ability looks at all cards in all graveyards. It gains any landwalk abilities and any protection abilities."
+          "text": "Cairn Wanderer's ability looks at all cards in all graveyards. It gains any landwalk abilities and any protection abilities."
         }
       ],
       "subtypes": [
@@ -11570,11 +11570,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The turn you cast Colfenor’s Plans, you have cast (at least) one spell that turn. After it enters the battlefield and its last ability goes into effect, you can’t cast any more spells that turn."
+          "text": "The turn you cast Colfenor's Plans, you have cast (at least) one spell that turn. After it enters the battlefield and its last ability goes into effect, you can't cast any more spells that turn."
         },
         {
           "date": "2007-10-01",
-          "text": "Playing a card exiled with Colfenor’s Plans follows all the normal rules for playing that card. You must pay its costs, and you must follow all timing restrictions, for example."
+          "text": "Playing a card exiled with Colfenor's Plans follows all the normal rules for playing that card. You must pay its costs, and you must follow all timing restrictions, for example."
         },
         {
           "date": "2007-10-01",
@@ -11582,7 +11582,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If Colfenor’s Plans leaves the battlefield, you can continue to look at cards exiled by it, but you can no longer play them."
+          "text": "If Colfenor's Plans leaves the battlefield, you can continue to look at cards exiled by it, but you can no longer play them."
         }
       ],
       "text": "When Colfenor's Plans enters the battlefield, exile the top seven cards of your library face down.\nYou may look at and play cards exiled with Colfenor's Plans.\nSkip your draw step.\nYou can't cast more than one spell each turn.",
@@ -11687,19 +11687,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -12231,7 +12231,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "You choose either to have each opponent lose 1 life or to have no opponent lose any life. You don’t choose for each opponent individually."
+          "text": "You choose either to have each opponent lose 1 life or to have no opponent lose any life. You don't choose for each opponent individually."
         }
       ],
       "subtypes": [
@@ -12547,7 +12547,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "You can cast this with zero targets. If you do, you’ll get to draw a card. However, if you cast this with at least one target and all of those targets become illegal, the spell will be countered and you won’t get to draw a card."
+          "text": "You can cast this with zero targets. If you do, you'll get to draw a card. However, if you cast this with at least one target and all of those targets become illegal, the spell will be countered and you won't get to draw a card."
         }
       ],
       "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
@@ -12756,7 +12756,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The effect will automatically repeat itself until its controller doesn’t win the clash. There’s no other way to stop it."
+          "text": "The effect will automatically repeat itself until its controller doesn't win the clash. There's no other way to stop it."
         }
       ],
       "text": "You lose 2 life and draw two cards, then clash with an opponent. If you win, repeat this process. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -12862,7 +12862,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Hornet Harasser’s ability is mandatory. If you’re the only player who controls any creatures, you must give one of your own creatures -2/-2."
+          "text": "Hornet Harasser's ability is mandatory. If you're the only player who controls any creatures, you must give one of your own creatures -2/-2."
         }
       ],
       "subtypes": [
@@ -13194,7 +13194,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -13304,7 +13304,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The number of Elves you control is counted only as Lys Alana Scarblade’s ability resolves. If Lys Alana Scarblade is still on the battlefield, it’ll count itself."
+          "text": "The number of Elves you control is counted only as Lys Alana Scarblade's ability resolves. If Lys Alana Scarblade is still on the battlefield, it'll count itself."
         }
       ],
       "subtypes": [
@@ -13628,7 +13628,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -14284,7 +14284,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Nettlevine Blight grants the triggered ability to the enchanted permanent, so “you” refers to that permanent’s controller. The ability will trigger at the end of that player’s turn, and that player chooses the new creature or land to attach Nettlevine Blight to. The player must choose a creature or land he or she controls."
+          "text": "Nettlevine Blight grants the triggered ability to the enchanted permanent, so \"you\" refers to that permanent's controller. The ability will trigger at the end of that player's turn, and that player chooses the new creature or land to attach Nettlevine Blight to. The player must choose a creature or land he or she controls."
         }
       ],
       "subtypes": [
@@ -14715,10 +14715,10 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The value chosen for X applies to each X in the spell’s effect. You pay {X} only once."
+          "text": "The value chosen for X applies to each X in the spell's effect. You pay {X} only once."
         }
       ],
-      "text": "Choose two —\n• Target player loses X life. \n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
+      "text": "Choose two —\n• Target player loses X life.\n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -14820,7 +14820,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If Prowess of the Fair and another nontoken Elf are put into your graveyard simultaneously (by Akroma’s Vengeance, for example), the other Elf will cause Prowess of the Fair’s ability to trigger."
+          "text": "If Prowess of the Fair and another nontoken Elf are put into your graveyard simultaneously (by Akroma's Vengeance, for example), the other Elf will cause Prowess of the Fair's ability to trigger."
         }
       ],
       "subtypes": [
@@ -15035,7 +15035,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If you activate the ability, the Elf card is exiled as a cost. This action can’t be responded to."
+          "text": "If you activate the ability, the Elf card is exiled as a cost. This action can't be responded to."
         }
       ],
       "subtypes": [
@@ -15790,13 +15790,14 @@
       "originalType": "Sorcery",
       "printings": [
         "LRW",
-        "THS"
+        "THS",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The loss of life is part of the spell’s effect. It’s not an additional cost. If Thoughtseize is countered, you won’t lose life."
+          "text": "The loss of life is part of the spell's effect. It's not an additional cost. If Thoughtseize is countered, you won't lose life."
         },
         {
           "date": "2014-02-01",
@@ -15911,7 +15912,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If the card is an illegla target as the ability resolves, the ability will be countered and none of its effects will happen. Warren Pilferers won’t gain haste."
+          "text": "If the card is an illegla target as the ability resolves, the ability will be countered and none of its effects will happen. Warren Pilferers won't gain haste."
         }
       ],
       "subtypes": [
@@ -16223,19 +16224,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "“That much damage” refers to the number of +1/+1 counters removed from Ashling the Pilgrim. Since the counters are removed, it’s likely that the damage will kill Ashling."
+          "text": "\"That much damage\" refers to the number of +1/+1 counters removed from Ashling the Pilgrim. Since the counters are removed, it's likely that the damage will kill Ashling."
         },
         {
           "date": "2007-10-01",
-          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won’t count toward the total."
+          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won't count toward the total."
         },
         {
           "date": "2007-10-01",
-          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn’t matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don’t count towards the total. Neither does an ability that’s been countered."
+          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn't matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don't count towards the total. Neither does an ability that's been countered."
         },
         {
           "date": "2007-10-01",
-          "text": "You get the bonus only the third time the ability resolves. You won’t get the bonus the fourth, fifth, sixth, or any subsequent times."
+          "text": "You get the bonus only the third time the ability resolves. You won't get the bonus the fourth, fifth, sixth, or any subsequent times."
         }
       ],
       "subtypes": [
@@ -16347,11 +16348,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The “chosen value” is either “odd” or “even.” So either creatures with odd converted mana costs enter the battlefield tapped and creatures with even converted mana costs have haste, or vice versa."
+          "text": "The \"chosen value\" is either \"odd\" or \"even.\" So either creatures with odd converted mana costs enter the battlefield tapped and creatures with even converted mana costs have haste, or vice versa."
         },
         {
           "date": "2007-10-01",
-          "text": "If a creature has X in its mana cost, that X is treated as 0 for the purposes of these effects. It doesn’t matter what the value of X was while the creature was on the stack."
+          "text": "If a creature has X in its mana cost, that X is treated as 0 for the purposes of these effects. It doesn't matter what the value of X was while the creature was on the stack."
         }
       ],
       "text": "As Ashling's Prerogative enters the battlefield, choose odd or even. (Zero is even.)\nEach creature with converted mana cost of the chosen value has haste.\nEach creature without converted mana cost of the chosen value enters the battlefield tapped.",
@@ -16671,7 +16672,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Blind-Spot Giant checks if you control another Giant only as you declare it as an attacking or blocking creature. Once you do, if you lose control of your other Giants, Blind-Spot Giant won’t stop attacking or blocking."
+          "text": "Blind-Spot Giant checks if you control another Giant only as you declare it as an attacking or blocking creature. Once you do, if you lose control of your other Giants, Blind-Spot Giant won't stop attacking or blocking."
         }
       ],
       "subtypes": [
@@ -17097,7 +17098,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Each creature you control that’s both a Goblin and an Elemental can’t be blocked except by two or more creatures (as opposed to four or more creatures)."
+          "text": "Each creature you control that's both a Goblin and an Elemental can't be blocked except by two or more creatures (as opposed to four or more creatures)."
         }
       ],
       "subtypes": [
@@ -17208,7 +17209,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "This triggers whenever you activate an activated ability of an Elemental permanent, but not when you activate an activated ability of an Elemental source that’s not on the battlefield."
+          "text": "This triggers whenever you activate an activated ability of an Elemental permanent, but not when you activate an activated ability of an Elemental source that's not on the battlefield."
         }
       ],
       "subtypes": [
@@ -17322,7 +17323,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can’t choose a negative number."
+          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can't choose a negative number."
         }
       ],
       "subtypes": [
@@ -17637,7 +17638,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Crush Underfoot doesn’t target the Giant creature you control. You choose that Giant as Crush Underfoot resolves. If you don’t control a Giant creature at that time, the spell will finish resolving with no effect."
+          "text": "Crush Underfoot doesn't target the Giant creature you control. You choose that Giant as Crush Underfoot resolves. If you don't control a Giant creature at that time, the spell will finish resolving with no effect."
         }
       ],
       "subtypes": [
@@ -19137,23 +19138,23 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If a spell you control would deal damage to an opponent and that opponent controls a planeswalker, that opponent chooses which of your effects to apply first. — If that player chooses to apply Hostility’s effect first, the damage is prevented, you put some tokens onto the battlefield, and the planeswalker redirection effect is moot because there’s no damage to redirect. — If that player chooses to apply the planeswalker redirection effect first, you have a choice. You can redirect the damage to the planeswalker (in which case Hostility’s prevention effect is moot because nothing’s dealing damage to the player anymore) or you can have your spell continue to deal damage to the opponent. If you choose the latter, Hostility’s effect then applies, the damage is prevented, and you get the tokens."
+          "text": "If a spell you control would deal damage to an opponent and that opponent controls a planeswalker, that opponent chooses which of your effects to apply first. — If that player chooses to apply Hostility's effect first, the damage is prevented, you put some tokens onto the battlefield, and the planeswalker redirection effect is moot because there's no damage to redirect. — If that player chooses to apply the planeswalker redirection effect first, you have a choice. You can redirect the damage to the planeswalker (in which case Hostility's prevention effect is moot because nothing's dealing damage to the player anymore) or you can have your spell continue to deal damage to the opponent. If you choose the latter, Hostility's effect then applies, the damage is prevented, and you get the tokens."
         },
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -19794,15 +19795,15 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won’t count toward the total."
+          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won't count toward the total."
         },
         {
           "date": "2007-10-01",
-          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn’t matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don’t count towards the total. Neither does an ability that’s been countered."
+          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn't matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don't count towards the total. Neither does an ability that's been countered."
         },
         {
           "date": "2007-10-01",
-          "text": "You get the bonus only the third time the ability resolves. You won’t get the bonus the fourth, fifth, sixth, or any subsequent times."
+          "text": "You get the bonus only the third time the ability resolves. You won't get the bonus the fourth, fifth, sixth, or any subsequent times."
         }
       ],
       "subtypes": [
@@ -20429,7 +20430,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If you clash because of a spell or ability an opponent controls, the ability will still trigger. Likewise, you can still win the clash even if you weren’t the player to initiate it."
+          "text": "If you clash because of a spell or ability an opponent controls, the ability will still trigger. Likewise, you can still win the clash even if you weren't the player to initiate it."
         }
       ],
       "subtypes": [
@@ -20541,15 +20542,15 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The mana can be two mana of the same color, or one mana of each of two different colors. The mana can’t be colorless."
+          "text": "The mana can be two mana of the same color, or one mana of each of two different colors. The mana can't be colorless."
         },
         {
           "date": "2007-10-01",
-          "text": "You can use this mana to pay an alternative cost (such as evoke) or additional cost incurred while casting an Elemental spell. It’s not limited to just that spell’s mana cost."
+          "text": "You can use this mana to pay an alternative cost (such as evoke) or additional cost incurred while casting an Elemental spell. It's not limited to just that spell's mana cost."
         },
         {
           "date": "2007-10-01",
-          "text": "The mana can’t be spent to activate activated abilities of Elemental sources that aren’t on the battlefield."
+          "text": "The mana can't be spent to activate activated abilities of Elemental sources that aren't on the battlefield."
         }
       ],
       "subtypes": [
@@ -20663,19 +20664,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Soulbright Flamekin’s ability uses the stack and can be responded to. It’s not a mana ability because it has a target."
+          "text": "Soulbright Flamekin's ability uses the stack and can be responded to. It's not a mana ability because it has a target."
         },
         {
           "date": "2007-10-01",
-          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won’t count toward the total."
+          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won't count toward the total."
         },
         {
           "date": "2007-10-01",
-          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn’t matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don’t count towards the total. Neither does an ability that’s been countered."
+          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn't matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don't count towards the total. Neither does an ability that's been countered."
         },
         {
           "date": "2007-10-01",
-          "text": "You get the bonus only the third time the ability resolves. You won’t get the bonus the fourth, fifth, sixth, or any subsequent times."
+          "text": "You get the bonus only the third time the ability resolves. You won't get the bonus the fourth, fifth, sixth, or any subsequent times."
         }
       ],
       "subtypes": [
@@ -21321,19 +21322,19 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Wild Ricochet can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Wild Ricochet can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2013-07-01",
-          "text": "When Wild Ricochet resolves, it creates a copy of a spell. You control the copy. The controller of the original spell retains control of that spell. The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. The copy resolves before the original spell."
+          "text": "When Wild Ricochet resolves, it creates a copy of a spell. You control the copy. The controller of the original spell retains control of that spell. The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. The copy resolves before the original spell."
         },
         {
           "date": "2013-07-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2013-07-01",
-          "text": "If the spell Wild Ricochet copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Wild Ricochet copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2013-07-01",
@@ -21341,11 +21342,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Wild Ricochet, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Wild Ricochet, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2013-07-01",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
@@ -22097,7 +22098,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "A permanent that’s both a Forest and a Treefolk will be counted twice when determining Dauntless Dourbark’s power and toughness."
+          "text": "A permanent that's both a Forest and a Treefolk will be counted twice when determining Dauntless Dourbark's power and toughness."
         }
       ],
       "subtypes": [
@@ -22208,7 +22209,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The value of X is determined when the ability resolves. It won’t change later, even if the number of Elves you control changes."
+          "text": "The value of X is determined when the ability resolves. It won't change later, even if the number of Elves you control changes."
         },
         {
           "date": "2007-10-01",
@@ -22216,7 +22217,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -23182,11 +23183,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two lands. They don’t have to be tapped."
+          "text": "The first ability can target any two lands. They don't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "The third ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "The third ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -23712,7 +23713,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If the first creature targeted by Hunt Down can’t block the second targeted creature (for example, because the second creature has flying and the first doesn’t, or because both creatures are controlled by the same player), the ability does nothing and the first creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "If the first creature targeted by Hunt Down can't block the second targeted creature (for example, because the second creature has flying and the first doesn't, or because both creatures are controlled by the same player), the ability does nothing and the first creature is free to block whichever creature its controller chooses, or block no creatures at all."
         }
       ],
       "text": "Target creature blocks target creature this turn if able.",
@@ -24368,7 +24369,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If an attacking creature that’s both a Kithkin and an Elf is put into your graveyard from the battlefield, Kithkin Mourncaller’s ability triggers only once."
+          "text": "If an attacking creature that's both a Kithkin and an Elf is put into your graveyard from the battlefield, Kithkin Mourncaller's ability triggers only once."
         }
       ],
       "subtypes": [
@@ -24792,7 +24793,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature’s power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
+          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature's power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
         },
         {
           "date": "2007-10-01",
@@ -24800,7 +24801,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites previous effects that changed the enchanted creature’s creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
+          "text": "Lignify overwrites previous effects that changed the enchanted creature's creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
         },
         {
           "date": "2007-10-01",
@@ -24808,11 +24809,11 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a previous effect switched the creature’s power and toughness, that effect still applies (though it will apply to the creature’s new power and toughness)."
+          "text": "If a previous effect switched the creature's power and toughness, that effect still applies (though it will apply to the creature's new power and toughness)."
         },
         {
           "date": "2007-10-01",
-          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it’s applied before the creature loses the ability."
+          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it's applied before the creature loses the ability."
         },
         {
           "date": "2007-10-01",
@@ -24820,11 +24821,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will overwrite any previous effects that set the enchanted creature’s power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
+          "text": "Lignify will overwrite any previous effects that set the enchanted creature's power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature’s power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
+          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature's power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
         }
       ],
       "subtypes": [
@@ -24941,7 +24942,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Lys Alana Huntmaster’s ability will resolve before the Elf spell that caused it to trigger."
+          "text": "Lys Alana Huntmaster's ability will resolve before the Elf spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -25381,11 +25382,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Primal Command’s modes are performed in the order listed. If you put a noncreature permanent on top of its owner’s library and have that player shuffle his or her graveyard into his or her library, that card is shuffled away."
+          "text": "Primal Command's modes are performed in the order listed. If you put a noncreature permanent on top of its owner's library and have that player shuffle his or her graveyard into his or her library, that card is shuffled away."
         },
         {
           "date": "2017-03-14",
-          "text": "Primal Command won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect if you target yourself with its third mode."
+          "text": "Primal Command won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect if you target yourself with its third mode."
         }
       ],
       "text": "Choose two —\n• Target player gains 7 life.\n• Put target noncreature permanent on top of its owner's library.\n• Target player shuffles his or her graveyard into his or her library.\n• Search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
@@ -25701,7 +25702,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If you win the clash and the targeted enchantment is controlled by an opponent, it will be destroyed a second time if it’s still on the battlefield (for instance, if it somehow regenerated)."
+          "text": "If you win the clash and the targeted enchantment is controlled by an opponent, it will be destroyed a second time if it's still on the battlefield (for instance, if it somehow regenerated)."
         }
       ],
       "text": "Destroy target enchantment. Clash with an opponent. If you win, destroy all enchantments your opponents control. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -25912,7 +25913,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If Timber Protector somehow becomes a Forest, it doesn’t give itself indestructible."
+          "text": "If Timber Protector somehow becomes a Forest, it doesn't give itself indestructible."
         }
       ],
       "subtypes": [
@@ -26127,19 +26128,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -26559,11 +26560,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Wren’s Run Packmaster gives deathtouch to all Wolf permanents you control, not just the tokens it creates."
+          "text": "Wren's Run Packmaster gives deathtouch to all Wolf permanents you control, not just the tokens it creates."
         },
         {
           "date": "2009-10-01",
-          "text": "A Wolf’s deathtouch ability will apply if both Wren’s Run Packmaster and that Wolf are on the battlefield at the time the Wolf deals damage. The creature dealt damage by the Wolf will be destroyed the next time state-based actions are checked, even if the Wolf or Wren’s Run Packmaster leaves the battlefield."
+          "text": "A Wolf's deathtouch ability will apply if both Wren's Run Packmaster and that Wolf are on the battlefield at the time the Wolf deals damage. The creature dealt damage by the Wolf will be destroyed the next time state-based actions are checked, even if the Wolf or Wren's Run Packmaster leaves the battlefield."
         }
       ],
       "subtypes": [
@@ -26898,11 +26899,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Doran’s ability means, for example, that a 2/3 creature will assign 3 damage in combat instead of 2."
+          "text": "Doran's ability means, for example, that a 2/3 creature will assign 3 damage in combat instead of 2."
         },
         {
           "date": "2007-10-01",
-          "text": "Doran’s ability doesn’t actually change creatures’ power; it changes only the value of the combat damage they assign. All other rules and effects that check power or toughness use the real values."
+          "text": "Doran's ability doesn't actually change creatures' power; it changes only the value of the combat damage they assign. All other rules and effects that check power or toughness use the real values."
         },
         {
           "date": "2007-10-01",
@@ -27022,7 +27023,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If one half of a split card has a converted mana cost of 3 or less and doesn’t have an {X} in its mana cost, Gaddock Teeg lets you cast that half."
+          "text": "If one half of a split card has a converted mana cost of 3 or less and doesn't have an {X} in its mana cost, Gaddock Teeg lets you cast that half."
         }
       ],
       "subtypes": [
@@ -27691,15 +27692,15 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The second ability checks how many creatures have been exiled with Colfenor’s Urn over the course of the entire game."
+          "text": "The second ability checks how many creatures have been exiled with Colfenor's Urn over the course of the entire game."
         },
         {
           "date": "2007-10-01",
-          "text": "The second ability forces you to sacrifice Colfenor’s Urn. If the ability triggers and the Urn isn’t sacrificed (because it left the battlefield or changed controllers, for example), the exiled cards won’t be returned to the battlefield."
+          "text": "The second ability forces you to sacrifice Colfenor's Urn. If the ability triggers and the Urn isn't sacrificed (because it left the battlefield or changed controllers, for example), the exiled cards won't be returned to the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "The first ability triggers when a token creature with toughness 4 or greater is put into your graveyard. However, that token will cease to exist before Colfenor’s Plans can exile it."
+          "text": "The first ability triggers when a token creature with toughness 4 or greater is put into your graveyard. However, that token will cease to exist before Colfenor's Plans can exile it."
         }
       ],
       "text": "Whenever a creature with toughness 4 or greater is put into your graveyard from the battlefield, you may exile it.\nAt the beginning of the end step, if three or more cards have been exiled with Colfenor's Urn, sacrifice it. If you do, return those cards to the battlefield under their owner's control.",
@@ -27798,7 +27799,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If the creature you put onto the battlefield can’t be equipped by Deathrender (due to protection from artifacts, for example), the creature enters the battlefield but Deathrender remains unattached."
+          "text": "If the creature you put onto the battlefield can't be equipped by Deathrender (due to protection from artifacts, for example), the creature enters the battlefield but Deathrender remains unattached."
         }
       ],
       "subtypes": [
@@ -28183,7 +28184,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "text": "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy.",
@@ -28384,7 +28385,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "You can tap a creature that hasn’t been under your control since your most recent turn began to activate the ability."
+          "text": "You can tap a creature that hasn't been under your control since your most recent turn began to activate the ability."
         }
       ],
       "text": "{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
@@ -28578,7 +28579,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Thousand-Year Elixir doesn’t actually grant haste to creatures you control, nor does it let you attack with them as though they had haste."
+          "text": "Thousand-Year Elixir doesn't actually grant haste to creatures you control, nor does it let you attack with them as though they had haste."
         }
       ],
       "text": "You may activate abilities of creatures you control as though those creatures had haste.\n{1}, {T}: Untap target creature.",
@@ -28677,19 +28678,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Activating Twinning Glass’s ability allows you to cast a single card from your hand as it resolves. It doesn’t create a continuous effect, and it doesn’t let you cast multiple cards for free."
+          "text": "Activating Twinning Glass's ability allows you to cast a single card from your hand as it resolves. It doesn't create a continuous effect, and it doesn't let you cast multiple cards for free."
         },
         {
           "date": "2007-10-01",
-          "text": "It doesn’t matter who cast the first spell."
+          "text": "It doesn't matter who cast the first spell."
         },
         {
           "date": "2007-10-01",
-          "text": "You can’t pay any alternative costs (such as those from evoke or morph) when casting the card. On the other hand, if the card has additional costs (such as those from kicker or buyback), you may pay those."
+          "text": "You can't pay any alternative costs (such as those from evoke or morph) when casting the card. On the other hand, if the card has additional costs (such as those from kicker or buyback), you may pay those."
         },
         {
           "date": "2007-10-01",
-          "text": "If one half of a split card has been cast this turn, you may use Twinning Glass’s ability to cast either half of a split card with that name. For example, if Dead from Dead/Gone has been cast, you may use Twinning Glass’s ability to cast either Dead or Gone."
+          "text": "If one half of a split card has been cast this turn, you may use Twinning Glass's ability to cast either half of a split card with that name. For example, if Dead from Dead/Gone has been cast, you may use Twinning Glass's ability to cast either Dead or Gone."
         }
       ],
       "text": "{1}, {T}: You may cast a nonland card from your hand without paying its mana cost if it has the same name as a spell that was cast this turn.",
@@ -29453,7 +29454,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "It doesn’t matter which library has twenty or fewer cards in it, and you don’t have to specify a library."
+          "text": "It doesn't matter which library has twenty or fewer cards in it, and you don't have to specify a library."
         }
       ],
       "text": "Hideaway (This land enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\n{T}: Add {U} to your mana pool.\n{U}, {T}: You may play the exiled card without paying its mana cost if a library has twenty or fewer cards in it.",
@@ -29655,15 +29656,15 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "At the time the last ability resolves, you’ll get to play the card if a player who is currently your opponent, or a player who was your opponent at the time he or she left the game, has been dealt 7 damage over the course of the turn."
+          "text": "At the time the last ability resolves, you'll get to play the card if a player who is currently your opponent, or a player who was your opponent at the time he or she left the game, has been dealt 7 damage over the course of the turn."
         },
         {
           "date": "2007-10-01",
-          "text": "It doesn’t matter how the opponent was dealt damage or by whom, as long as the total damage is 7 or more. You don’t specify an opponent when you activate the ability."
+          "text": "It doesn't matter how the opponent was dealt damage or by whom, as long as the total damage is 7 or more. You don't specify an opponent when you activate the ability."
         },
         {
           "date": "2007-10-01",
-          "text": "You’ll get to play the card even if Spinerock Knoll wasn’t on the battlefield at the time some or all of the 7 damage was dealt."
+          "text": "You'll get to play the card even if Spinerock Knoll wasn't on the battlefield at the time some or all of the 7 damage was dealt."
         }
       ],
       "text": "Hideaway (This land enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\n{T}: Add {R} to your mana pool.\n{R}, {T}: You may play the exiled card without paying its mana cost if an opponent was dealt 7 or more damage this turn.",
@@ -30351,7 +30352,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "At the time the ability resolves, you’ll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered the battlefield attacking (such as a token created by Militia’s Pride) doesn’t count because you never attacked with it."
+          "text": "At the time the ability resolves, you'll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered the battlefield attacking (such as a token created by Militia's Pride) doesn't count because you never attacked with it."
         }
       ],
       "text": "Hideaway (This land enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\n{T}: Add {W} to your mana pool.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",
@@ -35063,9 +35064,9 @@
           "multiverseid": 159004
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 158939
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 158981
         }
       ],
       "id": "175d11e11c1ce2417d608bd79fdb24394f1b30fa",
@@ -35448,9 +35449,9 @@
           "multiverseid": 159004
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 158939
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 158981
         }
       ],
       "id": "d46b38d7de38c166a024a0c64002491d66be8b70",
@@ -35833,9 +35834,9 @@
           "multiverseid": 159004
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 158939
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 158981
         }
       ],
       "id": "d8deb574007089e6a20dfe4e42707ae584f683cd",
@@ -36218,9 +36219,9 @@
           "multiverseid": 159004
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 158939
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 158981
         }
       ],
       "id": "af82fab5e2a1483b5bf6e857fe38cd8455ee9fc9",

--- a/json/M10.json
+++ b/json/M10.json
@@ -339,7 +339,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability counts the number of Plains controlled by Armored Ascension’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability counts the number of Plains controlled by Armored Ascension's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -449,7 +449,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "“Protection from Demons and from Dragons” means the following: -- Baneslayer Angel can't be blocked by creatures with the creature type Demon or the creature type Dragon. -- Baneslayer Angel can't be targeted abilities from sources with the creature type Demon or the creature type Dragon, or by spells with either of those types. -- All damage that would be dealt to Baneslayer Angel by sources with the creature type Demon or the creature type Dragon is prevented. -- Baneslayer Angel can't be enchanted by Auras or equipped by artifacts that have somehow gotten the creature type Demon or the creature type Dragon."
+          "text": "\"Protection from Demons and from Dragons\" means the following: -- Baneslayer Angel can't be blocked by creatures with the creature type Demon or the creature type Dragon. -- Baneslayer Angel can't be targeted abilities from sources with the creature type Demon or the creature type Dragon, or by spells with either of those types. -- All damage that would be dealt to Baneslayer Angel by sources with the creature type Demon or the creature type Dragon is prevented. -- Baneslayer Angel can't be enchanted by Auras or equipped by artifacts that have somehow gotten the creature type Demon or the creature type Dragon."
         }
       ],
       "subtypes": [
@@ -758,7 +758,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Lands are colorless (even if their frames have some colored elements to them). You can’t target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
+          "text": "Lands are colorless (even if their frames have some colored elements to them). You can't target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
         }
       ],
       "text": "Exile target black or red permanent.",
@@ -863,15 +863,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         },
         {
           "date": "2012-07-01",
-          "text": "Destroying a blocking creature won’t cause any of the creatures it was blocking to become unblocked. They won’t deal combat damage to the defending player or planeswalker (unless they have trample)."
+          "text": "Destroying a blocking creature won't cause any of the creatures it was blocking to become unblocked. They won't deal combat damage to the defending player or planeswalker (unless they have trample)."
         }
       ],
       "text": "Destroy target attacking or blocking creature.",
@@ -1162,7 +1162,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Glorious Charge affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn. It won’t affect permanents that become creatures later in the turn."
+          "text": "Glorious Charge affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn. It won't affect permanents that become creatures later in the turn."
         }
       ],
       "text": "Creatures you control get +1/+1 until end of turn.",
@@ -1360,7 +1360,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Spells and permanents have controllers, but cards that aren’t on the stack or the battlefield don’t. If a source without a controller (such as a cycled Jund Sojourners, for example) would deal damage to you, 1 of that damage is prevented if an opponent owns that source."
+          "text": "Spells and permanents have controllers, but cards that aren't on the stack or the battlefield don't. If a source without a controller (such as a cycled Jund Sojourners, for example) would deal damage to you, 1 of that damage is prevented if an opponent owns that source."
         },
         {
           "date": "2009-10-01",
@@ -1465,27 +1465,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As you cast Harm’s Way, you target the creature or player that the redirected damage will be dealt to. As Harm’s Way resolves, you choose a source of damage. You never choose the original recipient of the damage; Harm’s Way will apply to whatever the chosen source tries to deal damage to, as long as it’s you or a permanent you control."
+          "text": "As you cast Harm's Way, you target the creature or player that the redirected damage will be dealt to. As Harm's Way resolves, you choose a source of damage. You never choose the original recipient of the damage; Harm's Way will apply to whatever the chosen source tries to deal damage to, as long as it's you or a permanent you control."
         },
         {
           "date": "2009-10-01",
-          "text": "Harm’s Way can affect damage that would be dealt to a planeswalker you control (as well as damage that would be dealt to you, or to a creature you control)."
+          "text": "Harm's Way can affect damage that would be dealt to a planeswalker you control (as well as damage that would be dealt to you, or to a creature you control)."
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen source would deal just 1 damage to you or a permanent you control, Harm’s Way’s effect will redirect that damage and still have a “shield” left for another 1 damage from that source later in the turn."
+          "text": "If the chosen source would deal just 1 damage to you or a permanent you control, Harm's Way's effect will redirect that damage and still have a \"shield\" left for another 1 damage from that source later in the turn."
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen source would simultaneously deal damage to multiple permanents you control (like Pyroclasm could) or to you and at least one permanent you control (like Earthquake could), Harm’s Way will redirect just 2 of that damage. It won’t redirect the next 2 damage that would be dealt to each recipient. You choose which 2 damage is redirected. If you like, you can choose to redirect 1 damage that would be dealt by the chosen source to each of two different recipients."
+          "text": "If the chosen source would simultaneously deal damage to multiple permanents you control (like Pyroclasm could) or to you and at least one permanent you control (like Earthquake could), Harm's Way will redirect just 2 of that damage. It won't redirect the next 2 damage that would be dealt to each recipient. You choose which 2 damage is redirected. If you like, you can choose to redirect 1 damage that would be dealt by the chosen source to each of two different recipients."
         },
         {
           "date": "2009-10-01",
-          "text": "After Harm’s Way resolves, it no longer checks to see if the targeted creature or player is a legal target. However, if that creature or player can’t be dealt damage at the time the chosen source would deal damage (perhaps because the creature is no longer on the battlefield or is no longer a creature, or because the player is no longer in the game), the damage can’t be redirected. It’s dealt to the original recipient."
+          "text": "After Harm's Way resolves, it no longer checks to see if the targeted creature or player is a legal target. However, if that creature or player can't be dealt damage at the time the chosen source would deal damage (perhaps because the creature is no longer on the battlefield or is no longer a creature, or because the player is no longer in the game), the damage can't be redirected. It's dealt to the original recipient."
         },
         {
           "date": "2009-10-01",
-          "text": "Harm’s Way has no effect on damage that’s already been dealt."
+          "text": "Harm's Way has no effect on damage that's already been dealt."
         }
       ],
       "text": "The next 2 damage that a source of your choice would deal to you and/or permanents you control this turn is dealt to target creature or player instead.",
@@ -1781,15 +1781,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If an effect would simultaneously destroy Indestructibility and the creature it’s enchanting, only Indestructibility is destroyed."
+          "text": "If an effect would simultaneously destroy Indestructibility and the creature it's enchanting, only Indestructibility is destroyed."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage, damage from a source with deathtouch, and effects that say “destroy” won’t cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, if it’s a planeswalker and another planeswalker with the same subtype is controlled by the same player, if it’s a creature with toughness 0 or less, or if it’s an Aura that’s either unattached or attached to something illegal."
+          "text": "Lethal damage, damage from a source with deathtouch, and effects that say \"destroy\" won't cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, if it's a planeswalker and another planeswalker with the same subtype is controlled by the same player, if it's a creature with toughness 0 or less, or if it's an Aura that's either unattached or attached to something illegal."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted by Indestructibility is dealt lethal damage, the creature isn’t destroyed, but the damage remains marked on the creature. If Indestructibility stops enchanting that creature later in the turn, the creature will no longer have indestructible and will be destroyed."
+          "text": "If a creature enchanted by Indestructibility is dealt lethal damage, the creature isn't destroyed, but the damage remains marked on the creature. If Indestructibility stops enchanting that creature later in the turn, the creature will no longer have indestructible and will be destroyed."
         }
       ],
       "subtypes": [
@@ -1889,7 +1889,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The controller of the enchanted creature, not the controller of Lifelink, gains the life (in case they’re different players)."
+          "text": "The controller of the enchanted creature, not the controller of Lifelink, gains the life (in case they're different players)."
         }
       ],
       "subtypes": [
@@ -1989,7 +1989,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Lands are colorless (even if their frames have some colored elements to them). You can’t target a Swamp, a Mountain, or any other land with Lightwielder Paladin’s ability (unless some other effect has turned that land black or red)."
+          "text": "Lands are colorless (even if their frames have some colored elements to them). You can't target a Swamp, a Mountain, or any other land with Lightwielder Paladin's ability (unless some other effect has turned that land black or red)."
         }
       ],
       "subtypes": [
@@ -2099,15 +2099,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Mesa Enchantress’s last ability will resolve before the spell that caused it to trigger."
+          "text": "Mesa Enchantress's last ability will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "If the enchantment spell is countered, Mesa Enchantress’s last ability still resolves and causes you to draw a card."
+          "text": "If the enchantment spell is countered, Mesa Enchantress's last ability still resolves and causes you to draw a card."
         },
         {
           "date": "2016-06-08",
-          "text": "Enchantments put onto the battlefield without being cast won’t cause Mesa Enchantress’s last ability to trigger."
+          "text": "Enchantments put onto the battlefield without being cast won't cause Mesa Enchantress's last ability to trigger."
         }
       ],
       "subtypes": [
@@ -2214,11 +2214,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "An Aura put onto the battlefield this way can’t enchant an artifact or enchantment that’s also being put onto the battlefield with Open the Vaults."
+          "text": "An Aura put onto the battlefield this way can't enchant an artifact or enchantment that's also being put onto the battlefield with Open the Vaults."
         },
         {
           "date": "2009-10-01",
-          "text": "If an Aura can be returned to the battlefield with Open the Vaults, it must be, even if its owner doesn’t like what it would enchant."
+          "text": "If an Aura can be returned to the battlefield with Open the Vaults, it must be, even if its owner doesn't like what it would enchant."
         },
         {
           "date": "2009-10-01",
@@ -2849,7 +2849,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         }
       ],
       "text": "Target blocking creature gets +7/+7 until end of turn.",
@@ -2952,15 +2952,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage will prevent damage dealt to creatures that weren’t on the battlefield at the time it resolved."
+          "text": "Safe Passage will prevent damage dealt to creatures that weren't on the battlefield at the time it resolved."
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage doesn’t prevent damage that would be dealt to planeswalkers you control. Although it can’t prevent combat damage that would be dealt to your planeswalkers, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply Safe Passage’s prevention effect to that damage first, and there won’t be any damage to redirect."
+          "text": "Safe Passage doesn't prevent damage that would be dealt to planeswalkers you control. Although it can't prevent combat damage that would be dealt to your planeswalkers, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply Safe Passage's prevention effect to that damage first, and there won't be any damage to redirect."
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage has no effect on damage that’s already been dealt."
+          "text": "Safe Passage has no effect on damage that's already been dealt."
         }
       ],
       "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
@@ -3281,7 +3281,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Silence won’t affect spells that your opponents cast before you cast Silence. (In other words, it can’t be used as a retroactive Cancel.) Silence also won’t stop your opponents from casting spells after you cast Silence but before Silence resolves."
+          "text": "Silence won't affect spells that your opponents cast before you cast Silence. (In other words, it can't be used as a retroactive Cancel.) Silence also won't stop your opponents from casting spells after you cast Silence but before Silence resolves."
         },
         {
           "date": "2009-10-01",
@@ -3479,7 +3479,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted permanent is an illegal target by the time Solemn Offering would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted permanent is an illegal target by the time Solemn Offering would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Destroy target artifact or enchantment. You gain 4 life.",
@@ -3595,7 +3595,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other’s ability to trigger."
+          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other's ability to trigger."
         },
         {
           "date": "2005-08-01",
@@ -3896,7 +3896,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Undead Slayer’s ability must target a permanent (not a card in the graveyard) with at least one of the listed creature types."
+          "text": "Undead Slayer's ability must target a permanent (not a card in the graveyard) with at least one of the listed creature types."
         }
       ],
       "subtypes": [
@@ -4519,7 +4519,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "After the ability resolves, the targeted creature attacks you only if it’s able to do so as that turn’s declare attackers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” it can’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost, so the creature doesn’t have to attack in that case either."
+          "text": "After the ability resolves, the targeted creature attacks you only if it's able to do so as that turn's declare attackers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" it can't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost, so the creature doesn't have to attack in that case either."
         },
         {
           "date": "2009-10-01",
@@ -4527,11 +4527,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability during your opponent’s turn after attackers have been declared will have no effect. The same is true if you activate the ability during your own turn."
+          "text": "Activating the ability during your opponent's turn after attackers have been declared will have no effect. The same is true if you activate the ability during your own turn."
         },
         {
           "date": "2011-09-22",
-          "text": "If there are multiple combat phases in a turn, the creature must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, the creature must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -4625,6 +4625,10 @@
         },
         {
           "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -4785,7 +4789,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -4793,11 +4797,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -4805,7 +4809,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -4905,7 +4909,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The affected land loses its existing land types and any abilities printed on it. It becomes the chosen basic land type and now has the ability to tap to add one mana of the appropriate color to your mana pool. Convincing Mirage’s ability doesn’t change the affected land’s name or whether it’s legendary or basic."
+          "text": "The affected land loses its existing land types and any abilities printed on it. It becomes the chosen basic land type and now has the ability to tap to add one mana of the appropriate color to your mana pool. Convincing Mirage's ability doesn't change the affected land's name or whether it's legendary or basic."
         }
       ],
       "subtypes": [
@@ -5106,7 +5110,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A creature with power 0 or less assigns no combat damage. (It doesn’t assign a negative amount of combat damage.)"
+          "text": "A creature with power 0 or less assigns no combat damage. (It doesn't assign a negative amount of combat damage.)"
         }
       ],
       "text": "Target creature gets -7/-0 until end of turn.",
@@ -5308,19 +5312,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You play the revealed card as part of the resolution of Djinn of Wishes’s ability. Timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other play restrictions are not (such as “Cast [this card] only during combat”)."
+          "text": "You play the revealed card as part of the resolution of Djinn of Wishes's ability. Timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other play restrictions are not (such as \"Cast [this card] only during combat\")."
         },
         {
           "date": "2009-10-01",
-          "text": "If the revealed card is a spell, you may cast it only if you can choose legal targets for it. If you cast it, it’s put on the stack, then Djinn of Wishes’s ability finishes resolving. The spell will then resolve as normal, after players get a chance to cast spells and activate abilities."
+          "text": "If the revealed card is a spell, you may cast it only if you can choose legal targets for it. If you cast it, it's put on the stack, then Djinn of Wishes's ability finishes resolving. The spell will then resolve as normal, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2009-10-01",
-          "text": "If the revealed card is a land, you can play it only if it’s your turn and you haven’t yet played a land this turn."
+          "text": "If the revealed card is a land, you can play it only if it's your turn and you haven't yet played a land this turn."
         },
         {
           "date": "2009-10-01",
-          "text": "If you play a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs, such as conspire costs and kicker costs."
+          "text": "If you play a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs, such as conspire costs and kicker costs."
         }
       ],
       "subtypes": [
@@ -5406,6 +5410,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -5428,7 +5436,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -5719,7 +5727,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Hive Mind’s effect is mandatory. Each other player must copy the spell whether they want to or not."
+          "text": "Hive Mind's effect is mandatory. Each other player must copy the spell whether they want to or not."
         },
         {
           "date": "2009-10-01",
@@ -5727,31 +5735,31 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts an instant or sorcery spell, Hive Mind’s ability triggers and is put on the stack on top of that spell. Hive Mind’s ability will resolve first. When it does, it creates a number of copies of that spell equal to the number of players in the game minus one. First the player whose turn it is (or, if that’s the player who cast the original spell, the player to that player’s left) puts his or her copy on the stack, choosing new targets for it if he or she likes. Then each other player in turn order does the same. The last copy put on the stack will be the first one that resolves. (Note that the very last thing to happen is that the original spell resolves.)"
+          "text": "If a player casts an instant or sorcery spell, Hive Mind's ability triggers and is put on the stack on top of that spell. Hive Mind's ability will resolve first. When it does, it creates a number of copies of that spell equal to the number of players in the game minus one. First the player whose turn it is (or, if that's the player who cast the original spell, the player to that player's left) puts his or her copy on the stack, choosing new targets for it if he or she likes. Then each other player in turn order does the same. The last copy put on the stack will be the first one that resolves. (Note that the very last thing to happen is that the original spell resolves.)"
         },
         {
           "date": "2009-10-01",
-          "text": "The copies that Hive Mind’s ability creates are created on the stack, so they’re not “cast.” Abilities that trigger when a player casts a spell (like Hive Mind’s ability itself) won’t trigger."
+          "text": "The copies that Hive Mind's ability creates are created on the stack, so they're not \"cast.\" Abilities that trigger when a player casts a spell (like Hive Mind's ability itself) won't trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "Each copy will have the same targets as the spell it’s copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "Each copy will have the same targets as the spell it's copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. If, for one of the targets, the player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. A player can’t choose a different one."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. A player can't choose a different one."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
         },
         {
           "date": "2009-10-01",
-          "text": "A copy’s controller can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
+          "text": "A copy's controller can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
         },
         {
           "date": "2009-10-01",
-          "text": "If a copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if a copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If a copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if a copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "Whenever a player casts an instant or sorcery spell, each other player copies that spell. Each of those players may choose new targets for his or her copy.",
@@ -5952,11 +5960,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the enchanted creature becomes the target of a spell or ability, Ice Cage’s ability triggers and is put on the stack on top of that spell or ability. Ice Cage’s ability will resolve (causing Ice Cage to be destroyed) first."
+          "text": "If the enchanted creature becomes the target of a spell or ability, Ice Cage's ability triggers and is put on the stack on top of that spell or ability. Ice Cage's ability will resolve (causing Ice Cage to be destroyed) first."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -6056,7 +6064,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If Illusionary Servant becomes the target of a spell or ability, Illusionary Servant’s ability triggers and is put on the stack on top of that spell or ability. Illusionary Servant’s ability will resolve (causing it to be sacrificed) first. Unless the spell or ability has another target, it will then be countered when it tries to resolve for having no legal targets."
+          "text": "If Illusionary Servant becomes the target of a spell or ability, Illusionary Servant's ability triggers and is put on the stack on top of that spell or ability. Illusionary Servant's ability will resolve (causing it to be sacrificed) first. Unless the spell or ability has another target, it will then be countered when it tries to resolve for having no legal targets."
         }
       ],
       "subtypes": [
@@ -6165,7 +6173,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than twenty cards in the targeted player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than twenty cards in the targeted player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "subtypes": [
@@ -6271,7 +6279,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         }
       ],
       "text": "Target creature gains flying until end of turn.",
@@ -6574,7 +6582,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To have any effect, Merfolk Sovereign’s activated ability must be activated before the declare blockers step begins. Once a Merfolk has become blocked, activating Merfolk Sovereign’s ability won’t change that."
+          "text": "To have any effect, Merfolk Sovereign's activated ability must be activated before the declare blockers step begins. Once a Merfolk has become blocked, activating Merfolk Sovereign's ability won't change that."
         }
       ],
       "subtypes": [
@@ -6678,7 +6686,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -6906,7 +6914,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -7118,7 +7126,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If there are no creatures in the player’s library, then the target creature is still destroyed, you see all the cards in that player’s library, and then they shuffle and continue play."
+          "text": "If there are no creatures in the player's library, then the target creature is still destroyed, you see all the cards in that player's library, and then they shuffle and continue play."
         },
         {
           "date": "2009-10-01",
@@ -7126,15 +7134,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If there are no creature cards in the player’s library, all the cards in that library are revealed, then the library is shuffled. (The targeted creature remains destroyed.)"
+          "text": "If there are no creature cards in the player's library, all the cards in that library are revealed, then the library is shuffled. (The targeted creature remains destroyed.)"
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2013-07-01",
-          "text": "If the targeted creature has indestructible, it’s still a legal target — it just isn’t destroyed. The rest of Polymorph’s effect happens as normal."
+          "text": "If the targeted creature has indestructible, it's still a legal target — it just isn't destroyed. The rest of Polymorph's effect happens as normal."
         }
       ],
       "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card onto the battlefield, then shuffles all other cards revealed this way into his or her library.",
@@ -7534,11 +7542,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The second part of Sleep’s effect affects all creatures the targeted player controls as Sleep resolves, not just the ones that Sleep actually caused to become tapped."
+          "text": "The second part of Sleep's effect affects all creatures the targeted player controls as Sleep resolves, not just the ones that Sleep actually caused to become tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Sleep tracks both the player and the creatures. If one of the creatures controlled by the targeted player as Sleep resolves changes controllers, the creature will untap as normal during its new controller’s next untap step."
+          "text": "Sleep tracks both the player and the creatures. If one of the creatures controlled by the targeted player as Sleep resolves changes controllers, the creature will untap as normal during its new controller's next untap step."
         }
       ],
       "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
@@ -7740,19 +7748,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may search for any card, not just a creature card. Of course, if you choose a noncreature card, you won’t be able to put it onto the battlefield no matter what card the player names."
+          "text": "You may search for any card, not just a creature card. Of course, if you choose a noncreature card, you won't be able to put it onto the battlefield no matter what card the player names."
         },
         {
           "date": "2009-10-01",
-          "text": "Once you’ve chosen a card during your search, you must clearly indicate which card you’ve chosen (preferably without showing the front of that card to the player!). Then the player names a card."
+          "text": "Once you've chosen a card during your search, you must clearly indicate which card you've chosen (preferably without showing the front of that card to the player!). Then the player names a card."
         },
         {
           "date": "2009-10-01",
-          "text": "After the player names a card, check if the card you chose has that name. If it doesn’t, but it’s a creature card, you may put it onto the battlefield. If you don’t want to put that card onto the battlefield, it’s not a creature card, or it does have the name the player said, it simply stays in that player’s library without ever being revealed. The player then shuffles his or her library, including that card."
+          "text": "After the player names a card, check if the card you chose has that name. If it doesn't, but it's a creature card, you may put it onto the battlefield. If you don't want to put that card onto the battlefield, it's not a creature card, or it does have the name the player said, it simply stays in that player's library without ever being revealed. The player then shuffles his or her library, including that card."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -7959,7 +7967,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Target player takes an extra turn after this one.",
@@ -8057,7 +8065,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than five cards in the targeted player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than five cards in the targeted player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "text": "Target player puts the top five cards of his or her library into his or her graveyard.",
@@ -8264,27 +8272,27 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs paid for the targeted spell are copied as though those same costs were paid for the copy too."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs paid for the targeted spell are copied as though those same costs were paid for the copy too."
         },
         {
           "date": "2005-06-01",
-          "text": "Twincast copies any text spliced onto the targeted spell, but you can’t splice additional text onto the copy."
+          "text": "Twincast copies any text spliced onto the targeted spell, but you can't splice additional text onto the copy."
         },
         {
           "date": "2009-10-01",
-          "text": "Twincast can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Twincast can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2009-10-01",
-          "text": "As Twincast resolves, it creates a copy of a spell. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "As Twincast resolves, it creates a copy of a spell. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2009-10-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell Twincast copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Twincast copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2009-10-01",
@@ -8292,7 +8300,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
@@ -8357,6 +8365,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -8513,11 +8525,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Frost’s ability tracks the creature, not the creature’s controller. That is, if the creature changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "Wall of Frost's ability tracks the creature, not the creature's controller. That is, if the creature changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-07-18",
-          "text": "If the creature isn’t tapped during its controller’s next untap step (perhaps because it was untapped by a spell), Wall of Frost’s ability has no effect at that time. It won’t try to keep the creature tapped on subsequent turns."
+          "text": "If the creature isn't tapped during its controller's next untap step (perhaps because it was untapped by a spell), Wall of Frost's ability has no effect at that time. It won't try to keep the creature tapped on subsequent turns."
         }
       ],
       "subtypes": [
@@ -9259,7 +9271,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The creature card in a graveyard is exiled as part of the activated ability’s effect, not as a cost. If that card has left the graveyard by the time the ability would resolve, the ability is countered and you don’t get a Zombie token."
+          "text": "The creature card in a graveyard is exiled as part of the activated ability's effect, not as a cost. If that card has left the graveyard by the time the ability would resolve, the ability is countered and you don't get a Zombie token."
         }
       ],
       "subtypes": [
@@ -9476,7 +9488,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
@@ -9787,7 +9799,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -10290,6 +10302,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -10332,7 +10348,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -10437,7 +10453,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "While you’re searching the player’s library, you don’t have to find all the cards with the same name as an exiled card if you don’t want to. You can leave any number of them in that player’s library."
+          "text": "While you're searching the player's library, you don't have to find all the cards with the same name as an exiled card if you don't want to. You can leave any number of them in that player's library."
         }
       ],
       "text": "Exile all cards from target player's graveyard other than basic land cards. For each card exiled this way, search that player's library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
@@ -10643,7 +10659,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The ability triggers even if the Specter’s damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
+          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
         }
       ],
       "subtypes": [
@@ -10848,7 +10864,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -11395,19 +11411,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -11515,11 +11531,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Yes, you’re allowed to have a deck consisting of sixty Relentless Rats and nothing else."
+          "text": "Yes, you're allowed to have a deck consisting of sixty Relentless Rats and nothing else."
         },
         {
           "date": "2004-12-01",
-          "text": "Relentless Rats’s last ability overrides the normal limit of four of an individual card in a Constructed deck."
+          "text": "Relentless Rats's last ability overrides the normal limit of four of an individual card in a Constructed deck."
         }
       ],
       "subtypes": [
@@ -11636,19 +11652,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
+          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -11758,11 +11774,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -11865,7 +11881,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Sanguine Bond’s ability triggers just once for each life-gaining event, whether it’s 1 life from Soul Warden or 8 life from Tendrils of Corruption."
+          "text": "Sanguine Bond's ability triggers just once for each life-gaining event, whether it's 1 life from Soul Warden or 8 life from Tendrils of Corruption."
         }
       ],
       "text": "Whenever you gain life, target opponent loses that much life.",
@@ -12168,7 +12184,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -12482,11 +12498,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You can sacrifice Vampire Aristocrat to activate its own ability, but it won’t be around to get the bonus."
+          "text": "You can sacrifice Vampire Aristocrat to activate its own ability, but it won't be around to get the bonus."
         },
         {
           "date": "2009-10-01",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature has been dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature has been dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -12591,15 +12607,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -12607,7 +12623,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the top card of your library is black, Vampire Nocturnus will give itself +2/+1 and flying even if it’s somehow not a Vampire."
+          "text": "If the top card of your library is black, Vampire Nocturnus will give itself +2/+1 and flying even if it's somehow not a Vampire."
         }
       ],
       "subtypes": [
@@ -13019,7 +13035,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you have two Xathrid Demons, both abilities will trigger at the beginning of your upkeep. When the first Demon’s ability resolves, you can sacrifice the second Demon to satisfy the requirement (“Sacrifice a creature other than Xathrid Demon” really means “Sacrifice a creature other than this creature”). When the second Demon’s ability resolves, you must sacrifice another creature. If you can’t (because the first Demon has somehow left the battlefield and you control no other creatures), you lose 7 life, regardless of whether the second Demon is still on the battlefield at this time."
+          "text": "If you have two Xathrid Demons, both abilities will trigger at the beginning of your upkeep. When the first Demon's ability resolves, you can sacrifice the second Demon to satisfy the requirement (\"Sacrifice a creature other than Xathrid Demon\" really means \"Sacrifice a creature other than this creature\"). When the second Demon's ability resolves, you must sacrifice another creature. If you can't (because the first Demon has somehow left the battlefield and you control no other creatures), you lose 7 life, regardless of whether the second Demon is still on the battlefield at this time."
         }
       ],
       "subtypes": [
@@ -13232,15 +13248,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Act of Treason can target any creature, even one that’s untapped or one you already control."
+          "text": "Act of Treason can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2013-07-01",
-          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you’ll choose one to remain on the battlefield and put the other into its owner’s graveyard."
+          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you'll choose one to remain on the battlefield and put the other into its owner's graveyard."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
@@ -13445,11 +13461,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If, during your declare attackers step, Berserkers of Blood Ridge is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then it doesn’t attack. If there’s a cost associated with having Berserkers of Blood Ridge attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Berserkers of Blood Ridge is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then it doesn't attack. If there's a cost associated with having Berserkers of Blood Ridge attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2010-08-15",
-          "text": "If there are multiple combat phases in a turn, Berserkers of Blood Ridge must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Berserkers of Blood Ridge must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -13662,7 +13678,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Each player must discard three cards, even a player that (for some reason) didn’t actually draw three cards."
+          "text": "Each player must discard three cards, even a player that (for some reason) didn't actually draw three cards."
         }
       ],
       "text": "Each player draws three cards, then discards three cards at random.",
@@ -13758,7 +13774,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Burst of Speed affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Burst of Speed affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control gain haste until end of turn. (They can attack and {T} even if they just came under your control.)",
@@ -13958,19 +13974,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If Capricious Efreet is the only nonland permanent you control when its ability triggers, you’ll have to target it."
+          "text": "If Capricious Efreet is the only nonland permanent you control when its ability triggers, you'll have to target it."
         },
         {
           "date": "2009-10-01",
-          "text": "You may target zero, one, or two nonland permanents you don’t control."
+          "text": "You may target zero, one, or two nonland permanents you don't control."
         },
         {
           "date": "2009-10-01",
-          "text": "You target between one and three permanents as you put the ability on the stack. You don’t randomly choose which one will be destroyed until the ability resolves. If one of those permanents has become an illegal target by then, you randomly choose between the remaining ones."
+          "text": "You target between one and three permanents as you put the ability on the stack. You don't randomly choose which one will be destroyed until the ability resolves. If one of those permanents has become an illegal target by then, you randomly choose between the remaining ones."
         },
         {
           "date": "2009-10-01",
-          "text": "As the ability resolves, there is no time to react between the time a permanent is chosen at random and the time it’s destroyed. If you want to put a regeneration shield on one of those permanents, or sacrifice it for some effect, or anything else, you must do so before the ability resolves (and before you know which one of the permanents will be chosen at random)."
+          "text": "As the ability resolves, there is no time to react between the time a permanent is chosen at random and the time it's destroyed. If you want to put a regeneration shield on one of those permanents, or sacrifice it for some effect, or anything else, you must do so before the ability resolves (and before you know which one of the permanents will be chosen at random)."
         },
         {
           "date": "2013-07-01",
@@ -14082,7 +14098,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can’t choose a negative number."
+          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can't choose a negative number."
         }
       ],
       "subtypes": [
@@ -14198,11 +14214,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -14540,7 +14556,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -14552,7 +14568,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -14669,7 +14685,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -14773,7 +14789,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Goblin Artillery’s ability would resolve, the entire ability is countered. You won’t be dealt any damage."
+          "text": "If the targeted creature or player is an illegal target by the time Goblin Artillery's ability would resolve, the entire ability is countered. You won't be dealt any damage."
         }
       ],
       "subtypes": [
@@ -15181,11 +15197,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Inferno Elemental’s ability will trigger for each creature it blocks or becomes blocked by."
+          "text": "Inferno Elemental's ability will trigger for each creature it blocks or becomes blocked by."
         },
         {
           "date": "2009-10-01",
-          "text": "Inferno Elemental’s ability resolves during the declare blockers step, before even first strike damage is assigned. If the damage dealt to another creature this way is lethal damage, that creature will be destroyed before it can deal its combat damage."
+          "text": "Inferno Elemental's ability resolves during the declare blockers step, before even first strike damage is assigned. If the damage dealt to another creature this way is lethal damage, that creature will be destroyed before it can deal its combat damage."
         },
         {
           "date": "2009-10-01",
@@ -15290,19 +15306,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "“Can’t attack alone” means Jackal Familiar can’t be declared as an attacker during the declare attackers step unless at least one other creature is also declared as an attacker at that time (either by you or your Two-Headed Giant teammate)."
+          "text": "\"Can't attack alone\" means Jackal Familiar can't be declared as an attacker during the declare attackers step unless at least one other creature is also declared as an attacker at that time (either by you or your Two-Headed Giant teammate)."
         },
         {
           "date": "2009-10-01",
-          "text": "“Can’t block alone” has a similar meaning. Note that the other blocker(s) doesn’t have to block the same attacker as Jackal Familiar."
+          "text": "\"Can't block alone\" has a similar meaning. Note that the other blocker(s) doesn't have to block the same attacker as Jackal Familiar."
         },
         {
           "date": "2009-10-01",
-          "text": "Once Jackal Familiar has been legally declared as an attacking or blocking creature, how many other creatures it’s attacking or blocking with no longer matters. For example, if Jackal Familiar and Canyon Minotaur both attack, then Canyon Minotaur leaves the battlefield, Jackal Familiar continues to attack even though it’s now attacking alone."
+          "text": "Once Jackal Familiar has been legally declared as an attacking or blocking creature, how many other creatures it's attacking or blocking with no longer matters. For example, if Jackal Familiar and Canyon Minotaur both attack, then Canyon Minotaur leaves the battlefield, Jackal Familiar continues to attack even though it's now attacking alone."
         },
         {
           "date": "2009-10-01",
-          "text": "An effect may put Jackal Familiar onto the battlefield attacking even if no other creatures are attacking. That’s because it wasn’t declared as an attacker in this case. Similarly, an effect may put Jackal Familiar onto the battlefield blocking even if no other creatures are blocking."
+          "text": "An effect may put Jackal Familiar onto the battlefield attacking even if no other creatures are attacking. That's because it wasn't declared as an attacker in this case. Similarly, an effect may put Jackal Familiar onto the battlefield blocking even if no other creatures are blocking."
         }
       ],
       "subtypes": [
@@ -15372,6 +15388,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -15418,7 +15438,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn’t prevent that creature from dealing combat damage."
+          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn't prevent that creature from dealing combat damage."
         }
       ],
       "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
@@ -15954,7 +15974,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -16839,11 +16859,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander’s activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
+          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander's activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
         },
         {
           "date": "2016-06-08",
-          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -17056,19 +17076,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the Giant’s power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
+          "text": "If the Giant's power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
         },
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stone Giant’s ability is activated during a turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. The targeted creature will be destroyed at that time."
+          "text": "If Stone Giant's ability is activated during a turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. The targeted creature will be destroyed at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it’s no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant’s power at that time."
+          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it's no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant's power at that time."
         }
       ],
       "subtypes": [
@@ -17181,7 +17201,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
@@ -17189,7 +17209,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you’ve declared attackers usually won’t do anything."
+          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you've declared attackers usually won't do anything."
         }
       ],
       "text": "Attacking creatures get +2/+0 until end of turn.",
@@ -17502,7 +17522,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Tokens are permanents but not cards. They’ll count toward the number of permanents shuffled into your library, so you’ll get a card back for each token you owned. But the tokens themselves should be ignored while you’re revealing *cards* from your library. In practice, you shouldn’t actually shuffle them into your library since they’ll cease to exist as soon as Warp World finishes resolving. Note that a token’s owner is the player under whose control it first entered the battlefield."
+          "text": "Tokens are permanents but not cards. They'll count toward the number of permanents shuffled into your library, so you'll get a card back for each token you owned. But the tokens themselves should be ignored while you're revealing *cards* from your library. In practice, you shouldn't actually shuffle them into your library since they'll cease to exist as soon as Warp World finishes resolving. Note that a token's owner is the player under whose control it first entered the battlefield."
         }
       ],
       "text": "Each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, and land cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of his or her library.",
@@ -17896,23 +17916,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Awakener Druid’s ability affects a land with the land type Forest, not necessarily a land with the name Forest."
+          "text": "Awakener Druid's ability affects a land with the land type Forest, not necessarily a land with the name Forest."
         },
         {
           "date": "2009-10-01",
-          "text": "Awakener Druid’s ability is mandatory. When it enters the battlefield, you must target a Forest (if there is one), even if you don’t control that Forest."
+          "text": "Awakener Druid's ability is mandatory. When it enters the battlefield, you must target a Forest (if there is one), even if you don't control that Forest."
         },
         {
           "date": "2009-10-01",
-          "text": "If Awakener Druid leaves the battlefield before its enters-the-battlefield ability resolves, nothing happens to the targeted Forest when that ability resolves. It won’t become a creature."
+          "text": "If Awakener Druid leaves the battlefield before its enters-the-battlefield ability resolves, nothing happens to the targeted Forest when that ability resolves. It won't become a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted Forest entered the battlefield this turn, it will be affected by “summoning sickness” once it becomes a Treefolk. You won’t be able to attack with it or use its activated abilities that have {T} in the cost (including its mana ability)."
+          "text": "If the targeted Forest entered the battlefield this turn, it will be affected by \"summoning sickness\" once it becomes a Treefolk. You won't be able to attack with it or use its activated abilities that have {T} in the cost (including its mana ability)."
         },
         {
           "date": "2009-10-01",
-          "text": "If Awakener Druid and the Treefolk are dealt lethal damage at the same time, both will be destroyed. However, if Awakener Druid leaves the battlefield before the Treefolk is dealt damage, it will immediately revert to being just a land and thus can’t be dealt damage."
+          "text": "If Awakener Druid and the Treefolk are dealt lethal damage at the same time, both will be destroyed. However, if Awakener Druid leaves the battlefield before the Treefolk is dealt damage, it will immediately revert to being just a land and thus can't be dealt damage."
         }
       ],
       "subtypes": [
@@ -18619,7 +18639,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Activating Cudgel Troll’s ability causes a “regeneration shield” to be created for it. The next time Cudgel Troll would be destroyed that turn, the regeneration shield is used up instead. This works only if Cudgel Troll is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to “destroy” it. Other effects that cause Cudgel Troll to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don’t destroy it, so regeneration won’t save it. If it hasn’t been used, the regeneration shield goes away as the turn ends."
+          "text": "Activating Cudgel Troll's ability causes a \"regeneration shield\" to be created for it. The next time Cudgel Troll would be destroyed that turn, the regeneration shield is used up instead. This works only if Cudgel Troll is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to \"destroy\" it. Other effects that cause Cudgel Troll to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don't destroy it, so regeneration won't save it. If it hasn't been used, the regeneration shield goes away as the turn ends."
         },
         {
           "date": "2010-08-15",
@@ -18831,11 +18851,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Elvish Archdruid’s first ability affects only other Elves you control. However, Elvish Archdruid’s second ability counts all Elves you control — including itself."
+          "text": "Elvish Archdruid's first ability affects only other Elves you control. However, Elvish Archdruid's second ability counts all Elves you control — including itself."
         },
         {
           "date": "2011-09-22",
-          "text": "Elvish Archdruid’s activated ability is a mana ability. It doesn’t use the stack and players can’t respond to it."
+          "text": "Elvish Archdruid's activated ability is a mana ability. It doesn't use the stack and players can't respond to it."
         }
       ],
       "subtypes": [
@@ -18950,7 +18970,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -19356,11 +19376,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Entangling Vines can enchant only a creature that’s tapped. If at any time the enchanted creature is untapped, Entangling Vines is put into its owner’s graveyard as a state-based action."
+          "text": "Entangling Vines can enchant only a creature that's tapped. If at any time the enchanted creature is untapped, Entangling Vines is put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2009-10-01",
-          "text": "If Entangling Vines is cast as a spell, it can target only a tapped creature. If the creature has become untapped by the time Entangling Vines would resolve, it’s countered and put into its owner’s graveyard from the stack."
+          "text": "If Entangling Vines is cast as a spell, it can target only a tapped creature. If the creature has become untapped by the time Entangling Vines would resolve, it's countered and put into its owner's graveyard from the stack."
         }
       ],
       "subtypes": [
@@ -19582,11 +19602,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two lands. They don’t have to be tapped."
+          "text": "The first ability can target any two lands. They don't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "The third ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "The third ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -19801,6 +19821,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -19941,11 +19965,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Great Sable Stag can be targeted by spells that try to counter it (such as Cancel). Those spells will resolve, but the part of their effect that would counter Great Sable Stag won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Great Sable Stag can be targeted by spells that try to counter it (such as Cancel). Those spells will resolve, but the part of their effect that would counter Great Sable Stag won't do anything. Any other effects those spells have will work as normal."
         },
         {
           "date": "2009-10-01",
-          "text": "Although the reminder text doesn’t say so, Great Sable Stag also can’t be equipped by blue or black Equipment."
+          "text": "Although the reminder text doesn't say so, Great Sable Stag also can't be equipped by blue or black Equipment."
         }
       ],
       "subtypes": [
@@ -20373,11 +20397,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You must put the revealed card onto the battlefield if it’s a creature card. If it’s not a creature card and you don’t put it on the bottom of your library, it stops being revealed and simply remains on top of your library."
+          "text": "You must put the revealed card onto the battlefield if it's a creature card. If it's not a creature card and you don't put it on the bottom of your library, it stops being revealed and simply remains on top of your library."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Whenever an opponent casts a spell, reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, you may put that card on the bottom of your library.",
@@ -20473,23 +20497,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The Wolves are tapped as part of the activated ability’s effect, not as a cost."
+          "text": "The Wolves are tapped as part of the activated ability's effect, not as a cost."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time the activated ability would resolve, the entire ability is countered. Nothing else happens. (For example, the Wolves aren’t tapped.)"
+          "text": "If the targeted creature is an illegal target by the time the activated ability would resolve, the entire ability is countered. Nothing else happens. (For example, the Wolves aren't tapped.)"
         },
         {
           "date": "2009-10-01",
-          "text": "The Wolves deal their damage first. This may be important if the damage causes the targeted creature’s power to be reduced (if it’s Protean Hydra, for example). However, creatures aren’t destroyed for having been dealt lethal damage until a spell or ability has finished resolving. If the targeted creature is dealt lethal damage by the tapped Wolves, it will still get to deal damage to those Wolves before being destroyed."
+          "text": "The Wolves deal their damage first. This may be important if the damage causes the targeted creature's power to be reduced (if it's Protean Hydra, for example). However, creatures aren't destroyed for having been dealt lethal damage until a spell or ability has finished resolving. If the targeted creature is dealt lethal damage by the tapped Wolves, it will still get to deal damage to those Wolves before being destroyed."
         },
         {
           "date": "2009-10-01",
-          "text": "Only a Wolf creature tapped as part of the ability’s effect can be dealt damage by the targeted creature."
+          "text": "Only a Wolf creature tapped as part of the ability's effect can be dealt damage by the targeted creature."
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted creature’s controller doesn’t divide that creature’s damage as the ability is activated (since the Wolves that will receive that damage aren’t targeted), so that player does so as the ability resolves. Each Wolf chosen by that player must be dealt at least 1 damage. There is no time to react between the time a Wolf is chosen, the time damage is dealt to it, and the time it’s destroyed for having been dealt lethal damage. If you want to put a regeneration shield on one of those Wolves, or target it with a damage-prevention spell, or anything else, you must do so before the ability resolves (and before you know which Wolves will be chosen and how much damage will be dealt to them)."
+          "text": "The targeted creature's controller doesn't divide that creature's damage as the ability is activated (since the Wolves that will receive that damage aren't targeted), so that player does so as the ability resolves. Each Wolf chosen by that player must be dealt at least 1 damage. There is no time to react between the time a Wolf is chosen, the time damage is dealt to it, and the time it's destroyed for having been dealt lethal damage. If you want to put a regeneration shield on one of those Wolves, or target it with a damage-prevention spell, or anything else, you must do so before the ability resolves (and before you know which Wolves will be chosen and how much damage will be dealt to them)."
         }
       ],
       "subtypes": [
@@ -20785,11 +20809,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If an opponent casts a blue or black spell, Mold Adder’s ability triggers and is put on the stack on top of that spell. Mold Adder’s ability will resolve before the spell does."
+          "text": "If an opponent casts a blue or black spell, Mold Adder's ability triggers and is put on the stack on top of that spell. Mold Adder's ability will resolve before the spell does."
         },
         {
           "date": "2009-10-01",
-          "text": "If an opponent casts a spell that’s both blue and black, Mold Adder’s ability triggers only once."
+          "text": "If an opponent casts a spell that's both blue and black, Mold Adder's ability triggers only once."
         }
       ],
       "subtypes": [
@@ -21233,7 +21257,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -21332,11 +21356,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Prized Unicorn doesn’t give a creature the ability to block it. It just forces those creatures that are already able to block it to do so. For example, it can’t force a creature that’s tapped or affected by a spell or ability that says it can’t block to block it. If there’s a cost associated with having a creature block, its controller isn’t forced to pay that cost, so the creature doesn’t have to block Prized Unicorn in that case either."
+          "text": "Prized Unicorn doesn't give a creature the ability to block it. It just forces those creatures that are already able to block it to do so. For example, it can't force a creature that's tapped or affected by a spell or ability that says it can't block to block it. If there's a cost associated with having a creature block, its controller isn't forced to pay that cost, so the creature doesn't have to block Prized Unicorn in that case either."
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature the defending player controls can’t block Prized Unicorn, it can block any attacking creature, or not block at all."
+          "text": "If a creature the defending player controls can't block Prized Unicorn, it can block any attacking creature, or not block at all."
         },
         {
           "date": "2009-10-01",
@@ -21441,15 +21465,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "All damage that would be dealt to Protean Hydra is prevented, even if it doesn’t have that many +1/+1 counters on it. This is true even if Protean Hydra has no +1/+1 counters on it at all (and is able to remain on the battlefield because some other effect is boosting its toughness). If the amount of damage that would be dealt to Protean Hydra is greater than the number of +1/+1 counters on it, all the +1/+1 counters on Protean Hydra are removed from it."
+          "text": "All damage that would be dealt to Protean Hydra is prevented, even if it doesn't have that many +1/+1 counters on it. This is true even if Protean Hydra has no +1/+1 counters on it at all (and is able to remain on the battlefield because some other effect is boosting its toughness). If the amount of damage that would be dealt to Protean Hydra is greater than the number of +1/+1 counters on it, all the +1/+1 counters on Protean Hydra are removed from it."
         },
         {
           "date": "2009-10-01",
-          "text": "If unpreventable damage is dealt to Protean Hydra, the Hydra’s second ability will try to prevent it and fail (meaning that damage has its normal results), and it will also remove that many +1/+1 counters from Protean Hydra."
+          "text": "If unpreventable damage is dealt to Protean Hydra, the Hydra's second ability will try to prevent it and fail (meaning that damage has its normal results), and it will also remove that many +1/+1 counters from Protean Hydra."
         },
         {
           "date": "2009-10-01",
-          "text": "Protean Hydra’s last ability triggers whenever a +1/+1 counter is removed from it for any reason, not just when a +1/+1 counter is removed by its second ability."
+          "text": "Protean Hydra's last ability triggers whenever a +1/+1 counter is removed from it for any reason, not just when a +1/+1 counter is removed by its second ability."
         },
         {
           "date": "2009-10-01",
@@ -21457,7 +21481,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a -1/-1 counter is put on Protean Hydra while it has +1/+1 counters on it, that -1/-1 counter and a +1/+1 counter will be removed from it as a state-based action. This will cause Protean Hydra’s last ability to trigger."
+          "text": "If a -1/-1 counter is put on Protean Hydra while it has +1/+1 counters on it, that -1/-1 counter and a +1/+1 counter will be removed from it as a state-based action. This will cause Protean Hydra's last ability to trigger."
         },
         {
           "date": "2009-10-01",
@@ -21590,7 +21614,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -22077,7 +22101,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a white spell, Angel’s Feather’s ability triggers and is put on the stack on top of that spell. Angel’s Feather’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a white spell, Angel's Feather's ability triggers and is put on the stack on top of that spell. Angel's Feather's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a white spell, you may gain 1 life.",
@@ -22188,7 +22212,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Coat of Arms counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Coat of Arms counts creatures, not creature types."
         }
       ],
       "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
@@ -22283,7 +22307,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Lethal damage, damage from a source with deathtouch, and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed or if its toughness is 0 or less. (In these cases, of course, Darksteel Colossus would be shuffled into its owner’s library instead of being put into its owner’s graveyard.)"
+          "text": "Lethal damage, damage from a source with deathtouch, and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed or if its toughness is 0 or less. (In these cases, of course, Darksteel Colossus would be shuffled into its owner's library instead of being put into its owner's graveyard.)"
         }
       ],
       "subtypes": [
@@ -22394,7 +22418,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a black spell, Demon’s Horn’s ability triggers and is put on the stack on top of that spell. Demon’s Horn’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a black spell, Demon's Horn's ability triggers and is put on the stack on top of that spell. Demon's Horn's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a black spell, you may gain 1 life.",
@@ -22499,7 +22523,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a red spell, Dragon’s Claw’s ability triggers and is put on the stack on top of that spell. Dragon’s Claw’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a red spell, Dragon's Claw's ability triggers and is put on the stack on top of that spell. Dragon's Claw's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a red spell, you may gain 1 life.",
@@ -22806,7 +22830,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a blue spell, Kraken’s Eye’s ability triggers and is put on the stack on top of that spell. Kraken’s Eye’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a blue spell, Kraken's Eye's ability triggers and is put on the stack on top of that spell. Kraken's Eye's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a blue spell, you may gain 1 life.",
@@ -22895,7 +22919,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Magebane Armor can equip a creature that doesn’t have flying. The “lose flying” effect just won’t do anything in that case."
+          "text": "Magebane Armor can equip a creature that doesn't have flying. The \"lose flying\" effect just won't do anything in that case."
         },
         {
           "date": "2009-10-01",
@@ -22903,7 +22927,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Combat damage is the damage that’s dealt automatically by attacking and blocking creatures, even if it’s redirected (by Harm’s Way, perhaps). Noncombat damage is any other damage (generally, it’s damage dealt as the result of a spell or ability)."
+          "text": "Combat damage is the damage that's dealt automatically by attacking and blocking creatures, even if it's redirected (by Harm's Way, perhaps). Noncombat damage is any other damage (generally, it's damage dealt as the result of a spell or ability)."
         }
       ],
       "subtypes": [
@@ -22996,15 +23020,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t choose the exiled cards until Mirror of Fate’s ability resolves. It doesn’t matter how they wound up in the exile zone."
+          "text": "You don't choose the exiled cards until Mirror of Fate's ability resolves. It doesn't matter how they wound up in the exile zone."
         },
         {
           "date": "2009-10-01",
-          "text": "Exiled cards are face up by default; they’re face down only if the effect that exiled them said so. For example, the cards from your library that Mirror of Fate exiles are exiled face up."
+          "text": "Exiled cards are face up by default; they're face down only if the effect that exiled them said so. For example, the cards from your library that Mirror of Fate exiles are exiled face up."
         },
         {
           "date": "2009-10-01",
-          "text": "You choose the order that the chosen cards are put on top of your library. You don’t have to show anyone else that order."
+          "text": "You choose the order that the chosen cards are put on top of your library. You don't have to show anyone else that order."
         }
       ],
       "text": "{T}, Sacrifice Mirror of Fate: Choose up to seven face-up exiled cards you own. Exile all the cards from your library, then put the chosen cards on top of your library.",
@@ -23220,15 +23244,15 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Pithing Needle affects cards regardless of what zone they’re in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can’t cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
+          "text": "Pithing Needle affects cards regardless of what zone they're in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can't cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
         },
         {
           "date": "2005-06-01",
-          "text": "You can name any card, even if that card doesn’t normally have an activated ability. You can’t name a token unless that token has the same name as a card."
+          "text": "You can name any card, even if that card doesn't normally have an activated ability. You can't name a token unless that token has the same name as a card."
         },
         {
           "date": "2005-06-01",
-          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can’t be activated."
+          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -23236,7 +23260,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” Triggered abilities and static abilities of the named card work normally."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" Triggered abilities and static abilities of the named card work normally."
         }
       ],
       "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
@@ -23337,23 +23361,23 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They’ll still work."
+          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They'll still work."
         },
         {
           "date": "2004-12-01",
-          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can’t prevent you from losing the game)."
+          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can't prevent you from losing the game)."
         },
         {
           "date": "2009-10-01",
-          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn’t matter whether you have 0 or less life, you’re forced to draw a card while your library is empty, you have ten or more poison counters, you’re dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
+          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn't matter whether you have 0 or less life, you're forced to draw a card while your library is empty, you have ten or more poison counters, you're dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
         },
         {
           "date": "2009-10-01",
-          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you’re penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
+          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you're penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
         },
         {
           "date": "2009-10-01",
-          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can’t lose the game and the opposing team can’t win the game."
+          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can't lose the game and the opposing team can't win the game."
         }
       ],
       "subtypes": [
@@ -23558,7 +23582,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Spellbook onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.",
@@ -23759,7 +23783,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a green spell, Wurm’s Tooth’s ability triggers and is put on the stack on top of that spell. Wurm’s Tooth’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a green spell, Wurm's Tooth's ability triggers and is put on the stack on top of that spell. Wurm's Tooth's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a green spell, you may gain 1 life.",
@@ -23855,11 +23879,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don’t have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don't have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
@@ -23954,11 +23978,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don’t have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don't have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
@@ -24136,11 +24160,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Plains or Island, not for lands named Plains or Island. The lands it checks for don’t have to be basic lands. For example, if you control Watery Grave (a nonbasic land with the land types Island and Swamp), Glacial Fortress will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Plains or Island, not for lands named Plains or Island. The lands it checks for don't have to be basic lands. For example, if you control Watery Grave (a nonbasic land with the land types Island and Swamp), Glacial Fortress will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
@@ -24236,11 +24260,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don’t have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don't have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
@@ -24335,11 +24359,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don’t have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don't have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
@@ -29054,6 +29078,11 @@
           "multiverseid": 201045
         },
         {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 199548
+        },
+        {
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 199797
@@ -29072,6 +29101,21 @@
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 199800
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200544
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200545
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200546
         },
         {
           "language": "Italian",
@@ -29137,26 +29181,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 200298
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200793
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200794
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200795
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200796
         }
       ],
       "id": "52fc54f3e01108278a69a02ff10ec83f4c0e9cfc",
@@ -29439,6 +29463,11 @@
           "multiverseid": 201045
         },
         {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 199548
+        },
+        {
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 199797
@@ -29457,6 +29486,21 @@
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 199800
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200544
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200545
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200546
         },
         {
           "language": "Italian",
@@ -29522,26 +29566,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 200298
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200793
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200794
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200795
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200796
         }
       ],
       "id": "eb48e99765ee93b7d4178c8395499306b5d3d48f",
@@ -29824,6 +29848,11 @@
           "multiverseid": 201045
         },
         {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 199548
+        },
+        {
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 199797
@@ -29842,6 +29871,21 @@
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 199800
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200544
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200545
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200546
         },
         {
           "language": "Italian",
@@ -29907,26 +29951,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 200298
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200793
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200794
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200795
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200796
         }
       ],
       "id": "cdab0850b4d8f9fd7d008c6e76126988bc6c4d60",
@@ -30209,6 +30233,11 @@
           "multiverseid": 201045
         },
         {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 199548
+        },
+        {
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 199797
@@ -30227,6 +30256,21 @@
           "language": "German",
           "name": "Gebirge",
           "multiverseid": 199800
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200544
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200545
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 200546
         },
         {
           "language": "Italian",
@@ -30292,26 +30336,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 200298
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200793
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200794
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200795
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 200796
         }
       ],
       "id": "d07e128647cd1b0bea9d76aa7538bcf5b4b91927",

--- a/json/M11.json
+++ b/json/M11.json
@@ -347,11 +347,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Soulmender or 8 life from Meditation Puzzle."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Soulmender or 8 life from Meditation Puzzle."
         },
         {
           "date": "2014-07-18",
-          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Ajani’s Pridemate’s ability will trigger twice. However, if a single creature you control with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
+          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Ajani's Pridemate's ability will trigger twice. However, if a single creature you control with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
         }
       ],
       "subtypes": [
@@ -459,23 +459,23 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "During your turn, Angelic Arbiter’s abilities have no effect on the game."
+          "text": "During your turn, Angelic Arbiter's abilities have no effect on the game."
         },
         {
           "date": "2010-08-15",
-          "text": "During an opponent’s turn, that opponent may either cast spells or attack with creatures, but not both (assuming that Angelic Arbiter is on the battlefield for the entirety of that turn). The player may perform other actions, such as activating abilities and playing lands."
+          "text": "During an opponent's turn, that opponent may either cast spells or attack with creatures, but not both (assuming that Angelic Arbiter is on the battlefield for the entirety of that turn). The player may perform other actions, such as activating abilities and playing lands."
         },
         {
           "date": "2010-08-15",
-          "text": "If Angelic Arbiter leaves the battlefield during an opponent’s turn, its abilities cease to affect the game. For example, if an opponent casts Doom Blade to destroy Angelic Arbiter, that player may then attack with creatures."
+          "text": "If Angelic Arbiter leaves the battlefield during an opponent's turn, its abilities cease to affect the game. For example, if an opponent casts Doom Blade to destroy Angelic Arbiter, that player may then attack with creatures."
         },
         {
           "date": "2010-08-15",
-          "text": "If Angelic Arbiter enters the battlefield during an opponent’s turn, its abilities take actions that player performed earlier in the turn into account, even though it wasn’t on the battlefield at the time. For example, if an opponent casts a spell, then you use Leyline of Anticipation’s ability to cast Angelic Arbiter as though it had flash, that player won’t be able to attack with creatures that turn."
+          "text": "If Angelic Arbiter enters the battlefield during an opponent's turn, its abilities take actions that player performed earlier in the turn into account, even though it wasn't on the battlefield at the time. For example, if an opponent casts a spell, then you use Leyline of Anticipation's ability to cast Angelic Arbiter as though it had flash, that player won't be able to attack with creatures that turn."
         },
         {
           "date": "2010-08-15",
-          "text": "Angelic Arbiter’s last ability applies if an opponent attacked with at least one creature during the current turn."
+          "text": "Angelic Arbiter's last ability applies if an opponent attacked with at least one creature during the current turn."
         }
       ],
       "subtypes": [
@@ -586,7 +586,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability counts the number of Plains controlled by Armored Ascension’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability counts the number of Plains controlled by Armored Ascension's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -807,7 +807,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "“Protection from Demons and from Dragons” means the following: -- Baneslayer Angel can't be blocked by creatures with the creature type Demon or the creature type Dragon. -- Baneslayer Angel can't be targeted abilities from sources with the creature type Demon or the creature type Dragon, or by spells with either of those types. -- All damage that would be dealt to Baneslayer Angel by sources with the creature type Demon or the creature type Dragon is prevented. -- Baneslayer Angel can't be enchanted by Auras or equipped by artifacts that have somehow gotten the creature type Demon or the creature type Dragon."
+          "text": "\"Protection from Demons and from Dragons\" means the following: -- Baneslayer Angel can't be blocked by creatures with the creature type Demon or the creature type Dragon. -- Baneslayer Angel can't be targeted abilities from sources with the creature type Demon or the creature type Dragon, or by spells with either of those types. -- All damage that would be dealt to Baneslayer Angel by sources with the creature type Demon or the creature type Dragon is prevented. -- Baneslayer Angel can't be enchanted by Auras or equipped by artifacts that have somehow gotten the creature type Demon or the creature type Dragon."
         }
       ],
       "subtypes": [
@@ -1023,7 +1023,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Lands are colorless (even if their frames have some colored elements to them). You can’t target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
+          "text": "Lands are colorless (even if their frames have some colored elements to them). You can't target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
         }
       ],
       "text": "Exile target black or red permanent.",
@@ -1234,7 +1234,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The affected creature’s last known existence on the battlefield is checked to determine its toughness."
+          "text": "The affected creature's last known existence on the battlefield is checked to determine its toughness."
         }
       ],
       "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
@@ -1968,7 +1968,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         }
       ],
       "subtypes": [
@@ -2093,7 +2093,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The set of creatures affected by Inspired Charge is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won’t get +2/+1."
+          "text": "The set of creatures affected by Inspired Charge is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get +2/+1."
         }
       ],
       "text": "Creatures you control get +2/+1 until end of turn.",
@@ -2200,11 +2200,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage, damage from a source with deathtouch, and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage, damage from a source with deathtouch, and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If another Knight creature you control is dealt lethal damage, the creature isn’t destroyed, but the damage remains marked on it. If, at some point later in that turn, you no longer control Knight Exemplar or it loses its abilities, the other Knight creature will lose indestructible and will be destroyed."
+          "text": "If another Knight creature you control is dealt lethal damage, the creature isn't destroyed, but the damage remains marked on it. If, at some point later in that turn, you no longer control Knight Exemplar or it loses its abilities, the other Knight creature will lose indestructible and will be destroyed."
         },
         {
           "date": "2013-07-01",
@@ -2314,7 +2314,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of Sanctity is in your opening hand, you may begin the game with it on the battlefield.\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)",
@@ -2435,7 +2435,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
         }
       ],
       "text": "Target creature gets +2/+2 and gains flying until end of turn.",
@@ -2883,15 +2883,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage will prevent damage dealt to creatures that weren’t on the battlefield at the time it resolved."
+          "text": "Safe Passage will prevent damage dealt to creatures that weren't on the battlefield at the time it resolved."
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage doesn’t prevent damage that would be dealt to planeswalkers you control. Although it can’t prevent combat damage that would be dealt to your planeswalkers, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply Safe Passage’s prevention effect to that damage first, and there won’t be any damage to redirect."
+          "text": "Safe Passage doesn't prevent damage that would be dealt to planeswalkers you control. Although it can't prevent combat damage that would be dealt to your planeswalkers, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply Safe Passage's prevention effect to that damage first, and there won't be any damage to redirect."
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage has no effect on damage that’s already been dealt."
+          "text": "Safe Passage has no effect on damage that's already been dealt."
         }
       ],
       "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
@@ -3124,7 +3124,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "In a Two-Headed Giant game, anything that cares about your life total checks your team’s life total. Serra Ascendant gets +5/+5 and has flying as long as your team has 30 or more life."
+          "text": "In a Two-Headed Giant game, anything that cares about your life total checks your team's life total. Serra Ascendant gets +5/+5 and has flying as long as your team has 30 or more life."
         }
       ],
       "subtypes": [
@@ -3333,7 +3333,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Silence won’t affect spells that your opponents cast before you cast Silence. (In other words, it can’t be used as a retroactive Cancel.) Silence also won’t stop your opponents from casting spells after you cast Silence but before Silence resolves."
+          "text": "Silence won't affect spells that your opponents cast before you cast Silence. (In other words, it can't be used as a retroactive Cancel.) Silence also won't stop your opponents from casting spells after you cast Silence but before Silence resolves."
         },
         {
           "date": "2009-10-01",
@@ -3541,7 +3541,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted permanent is an illegal target by the time Solemn Offering would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted permanent is an illegal target by the time Solemn Offering would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Destroy target artifact or enchantment. You gain 4 life.",
@@ -3865,7 +3865,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         }
       ],
       "subtypes": [
@@ -4072,7 +4072,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The only target of Vengeful Archon’s ability is the player it may deal damage to. You choose that target as you activate the ability, not at the time it prevents damage."
+          "text": "The only target of Vengeful Archon's ability is the player it may deal damage to. You choose that target as you activate the ability, not at the time it prevents damage."
         },
         {
           "date": "2010-08-15",
@@ -4080,35 +4080,35 @@
         },
         {
           "date": "2010-08-15",
-          "text": "Vengeful Archon’s ability doesn’t have you choose a source of damage. It will apply to the next X damage you would be dealt that turn, regardless of where that damage comes from. It doesn’t matter whether the damage would all be dealt at the same time. For example, if X is 4 and you’d be dealt 3 damage by Lightning Bolt, that 3 damage is prevented and Vengeful Archon deals 3 damage to the targeted player. The prevention effect will still apply to the next 1 damage you’d be dealt that turn."
+          "text": "Vengeful Archon's ability doesn't have you choose a source of damage. It will apply to the next X damage you would be dealt that turn, regardless of where that damage comes from. It doesn't matter whether the damage would all be dealt at the same time. For example, if X is 4 and you'd be dealt 3 damage by Lightning Bolt, that 3 damage is prevented and Vengeful Archon deals 3 damage to the targeted player. The prevention effect will still apply to the next 1 damage you'd be dealt that turn."
         },
         {
           "date": "2010-08-15",
-          "text": "The effect of Vengeful Archon’s ability is not a redirection effect. If it prevents damage, Vengeful Archon (not the source of that damage) deals damage to the targeted player as part of that prevention effect. Vengeful Archon is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don’t affect this damage. The new damage is not combat damage, even if the prevented damage was. Since you control the source of the new damage, if you targeted an opponent with Vengeful Archon’s ability, you may have Vengeful Archon deal its damage to a planeswalker that opponent controls."
+          "text": "The effect of Vengeful Archon's ability is not a redirection effect. If it prevents damage, Vengeful Archon (not the source of that damage) deals damage to the targeted player as part of that prevention effect. Vengeful Archon is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don't affect this damage. The new damage is not combat damage, even if the prevented damage was. Since you control the source of the new damage, if you targeted an opponent with Vengeful Archon's ability, you may have Vengeful Archon deal its damage to a planeswalker that opponent controls."
         },
         {
           "date": "2010-08-15",
-          "text": "Whether the targeted player is still a legal target is no longer checked after Vengeful Archon’s ability resolves. For example, if a player targeted by Vengeful Archon’s ability puts Leyline of Sanctity (which says “You can’t be the target of spells or abilities your opponents control”) onto the battlefield after the ability resolves but before it prevents damage, the ability will still prevent damage and still deal damage to that player. If Vengeful Archon can’t deal damage to the targeted player (because the player is no longer in the game in a multiplayer game, for example), it will still prevent damage. It just won’t deal any damage itself."
+          "text": "Whether the targeted player is still a legal target is no longer checked after Vengeful Archon's ability resolves. For example, if a player targeted by Vengeful Archon's ability puts Leyline of Sanctity (which says \"You can't be the target of spells or abilities your opponents control\") onto the battlefield after the ability resolves but before it prevents damage, the ability will still prevent damage and still deal damage to that player. If Vengeful Archon can't deal damage to the targeted player (because the player is no longer in the game in a multiplayer game, for example), it will still prevent damage. It just won't deal any damage itself."
         },
         {
           "date": "2010-08-15",
-          "text": "If Vengeful Archon’s ability doesn’t prevent any damage (perhaps because a different prevention effect is applied to the damage that would be dealt to you, or because the damage is unpreventable), Vengeful Archon won’t deal any damage itself."
+          "text": "If Vengeful Archon's ability doesn't prevent any damage (perhaps because a different prevention effect is applied to the damage that would be dealt to you, or because the damage is unpreventable), Vengeful Archon won't deal any damage itself."
         },
         {
           "date": "2010-08-15",
-          "text": "If Vengeful Archon’s ability prevents damage, Vengeful Archon deals its damage immediately afterward as part of that same prevention effect. This happens before state-based actions are checked, and before any player can cast spells or activate abilities. If a spell or ability would have caused that damage to be dealt, this happens before that spell or ability resumes its resolution."
+          "text": "If Vengeful Archon's ability prevents damage, Vengeful Archon deals its damage immediately afterward as part of that same prevention effect. This happens before state-based actions are checked, and before any player can cast spells or activate abilities. If a spell or ability would have caused that damage to be dealt, this happens before that spell or ability resumes its resolution."
         },
         {
           "date": "2010-08-15",
-          "text": "If you would be dealt combat damage by multiple attacking creatures, you choose which of that damage to prevent. For example, if X is 3 and you’d be dealt combat damage by a 1/3 Scroll Thief and a 3/5 Siege Mastodon, you might choose to prevent 1 damage from the Scroll Thief and 2 damage from the Siege Mastodon. You don’t decide until the point at which the creatures would deal their damage."
+          "text": "If you would be dealt combat damage by multiple attacking creatures, you choose which of that damage to prevent. For example, if X is 3 and you'd be dealt combat damage by a 1/3 Scroll Thief and a 3/5 Siege Mastodon, you might choose to prevent 1 damage from the Scroll Thief and 2 damage from the Siege Mastodon. You don't decide until the point at which the creatures would deal their damage."
         },
         {
           "date": "2010-08-15",
-          "text": "If the amount of damage that would be dealt to you is in excess of the amount of damage that Vengeful Archon’s ability would prevent, that source deals its excess damage to you at the same time that the rest of it is prevented. Then Vengeful Archon deals its damage."
+          "text": "If the amount of damage that would be dealt to you is in excess of the amount of damage that Vengeful Archon's ability would prevent, that source deals its excess damage to you at the same time that the rest of it is prevented. Then Vengeful Archon deals its damage."
         },
         {
           "date": "2010-08-15",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage chooses the order to apply the effects. For example, say you’ve activated Vengeful Archon’s ability with X = 3 targeting Player A, and you’ve activated Vengeful Archon’s ability with X = 1 targeting Player B. You’re dealt 2 damage. You can apply the first prevention effect (dealing 2 damage to Player A), or you can apply the second prevention effect (dealing 1 damage to Player B) followed by the first prevention effect (dealing 1 damage to Player A). The unused portions of the prevention effects remain."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage chooses the order to apply the effects. For example, say you've activated Vengeful Archon's ability with X = 3 targeting Player A, and you've activated Vengeful Archon's ability with X = 1 targeting Player B. You're dealt 2 damage. You can apply the first prevention effect (dealing 2 damage to Player A), or you can apply the second prevention effect (dealing 1 damage to Player B) followed by the first prevention effect (dealing 1 damage to Player A). The unused portions of the prevention effects remain."
         }
       ],
       "subtypes": [
@@ -4759,7 +4759,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "After the ability resolves, the targeted creature attacks you only if it’s able to do so as that turn’s declare attackers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” it can’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost, so the creature doesn’t have to attack in that case either."
+          "text": "After the ability resolves, the targeted creature attacks you only if it's able to do so as that turn's declare attackers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" it can't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost, so the creature doesn't have to attack in that case either."
         },
         {
           "date": "2009-10-01",
@@ -4767,11 +4767,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability during your opponent’s turn after attackers have been declared will have no effect. The same is true if you activate the ability during your own turn."
+          "text": "Activating the ability during your opponent's turn after attackers have been declared will have no effect. The same is true if you activate the ability during your own turn."
         },
         {
           "date": "2011-09-22",
-          "text": "If there are multiple combat phases in a turn, the creature must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, the creature must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -5275,6 +5275,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Time Spiral Block",
           "legality": "Legal"
         },
@@ -5437,7 +5441,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -5445,11 +5449,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -5457,7 +5461,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -5675,7 +5679,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a card a player reveals this way is the card that particular player named, he or she must put it into his or her hand. Otherwise, he or she must put it on the bottom of his or her library, even if it’s the card a different player named. In no cases can a player leave the revealed card on top of his or her library."
+          "text": "If a card a player reveals this way is the card that particular player named, he or she must put it into his or her hand. Otherwise, he or she must put it on the bottom of his or her library, even if it's the card a different player named. In no cases can a player leave the revealed card on top of his or her library."
         }
       ],
       "subtypes": [
@@ -5697,7 +5701,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"‘That was a narrow escape!' said Alice, a good deal frightened at the sudden change, but very glad to find herself still in existence.\"\n—Lewis Carroll, Alice's Adventures in Wonderland",
+      "flavor": "\"'That was a narrow escape!' said Alice, a good deal frightened at the sudden change, but very glad to find herself still in existence.\"\n—Lewis Carroll, Alice's Adventures in Wonderland",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -5780,11 +5784,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Diminish overwrites all previous effects that set the targeted creature’s power and toughness to specific values. Other effects that set its power or toughness to specific values that start to apply after Diminish resolves will overwrite this effect."
+          "text": "Diminish overwrites all previous effects that set the targeted creature's power and toughness to specific values. Other effects that set its power or toughness to specific values that start to apply after Diminish resolves will overwrite this effect."
         },
         {
           "date": "2010-08-15",
-          "text": "Effects that modify the targeted creature’s power or toughness, such as the effects of Giant Growth or Honor of the Pure, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify the targeted creature's power or toughness, such as the effects of Giant Growth or Honor of the Pure, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         }
       ],
       "text": "Target creature has base power and toughness 1/1 until end of turn.",
@@ -6092,19 +6096,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Frost Titan’s first ability affects each spell (including Aura spells), activated ability, and triggered ability that’s controlled by an opponent and that Frost Titan becomes a target of."
+          "text": "Frost Titan's first ability affects each spell (including Aura spells), activated ability, and triggered ability that's controlled by an opponent and that Frost Titan becomes a target of."
         },
         {
           "date": "2010-08-15",
-          "text": "You may target any permanent with Frost Titan’s second ability. It’s okay if that permanent is already tapped."
+          "text": "You may target any permanent with Frost Titan's second ability. It's okay if that permanent is already tapped."
         },
         {
           "date": "2010-08-15",
-          "text": "If the permanent affected by Frost Titan’s second ability is untapped at the time that permanent’s controller’s next untap step begins, the last part of Frost Titan’s second ability has no effect."
+          "text": "If the permanent affected by Frost Titan's second ability is untapped at the time that permanent's controller's next untap step begins, the last part of Frost Titan's second ability has no effect."
         },
         {
           "date": "2010-08-15",
-          "text": "If the permanent affected by Frost Titan’s second ability changes controllers before its old controller’s next untap step, Frost Titan’s second ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "If the permanent affected by Frost Titan's second ability changes controllers before its old controller's next untap step, Frost Titan's second ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -6212,7 +6216,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Harbor Serpent’s abilities care about lands with the land type Island, not necessarily lands named Island."
+          "text": "Harbor Serpent's abilities care about lands with the land type Island, not necessarily lands named Island."
         },
         {
           "date": "2010-08-15",
@@ -6322,11 +6326,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the enchanted creature becomes the target of a spell or ability, Ice Cage’s ability triggers and is put on the stack on top of that spell or ability. Ice Cage’s ability will resolve (causing Ice Cage to be destroyed) first."
+          "text": "If the enchanted creature becomes the target of a spell or ability, Ice Cage's ability triggers and is put on the stack on top of that spell or ability. Ice Cage's ability will resolve (causing Ice Cage to be destroyed) first."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -6439,7 +6443,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than twenty cards in the targeted player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than twenty cards in the targeted player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "subtypes": [
@@ -6544,11 +6548,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If a spell or ability causes you to draw multiple cards, Jace’s Erasure’s ability triggers that many times. (The spell or ability finishes resolving before you put Jace’s Erasure’s abilities on the stack.)"
+          "text": "If a spell or ability causes you to draw multiple cards, Jace's Erasure's ability triggers that many times. (The spell or ability finishes resolving before you put Jace's Erasure's abilities on the stack.)"
         },
         {
           "date": "2010-08-15",
-          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word “draw,” Jace’s Erasure’s ability won’t trigger."
+          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word \"draw,\" Jace's Erasure's ability won't trigger."
         }
       ],
       "text": "Whenever you draw a card, you may have target player put the top card of his or her library into his or her graveyard.",
@@ -6746,7 +6750,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of Anticipation is in your opening hand, you may begin the game with it on the battlefield.\nYou may cast spells as though they had flash. (You may cast them any time you could cast an instant.)",
@@ -7059,7 +7063,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If the number of creatures you exile is greater than the number of creature cards remaining in your library, you’ll wind up revealing your entire library, putting all creature cards revealed that way onto the battlefield, then shuffling your library."
+          "text": "If the number of creatures you exile is greater than the number of creature cards remaining in your library, you'll wind up revealing your entire library, putting all creature cards revealed that way onto the battlefield, then shuffling your library."
         },
         {
           "date": "2010-08-15",
@@ -7067,7 +7071,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "Any abilities that trigger during the resolution of Mass Polymorph (such as a creature’s enters-the-battlefield ability) will wait to be put onto the stack until Mass Polymorph finishes resolving. The player whose turn it is will put all of his or her triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
+          "text": "Any abilities that trigger during the resolution of Mass Polymorph (such as a creature's enters-the-battlefield ability) will wait to be put onto the stack until Mass Polymorph finishes resolving. The player whose turn it is will put all of his or her triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
         }
       ],
       "text": "Exile all creatures you control, then reveal cards from the top of your library until you reveal that many creature cards. Put all creature cards revealed this way onto the battlefield, then shuffle the rest of the revealed cards into your library.",
@@ -7170,7 +7174,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To have any effect, Merfolk Sovereign’s activated ability must be activated before the declare blockers step begins. Once a Merfolk has become blocked, activating Merfolk Sovereign’s ability won’t change that."
+          "text": "To have any effect, Merfolk Sovereign's activated ability must be activated before the declare blockers step begins. Once a Merfolk has become blocked, activating Merfolk Sovereign's ability won't change that."
         }
       ],
       "subtypes": [
@@ -7284,11 +7288,11 @@
         },
         {
           "date": "2010-08-15",
-          "text": "After the second ability resolves, the revealed card stops being revealed in its owner’s hand."
+          "text": "After the second ability resolves, the revealed card stops being revealed in its owner's hand."
         },
         {
           "date": "2010-08-15",
-          "text": "The next time Merfolk Spy deals combat damage to the same player, the card that’s revealed at random may be the same card or may be a different card."
+          "text": "The next time Merfolk Spy deals combat damage to the same player, the card that's revealed at random may be the same card or may be a different card."
         }
       ],
       "subtypes": [
@@ -7398,7 +7402,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -7535,7 +7539,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -7637,7 +7641,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If Phantom Beast becomes the target of a spell or ability, Phantom Beast’s ability triggers and goes on the stack on top of that spell or ability. Phantom Beast’s ability will resolve (causing it to be sacrificed) first. Unless the spell or ability has another target, it will then be countered when it tries to resolve for having no legal targets."
+          "text": "If Phantom Beast becomes the target of a spell or ability, Phantom Beast's ability triggers and goes on the stack on top of that spell or ability. Phantom Beast's ability will resolve (causing it to be sacrificed) first. Unless the spell or ability has another target, it will then be countered when it tries to resolve for having no legal targets."
         }
       ],
       "subtypes": [
@@ -7841,19 +7845,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2010-08-15",
-          "text": "If the targeted spell is modal (that is, it says “Choose one —” or the like), you can’t choose a different mode."
+          "text": "If the targeted spell is modal (that is, it says \"Choose one —\" or the like), you can't choose a different mode."
         },
         {
           "date": "2010-08-15",
-          "text": "If you cast Redirect targeting a spell that targets a spell on the stack (like Cancel does, for example), you can’t change that spell’s target to itself. You can, however, change that spell’s target to Redirect. If you do, that spell will be countered when it tries to resolve because Redirect will have left the stack by then."
+          "text": "If you cast Redirect targeting a spell that targets a spell on the stack (like Cancel does, for example), you can't change that spell's target to itself. You can, however, change that spell's target to Redirect. If you do, that spell will be countered when it tries to resolve because Redirect will have left the stack by then."
         },
         {
           "date": "2010-08-15",
-          "text": "Redirect can target any spell, not just an instant or sorcery spell. For example, you could use it to change the target of an Aura spell. However, if the targeted spell has no targets (for example, if it’s an instant or sorcery spell that doesn’t specifically use the word “target,” or if it’s a creature spell), Redirect won’t have any effect on it."
+          "text": "Redirect can target any spell, not just an instant or sorcery spell. For example, you could use it to change the target of an Aura spell. However, if the targeted spell has no targets (for example, if it's an instant or sorcery spell that doesn't specifically use the word \"target,\" or if it's a creature spell), Redirect won't have any effect on it."
         }
       ],
       "text": "You may choose new targets for target spell.",
@@ -8071,11 +8075,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The second part of Sleep’s effect affects all creatures the targeted player controls as Sleep resolves, not just the ones that Sleep actually caused to become tapped."
+          "text": "The second part of Sleep's effect affects all creatures the targeted player controls as Sleep resolves, not just the ones that Sleep actually caused to become tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Sleep tracks both the player and the creatures. If one of the creatures controlled by the targeted player as Sleep resolves changes controllers, the creature will untap as normal during its new controller’s next untap step."
+          "text": "Sleep tracks both the player and the creatures. If one of the creatures controlled by the targeted player as Sleep resolves changes controllers, the creature will untap as normal during its new controller's next untap step."
         }
       ],
       "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
@@ -8178,15 +8182,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Stormtide Leviathan’s second ability causes each land on the battlefield to have the land type Island. Each land thus has the ability “{T}: Add {U} to your mana pool.” Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they’re legendary or basic."
+          "text": "Stormtide Leviathan's second ability causes each land on the battlefield to have the land type Island. Each land thus has the ability \"{T}: Add {U} to your mana pool.\" Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they're legendary or basic."
         },
         {
           "date": "2014-07-18",
-          "text": "If Stormtide Leviathan loses its abilities, all lands on the battlefield (including those that enter the battlefield later on) will still be Islands in addition to their other types and will still be able to tap to produce {U}. The way continuous effects work, Stormtide Leviathan’s type-changing ability is applied before the effect that removes that ability is applied."
+          "text": "If Stormtide Leviathan loses its abilities, all lands on the battlefield (including those that enter the battlefield later on) will still be Islands in addition to their other types and will still be able to tap to produce {U}. The way continuous effects work, Stormtide Leviathan's type-changing ability is applied before the effect that removes that ability is applied."
         },
         {
           "date": "2014-07-18",
-          "text": "Stormtide Leviathan’s third ability affects all creatures with neither flying nor islandwalk, regardless of who controls them. They can’t attack any player or planeswalker."
+          "text": "Stormtide Leviathan's third ability affects all creatures with neither flying nor islandwalk, regardless of who controls them. They can't attack any player or planeswalker."
         },
         {
           "date": "2014-07-18",
@@ -8393,7 +8397,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than five cards in the targeted player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than five cards in the targeted player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "text": "Target player puts the top five cards of his or her library into his or her graveyard.",
@@ -8574,6 +8578,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -8734,11 +8742,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Frost’s ability tracks the creature, not the creature’s controller. That is, if the creature changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "Wall of Frost's ability tracks the creature, not the creature's controller. That is, if the creature changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-07-18",
-          "text": "If the creature isn’t tapped during its controller’s next untap step (perhaps because it was untapped by a spell), Wall of Frost’s ability has no effect at that time. It won’t try to keep the creature tapped on subsequent turns."
+          "text": "If the creature isn't tapped during its controller's next untap step (perhaps because it was untapped by a spell), Wall of Frost's ability has no effect at that time. It won't try to keep the creature tapped on subsequent turns."
         }
       ],
       "subtypes": [
@@ -8846,7 +8854,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You can activate Water Servant’s second ability even if doing so would cause Water Servant’s power to be less than 0."
+          "text": "You can activate Water Servant's second ability even if doing so would cause Water Servant's power to be less than 0."
         }
       ],
       "subtypes": [
@@ -9372,11 +9380,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won’t be on the battlefield to get the bonus."
+          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won't be on the battlefield to get the bonus."
         },
         {
           "date": "2010-06-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -9588,15 +9596,15 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Since Captivating Vampire’s activated ability doesn’t have a tap symbol in its cost, you can tap a Vampire (including Captivating Vampire itself) that hasn’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since Captivating Vampire's activated ability doesn't have a tap symbol in its cost, you can tap a Vampire (including Captivating Vampire itself) that hasn't been under your control since your most recent turn began to pay the cost."
         },
         {
           "date": "2010-08-15",
-          "text": "The effect of Captivating Vampire’s activated ability has no duration. You retain control of the affected creature until the game ends, the creature leaves the battlefield, or a later effect causes someone else to gain control of it. It doesn’t matter whether Captivating Vampire remains on the battlefield. Similarly, the affected creature remains a Vampire in addition to its other types until the game ends, the creature leaves the battlefield, or a later effect changes its types or subtypes."
+          "text": "The effect of Captivating Vampire's activated ability has no duration. You retain control of the affected creature until the game ends, the creature leaves the battlefield, or a later effect causes someone else to gain control of it. It doesn't matter whether Captivating Vampire remains on the battlefield. Similarly, the affected creature remains a Vampire in addition to its other types until the game ends, the creature leaves the battlefield, or a later effect changes its types or subtypes."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -9833,7 +9841,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -9946,7 +9954,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If the revealed card has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If the revealed card has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         }
       ],
       "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
@@ -10152,15 +10160,15 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Casting Demon of Death’s Gate by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
+          "text": "Casting Demon of Death's Gate by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
         },
         {
           "date": "2010-08-15",
-          "text": "Casting Demon of Death’s Gate by paying its alternative cost doesn’t change its mana cost or converted mana cost."
+          "text": "Casting Demon of Death's Gate by paying its alternative cost doesn't change its mana cost or converted mana cost."
         },
         {
           "date": "2010-08-15",
-          "text": "Effects that increase or reduce the cost to cast Demon of Death’s Gate will apply to it even if you choose to pay its alternative cost."
+          "text": "Effects that increase or reduce the cost to cast Demon of Death's Gate will apply to it even if you choose to pay its alternative cost."
         }
       ],
       "subtypes": [
@@ -10386,7 +10394,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -10799,6 +10807,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -10841,7 +10853,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -10951,7 +10963,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "While you’re searching the player’s library, you don’t have to find all the cards with the same name as an exiled card if you don’t want to. You can leave any number of them in that player’s library."
+          "text": "While you're searching the player's library, you don't have to find all the cards with the same name as an exiled card if you don't want to. You can leave any number of them in that player's library."
         }
       ],
       "text": "Exile all cards from target player's graveyard other than basic land cards. For each card exiled this way, search that player's library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
@@ -11159,23 +11171,23 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Leyline of the Void affects cards that would be put into opponents’ graveyards from anywhere, not just from the battlefield."
+          "text": "Leyline of the Void affects cards that would be put into opponents' graveyards from anywhere, not just from the battlefield."
         },
         {
           "date": "2010-08-15",
-          "text": "Leyline of the Void’s second ability prevents cards from ever reaching your opponents’ graveyards. Abilities that would trigger when those cards are put into an opponent’s graveyard (such as Hoarding Dragon’s last ability) won’t trigger."
+          "text": "Leyline of the Void's second ability prevents cards from ever reaching your opponents' graveyards. Abilities that would trigger when those cards are put into an opponent's graveyard (such as Hoarding Dragon's last ability) won't trigger."
         },
         {
           "date": "2010-08-15",
-          "text": "Leyline of the Void’s second ability doesn’t affect token permanents that would be put into an opponent’s graveyard from the battlefield. They’ll be put into that graveyard as normal (causing any applicable triggered abilities to trigger), then they’ll cease to exist."
+          "text": "Leyline of the Void's second ability doesn't affect token permanents that would be put into an opponent's graveyard from the battlefield. They'll be put into that graveyard as normal (causing any applicable triggered abilities to trigger), then they'll cease to exist."
         },
         {
           "date": "2010-08-15",
-          "text": "If your opponent discards a card while you control Leyline of the Void, abilities that function when that card is discarded (such as Liliana’s Caress’s ability, or a madness ability of the discarded card) still work, even though that card never reaches that player’s graveyard. In addition, spells or abilities that check the characteristics of the discarded card (such as Chandra Ablaze’s first ability) can find that card in exile."
+          "text": "If your opponent discards a card while you control Leyline of the Void, abilities that function when that card is discarded (such as Liliana's Caress's ability, or a madness ability of the discarded card) still work, even though that card never reaches that player's graveyard. In addition, spells or abilities that check the characteristics of the discarded card (such as Chandra Ablaze's first ability) can find that card in exile."
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
@@ -11286,7 +11298,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -11390,7 +11402,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If an opponent discards multiple cards (due to a spell, an ability, or the action of discarding down to the maximum hand size during his or her cleanup step), Liliana’s Caress’s ability triggers that many times."
+          "text": "If an opponent discards multiple cards (due to a spell, an ability, or the action of discarding down to the maximum hand size during his or her cleanup step), Liliana's Caress's ability triggers that many times."
         }
       ],
       "text": "Whenever an opponent discards a card, that player loses 2 life.",
@@ -11830,19 +11842,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Necrotic Plague grants the sacrifice ability to the creature it’s enchanting. That means it triggers at the beginning of the upkeep of the creature’s controller (not necessarily Necrotic Plague’s controller)."
+          "text": "Necrotic Plague grants the sacrifice ability to the creature it's enchanting. That means it triggers at the beginning of the upkeep of the creature's controller (not necessarily Necrotic Plague's controller)."
         },
         {
           "date": "2010-08-15",
-          "text": "Necrotic Plague’s last ability triggers when the enchanted creature is put into a graveyard for any reason, not just when it’s sacrificed due to the ability it grants to that creature. It triggers if it and the creature it’s enchanting are both put into the graveyard at the same time, or if the creature it’s enchanting is put into the graveyard but Necrotic Plague isn’t. (In the second case, Necrotic Plague is then put into the graveyard as a state-based action.)"
+          "text": "Necrotic Plague's last ability triggers when the enchanted creature is put into a graveyard for any reason, not just when it's sacrificed due to the ability it grants to that creature. It triggers if it and the creature it's enchanting are both put into the graveyard at the same time, or if the creature it's enchanting is put into the graveyard but Necrotic Plague isn't. (In the second case, Necrotic Plague is then put into the graveyard as a state-based action.)"
         },
         {
           "date": "2010-08-15",
-          "text": "The player that controls Necrotic Plague at the time the enchanted creature is put into a graveyard is the player who controls the last ability (even though that creature’s controller is the one who chooses its target). The first player returns Necrotic Plague to the battlefield under his or her control, regardless of whose graveyard it was put into. Note that the ability is mandatory; a target must be chosen if able, and Necrotic Plague must be returned to the battlefield if able."
+          "text": "The player that controls Necrotic Plague at the time the enchanted creature is put into a graveyard is the player who controls the last ability (even though that creature's controller is the one who chooses its target). The first player returns Necrotic Plague to the battlefield under his or her control, regardless of whose graveyard it was put into. Note that the ability is mandatory; a target must be chosen if able, and Necrotic Plague must be returned to the battlefield if able."
         },
         {
           "date": "2010-08-15",
-          "text": "If no legal target can be chosen for Necrotic Plague’s last ability, it just remains in its owner’s graveyard. Similarly, if the targeted creature becomes an illegal target by the time the ability resolves, the ability is countered and Necrotic Plague remains in its owner’s graveyard."
+          "text": "If no legal target can be chosen for Necrotic Plague's last ability, it just remains in its owner's graveyard. Similarly, if the targeted creature becomes an illegal target by the time the ability resolves, the ability is countered and Necrotic Plague remains in its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -12146,35 +12158,35 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Phylactery Lich’s first ability doesn’t target the artifact. You can choose an artifact that has shroud, for example."
+          "text": "Phylactery Lich's first ability doesn't target the artifact. You can choose an artifact that has shroud, for example."
         },
         {
           "date": "2010-08-15",
-          "text": "If you control no artifacts as Phylactery Lich enters the battlefield, its first ability won’t do anything. As soon as it enters the battlefield, its last ability will trigger (unless you control some other permanent with a phylactery counter on it) and you’ll have to sacrifice it."
+          "text": "If you control no artifacts as Phylactery Lich enters the battlefield, its first ability won't do anything. As soon as it enters the battlefield, its last ability will trigger (unless you control some other permanent with a phylactery counter on it) and you'll have to sacrifice it."
         },
         {
           "date": "2010-08-15",
-          "text": "If Phylactery Lich and an artifact are entering the battlefield under your control at the same time, you can’t put a phylactery counter on that artifact. You must choose an artifact you control that’s already on the battlefield."
+          "text": "If Phylactery Lich and an artifact are entering the battlefield under your control at the same time, you can't put a phylactery counter on that artifact. You must choose an artifact you control that's already on the battlefield."
         },
         {
           "date": "2010-08-15",
-          "text": "Phylactery Lich’s last ability is a “state trigger.” Once a state trigger triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "Phylactery Lich's last ability is a \"state trigger.\" Once a state trigger triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         },
         {
           "date": "2010-08-15",
-          "text": "Phylactery Lich’s last ability checks whether you control any permanents with phylactery counters on them, not whether you control any artifacts with phylactery counters on them. If an artifact with a phylactery counter on it somehow ceases to be an artifact, Phylactery Lich doesn’t care."
+          "text": "Phylactery Lich's last ability checks whether you control any permanents with phylactery counters on them, not whether you control any artifacts with phylactery counters on them. If an artifact with a phylactery counter on it somehow ceases to be an artifact, Phylactery Lich doesn't care."
         },
         {
           "date": "2010-08-15",
-          "text": "Phylactery Lich’s last ability checks your permanents for any phylactery counters, not just the specific one that it caused you to put on an artifact. For example, say you put a phylactery counter on a Demon’s Horn as Phylactery Lich enters the battlefield. Then you put a phylactery counter on a Crystal Ball as another Phylactery Lich enters the battlefield. Then Crystal Ball is destroyed. Since you still control the Demon’s Horn, the last ability of neither Phylactery Lich triggers."
+          "text": "Phylactery Lich's last ability checks your permanents for any phylactery counters, not just the specific one that it caused you to put on an artifact. For example, say you put a phylactery counter on a Demon's Horn as Phylactery Lich enters the battlefield. Then you put a phylactery counter on a Crystal Ball as another Phylactery Lich enters the battlefield. Then Crystal Ball is destroyed. Since you still control the Demon's Horn, the last ability of neither Phylactery Lich triggers."
         },
         {
           "date": "2010-08-15",
-          "text": "The game continually checks whether you control a permanent with a phylactery counter on it. The moment you don’t, Phylactery Lich’s last ability triggers. The ability doesn’t check again, so you’ll have to sacrifice Phylactery Lich when it resolves even if you wind up controlling a permanent with a phylactery counter on it by then."
+          "text": "The game continually checks whether you control a permanent with a phylactery counter on it. The moment you don't, Phylactery Lich's last ability triggers. The ability doesn't check again, so you'll have to sacrifice Phylactery Lich when it resolves even if you wind up controlling a permanent with a phylactery counter on it by then."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage, damage from a source with deathtouch, and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons Phylactery Lich would be put into a graveyard are if it’s sacrificed (perhaps due to its last ability), or if its toughness is 0 or less."
+          "text": "Lethal damage, damage from a source with deathtouch, and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons Phylactery Lich would be put into a graveyard are if it's sacrificed (perhaps due to its last ability), or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -12280,7 +12292,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "This ability counts the number of Swamps controlled by Quag Sickness’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability counts the number of Swamps controlled by Quag Sickness's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2010-08-15",
@@ -12505,11 +12517,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Yes, you’re allowed to have a deck consisting of sixty Relentless Rats and nothing else."
+          "text": "Yes, you're allowed to have a deck consisting of sixty Relentless Rats and nothing else."
         },
         {
           "date": "2004-12-01",
-          "text": "Relentless Rats’s last ability overrides the normal limit of four of an individual card in a Constructed deck."
+          "text": "Relentless Rats's last ability overrides the normal limit of four of an individual card in a Constructed deck."
         }
       ],
       "subtypes": [
@@ -12631,19 +12643,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
+          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -12858,11 +12870,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -13073,11 +13085,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You may target any creature with Stabbing Pain. It’s okay if it’s already tapped."
+          "text": "You may target any creature with Stabbing Pain. It's okay if it's already tapped."
         },
         {
           "date": "2010-08-15",
-          "text": "If Stabbing Pain targets an untapped creature with 1 toughness, that creature gets -1/-1, then it becomes tapped, then (after Stabbing Pain resolves) it’s put into the graveyard as a state-based action. Similarly, if Stabbing Pain targets an untapped creature with 1 less than lethal damage marked on it (such as a 3/3 creature with 2 damage marked on it), that creature gets -1/-1, then it becomes tapped, then (after Stabbing Pain resolves) it’s destroyed as a state-based action. In each case, any abilities that trigger when that creature becomes tapped will trigger."
+          "text": "If Stabbing Pain targets an untapped creature with 1 toughness, that creature gets -1/-1, then it becomes tapped, then (after Stabbing Pain resolves) it's put into the graveyard as a state-based action. Similarly, if Stabbing Pain targets an untapped creature with 1 less than lethal damage marked on it (such as a 3/3 creature with 2 damage marked on it), that creature gets -1/-1, then it becomes tapped, then (after Stabbing Pain resolves) it's destroyed as a state-based action. In each case, any abilities that trigger when that creature becomes tapped will trigger."
         }
       ],
       "text": "Target creature gets -1/-1 until end of turn. Tap that creature.",
@@ -13299,7 +13311,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -13421,15 +13433,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Act of Treason can target any creature, even one that’s untapped or one you already control."
+          "text": "Act of Treason can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2013-07-01",
-          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you’ll choose one to remain on the battlefield and put the other into its owner’s graveyard."
+          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you'll choose one to remain on the battlefield and put the other into its owner's graveyard."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
@@ -13740,11 +13752,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If, during your declare attackers step, Berserkers of Blood Ridge is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then it doesn’t attack. If there’s a cost associated with having Berserkers of Blood Ridge attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Berserkers of Blood Ridge is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then it doesn't attack. If there's a cost associated with having Berserkers of Blood Ridge attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2010-08-15",
-          "text": "If there are multiple combat phases in a turn, Berserkers of Blood Ridge must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Berserkers of Blood Ridge must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -13855,19 +13867,19 @@
         },
         {
           "date": "2010-08-15",
-          "text": "It doesn’t matter how an opponent was dealt damage, or even who controlled the source of the damage."
+          "text": "It doesn't matter how an opponent was dealt damage, or even who controlled the source of the damage."
         },
         {
           "date": "2010-08-15",
-          "text": "If damage would have been dealt to an opponent but it was all prevented, redirected, or otherwise replaced, Bloodcrazed Goblin won’t be able to attack."
+          "text": "If damage would have been dealt to an opponent but it was all prevented, redirected, or otherwise replaced, Bloodcrazed Goblin won't be able to attack."
         },
         {
           "date": "2010-08-15",
-          "text": "Bloodcrazed Goblin’s ability checks only whether damage was dealt to an opponent. It doesn’t care whether that opponent also gained life. For example, if an opponent was dealt 4 damage and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Goblin Berserker will still be able to attack."
+          "text": "Bloodcrazed Goblin's ability checks only whether damage was dealt to an opponent. It doesn't care whether that opponent also gained life. For example, if an opponent was dealt 4 damage and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Goblin Berserker will still be able to attack."
         },
         {
           "date": "2010-08-15",
-          "text": "If Bloodcrazed Goblin attacks, it doesn’t have to attack the opponent who was dealt damage. It can attack a planeswalker. In a multiplayer game, it can attack a different opponent."
+          "text": "If Bloodcrazed Goblin attacks, it doesn't have to attack the opponent who was dealt damage. It can attack a planeswalker. In a multiplayer game, it can attack a different opponent."
         }
       ],
       "subtypes": [
@@ -14088,7 +14100,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can’t choose a negative number."
+          "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can't choose a negative number."
         }
       ],
       "subtypes": [
@@ -14197,7 +14209,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target creature is an illegal target by the time Chandra’s Outrage resolves, the entire spell is countered. No player is dealt damage."
+          "text": "If the target creature is an illegal target by the time Chandra's Outrage resolves, the entire spell is countered. No player is dealt damage."
         }
       ],
       "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
@@ -14299,11 +14311,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Combat damage is the damage that’s dealt automatically by attacking and blocking creatures, even if it’s redirected (by Harm’s Way, perhaps). Noncombat damage is any other damage (generally, it’s damage dealt as the result of a spell or ability)."
+          "text": "Combat damage is the damage that's dealt automatically by attacking and blocking creatures, even if it's redirected (by Harm's Way, perhaps). Noncombat damage is any other damage (generally, it's damage dealt as the result of a spell or ability)."
         },
         {
           "date": "2010-08-15",
-          "text": "The ability triggers just once for each event in which an opponent is dealt noncombat damage, regardless of how much damage that player is dealt. For example, if Lava Axe deals 5 damage to an opponent, Chandra’s Spitfire gets just +3/+0."
+          "text": "The ability triggers just once for each event in which an opponent is dealt noncombat damage, regardless of how much damage that player is dealt. For example, if Lava Axe deals 5 damage to an opponent, Chandra's Spitfire gets just +3/+0."
         },
         {
           "date": "2010-08-15",
@@ -14413,7 +14425,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Combust can be targeted by spells and abilities that try to counter it (such as Cancel). Those spells and abilities will resolve, but the part of their effect that would counter Combust won’t do anything. Any other effects those spells and abilities have will work as normal."
+          "text": "Combust can be targeted by spells and abilities that try to counter it (such as Cancel). Those spells and abilities will resolve, but the part of their effect that would counter Combust won't do anything. Any other effects those spells and abilities have will work as normal."
         },
         {
           "date": "2010-08-15",
@@ -14421,15 +14433,15 @@
         },
         {
           "date": "2010-08-15",
-          "text": "Spells that create prevention effects affecting the targeted creature can still be cast, and abilities that create prevention effects affecting the targeted creature can still be activated. However, damage prevention shields (including those created before Combust was cast) don’t have any effect on the damage dealt by Combust. If such a prevention effect has an additional effect, the additional effect will still work (if possible)."
+          "text": "Spells that create prevention effects affecting the targeted creature can still be cast, and abilities that create prevention effects affecting the targeted creature can still be activated. However, damage prevention shields (including those created before Combust was cast) don't have any effect on the damage dealt by Combust. If such a prevention effect has an additional effect, the additional effect will still work (if possible)."
         },
         {
           "date": "2010-08-15",
-          "text": "If a static ability would prevent damage from being dealt to the targeted creature, it fails to prevent the damage dealt by Combust. If that ability has an additional effect that doesn’t depend on the amount of damage prevented, that additional effect will still work. It’s applied just once as Combust resolves."
+          "text": "If a static ability would prevent damage from being dealt to the targeted creature, it fails to prevent the damage dealt by Combust. If that ability has an additional effect that doesn't depend on the amount of damage prevented, that additional effect will still work. It's applied just once as Combust resolves."
         },
         {
           "date": "2010-08-15",
-          "text": "Effects that replace or redirect damage without using the word “prevent” aren’t affected by Combust; they’ll work as normal."
+          "text": "Effects that replace or redirect damage without using the word \"prevent\" aren't affected by Combust; they'll work as normal."
         },
         {
           "date": "2010-08-15",
@@ -14534,11 +14546,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Cyclops Gladiator’s ability triggers and resolves during the declare attackers step, before blockers are declared. If it survives, it continues to attack (presumably with some damage marked on it) and may be blocked."
+          "text": "Cyclops Gladiator's ability triggers and resolves during the declare attackers step, before blockers are declared. If it survives, it continues to attack (presumably with some damage marked on it) and may be blocked."
         },
         {
           "date": "2010-08-15",
-          "text": "If the targeted creature leaves the battlefield (or otherwise becomes an illegal target) before the ability resolves, the ability is countered. Cyclops Gladiator isn’t dealt damage."
+          "text": "If the targeted creature leaves the battlefield (or otherwise becomes an illegal target) before the ability resolves, the ability is countered. Cyclops Gladiator isn't dealt damage."
         },
         {
           "date": "2010-08-15",
@@ -15191,19 +15203,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Fire Servant’s ability applies no matter who or what the damage would be dealt to: a creature, a player, or a planeswalker."
+          "text": "Fire Servant's ability applies no matter who or what the damage would be dealt to: a creature, a player, or a planeswalker."
         },
         {
           "date": "2010-08-15",
-          "text": "If a red instant or sorcery spell you control causes damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Lightning Bolt says “Lightning Bolt deals 3 damage to target creature or player.” Such a spell is affected by Fire Servant’s ability. If the source of the damage is something else (for example, if the spell is Soul’s Fire, which says “Target creature you control on the battlefield deals damage equal to its power to target creature or player”), it isn’t affected by Fire Servant’s ability."
+          "text": "If a red instant or sorcery spell you control causes damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Lightning Bolt says \"Lightning Bolt deals 3 damage to target creature or player.\" Such a spell is affected by Fire Servant's ability. If the source of the damage is something else (for example, if the spell is Soul's Fire, which says \"Target creature you control on the battlefield deals damage equal to its power to target creature or player\"), it isn't affected by Fire Servant's ability."
         },
         {
           "date": "2010-08-15",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the permanent that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn” and Lava Axe is a red sorcery that says “Lava Axe deals 5 damage to target player.” Suppose a Lava Axe controlled by a player who controls Fire Servant would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Fire Servant’s effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the permanent that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn\" and Lava Axe is a red sorcery that says \"Lava Axe deals 5 damage to target player.\" Suppose a Lava Axe controlled by a player who controls Fire Servant would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Fire Servant's effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         },
         {
           "date": "2010-08-15",
-          "text": "If a red instant or sorcery spell you control divides damage among multiple recipients (such as Fireball does), the damage is divided before Fire Servant’s effect doubles it."
+          "text": "If a red instant or sorcery spell you control divides damage among multiple recipients (such as Fireball does), the damage is divided before Fire Servant's effect doubles it."
         },
         {
           "date": "2010-08-15",
@@ -15339,7 +15351,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -15351,7 +15363,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -15446,6 +15458,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -15476,11 +15492,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its power."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         },
         {
           "date": "2013-04-15",
@@ -15604,7 +15620,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade’s ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
         }
       ],
       "subtypes": [
@@ -15925,11 +15941,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The power of the targeted creature is checked both as you target it and as the ability resolves. After the ability resolves, the creature can’t be blocked that turn even if its power becomes greater than 2."
+          "text": "The power of the targeted creature is checked both as you target it and as the ability resolves. After the ability resolves, the creature can't be blocked that turn even if its power becomes greater than 2."
         },
         {
           "date": "2010-06-15",
-          "text": "The ability doesn’t grant an ability to the targeted creature. Rather, it affects the game rules and states something that’s now true about that creature. After the ability resolves, the creature can’t be blocked that turn even if it loses all abilities."
+          "text": "The ability doesn't grant an ability to the targeted creature. Rather, it affects the game rules and states something that's now true about that creature. After the ability resolves, the creature can't be blocked that turn even if it loses all abilities."
         }
       ],
       "subtypes": [
@@ -16040,11 +16056,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If Hoarding Dragon is put into a graveyard before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve. If you choose to find an artifact card from your library, it will be exiled for the rest of the game."
-        },
-        {
-          "date": "2014-07-18",
-          "text": "Hoarding Dragon’s two abilities are linked. The second ability refers only to the card exiled by that Hoarding Dragon’s first ability. In other words, each Dragon has its own hoard."
+          "text": "Hoarding Dragon's two abilities are linked. The second ability refers only to the card exiled by that Hoarding Dragon's first ability. In other words, each Dragon has its own hoard."
         },
         {
           "date": "2014-07-18",
@@ -16153,19 +16165,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Incite overwrites all of the targeted creature’s old colors, leaving it just red. It doesn’t matter what colors it used to be (even if, for example, it used to be red and green)."
+          "text": "Incite overwrites all of the targeted creature's old colors, leaving it just red. It doesn't matter what colors it used to be (even if, for example, it used to be red and green)."
         },
         {
           "date": "2010-08-15",
-          "text": "You may target any creature with Incite. It’s okay if that creature is already red. It’s also okay if it would be unable to attack that turn."
+          "text": "You may target any creature with Incite. It's okay if that creature is already red. It's also okay if it would be unable to attack that turn."
         },
         {
           "date": "2010-08-15",
-          "text": "If, during its controller’s declare attackers step, a creature affected by Incite is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then that creature doesn’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost, so the creature doesn’t have to attack in that case either."
+          "text": "If, during its controller's declare attackers step, a creature affected by Incite is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then that creature doesn't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost, so the creature doesn't have to attack in that case either."
         },
         {
           "date": "2010-08-15",
-          "text": "If there are multiple combat phases in a turn, a creature affected by Incite must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, a creature affected by Incite must attack only in the first one in which it's able to."
         }
       ],
       "text": "Target creature becomes red until end of turn and attacks this turn if able.",
@@ -16271,7 +16283,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You divide the damage as you put Inferno Titan’s triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
+          "text": "You divide the damage as you put Inferno Titan's triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
         }
       ],
       "subtypes": [
@@ -16493,31 +16505,31 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a cost includes life gain (like Invigorate’s alternative cost does), that cost can’t be paid."
+          "text": "If a cost includes life gain (like Invigorate's alternative cost does), that cost can't be paid."
         },
         {
           "date": "2010-08-15",
-          "text": "Effects that would replace gaining life with some other effect won’t be able to do anything because it’s impossible for players to gain life."
+          "text": "Effects that would replace gaining life with some other effect won't be able to do anything because it's impossible for players to gain life."
         },
         {
           "date": "2010-08-15",
-          "text": "Effects that replace an event with gaining life (like Words of Worship’s effect does) will end up replacing the event with nothing."
+          "text": "Effects that replace an event with gaining life (like Words of Worship's effect does) will end up replacing the event with nothing."
         },
         {
           "date": "2010-08-15",
-          "text": "If an effect says to set a player’s life total to a certain number, and that number is higher than the player’s current life total, that part of the effect won’t do anything. (If the number is lower than the player’s current life total, the effect will work as normal.)"
+          "text": "If an effect says to set a player's life total to a certain number, and that number is higher than the player's current life total, that part of the effect won't do anything. (If the number is lower than the player's current life total, the effect will work as normal.)"
         },
         {
           "date": "2010-08-15",
-          "text": "Damage prevention shields don’t have any effect. If a prevention effect has an additional effect, the additional effect will still work (if possible). Spells that create prevention effects can still be cast, and abilities that create prevention effects can still be activated."
+          "text": "Damage prevention shields don't have any effect. If a prevention effect has an additional effect, the additional effect will still work (if possible). Spells that create prevention effects can still be cast, and abilities that create prevention effects can still be activated."
         },
         {
           "date": "2010-08-15",
-          "text": "Static abilities that prevent damage (including protection abilities) don’t do so. If they have additional effects that don’t depend on the amount of damage prevented, those additional effects will still work. Such effects are applied only once per source of damage."
+          "text": "Static abilities that prevent damage (including protection abilities) don't do so. If they have additional effects that don't depend on the amount of damage prevented, those additional effects will still work. Such effects are applied only once per source of damage."
         },
         {
           "date": "2010-08-15",
-          "text": "Effects that replace or redirect damage without using the word “prevent” are not affected by Leyline of Punishment."
+          "text": "Effects that replace or redirect damage without using the word \"prevent\" are not affected by Leyline of Punishment."
         },
         {
           "date": "2010-08-15",
@@ -16525,7 +16537,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of Punishment is in your opening hand, you may begin the game with it on the battlefield.\nPlayers can't gain life.\nDamage can't be prevented.",
@@ -16838,7 +16850,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Manic Vandal’s ability is mandatory. If you’re the only player who controls an artifact, you must target one of them."
+          "text": "Manic Vandal's ability is mandatory. If you're the only player who controls an artifact, you must target one of them."
         }
       ],
       "subtypes": [
@@ -17059,11 +17071,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Pyretic Ritual is not a mana ability and doesn’t behave like one. You cast it as a spell. It uses the stack. It can be responded to, and it can be countered."
+          "text": "Pyretic Ritual is not a mana ability and doesn't behave like one. You cast it as a spell. It uses the stack. It can be responded to, and it can be countered."
         },
         {
           "date": "2010-08-15",
-          "text": "In the same vein, you can cast Pyretic Ritual only at a time when you could cast any other instant, not at a time when you could activate a mana ability. For example, you can’t cast Pyretic Ritual in the midst of casting another spell; you’d need to cast Pyretic Ritual first."
+          "text": "In the same vein, you can cast Pyretic Ritual only at a time when you could cast any other instant, not at a time when you could activate a mana ability. For example, you can't cast Pyretic Ritual in the midst of casting another spell; you'd need to cast Pyretic Ritual first."
         }
       ],
       "text": "Add {R}{R}{R} to your mana pool.",
@@ -17278,19 +17290,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Reverberate can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Reverberate can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2010-08-15",
-          "text": "When Reverberate resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When Reverberate resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2010-08-15",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2010-08-15",
-          "text": "If the spell Reverberate copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Reverberate copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2010-08-15",
@@ -17298,11 +17310,11 @@
         },
         {
           "date": "2010-08-15",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Reverberate, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Reverberate, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2010-08-15",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
@@ -17409,11 +17421,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Only Shiv’s Embrace’s controller (who is not necessarily the enchanted creature’s controller) can activate its activated ability."
+          "text": "Only Shiv's Embrace's controller (who is not necessarily the enchanted creature's controller) can activate its activated ability."
         },
         {
           "date": "2010-08-15",
-          "text": "When Shiv’s Embrace’s activated ability resolves, the creature Shiv’s Embrace is enchanting at that time will get +1/+0 (regardless of what creature Shiv’s Embrace was enchanting when the ability was activated). If Shiv’s Embrace has left the battlefield by then, the creature it was enchanting at the time it left the battlefield will get +1/+0."
+          "text": "When Shiv's Embrace's activated ability resolves, the creature Shiv's Embrace is enchanting at that time will get +1/+0 (regardless of what creature Shiv's Embrace was enchanting when the ability was activated). If Shiv's Embrace has left the battlefield by then, the creature it was enchanting at the time it left the battlefield will get +1/+0."
         }
       ],
       "subtypes": [
@@ -17522,7 +17534,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a creature doesn’t have first strike, granting it first strike after combat damage has been dealt in the first-strike combat damage step won’t prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
+          "text": "If a creature doesn't have first strike, granting it first strike after combat damage has been dealt in the first-strike combat damage step won't prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
         }
       ],
       "text": "Target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
@@ -17828,23 +17840,23 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If a player reveals a nonland card, that player must cast that card if it’s possible to do so, even if he or she doesn’t want to. The player casts it as part of the resolution of Wild Evocation’s ability. Timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other play restrictions are not (such as “Cast [this card] only during combat”)."
+          "text": "If a player reveals a nonland card, that player must cast that card if it's possible to do so, even if he or she doesn't want to. The player casts it as part of the resolution of Wild Evocation's ability. Timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other play restrictions are not (such as \"Cast [this card] only during combat\")."
         },
         {
           "date": "2010-08-15",
-          "text": "If a player reveals a nonland card, but can’t cast it due to a lack of legal targets or a play restriction, it simply remains in his or her hand."
+          "text": "If a player reveals a nonland card, but can't cast it due to a lack of legal targets or a play restriction, it simply remains in his or her hand."
         },
         {
           "date": "2010-08-15",
-          "text": "If, as the result of Wild Evocation’s ability, a player casts a card “without paying its mana cost,” any X in the mana cost will be 0, and that player can’t pay any alternative costs (such as Demon of Death’s Gate’s alternative cost). On the other hand, if the card has optional additional costs (such as kicker or multikicker), the player may pay those."
+          "text": "If, as the result of Wild Evocation's ability, a player casts a card \"without paying its mana cost,\" any X in the mana cost will be 0, and that player can't pay any alternative costs (such as Demon of Death's Gate's alternative cost). On the other hand, if the card has optional additional costs (such as kicker or multikicker), the player may pay those."
         },
         {
           "date": "2010-08-15",
-          "text": "If casting the revealed card involves paying a mandatory additional cost (such as the one Fling has), the player casting that card must pay that cost if able. If he or she can’t, the card remains uncast in his or her hand. If the mandatory additional cost includes a mana payment, the situation is more complex. If the player has enough mana in his or her mana pool to pay the cost, that player must do so. If the player can’t possibly pay the cost, the card remains uncast in his or her hand. However, if the player has the means to produce enough mana to pay the cost, then he or she has a choice: The player may cast the card, produce mana, and pay the cost. Or the player may choose to activate no mana abilities, thus making the card impossible to cast because the additional mana can’t be paid."
+          "text": "If casting the revealed card involves paying a mandatory additional cost (such as the one Fling has), the player casting that card must pay that cost if able. If he or she can't, the card remains uncast in his or her hand. If the mandatory additional cost includes a mana payment, the situation is more complex. If the player has enough mana in his or her mana pool to pay the cost, that player must do so. If the player can't possibly pay the cost, the card remains uncast in his or her hand. However, if the player has the means to produce enough mana to pay the cost, then he or she has a choice: The player may cast the card, produce mana, and pay the cost. Or the player may choose to activate no mana abilities, thus making the card impossible to cast because the additional mana can't be paid."
         },
         {
           "date": "2010-08-15",
-          "text": "If a player casts a nonland card revealed with Wild Evocation’s ability, it’s put on the stack as a spell, then Wild Evocation’s ability finishes resolving. The spell will then resolve as normal, after players get a chance to cast spells and activate abilities."
+          "text": "If a player casts a nonland card revealed with Wild Evocation's ability, it's put on the stack as a spell, then Wild Evocation's ability finishes resolving. The spell will then resolve as normal, after players get a chance to cast spells and activate abilities."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player reveals a card at random from his or her hand. If it's a land card, the player puts it onto the battlefield. Otherwise, the player casts it without paying its mana cost if able.",
@@ -18054,31 +18066,31 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Autumn’s Veil itself may be countered by blue or black spells. Its effect doesn’t apply until after it resolves."
+          "text": "Autumn's Veil itself may be countered by blue or black spells. Its effect doesn't apply until after it resolves."
         },
         {
           "date": "2010-08-15",
-          "text": "After Autumn’s Veil resolves, any spell you control that turn can still be targeted by spells that try to counter it (such as Cancel), regardless of their color. If those spells are blue or black at the time they would resolve, they will resolve, but the part of their effect that would counter the spell you control simply won’t do anything. Any other effects those spells have will work as normal."
+          "text": "After Autumn's Veil resolves, any spell you control that turn can still be targeted by spells that try to counter it (such as Cancel), regardless of their color. If those spells are blue or black at the time they would resolve, they will resolve, but the part of their effect that would counter the spell you control simply won't do anything. Any other effects those spells have will work as normal."
         },
         {
           "date": "2010-08-15",
-          "text": "If a creature you control is being targeted by a spell when Autumn’s Veil resolves, nothing happens right away. When that spell would resolve, its color is checked. If it’s blue or black, that creature will be an illegal target for that spell, and will be unable to be affected by it. If all that spell’s targets have become illegal by the time it would resolve, it’s countered."
+          "text": "If a creature you control is being targeted by a spell when Autumn's Veil resolves, nothing happens right away. When that spell would resolve, its color is checked. If it's blue or black, that creature will be an illegal target for that spell, and will be unable to be affected by it. If all that spell's targets have become illegal by the time it would resolve, it's countered."
         },
         {
           "date": "2010-08-15",
-          "text": "After Autumn’s Veil resolves, no new blue or black spell may be cast that turn targeting a creature you control."
+          "text": "After Autumn's Veil resolves, no new blue or black spell may be cast that turn targeting a creature you control."
         },
         {
           "date": "2010-08-15",
-          "text": "Keep in mind that an Aura spell targets the permanent it will enchant (but an Aura on the battlefield doesn’t target the permanent it’s attached to)."
+          "text": "Keep in mind that an Aura spell targets the permanent it will enchant (but an Aura on the battlefield doesn't target the permanent it's attached to)."
         },
         {
           "date": "2010-08-15",
-          "text": "Autumn’s Veil affects any spells and creatures you happen to control at any point during the rest of the turn, not just spells and creatures you control as it resolves. That’s because it doesn’t grant an ability to those spells or creatures; rather, it affects the game rules and states something that’s now true about those spells and creatures."
+          "text": "Autumn's Veil affects any spells and creatures you happen to control at any point during the rest of the turn, not just spells and creatures you control as it resolves. That's because it doesn't grant an ability to those spells or creatures; rather, it affects the game rules and states something that's now true about those spells and creatures."
         },
         {
           "date": "2010-08-15",
-          "text": "Autumn’s Veil has no effect on abilities. After it resolves, spells you control may be countered by abilities from blue or black sources, and creatures you control may be targeted by abilities from blue or black sources."
+          "text": "Autumn's Veil has no effect on abilities. After it resolves, spells you control may be countered by abilities from blue or black sources, and creatures you control may be targeted by abilities from blue or black sources."
         }
       ],
       "text": "Spells you control can't be countered by blue or black spells this turn, and creatures you control can't be the targets of blue or black spells this turn.",
@@ -18181,23 +18193,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Awakener Druid’s ability affects a land with the land type Forest, not necessarily a land with the name Forest."
+          "text": "Awakener Druid's ability affects a land with the land type Forest, not necessarily a land with the name Forest."
         },
         {
           "date": "2009-10-01",
-          "text": "Awakener Druid’s ability is mandatory. When it enters the battlefield, you must target a Forest (if there is one), even if you don’t control that Forest."
+          "text": "Awakener Druid's ability is mandatory. When it enters the battlefield, you must target a Forest (if there is one), even if you don't control that Forest."
         },
         {
           "date": "2009-10-01",
-          "text": "If Awakener Druid leaves the battlefield before its enters-the-battlefield ability resolves, nothing happens to the targeted Forest when that ability resolves. It won’t become a creature."
+          "text": "If Awakener Druid leaves the battlefield before its enters-the-battlefield ability resolves, nothing happens to the targeted Forest when that ability resolves. It won't become a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted Forest entered the battlefield this turn, it will be affected by “summoning sickness” once it becomes a Treefolk. You won’t be able to attack with it or use its activated abilities that have {T} in the cost (including its mana ability)."
+          "text": "If the targeted Forest entered the battlefield this turn, it will be affected by \"summoning sickness\" once it becomes a Treefolk. You won't be able to attack with it or use its activated abilities that have {T} in the cost (including its mana ability)."
         },
         {
           "date": "2009-10-01",
-          "text": "If Awakener Druid and the Treefolk are dealt lethal damage at the same time, both will be destroyed. However, if Awakener Druid leaves the battlefield before the Treefolk is dealt damage, it will immediately revert to being just a land and thus can’t be dealt damage."
+          "text": "If Awakener Druid and the Treefolk are dealt lethal damage at the same time, both will be destroyed. However, if Awakener Druid leaves the battlefield before the Treefolk is dealt damage, it will immediately revert to being just a land and thus can't be dealt damage."
         }
       ],
       "subtypes": [
@@ -18523,7 +18535,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking Brindle Boar during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but Brindle Boar is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking Brindle Boar during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but Brindle Boar is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -18630,7 +18642,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Activating Cudgel Troll’s ability causes a “regeneration shield” to be created for it. The next time Cudgel Troll would be destroyed that turn, the regeneration shield is used up instead. This works only if Cudgel Troll is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to “destroy” it. Other effects that cause Cudgel Troll to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don’t destroy it, so regeneration won’t save it. If it hasn’t been used, the regeneration shield goes away as the turn ends."
+          "text": "Activating Cudgel Troll's ability causes a \"regeneration shield\" to be created for it. The next time Cudgel Troll would be destroyed that turn, the regeneration shield is used up instead. This works only if Cudgel Troll is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to \"destroy\" it. Other effects that cause Cudgel Troll to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don't destroy it, so regeneration won't save it. If it hasn't been used, the regeneration shield goes away as the turn ends."
         },
         {
           "date": "2010-08-15",
@@ -19067,11 +19079,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Elvish Archdruid’s first ability affects only other Elves you control. However, Elvish Archdruid’s second ability counts all Elves you control — including itself."
+          "text": "Elvish Archdruid's first ability affects only other Elves you control. However, Elvish Archdruid's second ability counts all Elves you control — including itself."
         },
         {
           "date": "2011-09-22",
-          "text": "Elvish Archdruid’s activated ability is a mana ability. It doesn’t use the stack and players can’t respond to it."
+          "text": "Elvish Archdruid's activated ability is a mana ability. It doesn't use the stack and players can't respond to it."
         }
       ],
       "subtypes": [
@@ -19398,19 +19410,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Gaea’s Revenge’s first ability works only while it’s a spell on the stack. Gaea’s Revenge’s last ability works only while it’s on the battlefield."
+          "text": "Gaea's Revenge's first ability works only while it's a spell on the stack. Gaea's Revenge's last ability works only while it's on the battlefield."
         },
         {
           "date": "2010-08-15",
-          "text": "A Gaea’s Revenge spell can be targeted by spells and abilities that would counter it. The part of their effect that would counter Gaea’s Revenge won’t do anything, but any other effects those spells or abilities may have will still happen, if applicable."
+          "text": "A Gaea's Revenge spell can be targeted by spells and abilities that would counter it. The part of their effect that would counter Gaea's Revenge won't do anything, but any other effects those spells or abilities may have will still happen, if applicable."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaea’s Revenge’s last ability applies to all nongreen spells and abilities from nongreen sources, including ones you control. For example, you can’t target it with the equip ability of an Equipment you control (unless the Equipment is somehow green)."
+          "text": "Gaea's Revenge's last ability applies to all nongreen spells and abilities from nongreen sources, including ones you control. For example, you can't target it with the equip ability of an Equipment you control (unless the Equipment is somehow green)."
         },
         {
           "date": "2015-06-22",
-          "text": "If a spell is one or more colors, and one of those colors is green, that spell can target Gaea’s Revenge."
+          "text": "If a spell is one or more colors, and one of those colors is green, that spell can target Gaea's Revenge."
         }
       ],
       "subtypes": [
@@ -19525,11 +19537,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two lands. They don’t have to be tapped."
+          "text": "The first ability can target any two lands. They don't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "The third ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "The third ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -19736,15 +19748,15 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If Garruk’s Packleader and another creature with power 3 or greater enter the battlefield under your control at the same time, the ability will trigger."
+          "text": "If Garruk's Packleader and another creature with power 3 or greater enter the battlefield under your control at the same time, the ability will trigger."
         },
         {
           "date": "2012-07-01",
-          "text": "The ability checks the power of each creature as it enters the battlefield. It will take into account counters the permanent enters the battlefield with and static abilities that affect its power (such as Flinthoof Boar’s ability). After the creature is on the battlefield, raising its power with a spell (such as Titanic Growth), an activated ability, or a triggered ability won’t cause this ability to retroactively trigger."
+          "text": "The ability checks the power of each creature as it enters the battlefield. It will take into account counters the permanent enters the battlefield with and static abilities that affect its power (such as Flinthoof Boar's ability). After the creature is on the battlefield, raising its power with a spell (such as Titanic Growth), an activated ability, or a triggered ability won't cause this ability to retroactively trigger."
         },
         {
           "date": "2012-07-01",
-          "text": "The creature’s power is checked only to see if the ability triggers. It doesn’t matter what the creature’s power is when the ability resolves."
+          "text": "The creature's power is checked only to see if the ability triggers. It doesn't matter what the creature's power is when the ability resolves."
         }
       ],
       "subtypes": [
@@ -19967,6 +19979,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -20404,11 +20420,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If Leyline of Vitality and a creature enter the battlefield under your control at the same time, Leyline of Vitality’s third ability will trigger."
+          "text": "If Leyline of Vitality and a creature enter the battlefield under your control at the same time, Leyline of Vitality's third ability will trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of Vitality is in your opening hand, you may begin the game with it on the battlefield.\nCreatures you control get +0/+1.\nWhenever a creature enters the battlefield under your control, you may gain 1 life.",
@@ -20969,11 +20985,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If a spell or ability an opponent controls causes you to discard Obstinate Baloth, and both Obstinate Baloth’s ability and another ability (such as the one from an opponent’s Leyline of the Void) instruct you to put Obstinate Baloth somewhere else instead of putting it into your graveyard, you choose which one to apply."
+          "text": "If a spell or ability an opponent controls causes you to discard Obstinate Baloth, and both Obstinate Baloth's ability and another ability (such as the one from an opponent's Leyline of the Void) instruct you to put Obstinate Baloth somewhere else instead of putting it into your graveyard, you choose which one to apply."
         },
         {
           "date": "2010-08-15",
-          "text": "If you discard Obstinate Baloth and wind up putting it onto the battlefield, you’ve still discarded it. Abilities that trigger when you discard a card (such as the one from Liliana’s Caress) will still trigger."
+          "text": "If you discard Obstinate Baloth and wind up putting it onto the battlefield, you've still discarded it. Abilities that trigger when you discard a card (such as the one from Liliana's Caress) will still trigger."
         }
       ],
       "subtypes": [
@@ -21294,11 +21310,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Primal Cocoon’s first triggered ability triggers at the beginning of the upkeep of Primal Cocoon’s controller (who is not necessarily the enchanted creature’s controller)."
+          "text": "Primal Cocoon's first triggered ability triggers at the beginning of the upkeep of Primal Cocoon's controller (who is not necessarily the enchanted creature's controller)."
         },
         {
           "date": "2010-08-15",
-          "text": "The counters are put on the creature, not on Primal Cocoon. They’ll stay on the creature even after Primal Cocoon is sacrificed or otherwise stops enchanting that creature."
+          "text": "The counters are put on the creature, not on Primal Cocoon. They'll stay on the creature even after Primal Cocoon is sacrificed or otherwise stops enchanting that creature."
         }
       ],
       "subtypes": [
@@ -21514,11 +21530,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Prized Unicorn doesn’t give a creature the ability to block it. It just forces those creatures that are already able to block it to do so. For example, it can’t force a creature that’s tapped or affected by a spell or ability that says it can’t block to block it. If there’s a cost associated with having a creature block, its controller isn’t forced to pay that cost, so the creature doesn’t have to block Prized Unicorn in that case either."
+          "text": "Prized Unicorn doesn't give a creature the ability to block it. It just forces those creatures that are already able to block it to do so. For example, it can't force a creature that's tapped or affected by a spell or ability that says it can't block to block it. If there's a cost associated with having a creature block, its controller isn't forced to pay that cost, so the creature doesn't have to block Prized Unicorn in that case either."
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature the defending player controls can’t block Prized Unicorn, it can block any attacking creature, or not block at all."
+          "text": "If a creature the defending player controls can't block Prized Unicorn, it can block any attacking creature, or not block at all."
         },
         {
           "date": "2009-10-01",
@@ -21628,15 +21644,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "All damage that would be dealt to Protean Hydra is prevented, even if it doesn’t have that many +1/+1 counters on it. This is true even if Protean Hydra has no +1/+1 counters on it at all (and is able to remain on the battlefield because some other effect is boosting its toughness). If the amount of damage that would be dealt to Protean Hydra is greater than the number of +1/+1 counters on it, all the +1/+1 counters on Protean Hydra are removed from it."
+          "text": "All damage that would be dealt to Protean Hydra is prevented, even if it doesn't have that many +1/+1 counters on it. This is true even if Protean Hydra has no +1/+1 counters on it at all (and is able to remain on the battlefield because some other effect is boosting its toughness). If the amount of damage that would be dealt to Protean Hydra is greater than the number of +1/+1 counters on it, all the +1/+1 counters on Protean Hydra are removed from it."
         },
         {
           "date": "2009-10-01",
-          "text": "If unpreventable damage is dealt to Protean Hydra, the Hydra’s second ability will try to prevent it and fail (meaning that damage has its normal results), and it will also remove that many +1/+1 counters from Protean Hydra."
+          "text": "If unpreventable damage is dealt to Protean Hydra, the Hydra's second ability will try to prevent it and fail (meaning that damage has its normal results), and it will also remove that many +1/+1 counters from Protean Hydra."
         },
         {
           "date": "2009-10-01",
-          "text": "Protean Hydra’s last ability triggers whenever a +1/+1 counter is removed from it for any reason, not just when a +1/+1 counter is removed by its second ability."
+          "text": "Protean Hydra's last ability triggers whenever a +1/+1 counter is removed from it for any reason, not just when a +1/+1 counter is removed by its second ability."
         },
         {
           "date": "2009-10-01",
@@ -21644,7 +21660,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a -1/-1 counter is put on Protean Hydra while it has +1/+1 counters on it, that -1/-1 counter and a +1/+1 counter will be removed from it as a state-based action. This will cause Protean Hydra’s last ability to trigger."
+          "text": "If a -1/-1 counter is put on Protean Hydra while it has +1/+1 counters on it, that -1/-1 counter and a +1/+1 counter will be removed from it as a state-based action. This will cause Protean Hydra's last ability to trigger."
         },
         {
           "date": "2009-10-01",
@@ -22390,7 +22406,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a white spell, Angel’s Feather’s ability triggers and is put on the stack on top of that spell. Angel’s Feather’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a white spell, Angel's Feather's ability triggers and is put on the stack on top of that spell. Angel's Feather's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a white spell, you may gain 1 life.",
@@ -22685,7 +22701,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a black spell, Demon’s Horn’s ability triggers and is put on the stack on top of that spell. Demon’s Horn’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a black spell, Demon's Horn's ability triggers and is put on the stack on top of that spell. Demon's Horn's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a black spell, you may gain 1 life.",
@@ -22795,7 +22811,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a red spell, Dragon’s Claw’s ability triggers and is put on the stack on top of that spell. Dragon’s Claw’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a red spell, Dragon's Claw's ability triggers and is put on the stack on top of that spell. Dragon's Claw's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a red spell, you may gain 1 life.",
@@ -22894,19 +22910,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Paying the activation cost of Elixir of Immortality’s ability doesn’t cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
+          "text": "Paying the activation cost of Elixir of Immortality's ability doesn't cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
         },
         {
           "date": "2011-09-22",
-          "text": "As the ability resolves, you’ll shuffle Elixir of Immortality into its owner’s library directly from the battlefield, if it’s still there."
+          "text": "As the ability resolves, you'll shuffle Elixir of Immortality into its owner's library directly from the battlefield, if it's still there."
         },
         {
           "date": "2011-09-22",
-          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you’ll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it’s anywhere else by that time, including in another player’s graveyard, it remains where it is and you shuffle just your graveyard into your library."
+          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you'll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it's anywhere else by that time, including in another player's graveyard, it remains where it is and you shuffle just your graveyard into your library."
         },
         {
           "date": "2011-09-22",
-          "text": "If you gain control of another player’s Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner’s library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
+          "text": "If you gain control of another player's Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner's library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
         }
       ],
       "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
@@ -23107,11 +23123,11 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The control-change effect has no duration. The targeted player retains control of Jinxed Idol until the game ends, Jinxed Idol leaves the battlefield, or an effect causes someone else to gain control of it (perhaps because Jinxed Idol’s ability is activated again)."
+          "text": "The control-change effect has no duration. The targeted player retains control of Jinxed Idol until the game ends, Jinxed Idol leaves the battlefield, or an effect causes someone else to gain control of it (perhaps because Jinxed Idol's ability is activated again)."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "text": "At the beginning of your upkeep, Jinxed Idol deals 2 damage to you.\nSacrifice a creature: Target opponent gains control of Jinxed Idol.",
@@ -23225,11 +23241,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -23343,7 +23359,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a blue spell, Kraken’s Eye’s ability triggers and is put on the stack on top of that spell. Kraken’s Eye’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a blue spell, Kraken's Eye's ability triggers and is put on the stack on top of that spell. Kraken's Eye's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a blue spell, you may gain 1 life.",
@@ -23568,23 +23584,23 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They’ll still work."
+          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They'll still work."
         },
         {
           "date": "2004-12-01",
-          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can’t prevent you from losing the game)."
+          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can't prevent you from losing the game)."
         },
         {
           "date": "2009-10-01",
-          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn’t matter whether you have 0 or less life, you’re forced to draw a card while your library is empty, you have ten or more poison counters, you’re dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
+          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn't matter whether you have 0 or less life, you're forced to draw a card while your library is empty, you have ten or more poison counters, you're dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
         },
         {
           "date": "2009-10-01",
-          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you’re penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
+          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you're penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
         },
         {
           "date": "2009-10-01",
-          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can’t lose the game and the opposing team can’t win the game."
+          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can't lose the game and the opposing team can't win the game."
         }
       ],
       "subtypes": [
@@ -23689,7 +23705,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If you no longer control Sorcerer’s Strongbox by the time you win the flip, you won’t be able to sacrifice it. You’ll still draw three cards, though."
+          "text": "If you no longer control Sorcerer's Strongbox by the time you win the flip, you won't be able to sacrifice it. You'll still draw three cards, though."
         }
       ],
       "text": "{2}, {T}: Flip a coin. If you win the flip, sacrifice Sorcerer's Strongbox and draw three cards.",
@@ -23787,7 +23803,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Steel Overseer is affected by its own ability (assuming that, by the time the ability resolves, you still control Steel Overseer and its types haven’t changed). You’ll put a +1/+1 counter on it, as well as on each other artifact creature you control."
+          "text": "Steel Overseer is affected by its own ability (assuming that, by the time the ability resolves, you still control Steel Overseer and its types haven't changed). You'll put a +1/+1 counter on it, as well as on each other artifact creature you control."
         }
       ],
       "subtypes": [
@@ -24174,11 +24190,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it’ll be destroyed before you get a chance to activate its ability."
+          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it'll be destroyed before you get a chance to activate its ability."
         },
         {
           "date": "2010-08-15",
-          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won’t be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
+          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won't be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
         }
       ],
       "subtypes": [
@@ -24581,7 +24597,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a green spell, Wurm’s Tooth’s ability triggers and is put on the stack on top of that spell. Wurm’s Tooth’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a green spell, Wurm's Tooth's ability triggers and is put on the stack on top of that spell. Wurm's Tooth's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a green spell, you may gain 1 life.",
@@ -24682,11 +24698,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don’t have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don't have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
@@ -24786,11 +24802,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don’t have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don't have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
@@ -24889,11 +24905,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Plains or Island, not for lands named Plains or Island. The lands it checks for don’t have to be basic lands. For example, if you control Watery Grave (a nonbasic land with the land types Island and Swamp), Glacial Fortress will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Plains or Island, not for lands named Plains or Island. The lands it checks for don't have to be basic lands. For example, if you control Watery Grave (a nonbasic land with the land types Island and Swamp), Glacial Fortress will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
@@ -24985,11 +25001,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2010-08-15",
-          "text": "The targeted creature doesn’t have to be attacking you. It can be attacking a planeswalker, or (in a multiplayer game) it can be attacking another player."
+          "text": "The targeted creature doesn't have to be attacking you. It can be attacking a planeswalker, or (in a multiplayer game) it can be attacking another player."
         },
         {
           "date": "2010-08-15",
@@ -25094,11 +25110,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don’t have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don't have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
@@ -25198,11 +25214,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don’t have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don't have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
@@ -30004,27 +30020,27 @@
         {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
-          "multiverseid": 225249
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 225250
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
           "multiverseid": 225251
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 225252
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 225000
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 225499
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 225001
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 225002
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 225003
         }
       ],
       "id": "057d073787f94c8dfc2a05aa8ba4ad96d167be88",
@@ -30774,27 +30790,27 @@
         {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
-          "multiverseid": 225249
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 225250
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
           "multiverseid": 225251
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 225252
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 225000
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 225499
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 225001
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 225002
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 225003
         }
       ],
       "id": "6a34ec592450f5602832d50da214b2e5557f518e",

--- a/json/M12.json
+++ b/json/M12.json
@@ -254,7 +254,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Multiple instances of lifelink on the same creature provide no additional benefit. The creature’s controller gains life equal the damage dealt and no more."
+          "text": "Multiple instances of lifelink on the same creature provide no additional benefit. The creature's controller gains life equal the damage dealt and no more."
         }
       ],
       "subtypes": [
@@ -359,11 +359,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the creature dies before the Angelic Destiny spell resolves, Angelic Destiny will go to its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the creature dies before the Angelic Destiny spell resolves, Angelic Destiny will go to its owner's graveyard. It won't return to its owner's hand."
         },
         {
           "date": "2011-09-22",
-          "text": "If Angelic Destiny is no longer in a graveyard when its triggered ability resolves, it won’t be returned to its owner’s hand."
+          "text": "If Angelic Destiny is no longer in a graveyard when its triggered ability resolves, it won't be returned to its owner's hand."
         }
       ],
       "subtypes": [
@@ -570,11 +570,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the creature is an illegal target when Arbalest Elite’s ability tries to resolve, the ability will be countered and none of its effects will happen. Arbalest Elite will untap during its controller’s next untap step."
+          "text": "If the creature is an illegal target when Arbalest Elite's ability tries to resolve, the ability will be countered and none of its effects will happen. Arbalest Elite will untap during its controller's next untap step."
         },
         {
           "date": "2011-09-22",
-          "text": "If another player controls Arbalest Elite during your next untap step, the part of the effect that keeps it from untapping does nothing. It won’t try to apply during a future untap step."
+          "text": "If another player controls Arbalest Elite during your next untap step, the part of the effect that keeps it from untapping does nothing. It won't try to apply during a future untap step."
         }
       ],
       "subtypes": [
@@ -1211,7 +1211,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Lands are colorless (even if their frames have some colored elements to them). You can’t target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
+          "text": "Lands are colorless (even if their frames have some colored elements to them). You can't target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
         }
       ],
       "text": "Exile target black or red permanent.",
@@ -1525,7 +1525,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If the creature targeted by Divine Favor is an illegal target when Divine Favor tries to resolve, Divine Favor will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the creature targeted by Divine Favor is an illegal target when Divine Favor tries to resolve, Divine Favor will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -1738,43 +1738,43 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s first ability doesn’t lock in what it applies to. That’s because the effect states a true thing about a set of creatures, but doesn’t actually change the characteristics of those creatures. As a result, whatever creatures the targeted opponent controls during the declare attackers step of his or her next turn must attack Gideon Jura if able. This includes creatures that come under that player’s control after the ability has resolved and creatures that have lost all abilities."
+          "text": "Gideon Jura's first ability doesn't lock in what it applies to. That's because the effect states a true thing about a set of creatures, but doesn't actually change the characteristics of those creatures. As a result, whatever creatures the targeted opponent controls during the declare attackers step of his or her next turn must attack Gideon Jura if able. This includes creatures that come under that player's control after the ability has resolved and creatures that have lost all abilities."
         },
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s first ability causes creatures to attack him if able. If, during the affected player’s declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then that creature doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so the creature doesn’t have to attack in that case either."
+          "text": "Gideon Jura's first ability causes creatures to attack him if able. If, during the affected player's declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then that creature doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so the creature doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature controlled by the affected player can’t attack Gideon Jura (because he’s no longer on the battlefield, for example), that player may have it attack you, another one of your planeswalkers, or nothing at all."
+          "text": "If a creature controlled by the affected player can't attack Gideon Jura (because he's no longer on the battlefield, for example), that player may have it attack you, another one of your planeswalkers, or nothing at all."
         },
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s first ability applies during each combat phase of the affected player’s next turn (as opposed to applying during the affected player’s next combat phase). The distinction is relevant if there are no combat phases during that turn (due to Fatespinner’s effect, for example) or there are multiples (due to World at War, for example)."
+          "text": "Gideon Jura's first ability applies during each combat phase of the affected player's next turn (as opposed to applying during the affected player's next combat phase). The distinction is relevant if there are no combat phases during that turn (due to Fatespinner's effect, for example) or there are multiples (due to World at War, for example)."
         },
         {
           "date": "2010-06-15",
-          "text": "If Gideon Jura becomes a creature due to his third ability, that doesn’t count as having a creature enter the battlefield. Gideon Jura was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "If Gideon Jura becomes a creature due to his third ability, that doesn't count as having a creature enter the battlefield. Gideon Jura was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-06-15",
-          "text": "If Gideon Jura becomes a creature, he may be affected by “summoning sickness.” You can’t attack with him or use any of his {T} abilities (if he gains any) unless he began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when Gideon Jura came under your control, not when he became a creature."
+          "text": "If Gideon Jura becomes a creature, he may be affected by \"summoning sickness.\" You can't attack with him or use any of his {T} abilities (if he gains any) unless he began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when Gideon Jura came under your control, not when he became a creature."
         },
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s third ability causes him to become a creature with the creature types Human Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
+          "text": "Gideon Jura's third ability causes him to become a creature with the creature types Human Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you activate Gideon Jura’s third ability and then unpreventable damage is dealt to him (due to Unstable Footing, for example), that damage has all applicable results: specifically, the damage is marked on Gideon Jura (since he’s a creature) and that damage causes that many loyalty counters to be removed from him (since he’s a planeswalker). If the total amount of damage marked on Gideon Jura is lethal damage, he’s destroyed as a state-based action. If Gideon Jura has no loyalty counters on him, he’s put into his owner’s graveyard as a state-based action."
+          "text": "If you activate Gideon Jura's third ability and then unpreventable damage is dealt to him (due to Unstable Footing, for example), that damage has all applicable results: specifically, the damage is marked on Gideon Jura (since he's a creature) and that damage causes that many loyalty counters to be removed from him (since he's a planeswalker). If the total amount of damage marked on Gideon Jura is lethal damage, he's destroyed as a state-based action. If Gideon Jura has no loyalty counters on him, he's put into his owner's graveyard as a state-based action."
         },
         {
           "date": "2010-06-15",
-          "text": "Say you activate Gideon Jura’s third ability, then an opponent gains control of him before combat. You may have any of your creatures attack Gideon Jura (since he’s still a planeswalker). Then Gideon Jura may block (since he’s a creature). He may block any eligible attacking creature, including one that’s attacking him! During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he’s blocking, but he doesn’t deal combat damage to any unblocked creatures that are attacking him."
+          "text": "Say you activate Gideon Jura's third ability, then an opponent gains control of him before combat. You may have any of your creatures attack Gideon Jura (since he's still a planeswalker). Then Gideon Jura may block (since he's a creature). He may block any eligible attacking creature, including one that's attacking him! During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he's blocking, but he doesn't deal combat damage to any unblocked creatures that are attacking him."
         },
         {
           "date": "2011-01-22",
-          "text": "The first ability only affects the declaration of attackers. If a creature is put onto the battlefield attacking (thanks to Hero of Bladehold, Preeminent Captain, or the Ninjutsu ability, for example), that creature’s controller may choose the defending player or planeswalker that it will be attacking in the normal way."
+          "text": "The first ability only affects the declaration of attackers. If a creature is put onto the battlefield attacking (thanks to Hero of Bladehold, Preeminent Captain, or the Ninjutsu ability, for example), that creature's controller may choose the defending player or planeswalker that it will be attacking in the normal way."
         }
       ],
       "subtypes": [
@@ -1879,7 +1879,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If an opponent’s creature enters the battlefield tapped, Gideon’s Avenger’s ability doesn’t trigger."
+          "text": "If an opponent's creature enters the battlefield tapped, Gideon's Avenger's ability doesn't trigger."
         }
       ],
       "subtypes": [
@@ -2091,11 +2091,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Grand Abolisher doesn’t stop your opponents from activating abilities of artifact, creature, or enchantment cards in zones other than the battlefield (like cycling abilities, for example)."
+          "text": "Grand Abolisher doesn't stop your opponents from activating abilities of artifact, creature, or enchantment cards in zones other than the battlefield (like cycling abilities, for example)."
         },
         {
           "date": "2011-09-22",
-          "text": "Grand Abolisher doesn’t affect triggered abilities or static abilities."
+          "text": "Grand Abolisher doesn't affect triggered abilities or static abilities."
         }
       ],
       "subtypes": [
@@ -2404,7 +2404,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Guardians’ Pledge only gives a bonus to white creatures you control when it resolves. Creatures that enter the battlefield later in the turn and nonwhite creatures that become white later in the turn will not get the bonus."
+          "text": "Guardians' Pledge only gives a bonus to white creatures you control when it resolves. Creatures that enter the battlefield later in the turn and nonwhite creatures that become white later in the turn will not get the bonus."
         },
         {
           "date": "2011-09-22",
@@ -2609,7 +2609,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The controller of the enchanted creature, not the controller of Lifelink, gains the life (in case they’re different players)."
+          "text": "The controller of the enchanted creature, not the controller of Lifelink, gains the life (in case they're different players)."
         }
       ],
       "subtypes": [
@@ -2722,15 +2722,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Mesa Enchantress’s last ability will resolve before the spell that caused it to trigger."
+          "text": "Mesa Enchantress's last ability will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "If the enchantment spell is countered, Mesa Enchantress’s last ability still resolves and causes you to draw a card."
+          "text": "If the enchantment spell is countered, Mesa Enchantress's last ability still resolves and causes you to draw a card."
         },
         {
           "date": "2016-06-08",
-          "text": "Enchantments put onto the battlefield without being cast won’t cause Mesa Enchantress’s last ability to trigger."
+          "text": "Enchantments put onto the battlefield without being cast won't cause Mesa Enchantress's last ability to trigger."
         }
       ],
       "subtypes": [
@@ -2856,7 +2856,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
         }
       ],
       "text": "Target creature gets +2/+2 and gains flying until end of turn.",
@@ -2982,11 +2982,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -3422,7 +3422,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If Pride Guardian gains the ability to block additional creatures and does so, you’ll still gain only 3 life."
+          "text": "If Pride Guardian gains the ability to block additional creatures and does so, you'll still gain only 3 life."
         }
       ],
       "subtypes": [
@@ -4069,7 +4069,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, the targeted opponent’s team skips its next combat phase."
+          "text": "In a Two-Headed Giant game, the targeted opponent's team skips its next combat phase."
         }
       ],
       "subtypes": [
@@ -4297,7 +4297,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If a card in your graveyard has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         }
       ],
       "subtypes": [
@@ -4402,15 +4402,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You compare life totals with each of your opponents when Timely Reinforcements resolves. At that time, if you have less life than an opponent, you’ll gain 6 life. Similarly, you compare the number of creatures you control with the number of creatures each opponent controls when Timely Reinforcements resolves."
+          "text": "You compare life totals with each of your opponents when Timely Reinforcements resolves. At that time, if you have less life than an opponent, you'll gain 6 life. Similarly, you compare the number of creatures you control with the number of creatures each opponent controls when Timely Reinforcements resolves."
         },
         {
           "date": "2011-09-22",
-          "text": "In a multiplayer game, you consider each opponent. If you have less life than one of your opponents and fewer creatures than one of your opponents (although this may be a different opponent), you’ll get both bonuses."
+          "text": "In a multiplayer game, you consider each opponent. If you have less life than one of your opponents and fewer creatures than one of your opponents (although this may be a different opponent), you'll get both bonuses."
         },
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, you’ll compare your team’s life total with the opposing team’s life total. You’ll then compare the number of creatures you control (ignoring creatures your teammate controls) to the number of creatures each opponent controls separately."
+          "text": "In a Two-Headed Giant game, you'll compare your team's life total with the opposing team's life total. You'll then compare the number of creatures you control (ignoring creatures your teammate controls) to the number of creatures each opponent controls separately."
         }
       ],
       "text": "If you have less life than an opponent, you gain 6 life. If you control fewer creatures than an opponent, create three 1/1 white Soldier creature tokens.",
@@ -4622,7 +4622,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "After the ability resolves, the targeted creature attacks you only if it’s able to do so as that turn’s declare attackers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” it can’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost, so the creature doesn’t have to attack in that case either."
+          "text": "After the ability resolves, the targeted creature attacks you only if it's able to do so as that turn's declare attackers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" it can't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost, so the creature doesn't have to attack in that case either."
         },
         {
           "date": "2009-10-01",
@@ -4630,11 +4630,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability during your opponent’s turn after attackers have been declared will have no effect. The same is true if you activate the ability during your own turn."
+          "text": "Activating the ability during your opponent's turn after attackers have been declared will have no effect. The same is true if you activate the ability during your own turn."
         },
         {
           "date": "2011-09-22",
-          "text": "If there are multiple combat phases in a turn, the creature must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, the creature must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -5143,6 +5143,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Time Spiral Block",
           "legality": "Legal"
         },
@@ -5597,19 +5601,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You play the revealed card as part of the resolution of Djinn of Wishes’s ability. Timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other play restrictions are not (such as “Cast [this card] only during combat”)."
+          "text": "You play the revealed card as part of the resolution of Djinn of Wishes's ability. Timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other play restrictions are not (such as \"Cast [this card] only during combat\")."
         },
         {
           "date": "2009-10-01",
-          "text": "If the revealed card is a spell, you may cast it only if you can choose legal targets for it. If you cast it, it’s put on the stack, then Djinn of Wishes’s ability finishes resolving. The spell will then resolve as normal, after players get a chance to cast spells and activate abilities."
+          "text": "If the revealed card is a spell, you may cast it only if you can choose legal targets for it. If you cast it, it's put on the stack, then Djinn of Wishes's ability finishes resolving. The spell will then resolve as normal, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2009-10-01",
-          "text": "If the revealed card is a land, you can play it only if it’s your turn and you haven’t yet played a land this turn."
+          "text": "If the revealed card is a land, you can play it only if it's your turn and you haven't yet played a land this turn."
         },
         {
           "date": "2009-10-01",
-          "text": "If you play a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs, such as conspire costs and kicker costs."
+          "text": "If you play a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs, such as conspire costs and kicker costs."
         }
       ],
       "subtypes": [
@@ -5930,11 +5934,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If a creature affected by Frost Breath changes controllers before its old controller’s next untap step, Frost Breath will prevent it from becoming untapped during its new controller’s next untap step."
+          "text": "If a creature affected by Frost Breath changes controllers before its old controller's next untap step, Frost Breath will prevent it from becoming untapped during its new controller's next untap step."
         },
         {
           "date": "2013-04-15",
-          "text": "This spell can target tapped creatures. If a targeted creature is already tapped when the spell resolves, that creature just remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "This spell can target tapped creatures. If a targeted creature is already tapped when the spell resolves, that creature just remains tapped and doesn't untap during its controller's next untap step."
         }
       ],
       "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
@@ -6038,19 +6042,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Frost Titan’s first ability affects each spell (including Aura spells), activated ability, and triggered ability that’s controlled by an opponent and that Frost Titan becomes a target of."
+          "text": "Frost Titan's first ability affects each spell (including Aura spells), activated ability, and triggered ability that's controlled by an opponent and that Frost Titan becomes a target of."
         },
         {
           "date": "2010-08-15",
-          "text": "You may target any permanent with Frost Titan’s second ability. It’s okay if that permanent is already tapped."
+          "text": "You may target any permanent with Frost Titan's second ability. It's okay if that permanent is already tapped."
         },
         {
           "date": "2010-08-15",
-          "text": "If the permanent affected by Frost Titan’s second ability is untapped at the time that permanent’s controller’s next untap step begins, the last part of Frost Titan’s second ability has no effect."
+          "text": "If the permanent affected by Frost Titan's second ability is untapped at the time that permanent's controller's next untap step begins, the last part of Frost Titan's second ability has no effect."
         },
         {
           "date": "2010-08-15",
-          "text": "If the permanent affected by Frost Titan’s second ability changes controllers before its old controller’s next untap step, Frost Titan’s second ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "If the permanent affected by Frost Titan's second ability changes controllers before its old controller's next untap step, Frost Titan's second ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -6158,7 +6162,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Harbor Serpent’s abilities care about lands with the land type Island, not necessarily lands named Island."
+          "text": "Harbor Serpent's abilities care about lands with the land type Island, not necessarily lands named Island."
         },
         {
           "date": "2010-08-15",
@@ -6268,11 +6272,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the enchanted creature becomes the target of a spell or ability, Ice Cage’s ability triggers and is put on the stack on top of that spell or ability. Ice Cage’s ability will resolve (causing Ice Cage to be destroyed) first."
+          "text": "If the enchanted creature becomes the target of a spell or ability, Ice Cage's ability triggers and is put on the stack on top of that spell or ability. Ice Cage's ability will resolve (causing Ice Cage to be destroyed) first."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -6379,15 +6383,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you target yourself with Jace’s first ability, you’ll draw a card first, then put the top card of your library into your graveyard."
+          "text": "If you target yourself with Jace's first ability, you'll draw a card first, then put the top card of your library into your graveyard."
         },
         {
           "date": "2011-09-22",
-          "text": "If you activate Jace’s first ability, and the player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If you activate Jace's first ability, and the player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         },
         {
           "date": "2011-09-22",
-          "text": "If Jace’s third ability causes a player to draw more cards than are left in his or her library, that player loses the game as a state-based action. If this ability causes all players to do this, the game is a draw."
+          "text": "If Jace's third ability causes a player to draw more cards than are left in his or her library, that player loses the game as a state-based action. If this ability causes all players to do this, the game is a draw."
         }
       ],
       "subtypes": [
@@ -6601,11 +6605,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If a spell or ability causes you to draw multiple cards, Jace’s Erasure’s ability triggers that many times. (The spell or ability finishes resolving before you put Jace’s Erasure’s abilities on the stack.)"
+          "text": "If a spell or ability causes you to draw multiple cards, Jace's Erasure's ability triggers that many times. (The spell or ability finishes resolving before you put Jace's Erasure's abilities on the stack.)"
         },
         {
           "date": "2010-08-15",
-          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word “draw,” Jace’s Erasure’s ability won’t trigger."
+          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word \"draw,\" Jace's Erasure's ability won't trigger."
         }
       ],
       "text": "Whenever you draw a card, you may have target player put the top card of his or her library into his or her graveyard.",
@@ -7024,11 +7028,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If Master Thief ceases to be under your control before its ability resolves, you won’t gain control of the targeted artifact at all."
+          "text": "If Master Thief ceases to be under your control before its ability resolves, you won't gain control of the targeted artifact at all."
         },
         {
           "date": "2011-09-22",
-          "text": "If another player gains control of Master Thief, its control-change effect ends. Regaining control of Master Thief won’t cause you to regain control of the artifact."
+          "text": "If another player gains control of Master Thief, its control-change effect ends. Regaining control of Master Thief won't cause you to regain control of the artifact."
         }
       ],
       "subtypes": [
@@ -7352,7 +7356,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -7456,7 +7460,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The ability is mandatory. You can’t choose to draw fewer cards than the number of lore counters on Mind Unbound."
+          "text": "The ability is mandatory. You can't choose to draw fewer cards than the number of lore counters on Mind Unbound."
         }
       ],
       "text": "At the beginning of your upkeep, put a lore counter on Mind Unbound, then draw a card for each lore counter on Mind Unbound.",
@@ -7590,7 +7594,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -7896,7 +7900,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Phantasmal Image copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it gains the Illusion creature type and the triggered ability. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Phantasmal Image copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it gains the Illusion creature type and the triggered ability. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2017-03-14",
@@ -7916,11 +7920,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Phantasmal Image enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Phantasmal Image enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2017-03-14",
-          "text": "If Phantasmal Image somehow enters the battlefield at the same time as another creature, Phantasmal Image can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Phantasmal Image somehow enters the battlefield at the same time as another creature, Phantasmal Image can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         }
       ],
       "subtypes": [
@@ -8135,19 +8139,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2010-08-15",
-          "text": "If the targeted spell is modal (that is, it says “Choose one —” or the like), you can’t choose a different mode."
+          "text": "If the targeted spell is modal (that is, it says \"Choose one —\" or the like), you can't choose a different mode."
         },
         {
           "date": "2010-08-15",
-          "text": "If you cast Redirect targeting a spell that targets a spell on the stack (like Cancel does, for example), you can’t change that spell’s target to itself. You can, however, change that spell’s target to Redirect. If you do, that spell will be countered when it tries to resolve because Redirect will have left the stack by then."
+          "text": "If you cast Redirect targeting a spell that targets a spell on the stack (like Cancel does, for example), you can't change that spell's target to itself. You can, however, change that spell's target to Redirect. If you do, that spell will be countered when it tries to resolve because Redirect will have left the stack by then."
         },
         {
           "date": "2010-08-15",
-          "text": "Redirect can target any spell, not just an instant or sorcery spell. For example, you could use it to change the target of an Aura spell. However, if the targeted spell has no targets (for example, if it’s an instant or sorcery spell that doesn’t specifically use the word “target,” or if it’s a creature spell), Redirect won’t have any effect on it."
+          "text": "Redirect can target any spell, not just an instant or sorcery spell. For example, you could use it to change the target of an Aura spell. However, if the targeted spell has no targets (for example, if it's an instant or sorcery spell that doesn't specifically use the word \"target,\" or if it's a creature spell), Redirect won't have any effect on it."
         }
       ],
       "text": "You may choose new targets for target spell.",
@@ -8356,7 +8360,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "A pile can have no cards in it. In this case, you’ll choose whether to put all the revealed cards into your hand or into your graveyard."
+          "text": "A pile can have no cards in it. In this case, you'll choose whether to put all the revealed cards into your hand or into your graveyard."
         },
         {
           "date": "2011-09-22",
@@ -8364,7 +8368,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn’t target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
+          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn't target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
         }
       ],
       "subtypes": [
@@ -8572,11 +8576,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Turn to Frog overwrites all previous effects that set the creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Turn to Frog resolves will overwrite this effect."
+          "text": "Turn to Frog overwrites all previous effects that set the creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Turn to Frog resolves will overwrite this effect."
         },
         {
           "date": "2014-07-18",
-          "text": "Turn to Frog doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature’s ability that says “At the beginning of your upkeep,” “When this creature enters the battlefield,” or similar from triggering."
+          "text": "Turn to Frog doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature's ability that says \"At the beginning of your upkeep,\" \"When this creature enters the battlefield,\" or similar from triggering."
         },
         {
           "date": "2014-07-18",
@@ -8584,11 +8588,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
         },
         {
           "date": "2014-07-18",
-          "text": "If one of the Theros block Gods is affected by Turn to Frog, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God’s type-changing ability is applied before the effect that removes that ability is applied."
+          "text": "If one of the Theros block Gods is affected by Turn to Frog, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God's type-changing ability is applied before the effect that removes that ability is applied."
         }
       ],
       "text": "Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
@@ -8658,6 +8662,10 @@
       "imageName": "unsummon",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -8812,7 +8820,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The number of cards in each player’s graveyard is counted when Visions of Beyond resolves. Visions of Beyond won’t count itself as it will still be on the stack at this time."
+          "text": "The number of cards in each player's graveyard is counted when Visions of Beyond resolves. Visions of Beyond won't count itself as it will still be on the stack at this time."
         }
       ],
       "text": "Draw a card. If a graveyard has twenty or more cards in it, draw three cards instead.",
@@ -8919,7 +8927,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Life loss is not the same as damage. Blood Seeker’s ability will not cause creatures with bloodthirst to enter the battlefield with +1/+1 counters."
+          "text": "Life loss is not the same as damage. Blood Seeker's ability will not cause creatures with bloodthirst to enter the battlefield with +1/+1 counters."
         }
       ],
       "subtypes": [
@@ -9246,19 +9254,19 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Brink of Disaster may target and may enchant a permanent that’s already tapped. It won’t do anything until the enchanted permanent changes from being untapped to being tapped."
+          "text": "Brink of Disaster may target and may enchant a permanent that's already tapped. It won't do anything until the enchanted permanent changes from being untapped to being tapped."
         },
         {
           "date": "2010-03-01",
-          "text": "When the enchanted permanent becomes tapped, Brink of Disaster’s ability triggers. That permanent will be destroyed when the ability resolves, even if Brink of Disaster has left the battlefield or is somehow enchanting a different permanent by then."
+          "text": "When the enchanted permanent becomes tapped, Brink of Disaster's ability triggers. That permanent will be destroyed when the ability resolves, even if Brink of Disaster has left the battlefield or is somehow enchanting a different permanent by then."
         },
         {
           "date": "2010-03-01",
-          "text": "If the enchanted permanent is tapped as a cost to activate a mana ability, the mana ability resolves immediately, then Brink of Disaster’s ability goes on the stack."
+          "text": "If the enchanted permanent is tapped as a cost to activate a mana ability, the mana ability resolves immediately, then Brink of Disaster's ability goes on the stack."
         },
         {
           "date": "2010-03-01",
-          "text": "If the enchanted permanent is tapped as a cost to activate an ability that’s not a mana ability, Brink of Disaster’s ability will go on the stack on top of that activated ability. Brink of Disaster’s ability resolves first (destroying that permanent), then the permanent’s activated ability resolves."
+          "text": "If the enchanted permanent is tapped as a cost to activate an ability that's not a mana ability, Brink of Disaster's ability will go on the stack on top of that activated ability. Brink of Disaster's ability resolves first (destroying that permanent), then the permanent's activated ability resolves."
         }
       ],
       "subtypes": [
@@ -9370,11 +9378,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If there is at least one creature on the battlefield at the beginning of the end step, the last ability won’t trigger. If it does trigger, but a creature enters the battlefield before it resolves, the ability won’t do anything when it resolves. Call to the Grave’s controller won’t sacrifice it."
+          "text": "If there is at least one creature on the battlefield at the beginning of the end step, the last ability won't trigger. If it does trigger, but a creature enters the battlefield before it resolves, the ability won't do anything when it resolves. Call to the Grave's controller won't sacrifice it."
         },
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, Call to the Grave will trigger twice during each team’s upkeep, once for each player. Each of the two players will sacrifice a non-Zombie creature when the ability referring to that player resolves."
+          "text": "In a Two-Headed Giant game, Call to the Grave will trigger twice during each team's upkeep, once for each player. Each of the two players will sacrifice a non-Zombie creature when the ability referring to that player resolves."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player sacrifices a non-Zombie creature.\nAt the beginning of the end step, if no creatures are on the battlefield, sacrifice Call to the Grave.",
@@ -9482,7 +9490,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The creature card in a graveyard is exiled as part of the activated ability’s effect, not as a cost. If that card has left the graveyard by the time the ability would resolve, the ability is countered and you don’t get a Zombie token."
+          "text": "The creature card in a graveyard is exiled as part of the activated ability's effect, not as a cost. If that card has left the graveyard by the time the ability would resolve, the ability is countered and you don't get a Zombie token."
         }
       ],
       "subtypes": [
@@ -9710,7 +9718,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
@@ -9813,7 +9821,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the creature targeted by Dark Favor is an illegal target when Dark Favor tries to resolve, Dark Favor will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the creature targeted by Dark Favor is an illegal target when Dark Favor tries to resolve, Dark Favor will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -10242,7 +10250,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -10846,6 +10854,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -10888,7 +10900,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -10993,7 +11005,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it’s blocked, changing its colors won’t change that."
+          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it's blocked, changing its colors won't change that."
         },
         {
           "date": "2011-09-22",
@@ -11227,7 +11239,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If there are one or zero cards in the player’s hand, he or she will discard no cards."
+          "text": "If there are one or zero cards in the player's hand, he or she will discard no cards."
         }
       ],
       "text": "Target player chooses a card in his or her hand and discards the rest.",
@@ -11555,11 +11567,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t target itself because you choose the target before you tap him. At that time he is not yet a legal target."
+          "text": "Can't target itself because you choose the target before you tap him. At that time he is not yet a legal target."
         },
         {
           "date": "2004-10-04",
-          "text": "If the creature is no longer tapped when the Assassin’s ability resolves, then the ability is countered."
+          "text": "If the creature is no longer tapped when the Assassin's ability resolves, then the ability is countered."
         }
       ],
       "subtypes": [
@@ -11794,15 +11806,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -12020,15 +12032,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Sorin’s first ability resolves, the entire ability is countered. You won’t gain life."
+          "text": "If the targeted creature or player is an illegal target by the time Sorin's first ability resolves, the entire ability is countered. You won't gain life."
         },
         {
           "date": "2009-10-01",
-          "text": "For a player’s life total to become 10, what actually happens is that the player gains or loses the appropriate amount of life. For example, if the targeted opponent’s life total is 4 when this ability resolves, it will cause that player to gain 6 life; alternately, if the targeted player’s life total is 17 when this ability resolves, it will cause that player to lose 7 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For a player's life total to become 10, what actually happens is that the player gains or loses the appropriate amount of life. For example, if the targeted opponent's life total is 4 when this ability resolves, it will cause that player to gain 6 life; alternately, if the targeted player's life total is 17 when this ability resolves, it will cause that player to lose 7 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2009-10-01",
-          "text": "Sorin’s third ability allows you to control another player. This effect applies to the next turn that the affected player actually takes."
+          "text": "Sorin's third ability allows you to control another player. This effect applies to the next turn that the affected player actually takes."
         },
         {
           "date": "2009-10-01",
@@ -12044,23 +12056,23 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t make the affected player concede. That player may choose to concede at any time, even while you’re controlling his or her turn."
+          "text": "You can't make the affected player concede. That player may choose to concede at any time, even while you're controlling his or her turn."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t make any illegal decisions or illegal choices — you can’t do anything that player couldn’t do. You can’t make choices or decisions for that player that aren’t called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the affected player would normally make (such as Master Warcraft does), that effect takes precedence. (In other words, if the affected player wouldn’t make a decision, you wouldn’t make that decision on his or her behalf.) You also can’t make any choices or decisions for the player that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
+          "text": "You can't make any illegal decisions or illegal choices — you can't do anything that player couldn't do. You can't make choices or decisions for that player that aren't called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the affected player would normally make (such as Master Warcraft does), that effect takes precedence. (In other words, if the affected player wouldn't make a decision, you wouldn't make that decision on his or her behalf.) You also can't make any choices or decisions for the player that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
         },
         {
           "date": "2009-10-01",
-          "text": "You can use only the affected player’s resources (cards, mana, and so on) to pay costs for that player; you can’t use your own. Similarly, you can use the affected player’s resources only to pay that player’s costs; you can’t spend them on your costs."
+          "text": "You can use only the affected player's resources (cards, mana, and so on) to pay costs for that player; you can't use your own. Similarly, you can use the affected player's resources only to pay that player's costs; you can't spend them on your costs."
         },
         {
           "date": "2009-10-01",
-          "text": "You only control the player. You don’t control any of the other player’s permanents, spells, or abilities."
+          "text": "You only control the player. You don't control any of the other player's permanents, spells, or abilities."
         },
         {
           "date": "2009-10-01",
-          "text": "If the player affected by Sorin’s third ability skips his or her next turn, the ability will wait. You’ll control the next turn the affected player actually takes."
+          "text": "If the player affected by Sorin's third ability skips his or her next turn, the ability will wait. You'll control the next turn the affected player actually takes."
         },
         {
           "date": "2009-10-01",
@@ -12068,19 +12080,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You could gain control of yourself using Sorin’s third ability, but unless you do so to overwrite someone else’s player-controlling effect, this doesn’t do anything."
+          "text": "You could gain control of yourself using Sorin's third ability, but unless you do so to overwrite someone else's player-controlling effect, this doesn't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, Sorin’s second ability causes the targeted opponent’s team’s life total to become 10. Only the targeted player is actually considered to have actually gained or lost life."
+          "text": "In a Two-Headed Giant game, Sorin's second ability causes the targeted opponent's team's life total to become 10. Only the targeted player is actually considered to have actually gained or lost life."
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "subtypes": [
@@ -12185,7 +12197,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the creature is an illegal target when Sorin’s Thirst tries to resolve, Sorin’s Thirst will be countered and none of its effects will happen. You won’t gain life."
+          "text": "If the creature is an illegal target when Sorin's Thirst tries to resolve, Sorin's Thirst will be countered and none of its effects will happen. You won't gain life."
         }
       ],
       "text": "Sorin's Thirst deals 2 damage to target creature and you gain 2 life.",
@@ -12286,7 +12298,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the player is an illegal target when Sorin’s Vengeance tries to resolve, Sorin’s Vengeance will be countered and none of its effects will happen. You won’t gain life."
+          "text": "If the player is an illegal target when Sorin's Vengeance tries to resolve, Sorin's Vengeance will be countered and none of its effects will happen. You won't gain life."
         }
       ],
       "text": "Sorin's Vengeance deals 10 damage to target player and you gain 10 life.",
@@ -12392,15 +12404,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If any of the creature cards you exile has a characteristic-defining ability that defines its power and/or toughness, that ability will apply. For example, if Dungrove Elder is exiled this way, its power and toughness while it’s in exile are equal to the number of Forests you control, and Sutured Ghoul’s power and toughness will change as the number of Forests you control changes. If the characteristic-defining ability can’t be applied (for instance, it relies on a choice made as the card enters the battlefield), then use 0."
+          "text": "If any of the creature cards you exile has a characteristic-defining ability that defines its power and/or toughness, that ability will apply. For example, if Dungrove Elder is exiled this way, its power and toughness while it's in exile are equal to the number of Forests you control, and Sutured Ghoul's power and toughness will change as the number of Forests you control changes. If the characteristic-defining ability can't be applied (for instance, it relies on a choice made as the card enters the battlefield), then use 0."
         },
         {
           "date": "2011-09-22",
-          "text": "In zones other than the battlefield, Sutured Ghoul’s power and toughness are each 0."
+          "text": "In zones other than the battlefield, Sutured Ghoul's power and toughness are each 0."
         },
         {
           "date": "2011-09-22",
-          "text": "You can’t have Sutured Ghoul exile itself, even if it’s entering the battlefield from your graveyard."
+          "text": "You can't have Sutured Ghoul exile itself, even if it's entering the battlefield from your graveyard."
         }
       ],
       "subtypes": [
@@ -12505,7 +12517,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the player is an illegal target when Taste of Blood tries to resolve, Taste of Blood will be countered and none of its effects will happen. You won’t gain life."
+          "text": "If the player is an illegal target when Taste of Blood tries to resolve, Taste of Blood will be countered and none of its effects will happen. You won't gain life."
         }
       ],
       "text": "Taste of Blood deals 1 damage to target player and you gain 1 life.",
@@ -12811,11 +12823,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Vengeful Pharaoh must be in your graveyard when combat damage is dealt to you or a planeswalker you control in order for its ability to trigger. That is, it can’t die and trigger from your graveyard during the same combat damage step."
+          "text": "Vengeful Pharaoh must be in your graveyard when combat damage is dealt to you or a planeswalker you control in order for its ability to trigger. That is, it can't die and trigger from your graveyard during the same combat damage step."
         },
         {
           "date": "2011-09-22",
-          "text": "If Vengeful Pharaoh is no longer in your graveyard when the triggered ability would resolve, the triggered ability won’t do anything."
+          "text": "If Vengeful Pharaoh is no longer in your graveyard when the triggered ability would resolve, the triggered ability won't do anything."
         },
         {
           "date": "2011-09-22",
@@ -12827,7 +12839,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If multiple creatures deal combat damage to you and to a planeswalker you control simultaneously, Vengeful Pharaoh will trigger twice. The first trigger will cause Vengeful Pharaoh to be put on top of your library. The second trigger will then do nothing, as Vengeful Pharaoh is no longer in your graveyard when it tries to resolve. Note that the second trigger will do nothing even if Vengeful Pharaoh is put back into your graveyard before it tries to resolve, as it’s a different Vengeful Pharaoh than the one that was there before."
+          "text": "If multiple creatures deal combat damage to you and to a planeswalker you control simultaneously, Vengeful Pharaoh will trigger twice. The first trigger will cause Vengeful Pharaoh to be put on top of your library. The second trigger will then do nothing, as Vengeful Pharaoh is no longer in your graveyard when it tries to resolve. Note that the second trigger will do nothing even if Vengeful Pharaoh is put back into your graveyard before it tries to resolve, as it's a different Vengeful Pharaoh than the one that was there before."
         },
         {
           "date": "2011-09-22",
@@ -13351,15 +13363,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Act of Treason can target any creature, even one that’s untapped or one you already control."
+          "text": "Act of Treason can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2013-07-01",
-          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you’ll choose one to remain on the battlefield and put the other into its owner’s graveyard."
+          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you'll choose one to remain on the battlefield and put the other into its owner's graveyard."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
@@ -13662,19 +13674,19 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Chandra’s second ability creates a delayed triggered ability that will copy the next instant or sorcery spell you cast that turn, regardless of whether that spell has targets."
+          "text": "Chandra's second ability creates a delayed triggered ability that will copy the next instant or sorcery spell you cast that turn, regardless of whether that spell has targets."
         },
         {
           "date": "2011-09-22",
-          "text": "When the delayed trigger resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When the delayed trigger resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2011-09-22",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2011-09-22",
-          "text": "If the spell Chandra copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Chandra copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2011-09-22",
@@ -13682,11 +13694,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you sacrifice a 3/3 creature to cast Fling after activating Chandra’s second ability, the copy of Fling will also deal 3 damage."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you sacrifice a 3/3 creature to cast Fling after activating Chandra's second ability, the copy of Fling will also deal 3 damage."
         },
         {
           "date": "2011-09-22",
-          "text": "When you activate Chandra’s last ability, you choose up to six target creatures and/or players. No damage is divided, and Chandra can’t deal more than 6 damage to any one target. Chandra deals 6 damage to each target that is still legal when the ability resolves."
+          "text": "When you activate Chandra's last ability, you choose up to six target creatures and/or players. No damage is divided, and Chandra can't deal more than 6 damage to any one target. Chandra deals 6 damage to each target that is still legal when the ability resolves."
         }
       ],
       "subtypes": [
@@ -13795,7 +13807,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target creature is an illegal target by the time Chandra’s Outrage resolves, the entire spell is countered. No player is dealt damage."
+          "text": "If the target creature is an illegal target by the time Chandra's Outrage resolves, the entire spell is countered. No player is dealt damage."
         }
       ],
       "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
@@ -14000,7 +14012,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Circle of Flame’s ability triggers only if a creature without flying is declared as an attacker during the declare attackers step. If a creature with flying attacks you or a planeswalker you control and then loses flying, or if a creature without flying is put onto the battlefield attacking you or a planeswalker you control, the ability won’t trigger."
+          "text": "Circle of Flame's ability triggers only if a creature without flying is declared as an attacker during the declare attackers step. If a creature with flying attacks you or a planeswalker you control and then loses flying, or if a creature without flying is put onto the battlefield attacking you or a planeswalker you control, the ability won't trigger."
         }
       ],
       "text": "Whenever a creature without flying attacks you or a planeswalker you control, Circle of Flame deals 1 damage to that creature.",
@@ -14102,7 +14114,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Combust can be targeted by spells and abilities that try to counter it (such as Cancel). Those spells and abilities will resolve, but the part of their effect that would counter Combust won’t do anything. Any other effects those spells and abilities have will work as normal."
+          "text": "Combust can be targeted by spells and abilities that try to counter it (such as Cancel). Those spells and abilities will resolve, but the part of their effect that would counter Combust won't do anything. Any other effects those spells and abilities have will work as normal."
         },
         {
           "date": "2010-08-15",
@@ -14110,15 +14122,15 @@
         },
         {
           "date": "2010-08-15",
-          "text": "Spells that create prevention effects affecting the targeted creature can still be cast, and abilities that create prevention effects affecting the targeted creature can still be activated. However, damage prevention shields (including those created before Combust was cast) don’t have any effect on the damage dealt by Combust. If such a prevention effect has an additional effect, the additional effect will still work (if possible)."
+          "text": "Spells that create prevention effects affecting the targeted creature can still be cast, and abilities that create prevention effects affecting the targeted creature can still be activated. However, damage prevention shields (including those created before Combust was cast) don't have any effect on the damage dealt by Combust. If such a prevention effect has an additional effect, the additional effect will still work (if possible)."
         },
         {
           "date": "2010-08-15",
-          "text": "If a static ability would prevent damage from being dealt to the targeted creature, it fails to prevent the damage dealt by Combust. If that ability has an additional effect that doesn’t depend on the amount of damage prevented, that additional effect will still work. It’s applied just once as Combust resolves."
+          "text": "If a static ability would prevent damage from being dealt to the targeted creature, it fails to prevent the damage dealt by Combust. If that ability has an additional effect that doesn't depend on the amount of damage prevented, that additional effect will still work. It's applied just once as Combust resolves."
         },
         {
           "date": "2010-08-15",
-          "text": "Effects that replace or redirect damage without using the word “prevent” aren’t affected by Combust; they’ll work as normal."
+          "text": "Effects that replace or redirect damage without using the word \"prevent\" aren't affected by Combust; they'll work as normal."
         },
         {
           "date": "2010-08-15",
@@ -14456,7 +14468,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -14468,7 +14480,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -14590,7 +14602,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -14705,7 +14717,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You choose the target when the ability triggers. When the ability resolves, you choose a value for X and decide whether to pay {X}{R}. If you do decide to pay {X}{R}, it’s too late for any player to respond since the ability is already in the midst of resolving."
+          "text": "You choose the target when the ability triggers. When the ability resolves, you choose a value for X and decide whether to pay {X}{R}. If you do decide to pay {X}{R}, it's too late for any player to respond since the ability is already in the midst of resolving."
         }
       ],
       "subtypes": [
@@ -14800,6 +14812,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -14830,11 +14846,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its power."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         },
         {
           "date": "2013-04-15",
@@ -15151,11 +15167,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You choose the target creature or player when you activate the ability. You don’t flip the coin until the ability resolves. Players may respond to the ability, but they won’t know the results of the coin flip."
+          "text": "You choose the target creature or player when you activate the ability. You don't flip the coin until the ability resolves. Players may respond to the ability, but they won't know the results of the coin flip."
         },
         {
           "date": "2011-09-22",
-          "text": "If the creature or player is an illegal target when Goblin Bangchuckers’ ability tries to resolve, it will be countered and none of its effects will happen. You won’t flip a coin and no damage will be dealt."
+          "text": "If the creature or player is an illegal target when Goblin Bangchuckers' ability tries to resolve, it will be countered and none of its effects will happen. You won't flip a coin and no damage will be dealt."
         }
       ],
       "subtypes": [
@@ -15178,7 +15194,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"It's time for the ‘Smash, Smash' song!\"",
+      "flavor": "\"It's time for the 'Smash, Smash' song!\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -15468,7 +15484,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t sacrifice more than one Goblin to get a greater effect."
+          "text": "You can't sacrifice more than one Goblin to get a greater effect."
         },
         {
           "date": "2011-09-22",
@@ -15476,7 +15492,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn’t have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
+          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn't have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
         }
       ],
       "text": "As an additional cost to cast Goblin Grenade, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to target creature or player.",
@@ -15690,11 +15706,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The power of the targeted creature is checked both as you target it and as the ability resolves. After the ability resolves, the creature can’t be blocked that turn even if its power becomes greater than 2."
+          "text": "The power of the targeted creature is checked both as you target it and as the ability resolves. After the ability resolves, the creature can't be blocked that turn even if its power becomes greater than 2."
         },
         {
           "date": "2010-06-15",
-          "text": "The ability doesn’t grant an ability to the targeted creature. Rather, it affects the game rules and states something that’s now true about that creature. After the ability resolves, the creature can’t be blocked that turn even if it loses all abilities."
+          "text": "The ability doesn't grant an ability to the targeted creature. Rather, it affects the game rules and states something that's now true about that creature. After the ability resolves, the creature can't be blocked that turn even if it loses all abilities."
         }
       ],
       "subtypes": [
@@ -16027,7 +16043,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The two cards are exiled as the cost of Grim Lavamancer’s ability is paid. Players can’t respond to the paying of costs by trying to move those cards to another zone."
+          "text": "The two cards are exiled as the cost of Grim Lavamancer's ability is paid. Players can't respond to the paying of costs by trying to move those cards to another zone."
         }
       ],
       "subtypes": [
@@ -16153,7 +16169,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Regeneration abilities that would affect that creature can still be activated; they just won’t do anything. The creature can’t be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
+          "text": "Regeneration abilities that would affect that creature can still be activated; they just won't do anything. The creature can't be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
         }
       ],
       "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
@@ -16259,7 +16275,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You divide the damage as you put Inferno Titan’s triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
+          "text": "You divide the damage as you put Inferno Titan's triggered ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. (In other words, as you put the ability on the stack, you choose whether to have it deal 3 damage to a single target, 2 damage to one target and 1 damage to another target, or 1 damage to each of three targets.)"
         }
       ],
       "subtypes": [
@@ -16613,7 +16629,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it’s put on the stack, then Manabarbs’s triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
+          "text": "If any lands are tapped for mana while a player is casting a spell or activating an ability, Manabarbs's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, it's put on the stack, then Manabarbs's triggered abilities are put on the stack on top of it. The Manabarbs abilities will resolve first."
         },
         {
           "date": "2009-10-01",
@@ -16720,7 +16736,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Manic Vandal’s ability is mandatory. If you’re the only player who controls an artifact, you must target one of them."
+          "text": "Manic Vandal's ability is mandatory. If you're the only player who controls an artifact, you must target one of them."
         }
       ],
       "subtypes": [
@@ -16829,19 +16845,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Reverberate can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Reverberate can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2010-08-15",
-          "text": "When Reverberate resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When Reverberate resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2010-08-15",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2010-08-15",
-          "text": "If the spell Reverberate copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Reverberate copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2010-08-15",
@@ -16849,11 +16865,11 @@
         },
         {
           "date": "2010-08-15",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Reverberate, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Reverberate, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2010-08-15",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
@@ -16954,11 +16970,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Once Scrambleverse starts to resolve, no player may respond until it has finished resolving. For example, you can’t wait to see who will control a creature before deciding whether or not to activate one of its abilities."
+          "text": "Once Scrambleverse starts to resolve, no player may respond until it has finished resolving. For example, you can't wait to see who will control a creature before deciding whether or not to activate one of its abilities."
         },
         {
           "date": "2011-09-22",
-          "text": "For each nonland permanent, any player may be randomly chosen, including the permanent’s current controller."
+          "text": "For each nonland permanent, any player may be randomly chosen, including the permanent's current controller."
         },
         {
           "date": "2011-09-22",
@@ -17197,7 +17213,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If a creature doesn’t have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won’t prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
+          "text": "If a creature doesn't have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won't prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
         }
       ],
       "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
@@ -17406,7 +17422,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The set of affected creatures isn’t locked in when Tectonic Rift resolves. Creatures without flying that enter the battlefield later that turn or creatures that lose flying later that turn won’t be able to block."
+          "text": "The set of affected creatures isn't locked in when Tectonic Rift resolves. Creatures without flying that enter the battlefield later that turn or creatures that lose flying later that turn won't be able to block."
         }
       ],
       "text": "Destroy target land. Creatures without flying can't block this turn.",
@@ -17720,11 +17736,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it’s no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
+          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it's no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2011-09-22",
-          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn’t target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
+          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn't target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to target creature or player.",
@@ -17934,11 +17950,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You can tap any untapped Spider you control, including one you haven’t controlled continuously since the beginning of your most recent turn, to pay the cost of Arachnus Spinner’s activated ability. You can even tap Arachnus Spinner itself to pay this cost."
+          "text": "You can tap any untapped Spider you control, including one you haven't controlled continuously since the beginning of your most recent turn, to pay the cost of Arachnus Spinner's activated ability. You can even tap Arachnus Spinner itself to pay this cost."
         },
         {
           "date": "2017-03-14",
-          "text": "If you choose to search your library this way, you don’t have to find a card named Arachnus Web, even if one is there. You’ll still shuffle your library after searching it."
+          "text": "If you choose to search your library this way, you don't have to find a card named Arachnus Web, even if one is there. You'll still shuffle your library after searching it."
         },
         {
           "date": "2017-03-14",
@@ -18047,27 +18063,27 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2017-03-14",
-          "text": "Arachnus Web’s triggered ability checks at the beginning of each end step, not just yours."
+          "text": "Arachnus Web's triggered ability checks at the beginning of each end step, not just yours."
         },
         {
           "date": "2017-03-14",
-          "text": "If the enchanted creature’s power isn’t 4 or greater when the end step begins, the last ability won’t trigger at all."
+          "text": "If the enchanted creature's power isn't 4 or greater when the end step begins, the last ability won't trigger at all."
         },
         {
           "date": "2017-03-14",
-          "text": "If Arachnus Web’s last ability triggers, but the enchanted creature’s power is reduced to 3 or less before the ability resolves, the ability will have no effect. Arachnus Web won’t be destroyed."
+          "text": "If Arachnus Web's last ability triggers, but the enchanted creature's power is reduced to 3 or less before the ability resolves, the ability will have no effect. Arachnus Web won't be destroyed."
         },
         {
           "date": "2017-03-14",
-          "text": "If Arachnus Web enters the battlefield attached to an attacking or blocking creature (due to Arachnus Spinner’s ability, for example), that creature will continue to attack or block."
+          "text": "If Arachnus Web enters the battlefield attached to an attacking or blocking creature (due to Arachnus Spinner's ability, for example), that creature will continue to attack or block."
         },
         {
           "date": "2017-03-14",
-          "text": "Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected."
+          "text": "Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected."
         }
       ],
       "subtypes": [
@@ -18172,31 +18188,31 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Autumn’s Veil itself may be countered by blue or black spells. Its effect doesn’t apply until after it resolves."
+          "text": "Autumn's Veil itself may be countered by blue or black spells. Its effect doesn't apply until after it resolves."
         },
         {
           "date": "2010-08-15",
-          "text": "After Autumn’s Veil resolves, any spell you control that turn can still be targeted by spells that try to counter it (such as Cancel), regardless of their color. If those spells are blue or black at the time they would resolve, they will resolve, but the part of their effect that would counter the spell you control simply won’t do anything. Any other effects those spells have will work as normal."
+          "text": "After Autumn's Veil resolves, any spell you control that turn can still be targeted by spells that try to counter it (such as Cancel), regardless of their color. If those spells are blue or black at the time they would resolve, they will resolve, but the part of their effect that would counter the spell you control simply won't do anything. Any other effects those spells have will work as normal."
         },
         {
           "date": "2010-08-15",
-          "text": "If a creature you control is being targeted by a spell when Autumn’s Veil resolves, nothing happens right away. When that spell would resolve, its color is checked. If it’s blue or black, that creature will be an illegal target for that spell, and will be unable to be affected by it. If all that spell’s targets have become illegal by the time it would resolve, it’s countered."
+          "text": "If a creature you control is being targeted by a spell when Autumn's Veil resolves, nothing happens right away. When that spell would resolve, its color is checked. If it's blue or black, that creature will be an illegal target for that spell, and will be unable to be affected by it. If all that spell's targets have become illegal by the time it would resolve, it's countered."
         },
         {
           "date": "2010-08-15",
-          "text": "After Autumn’s Veil resolves, no new blue or black spell may be cast that turn targeting a creature you control."
+          "text": "After Autumn's Veil resolves, no new blue or black spell may be cast that turn targeting a creature you control."
         },
         {
           "date": "2010-08-15",
-          "text": "Keep in mind that an Aura spell targets the permanent it will enchant (but an Aura on the battlefield doesn’t target the permanent it’s attached to)."
+          "text": "Keep in mind that an Aura spell targets the permanent it will enchant (but an Aura on the battlefield doesn't target the permanent it's attached to)."
         },
         {
           "date": "2010-08-15",
-          "text": "Autumn’s Veil affects any spells and creatures you happen to control at any point during the rest of the turn, not just spells and creatures you control as it resolves. That’s because it doesn’t grant an ability to those spells or creatures; rather, it affects the game rules and states something that’s now true about those spells and creatures."
+          "text": "Autumn's Veil affects any spells and creatures you happen to control at any point during the rest of the turn, not just spells and creatures you control as it resolves. That's because it doesn't grant an ability to those spells or creatures; rather, it affects the game rules and states something that's now true about those spells and creatures."
         },
         {
           "date": "2010-08-15",
-          "text": "Autumn’s Veil has no effect on abilities. After it resolves, spells you control may be countered by abilities from blue or black sources, and creatures you control may be targeted by abilities from blue or black sources."
+          "text": "Autumn's Veil has no effect on abilities. After it resolves, spells you control may be countered by abilities from blue or black sources, and creatures you control may be targeted by abilities from blue or black sources."
         }
       ],
       "text": "Spells you control can't be countered by blue or black spells this turn, and creatures you control can't be the targets of blue or black spells this turn.",
@@ -18518,7 +18534,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking Brindle Boar during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but Brindle Boar is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking Brindle Boar during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but Brindle Boar is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -18724,7 +18740,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Activating Cudgel Troll’s ability causes a “regeneration shield” to be created for it. The next time Cudgel Troll would be destroyed that turn, the regeneration shield is used up instead. This works only if Cudgel Troll is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to “destroy” it. Other effects that cause Cudgel Troll to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don’t destroy it, so regeneration won’t save it. If it hasn’t been used, the regeneration shield goes away as the turn ends."
+          "text": "Activating Cudgel Troll's ability causes a \"regeneration shield\" to be created for it. The next time Cudgel Troll would be destroyed that turn, the regeneration shield is used up instead. This works only if Cudgel Troll is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to \"destroy\" it. Other effects that cause Cudgel Troll to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don't destroy it, so regeneration won't save it. If it hasn't been used, the regeneration shield goes away as the turn ends."
         },
         {
           "date": "2010-08-15",
@@ -18837,11 +18853,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The cards you find in your library must be creature cards. For example, you can’t put a land card onto the battlefield even if it has the same name as a land you control that’s also a creature (perhaps because of an ability of that land)."
+          "text": "The cards you find in your library must be creature cards. For example, you can't put a land card onto the battlefield even if it has the same name as a land you control that's also a creature (perhaps because of an ability of that land)."
         },
         {
           "date": "2011-09-22",
-          "text": "If you control a creature whose name has been changed by an effect (for example, a Clone that’s copying another creature), you’ll search for a card with the new name, not one with the original name."
+          "text": "If you control a creature whose name has been changed by an effect (for example, a Clone that's copying another creature), you'll search for a card with the new name, not one with the original name."
         },
         {
           "date": "2011-09-22",
@@ -18948,15 +18964,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Dungrove Elder’s power and toughness are each equal to the number of lands you control with the land type Forest, not necessarily lands named Forest."
+          "text": "Dungrove Elder's power and toughness are each equal to the number of lands you control with the land type Forest, not necessarily lands named Forest."
         },
         {
           "date": "2011-09-22",
-          "text": "Dungrove Elder’s power and toughness will change as the number of Forests you control changes."
+          "text": "Dungrove Elder's power and toughness will change as the number of Forests you control changes."
         },
         {
           "date": "2011-09-22",
-          "text": "Dungrove Elder’s ability sets its power and toughness in all zones, not just the battlefield."
+          "text": "Dungrove Elder's ability sets its power and toughness in all zones, not just the battlefield."
         }
       ],
       "subtypes": [
@@ -19067,11 +19083,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Elvish Archdruid’s first ability affects only other Elves you control. However, Elvish Archdruid’s second ability counts all Elves you control — including itself."
+          "text": "Elvish Archdruid's first ability affects only other Elves you control. However, Elvish Archdruid's second ability counts all Elves you control — including itself."
         },
         {
           "date": "2011-09-22",
-          "text": "Elvish Archdruid’s activated ability is a mana ability. It doesn’t use the stack and players can’t respond to it."
+          "text": "Elvish Archdruid's activated ability is a mana ability. It doesn't use the stack and players can't respond to it."
         }
       ],
       "subtypes": [
@@ -19296,15 +19312,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "For Garruk’s second ability, the greatest power among creatures you control is determined when that ability begins resolving."
+          "text": "For Garruk's second ability, the greatest power among creatures you control is determined when that ability begins resolving."
         },
         {
           "date": "2011-09-22",
-          "text": "If the greatest power among creatures you control is 0 or less, you’ll draw no cards. You won’t discard any cards this way."
+          "text": "If the greatest power among creatures you control is 0 or less, you'll draw no cards. You won't discard any cards this way."
         },
         {
           "date": "2011-09-22",
-          "text": "For Garruk’s third ability, the number of Wurm tokens you put onto the battlefield is determined when that ability begins resolving."
+          "text": "For Garruk's third ability, the number of Wurm tokens you put onto the battlefield is determined when that ability begins resolving."
         }
       ],
       "subtypes": [
@@ -19511,23 +19527,23 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Normally, Garruk’s Horde allows you to cast the top card of your library if it’s a creature card, it’s your main phase, and the stack is empty. If that creature card has flash, you’ll be able to cast it at the time you could cast an instant, even on an opponent’s turn."
+          "text": "Normally, Garruk's Horde allows you to cast the top card of your library if it's a creature card, it's your main phase, and the stack is empty. If that creature card has flash, you'll be able to cast it at the time you could cast an instant, even on an opponent's turn."
         },
         {
           "date": "2011-09-22",
-          "text": "You’ll still pay all costs for that spell, including additional costs. You may also pay alternative costs."
+          "text": "You'll still pay all costs for that spell, including additional costs. You may also pay alternative costs."
         },
         {
           "date": "2011-09-22",
-          "text": "If the top card of your library is Dryad Arbor (the only card that’s both a creature and a land), you can’t play it this way. Dryad Arbor can’t be cast as a spell."
+          "text": "If the top card of your library is Dryad Arbor (the only card that's both a creature and a land), you can't play it this way. Dryad Arbor can't be cast as a spell."
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -19619,6 +19635,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -20688,7 +20708,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -21013,7 +21033,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Consider only the number of +1/+1 counters on Primordial Hydra when determining if it has trample, not its power and toughness. For example, a Primordial Hydra with six +1/+1 counters on it that’s been the target of Titanic Growth (giving it +4/+4) would not have trample."
+          "text": "Consider only the number of +1/+1 counters on Primordial Hydra when determining if it has trample, not its power and toughness. For example, a Primordial Hydra with six +1/+1 counters on it that's been the target of Titanic Growth (giving it +4/+4) would not have trample."
         }
       ],
       "subtypes": [
@@ -21147,7 +21167,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -21661,11 +21681,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You choose the ability’s mode when you activate it."
+          "text": "You choose the ability's mode when you activate it."
         },
         {
           "date": "2011-09-22",
-          "text": "No matter which mode you choose, Skinshifter will cease to have any creature types it previously had. If you activate its ability choosing the first mode, it will become only a Rhino; it’s no longer a Human or a Shaman."
+          "text": "No matter which mode you choose, Skinshifter will cease to have any creature types it previously had. If you activate its ability choosing the first mode, it will become only a Rhino; it's no longer a Human or a Shaman."
         },
         {
           "date": "2011-09-22",
@@ -21673,15 +21693,15 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Skinshifter’s ability doesn’t cause it to lose any other abilities it may have."
+          "text": "Skinshifter's ability doesn't cause it to lose any other abilities it may have."
         },
         {
           "date": "2011-09-22",
-          "text": "Skinshifter’s ability doesn’t affect its copiable values. Creatures that enter the battlefield as a copy of Skinshifter will enter as 1/1 Human Shaman creatures."
+          "text": "Skinshifter's ability doesn't affect its copiable values. Creatures that enter the battlefield as a copy of Skinshifter will enter as 1/1 Human Shaman creatures."
         },
         {
           "date": "2011-09-22",
-          "text": "You can activate Skinshifter’s ability during any player’s turn, but only once on each turn."
+          "text": "You can activate Skinshifter's ability during any player's turn, but only once on each turn."
         }
       ],
       "subtypes": [
@@ -22095,7 +22115,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Activating the ability granted to the enchanted creature causes a “regeneration shield” to be created for it. The next time that creature would be destroyed that turn, the regeneration shield is used up instead. This works only if the creature is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to “destroy” it. Other effects that cause the creature to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don’t destroy it, so regeneration won’t save it. If it hasn’t been used, the regeneration shield goes away as the turn ends."
+          "text": "Activating the ability granted to the enchanted creature causes a \"regeneration shield\" to be created for it. The next time that creature would be destroyed that turn, the regeneration shield is used up instead. This works only if the creature is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to \"destroy\" it. Other effects that cause the creature to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don't destroy it, so regeneration won't save it. If it hasn't been used, the regeneration shield goes away as the turn ends."
         },
         {
           "date": "2011-09-22",
@@ -22311,7 +22331,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The choice of creature type is made as Adaptive Automaton enters the battlefield. Players can’t respond to this choice. The bonus starts applying immediately."
+          "text": "The choice of creature type is made as Adaptive Automaton enters the battlefield. Players can't respond to this choice. The bonus starts applying immediately."
         },
         {
           "date": "2011-09-22",
@@ -22319,7 +22339,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Even though Adaptive Automaton is a Construct, other Construct creatures you control won’t get +1/+1 (unless you chose Construct as Adaptive Automaton entered the battlefield)."
+          "text": "Even though Adaptive Automaton is a Construct, other Construct creatures you control won't get +1/+1 (unless you chose Construct as Adaptive Automaton entered the battlefield)."
         }
       ],
       "subtypes": [
@@ -22434,7 +22454,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a white spell, Angel’s Feather’s ability triggers and is put on the stack on top of that spell. Angel’s Feather’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a white spell, Angel's Feather's ability triggers and is put on the stack on top of that spell. Angel's Feather's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a white spell, you may gain 1 life.",
@@ -22533,11 +22553,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If any of the named cards stops being an artifact, it won’t be considered by these abilities."
+          "text": "If any of the named cards stops being an artifact, it won't be considered by these abilities."
         },
         {
           "date": "2011-09-22",
-          "text": "If you control artifacts named Scepter of Empires and Throne of Empires, the targeted creature won’t be tapped. You’ll just gain control of it."
+          "text": "If you control artifacts named Scepter of Empires and Throne of Empires, the targeted creature won't be tapped. You'll just gain control of it."
         }
       ],
       "text": "{3}, {T}: Tap target creature. Gain control of that creature instead if you control artifacts named Scepter of Empires and Throne of Empires.",
@@ -22632,7 +22652,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If another player controls Crumbling Colossus when its ability tries to resolve, you’ll be unable to sacrifice it. It will simply remain on the battlefield."
+          "text": "If another player controls Crumbling Colossus when its ability tries to resolve, you'll be unable to sacrifice it. It will simply remain on the battlefield."
         }
       ],
       "subtypes": [
@@ -22748,7 +22768,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a black spell, Demon’s Horn’s ability triggers and is put on the stack on top of that spell. Demon’s Horn’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a black spell, Demon's Horn's ability triggers and is put on the stack on top of that spell. Demon's Horn's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a black spell, you may gain 1 life.",
@@ -22858,7 +22878,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a red spell, Dragon’s Claw’s ability triggers and is put on the stack on top of that spell. Dragon’s Claw’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a red spell, Dragon's Claw's ability triggers and is put on the stack on top of that spell. Dragon's Claw's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a red spell, you may gain 1 life.",
@@ -22953,7 +22973,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the revealed card is both a creature and a land (such as Dryad Arbor), you’ll put a Saproling creature token and that card onto the battlefield."
+          "text": "If the revealed card is both a creature and a land (such as Dryad Arbor), you'll put a Saproling creature token and that card onto the battlefield."
         },
         {
           "date": "2011-09-22",
@@ -23056,19 +23076,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Paying the activation cost of Elixir of Immortality’s ability doesn’t cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
+          "text": "Paying the activation cost of Elixir of Immortality's ability doesn't cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
         },
         {
           "date": "2011-09-22",
-          "text": "As the ability resolves, you’ll shuffle Elixir of Immortality into its owner’s library directly from the battlefield, if it’s still there."
+          "text": "As the ability resolves, you'll shuffle Elixir of Immortality into its owner's library directly from the battlefield, if it's still there."
         },
         {
           "date": "2011-09-22",
-          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you’ll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it’s anywhere else by that time, including in another player’s graveyard, it remains where it is and you shuffle just your graveyard into your library."
+          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you'll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it's anywhere else by that time, including in another player's graveyard, it remains where it is and you shuffle just your graveyard into your library."
         },
         {
           "date": "2011-09-22",
-          "text": "If you gain control of another player’s Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner’s library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
+          "text": "If you gain control of another player's Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner's library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
         }
       ],
       "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
@@ -23361,7 +23381,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a blue spell, Kraken’s Eye’s ability triggers and is put on the stack on top of that spell. Kraken’s Eye’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a blue spell, Kraken's Eye's ability triggers and is put on the stack on top of that spell. Kraken's Eye's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a blue spell, you may gain 1 life.",
@@ -23425,6 +23445,10 @@
       "imageName": "manalith",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -23558,11 +23582,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus's other abilities."
         },
         {
           "date": "2011-09-22",
-          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus’s second activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus's second activated ability, not just ones created by Pentavus's other abilities."
         }
       ],
       "subtypes": [
@@ -23667,7 +23691,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Any ‘X’ in the creature’s cost is treated as zero."
+          "text": "Any 'X' in the creature's cost is treated as zero."
         },
         {
           "date": "2007-05-01",
@@ -23675,11 +23699,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2011-09-22",
-          "text": "You don’t pay any costs of that creature card, including additional costs."
+          "text": "You don't pay any costs of that creature card, including additional costs."
         }
       ],
       "text": "{4}, {T}: You may put a creature card from your hand onto the battlefield.",
@@ -23873,7 +23897,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If any of the named cards stops being an artifact, it won’t be considered by these abilities."
+          "text": "If any of the named cards stops being an artifact, it won't be considered by these abilities."
         }
       ],
       "text": "{T}: Scepter of Empires deals 1 damage to target player. It deals 3 damage to that player instead if you control artifacts named Crown of Empires and Throne of Empires.",
@@ -24075,19 +24099,19 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If any triggered abilities do trigger during this process, they’re put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn finally ends."
+          "text": "If any triggered abilities do trigger during this process, they're put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn finally ends."
         },
         {
           "date": "2011-09-22",
-          "text": "Though spells and abilities that are exiled won’t get a chance to resolve, they don’t count as being “countered.”"
+          "text": "Though spells and abilities that are exiled won't get a chance to resolve, they don't count as being \"countered.\""
         },
         {
           "date": "2011-09-22",
-          "text": "If Sundial of the Infinite’s ability is activated before the end step, any “at the beginning of the end step”-triggered abilities won’t get the chance to trigger that turn because the end step is skipped. Those abilities will trigger at the beginning of the end step of the next turn. The same is true of abilities that trigger at the beginning of other phases or steps (except upkeep)."
+          "text": "If Sundial of the Infinite's ability is activated before the end step, any \"at the beginning of the end step\"-triggered abilities won't get the chance to trigger that turn because the end step is skipped. Those abilities will trigger at the beginning of the end step of the next turn. The same is true of abilities that trigger at the beginning of other phases or steps (except upkeep)."
         },
         {
           "date": "2011-09-22",
-          "text": "The earliest that you can activate Sundial of the Infinite’s ability is during your upkeep step, after abilities that trigger “at the beginning of your upkeep” have been put onto the stack but before they resolve."
+          "text": "The earliest that you can activate Sundial of the Infinite's ability is during your upkeep step, after abilities that trigger \"at the beginning of your upkeep\" have been put onto the stack but before they resolve."
         }
       ],
       "text": "{1}, {T}: End the turn. Activate this ability only during your turn. (Exile all spells and abilities on the stack. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
@@ -24186,7 +24210,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can’t be the target of spells and abilities you control."
+          "text": "If an opponent gains control of a creature equipped by your Swiftfoot Boots, that creature can't be the target of spells and abilities you control."
         }
       ],
       "subtypes": [
@@ -24391,7 +24415,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If any of the named cards stops being an artifact, it won’t be considered by these abilities."
+          "text": "If any of the named cards stops being an artifact, it won't be considered by these abilities."
         }
       ],
       "text": "{1}, {T}: Create a 1/1 white Soldier creature token. Create five of those tokens instead if you control artifacts named Crown of Empires and Scepter of Empires.",
@@ -24603,7 +24627,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a player casts a green spell, Wurm’s Tooth’s ability triggers and is put on the stack on top of that spell. Wurm’s Tooth’s ability will resolve (causing you to gain 1 life) before the spell does."
+          "text": "If a player casts a green spell, Wurm's Tooth's ability triggers and is put on the stack on top of that spell. Wurm's Tooth's ability will resolve (causing you to gain 1 life) before the spell does."
         }
       ],
       "text": "Whenever a player casts a green spell, you may gain 1 life.",
@@ -24793,11 +24817,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don’t have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don't have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
@@ -24897,11 +24921,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don’t have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don't have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
@@ -25000,11 +25024,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Plains or Island, not for lands named Plains or Island. The lands it checks for don’t have to be basic lands. For example, if you control Watery Grave (a nonbasic land with the land types Island and Swamp), Glacial Fortress will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Plains or Island, not for lands named Plains or Island. The lands it checks for don't have to be basic lands. For example, if you control Watery Grave (a nonbasic land with the land types Island and Swamp), Glacial Fortress will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
@@ -25105,11 +25129,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don’t have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don't have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
@@ -25209,11 +25233,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don’t have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don't have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
@@ -30252,7 +30276,27 @@
         {
           "language": "Italian",
           "name": "Montagna",
+          "multiverseid": 264115
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
           "multiverseid": 264116
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 264117
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 264118
+        },
+        {
+          "language": "Japanese",
+          "name": "山",
+          "multiverseid": 264366
         },
         {
           "language": "Portuguese (Brazil)",
@@ -30293,26 +30337,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 264865
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265111
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265112
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265113
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265114
         }
       ],
       "id": "82549b1066038cf010cbf77537a63be081871bad",
@@ -30637,7 +30661,27 @@
         {
           "language": "Italian",
           "name": "Montagna",
+          "multiverseid": 264115
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
           "multiverseid": 264116
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 264117
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 264118
+        },
+        {
+          "language": "Japanese",
+          "name": "山",
+          "multiverseid": 264366
         },
         {
           "language": "Portuguese (Brazil)",
@@ -30678,26 +30722,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 264865
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265111
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265112
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265113
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265114
         }
       ],
       "id": "27ff7e2717fb34a981db8d6004c191808222caea",
@@ -31022,7 +31046,27 @@
         {
           "language": "Italian",
           "name": "Montagna",
+          "multiverseid": 264115
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
           "multiverseid": 264116
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 264117
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna",
+          "multiverseid": 264118
+        },
+        {
+          "language": "Japanese",
+          "name": "山",
+          "multiverseid": 264366
         },
         {
           "language": "Portuguese (Brazil)",
@@ -31063,26 +31107,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 264865
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265111
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265112
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265113
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 265114
         }
       ],
       "id": "bca32b444b8cc4b5235bbe1037a34aa8269a7d59",

--- a/json/M13.json
+++ b/json/M13.json
@@ -140,7 +140,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can activate the first ability without a target. You’ll still put one loyalty counter on Ajani when you activate the ability."
+          "text": "You can activate the first ability without a target. You'll still put one loyalty counter on Ajani when you activate the ability."
         },
         {
           "date": "2012-07-01",
@@ -478,11 +478,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -494,7 +494,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         },
         {
           "date": "2012-07-01",
@@ -822,7 +822,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Battleflight Eagle’s ability is mandatory, although you can choose Battleflight Eagle as the target."
+          "text": "Battleflight Eagle's ability is mandatory, although you can choose Battleflight Eagle as the target."
         }
       ],
       "subtypes": [
@@ -1146,7 +1146,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The ability that defines Crusader of Odric’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Crusader of Odric's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -1264,7 +1264,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If the creature targeted by Divine Favor is an illegal target when Divine Favor tries to resolve, Divine Favor will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the creature targeted by Divine Favor is an illegal target when Divine Favor tries to resolve, Divine Favor will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -1382,15 +1382,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         },
         {
           "date": "2012-07-01",
-          "text": "Destroying a blocking creature won’t cause any of the creatures it was blocking to become unblocked. They won’t deal combat damage to the defending player or planeswalker (unless they have trample)."
+          "text": "Destroying a blocking creature won't cause any of the creatures it was blocking to become unblocked. They won't deal combat damage to the defending player or planeswalker (unless they have trample)."
         }
       ],
       "text": "Destroy target attacking or blocking creature.",
@@ -1613,19 +1613,19 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "A permanent card is a card that could be put onto the battlefield. Specifically, it means an artifact, creature, enchantment, land, or planeswalker card (instant and sorcery cards aren’t permanent cards)."
+          "text": "A permanent card is a card that could be put onto the battlefield. Specifically, it means an artifact, creature, enchantment, land, or planeswalker card (instant and sorcery cards aren't permanent cards)."
         },
         {
           "date": "2012-07-01",
-          "text": "Permanent cards that were put into your graveyard from anywhere else, such as a card that was discarded, stay in the graveyard. Permanent cards that you gained control of and went to another player’s graveyard from the battlefield will likewise stay in the graveyard."
+          "text": "Permanent cards that were put into your graveyard from anywhere else, such as a card that was discarded, stay in the graveyard. Permanent cards that you gained control of and went to another player's graveyard from the battlefield will likewise stay in the graveyard."
         },
         {
           "date": "2012-07-01",
-          "text": "You choose what an Aura card put onto the battlefield this way will enchant. You can’t choose any permanent cards entering the battlefield at the same time as that Aura. If there’s nothing legal for the Aura to enchant, it stays in the graveyard."
+          "text": "You choose what an Aura card put onto the battlefield this way will enchant. You can't choose any permanent cards entering the battlefield at the same time as that Aura. If there's nothing legal for the Aura to enchant, it stays in the graveyard."
         },
         {
           "date": "2012-07-01",
-          "text": "Permanent spells that were countered earlier in the turn never entered the battlefield, so they won’t return to the battlefield because of Faith’s Reward."
+          "text": "Permanent spells that were countered earlier in the turn never entered the battlefield, so they won't return to the battlefield because of Faith's Reward."
         }
       ],
       "text": "Return to the battlefield all permanent cards in your graveyard that were put there from the battlefield this turn.",
@@ -1732,7 +1732,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Glorious Charge affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn. It won’t affect permanents that become creatures later in the turn."
+          "text": "Glorious Charge affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn. It won't affect permanents that become creatures later in the turn."
         }
       ],
       "text": "Creatures you control get +1/+1 until end of turn.",
@@ -2064,11 +2064,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -2080,7 +2080,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -2311,7 +2311,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The power of the creature is checked on activation and on resolution. If the targeted creature’s power is not 4 or greater on resolution, the ability is countered."
+          "text": "The power of the creature is checked on activation and on resolution. If the targeted creature's power is not 4 or greater on resolution, the ability is countered."
         }
       ],
       "subtypes": [
@@ -2553,11 +2553,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -2665,7 +2665,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can decide that a creature won’t block."
+          "text": "You can decide that a creature won't block."
         },
         {
           "date": "2012-07-01",
@@ -2673,7 +2673,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If there’s a cost associated with having a creature block and you choose for that creature to block, its controller can choose to pay that cost or not. If that player decides to not pay that cost, you must propose a new set of blocking creatures."
+          "text": "If there's a cost associated with having a creature block and you choose for that creature to block, its controller can choose to pay that cost or not. If that player decides to not pay that cost, you must propose a new set of blocking creatures."
         }
       ],
       "subtypes": [
@@ -3357,11 +3357,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If an effect sets your life total to a specific number, and that number is higher than your current life total, the effect will cause you to gain life equal to the difference. Rhox Faithmender will then double that number. For example, if you have 3 life and an effect says that your life total “becomes 10,” your life total will actually become 17."
+          "text": "If an effect sets your life total to a specific number, and that number is higher than your current life total, the effect will cause you to gain life equal to the difference. Rhox Faithmender will then double that number. For example, if you have 3 life and an effect says that your life total \"becomes 10,\" your life total will actually become 17."
         },
         {
           "date": "2012-07-01",
-          "text": "In a Two-Headed Giant game, only Rhox Faithmender’s controller is affected by it. If that player’s teammate gains life, Rhox Faithmender will have no effect, even when that life gain is applied to the shared team life total."
+          "text": "In a Two-Headed Giant game, only Rhox Faithmender's controller is affected by it. If that player's teammate gains life, Rhox Faithmender will have no effect, even when that life gain is applied to the shared team life total."
         }
       ],
       "subtypes": [
@@ -3479,15 +3479,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage will prevent damage dealt to creatures that weren’t on the battlefield at the time it resolved."
+          "text": "Safe Passage will prevent damage dealt to creatures that weren't on the battlefield at the time it resolved."
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage doesn’t prevent damage that would be dealt to planeswalkers you control. Although it can’t prevent combat damage that would be dealt to your planeswalkers, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply Safe Passage’s prevention effect to that damage first, and there won’t be any damage to redirect."
+          "text": "Safe Passage doesn't prevent damage that would be dealt to planeswalkers you control. Although it can't prevent combat damage that would be dealt to your planeswalkers, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply Safe Passage's prevention effect to that damage first, and there won't be any damage to redirect."
         },
         {
           "date": "2009-10-01",
-          "text": "Safe Passage has no effect on damage that’s already been dealt."
+          "text": "Safe Passage has no effect on damage that's already been dealt."
         }
       ],
       "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
@@ -3740,19 +3740,19 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Whether or not the ability triggers depends on if the Avatar has the ability while in the graveyard. If it doesn’t (thanks to Yixlid Jailer, for instance), then the ability won’t trigger. It doesn’t matter whether the Avatar had the ability in its previous zone (it will trigger even if it had been on the battlefield with Humility)."
+          "text": "Whether or not the ability triggers depends on if the Avatar has the ability while in the graveyard. If it doesn't (thanks to Yixlid Jailer, for instance), then the ability won't trigger. It doesn't matter whether the Avatar had the ability in its previous zone (it will trigger even if it had been on the battlefield with Humility)."
         },
         {
           "date": "2012-07-01",
-          "text": "Serra Avatar’s power and toughness are constantly updated as your life total changes."
+          "text": "Serra Avatar's power and toughness are constantly updated as your life total changes."
         },
         {
           "date": "2012-07-01",
-          "text": "The ability that defines Serra Avatar’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Serra Avatar's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2012-07-01",
-          "text": "If Serra Avatar is no longer in your graveyard when its triggered ability resolves, you won’t shuffle your library."
+          "text": "If Serra Avatar is no longer in your graveyard when its triggered ability resolves, you won't shuffle your library."
         }
       ],
       "subtypes": [
@@ -3868,7 +3868,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You can cast Serra Avenger during another player’s first, second, or third turns of the game if some other effect (such as Vedalken Orrery) enables that."
+          "text": "You can cast Serra Avenger during another player's first, second, or third turns of the game if some other effect (such as Vedalken Orrery) enables that."
         },
         {
           "date": "2012-07-01",
@@ -3876,7 +3876,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If the game is restarted (by Karn Liberated), you can’t cast Serra Avenger in your first, second, or third turn in the new game."
+          "text": "If the game is restarted (by Karn Liberated), you can't cast Serra Avenger in your first, second, or third turn in the new game."
         }
       ],
       "subtypes": [
@@ -4192,7 +4192,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Whenever a creature you control attacks alone, count the number of instances of exalted among permanents you control. After those abilities resolve, that’s how many times the creature will get +1/+1."
+          "text": "Whenever a creature you control attacks alone, count the number of instances of exalted among permanents you control. After those abilities resolve, that's how many times the creature will get +1/+1."
         }
       ],
       "subtypes": [
@@ -4409,11 +4409,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "To attack with War Falcon, you must control a Knight or a Soldier when you declare attackers. Once War Falcon is attacking, it won’t be removed from combat if at any point you no longer control a Knight or Soldier."
+          "text": "To attack with War Falcon, you must control a Knight or a Soldier when you declare attackers. Once War Falcon is attacking, it won't be removed from combat if at any point you no longer control a Knight or Soldier."
         },
         {
           "date": "2012-07-01",
-          "text": "If an effect makes War Falcon a Knight or a Soldier, it will be able to attack even if it’s the only creature you control."
+          "text": "If an effect makes War Falcon a Knight or a Soldier, it will be able to attack even if it's the only creature you control."
         }
       ],
       "subtypes": [
@@ -4851,7 +4851,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Multiple instances of lifelink aren’t cumulative. Activating Arctic Aven’s ability more than once during a single turn won’t cause you to gain more life."
+          "text": "Multiple instances of lifelink aren't cumulative. Activating Arctic Aven's ability more than once during a single turn won't cause you to gain more life."
         }
       ],
       "subtypes": [
@@ -4964,11 +4964,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You don’t reveal the other two cards, nor do you reveal their order on the bottom of the library."
+          "text": "You don't reveal the other two cards, nor do you reveal their order on the bottom of the library."
         },
         {
           "date": "2012-07-01",
-          "text": "If there are fewer than three cards in your library when Augur of Bolas’s ability resolves, you’ll look at the remaining cards. This won’t cause you to lose the game as you haven’t drawn from an empty library."
+          "text": "If there are fewer than three cards in your library when Augur of Bolas's ability resolves, you'll look at the remaining cards. This won't cause you to lose the game as you haven't drawn from an empty library."
         }
       ],
       "subtypes": [
@@ -5085,7 +5085,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Battle of Wits has an “intervening ‘if’ clause.” This means that if you don’t have 200 or more cards in your library at the beginning of your upkeep, the ability won’t trigger. If the ability does trigger, but you have fewer than 200 cards in your library when the ability resolves, the ability will do nothing."
+          "text": "Battle of Wits has an \"intervening 'if' clause.\" This means that if you don't have 200 or more cards in your library at the beginning of your upkeep, the ability won't trigger. If the ability does trigger, but you have fewer than 200 cards in your library when the ability resolves, the ability will do nothing."
         },
         {
           "date": "2012-07-01",
@@ -5221,7 +5221,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -5229,11 +5229,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -5241,7 +5241,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -5352,7 +5352,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "After the first ability resolves, the creature attacks only if it’s able to do so as the declare attackers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having the creature attack, the player isn’t forced to pay that cost, so it doesn’t attack in that case either."
+          "text": "After the first ability resolves, the creature attacks only if it's able to do so as the declare attackers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having the creature attack, the player isn't forced to pay that cost, so it doesn't attack in that case either."
         },
         {
           "date": "2012-07-01",
@@ -5360,7 +5360,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "After the second ability resolves, the creature blocks only if it’s able to do so as the declare blockers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can’t block, or no creatures are attacking that player or a planeswalker controlled by that player, then it doesn’t block. If there’s a cost associated with having the creature block, the player isn’t forced to pay that cost, so it doesn’t block in that case either."
+          "text": "After the second ability resolves, the creature blocks only if it's able to do so as the declare blockers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can't block, or no creatures are attacking that player or a planeswalker controlled by that player, then it doesn't block. If there's a cost associated with having the creature block, the player isn't forced to pay that cost, so it doesn't block in that case either."
         },
         {
           "date": "2012-07-01",
@@ -5368,7 +5368,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If there are multiple combat phases in a turn, the creature must attack or block only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, the creature must attack or block only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -5709,7 +5709,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -5804,6 +5804,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -5826,7 +5830,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -6048,7 +6052,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If Fog Bank blocks a creature with trample, that creature’s controller must assign 2 damage to Fog Bank (assuming it’s blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
+          "text": "If Fog Bank blocks a creature with trample, that creature's controller must assign 2 damage to Fog Bank (assuming it's blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
         }
       ],
       "subtypes": [
@@ -6161,7 +6165,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Harbor Serpent’s abilities care about lands with the land type Island, not necessarily lands named Island."
+          "text": "Harbor Serpent's abilities care about lands with the land type Island, not necessarily lands named Island."
         },
         {
           "date": "2010-08-15",
@@ -6486,15 +6490,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you target yourself with Jace’s first ability, you’ll draw a card first, then put the top card of your library into your graveyard."
+          "text": "If you target yourself with Jace's first ability, you'll draw a card first, then put the top card of your library into your graveyard."
         },
         {
           "date": "2011-09-22",
-          "text": "If you activate Jace’s first ability, and the player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If you activate Jace's first ability, and the player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         },
         {
           "date": "2011-09-22",
-          "text": "If Jace’s third ability causes a player to draw more cards than are left in his or her library, that player loses the game as a state-based action. If this ability causes all players to do this, the game is a draw."
+          "text": "If Jace's third ability causes a player to draw more cards than are left in his or her library, that player loses the game as a state-based action. If this ability causes all players to do this, the game is a draw."
         }
       ],
       "subtypes": [
@@ -6605,11 +6609,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The last ability constantly monitors each opponent’s graveyard to see if the bonus applies. If the stated condition becomes no longer true, the bonus immediately stops applying."
+          "text": "The last ability constantly monitors each opponent's graveyard to see if the bonus applies. If the stated condition becomes no longer true, the bonus immediately stops applying."
         },
         {
           "date": "2012-07-01",
-          "text": "In a multiplayer game, a single opponent must have ten or more cards in his or her graveyard for the bonus to apply, although this opponent may change over the course of the game. You don’t have to pick a single opponent; the ability will monitor each opponent’s graveyard."
+          "text": "In a multiplayer game, a single opponent must have ten or more cards in his or her graveyard for the bonus to apply, although this opponent may change over the course of the game. You don't have to pick a single opponent; the ability will monitor each opponent's graveyard."
         }
       ],
       "subtypes": [
@@ -7052,7 +7056,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can cast Mind Sculpt no matter how many cards are in the opponent’s library. If there are fewer than seven, the opponent will put all of them into his or her graveyard."
+          "text": "You can cast Mind Sculpt no matter how many cards are in the opponent's library. If there are fewer than seven, the opponent will put all of them into his or her graveyard."
         }
       ],
       "text": "Target opponent puts the top seven cards of his or her library into his or her graveyard.",
@@ -7191,7 +7195,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -7291,7 +7295,8 @@
       "originalText": "You may cast nonland cards from your hand without paying their mana costs.",
       "originalType": "Enchantment",
       "printings": [
-        "M13"
+        "M13",
+        "MPS_AKH"
       ],
       "rarity": "Mythic Rare",
       "rulings": [
@@ -7301,7 +7306,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-07-01",
@@ -7413,19 +7418,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2010-08-15",
-          "text": "If the targeted spell is modal (that is, it says “Choose one —” or the like), you can’t choose a different mode."
+          "text": "If the targeted spell is modal (that is, it says \"Choose one —\" or the like), you can't choose a different mode."
         },
         {
           "date": "2010-08-15",
-          "text": "If you cast Redirect targeting a spell that targets a spell on the stack (like Cancel does, for example), you can’t change that spell’s target to itself. You can, however, change that spell’s target to Redirect. If you do, that spell will be countered when it tries to resolve because Redirect will have left the stack by then."
+          "text": "If you cast Redirect targeting a spell that targets a spell on the stack (like Cancel does, for example), you can't change that spell's target to itself. You can, however, change that spell's target to Redirect. If you do, that spell will be countered when it tries to resolve because Redirect will have left the stack by then."
         },
         {
           "date": "2010-08-15",
-          "text": "Redirect can target any spell, not just an instant or sorcery spell. For example, you could use it to change the target of an Aura spell. However, if the targeted spell has no targets (for example, if it’s an instant or sorcery spell that doesn’t specifically use the word “target,” or if it’s a creature spell), Redirect won’t have any effect on it."
+          "text": "Redirect can target any spell, not just an instant or sorcery spell. For example, you could use it to change the target of an Aura spell. However, if the targeted spell has no targets (for example, if it's an instant or sorcery spell that doesn't specifically use the word \"target,\" or if it's a creature spell), Redirect won't have any effect on it."
         }
       ],
       "text": "You may choose new targets for target spell.",
@@ -7540,19 +7545,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Rewind targets only a spell. It doesn’t target any lands. The lands are chosen as Rewind resolves."
+          "text": "Rewind targets only a spell. It doesn't target any lands. The lands are chosen as Rewind resolves."
         },
         {
           "date": "2017-03-14",
-          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can’t choose one land and have it untap four times, for example."
+          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can't choose one land and have it untap four times, for example."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won’t untap any lands."
+          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won't untap any lands."
         },
         {
           "date": "2017-03-14",
-          "text": "If Rewind resolves but the target spell can’t be countered, you’ll still untap lands."
+          "text": "If Rewind resolves but the target spell can't be countered, you'll still untap lands."
         }
       ],
       "text": "Counter target spell. Untap up to four lands.",
@@ -7780,11 +7785,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The second part of Sleep’s effect affects all creatures the targeted player controls as Sleep resolves, not just the ones that Sleep actually caused to become tapped."
+          "text": "The second part of Sleep's effect affects all creatures the targeted player controls as Sleep resolves, not just the ones that Sleep actually caused to become tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Sleep tracks both the player and the creatures. If one of the creatures controlled by the targeted player as Sleep resolves changes controllers, the creature will untap as normal during its new controller’s next untap step."
+          "text": "Sleep tracks both the player and the creatures. If one of the creatures controlled by the targeted player as Sleep resolves changes controllers, the creature will untap as normal during its new controller's next untap step."
         }
       ],
       "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
@@ -7891,11 +7896,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Spelltwine has two targets: the instant or sorcery card in your graveyard and the one in an opponent’s graveyard. You can’t cast Spelltwine unless you can choose both legal targets."
+          "text": "Spelltwine has two targets: the instant or sorcery card in your graveyard and the one in an opponent's graveyard. You can't cast Spelltwine unless you can choose both legal targets."
         },
         {
           "date": "2012-07-01",
-          "text": "If one of Spelltwine’s targets is illegal when Spelltwine tries to resolve, you’ll still exile and copy the remaining legal target."
+          "text": "If one of Spelltwine's targets is illegal when Spelltwine tries to resolve, you'll still exile and copy the remaining legal target."
         },
         {
           "date": "2012-07-01",
@@ -7911,7 +7916,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-07-01",
@@ -8029,7 +8034,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "A pile can have no cards in it. In this case, you’ll choose whether to put all the revealed cards into your hand or into your graveyard."
+          "text": "A pile can have no cards in it. In this case, you'll choose whether to put all the revealed cards into your hand or into your graveyard."
         },
         {
           "date": "2011-09-22",
@@ -8037,7 +8042,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn’t target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
+          "text": "In multiplayer games, you choose an opponent to separate the cards when the ability resolves. This doesn't target that opponent. Because the cards are revealed, all players may see the cards and offer opinions."
         }
       ],
       "subtypes": [
@@ -8149,15 +8154,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Stormtide Leviathan’s second ability causes each land on the battlefield to have the land type Island. Each land thus has the ability “{T}: Add {U} to your mana pool.” Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they’re legendary or basic."
+          "text": "Stormtide Leviathan's second ability causes each land on the battlefield to have the land type Island. Each land thus has the ability \"{T}: Add {U} to your mana pool.\" Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they're legendary or basic."
         },
         {
           "date": "2014-07-18",
-          "text": "If Stormtide Leviathan loses its abilities, all lands on the battlefield (including those that enter the battlefield later on) will still be Islands in addition to their other types and will still be able to tap to produce {U}. The way continuous effects work, Stormtide Leviathan’s type-changing ability is applied before the effect that removes that ability is applied."
+          "text": "If Stormtide Leviathan loses its abilities, all lands on the battlefield (including those that enter the battlefield later on) will still be Islands in addition to their other types and will still be able to tap to produce {U}. The way continuous effects work, Stormtide Leviathan's type-changing ability is applied before the effect that removes that ability is applied."
         },
         {
           "date": "2014-07-18",
-          "text": "Stormtide Leviathan’s third ability affects all creatures with neither flying nor islandwalk, regardless of who controls them. They can’t attack any player or planeswalker."
+          "text": "Stormtide Leviathan's third ability affects all creatures with neither flying nor islandwalk, regardless of who controls them. They can't attack any player or planeswalker."
         },
         {
           "date": "2014-07-18",
@@ -8271,11 +8276,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If one of the target creatures is an illegal target when Switcheroo resolves, the exchange won’t happen. If both creatures are illegal targets, Switcheroo will be countered."
+          "text": "If one of the target creatures is an illegal target when Switcheroo resolves, the exchange won't happen. If both creatures are illegal targets, Switcheroo will be countered."
         },
         {
           "date": "2012-07-01",
-          "text": "You don’t have to control either target."
+          "text": "You don't have to control either target."
         },
         {
           "date": "2012-07-01",
@@ -8388,7 +8393,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You’ll put the Drake token onto the battlefield before the spell that caused the ability to trigger resolves. However, that Drake token isn’t on the battlefield when you choose targets for that spell."
+          "text": "You'll put the Drake token onto the battlefield before the spell that caused the ability to trigger resolves. However, that Drake token isn't on the battlefield when you choose targets for that spell."
         },
         {
           "date": "2012-07-01",
@@ -8680,6 +8685,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -8950,7 +8959,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can activate Void Stalker’s ability targeting a creature you control, including Void Stalker itself. In that case, only you will shuffle your library."
+          "text": "You can activate Void Stalker's ability targeting a creature you control, including Void Stalker itself. In that case, only you will shuffle your library."
         },
         {
           "date": "2012-07-01",
@@ -8958,7 +8967,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If Void Stalker leaves the battlefield before its ability resolves, the target creature will be shuffled into its owner’s library but Void Stalker will remain wherever it is."
+          "text": "If Void Stalker leaves the battlefield before its ability resolves, the target creature will be shuffled into its owner's library but Void Stalker will remain wherever it is."
         }
       ],
       "subtypes": [
@@ -9423,7 +9432,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Creatures that are put onto the battlefield attacking were never declared as attackers and won’t cause Blood Reckoning to trigger."
+          "text": "Creatures that are put onto the battlefield attacking were never declared as attackers and won't cause Blood Reckoning to trigger."
         }
       ],
       "text": "Whenever a creature attacks you or a planeswalker you control, that creature's controller loses 1 life.",
@@ -9645,11 +9654,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won’t be on the battlefield to get the bonus."
+          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won't be on the battlefield to get the bonus."
         },
         {
           "date": "2010-06-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -9760,7 +9769,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Cower in Fear affects only creatures your opponents control at the time it resolves. It won’t affect creatures that come under their control later in the turn."
+          "text": "Cower in Fear affects only creatures your opponents control at the time it resolves. It won't affect creatures that come under their control later in the turn."
         }
       ],
       "text": "Creatures your opponents control get -1/-1 until end of turn.",
@@ -9972,7 +9981,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the creature targeted by Dark Favor is an illegal target when Dark Favor tries to resolve, Dark Favor will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the creature targeted by Dark Favor is an illegal target when Dark Favor tries to resolve, Dark Favor will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -10183,19 +10192,19 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can’t sacrifice Disciple of Bolas to its own ability, because it says “another.”"
+          "text": "You can't sacrifice Disciple of Bolas to its own ability, because it says \"another.\""
         },
         {
           "date": "2012-07-01",
-          "text": "You can’t sacrifice more than one creature this way."
+          "text": "You can't sacrifice more than one creature this way."
         },
         {
           "date": "2012-07-01",
-          "text": "The ability is mandatory. If you control at least one other creature when the ability resolves, you must sacrifice one. If you don’t control any other creatures at that time, the ability won’t do anything."
+          "text": "The ability is mandatory. If you control at least one other creature when the ability resolves, you must sacrifice one. If you don't control any other creatures at that time, the ability won't do anything."
         },
         {
           "date": "2012-07-01",
-          "text": "The creature’s power when it was last on the battlefield is the amount of life you gain and the number of cards you draw."
+          "text": "The creature's power when it was last on the battlefield is the amount of life you gain and the number of cards you draw."
         }
       ],
       "subtypes": [
@@ -10309,7 +10318,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -10753,7 +10762,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If the target creature or player is an illegal target when Essence Drain tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "If the target creature or player is an illegal target when Essence Drain tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "text": "Essence Drain deals 3 damage to target creature or player and you gain 3 life.",
@@ -10972,7 +10981,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Activating Harbor Bandit’s ability after it’s been blocked won’t cause it to become unblocked."
+          "text": "Activating Harbor Bandit's ability after it's been blocked won't cause it to become unblocked."
         }
       ],
       "subtypes": [
@@ -11191,25 +11200,25 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can activate Liliana’s first ability even if your library contains no Swamp cards (or you don’t want to find one). You’ll still search your library and shuffle it."
+          "text": "You can activate Liliana's first ability even if your library contains no Swamp cards (or you don't want to find one). You'll still search your library and shuffle it."
         },
         {
           "date": "2012-07-01",
-          "text": "When you activate Liliana’s second ability, you choose only the target creature. You choose whether that creature gets +X/+X or -X/-X when the ability resolves. The value of X is determined by the number of Swamps you control when the ability resolves."
+          "text": "When you activate Liliana's second ability, you choose only the target creature. You choose whether that creature gets +X/+X or -X/-X when the ability resolves. The value of X is determined by the number of Swamps you control when the ability resolves."
         },
         {
           "date": "2012-07-01",
-          "text": "Liliana’s emblem doesn’t remove any other abilities of Swamps you control."
+          "text": "Liliana's emblem doesn't remove any other abilities of Swamps you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Each of Liliana’s abilities refers to lands (or land cards) with the subtype Swamp, not just ones named Swamp."
+          "text": "Each of Liliana's abilities refers to lands (or land cards) with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
         "Liliana"
       ],
-      "text": "+1: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.\n−3: Target creature gets +X/+X or -X/-X until end of turn, where X is the number of Swamps you control.\n−6: You get an emblem with \"Swamps you control have ‘{T}: Add {B}{B}{B}{B} to your mana pool.'\"",
+      "text": "+1: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.\n−3: Target creature gets +X/+X or -X/-X until end of turn, where X is the number of Swamps you control.\n−6: You get an emblem with \"Swamps you control have '{T}: Add {B}{B}{B}{B} to your mana pool.'\"",
       "type": "Planeswalker — Liliana",
       "types": [
         "Planeswalker"
@@ -11328,7 +11337,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"My ‘condition' is a trial. The weak are consumed by it. The strong transcend it.\"\n—Sorin Markov",
+      "flavor": "\"My 'condition' is a trial. The weak are consumed by it. The strong transcend it.\"\n—Sorin Markov",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -11418,7 +11427,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Multiple instances of lifelink are redundant. If Mark of the Vampire enchants a creature that already has lifelink, damage that creature deals won’t cause you to gain additional life."
+          "text": "multiple instances of lifelink on the same creature are redundant. If Mark of the Vampire enchants a creature that already has lifelink, damage that creature deals won't cause you to gain additional life."
         }
       ],
       "subtypes": [
@@ -11778,7 +11787,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won’t change later in the turn, even if the number of Swamps you control changes."
+          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won't change later in the turn, even if the number of Swamps you control changes."
         }
       ],
       "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
@@ -11884,11 +11893,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Nefarox’s last ability will trigger and resolve before blockers are declared."
+          "text": "Nefarox's last ability will trigger and resolve before blockers are declared."
         },
         {
           "date": "2012-07-01",
-          "text": "In a Two-Headed Giant game, you’ll choose one player on the defending team to sacrifice a creature."
+          "text": "In a Two-Headed Giant game, you'll choose one player on the defending team to sacrifice a creature."
         }
       ],
       "subtypes": [
@@ -12002,35 +12011,35 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Phylactery Lich’s first ability doesn’t target the artifact. You can choose an artifact that has shroud, for example."
+          "text": "Phylactery Lich's first ability doesn't target the artifact. You can choose an artifact that has shroud, for example."
         },
         {
           "date": "2010-08-15",
-          "text": "If you control no artifacts as Phylactery Lich enters the battlefield, its first ability won’t do anything. As soon as it enters the battlefield, its last ability will trigger (unless you control some other permanent with a phylactery counter on it) and you’ll have to sacrifice it."
+          "text": "If you control no artifacts as Phylactery Lich enters the battlefield, its first ability won't do anything. As soon as it enters the battlefield, its last ability will trigger (unless you control some other permanent with a phylactery counter on it) and you'll have to sacrifice it."
         },
         {
           "date": "2010-08-15",
-          "text": "If Phylactery Lich and an artifact are entering the battlefield under your control at the same time, you can’t put a phylactery counter on that artifact. You must choose an artifact you control that’s already on the battlefield."
+          "text": "If Phylactery Lich and an artifact are entering the battlefield under your control at the same time, you can't put a phylactery counter on that artifact. You must choose an artifact you control that's already on the battlefield."
         },
         {
           "date": "2010-08-15",
-          "text": "Phylactery Lich’s last ability is a “state trigger.” Once a state trigger triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "Phylactery Lich's last ability is a \"state trigger.\" Once a state trigger triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         },
         {
           "date": "2010-08-15",
-          "text": "Phylactery Lich’s last ability checks whether you control any permanents with phylactery counters on them, not whether you control any artifacts with phylactery counters on them. If an artifact with a phylactery counter on it somehow ceases to be an artifact, Phylactery Lich doesn’t care."
+          "text": "Phylactery Lich's last ability checks whether you control any permanents with phylactery counters on them, not whether you control any artifacts with phylactery counters on them. If an artifact with a phylactery counter on it somehow ceases to be an artifact, Phylactery Lich doesn't care."
         },
         {
           "date": "2010-08-15",
-          "text": "Phylactery Lich’s last ability checks your permanents for any phylactery counters, not just the specific one that it caused you to put on an artifact. For example, say you put a phylactery counter on a Demon’s Horn as Phylactery Lich enters the battlefield. Then you put a phylactery counter on a Crystal Ball as another Phylactery Lich enters the battlefield. Then Crystal Ball is destroyed. Since you still control the Demon’s Horn, the last ability of neither Phylactery Lich triggers."
+          "text": "Phylactery Lich's last ability checks your permanents for any phylactery counters, not just the specific one that it caused you to put on an artifact. For example, say you put a phylactery counter on a Demon's Horn as Phylactery Lich enters the battlefield. Then you put a phylactery counter on a Crystal Ball as another Phylactery Lich enters the battlefield. Then Crystal Ball is destroyed. Since you still control the Demon's Horn, the last ability of neither Phylactery Lich triggers."
         },
         {
           "date": "2010-08-15",
-          "text": "The game continually checks whether you control a permanent with a phylactery counter on it. The moment you don’t, Phylactery Lich’s last ability triggers. The ability doesn’t check again, so you’ll have to sacrifice Phylactery Lich when it resolves even if you wind up controlling a permanent with a phylactery counter on it by then."
+          "text": "The game continually checks whether you control a permanent with a phylactery counter on it. The moment you don't, Phylactery Lich's last ability triggers. The ability doesn't check again, so you'll have to sacrifice Phylactery Lich when it resolves even if you wind up controlling a permanent with a phylactery counter on it by then."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage, damage from a source with deathtouch, and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons Phylactery Lich would be put into a graveyard are if it’s sacrificed (perhaps due to its last ability), or if its toughness is 0 or less."
+          "text": "Lethal damage, damage from a source with deathtouch, and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons Phylactery Lich would be put into a graveyard are if it's sacrificed (perhaps due to its last ability), or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -12141,7 +12150,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Only creatures controlled by the player when Public Execution resolves will get -2/-0. Creatures that enter the battlefield under that player’s control or that the player gains control of later in the turn are unaffected."
+          "text": "Only creatures controlled by the player when Public Execution resolves will get -2/-0. Creatures that enter the battlefield under that player's control or that the player gains control of later in the turn are unaffected."
         },
         {
           "date": "2012-07-01",
@@ -12149,7 +12158,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the target creature regenerates or has indestructible, each other creature controlled by that creature’s controller will still get -2/-0."
+          "text": "If the target creature regenerates or has indestructible, each other creature controlled by that creature's controller will still get -2/-0."
         }
       ],
       "text": "Destroy target creature an opponent controls. Each other creature that player controls gets -2/-0 until end of turn.",
@@ -12396,19 +12405,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
+          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -12625,11 +12634,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The cards you’re searching for must be found and exiled if they’re in the graveyard because it’s a public zone. Finding those cards in the hand and library is optional, because those zones are hidden (even if the hand is temporarily revealed)."
+          "text": "The cards you're searching for must be found and exiled if they're in the graveyard because it's a public zone. Finding those cards in the hand and library is optional, because those zones are hidden (even if the hand is temporarily revealed)."
         },
         {
           "date": "2012-07-01",
-          "text": "If the player has no nonland cards in his or her hand, you can still search that player’s library and have him or her shuffle it."
+          "text": "If the player has no nonland cards in his or her hand, you can still search that player's library and have him or her shuffle it."
         }
       ],
       "subtypes": [
@@ -13079,15 +13088,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -13095,7 +13104,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the top card of your library is black, Vampire Nocturnus will give itself +2/+1 and flying even if it’s somehow not a Vampire."
+          "text": "If the top card of your library is black, Vampire Nocturnus will give itself +2/+1 and flying even if it's somehow not a Vampire."
         }
       ],
       "subtypes": [
@@ -13206,7 +13215,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Veilborn Ghoul’s ability triggers only if it’s in your graveyard at the moment the Swamp enters the battlefield."
+          "text": "Veilborn Ghoul's ability triggers only if it's in your graveyard at the moment the Swamp enters the battlefield."
         }
       ],
       "subtypes": [
@@ -13228,7 +13237,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"‘Here lies our beloved Gartu, the gentlest of all men.' Ooh, I love irony.\"\n—Jadar, ghoulcaller of Nephalia",
+      "flavor": "\"'Here lies our beloved Gartu, the gentlest of all men.' Ooh, I love irony.\"\n—Jadar, ghoulcaller of Nephalia",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -13317,7 +13326,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If the creature card is an illegal target when Vile Rebirth tries to resolve, it will be countered and none of its effects will happen. You won’t put a Zombie token onto the battlefield."
+          "text": "If the creature card is an illegal target when Vile Rebirth tries to resolve, it will be countered and none of its effects will happen. You won't put a Zombie token onto the battlefield."
         }
       ],
       "text": "Exile target creature card from a graveyard. Create a 2/2 black Zombie creature token.",
@@ -13643,11 +13652,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The effects of Xathrid Gorgon’s ability don’t depend on the petrification counter. If that counter is removed, the creature remains a colorless artifact with defender, and so on."
+          "text": "The effects of Xathrid Gorgon's ability don't depend on the petrification counter. If that counter is removed, the creature remains a colorless artifact with defender, and so on."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -13992,11 +14001,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Intimidate looks at the current colors of a creature that has it. Normally, Bladetusk Boar can’t be blocked except by artifact creatures and/or red creatures. If it’s turned blue, then it can’t be blocked except by artifact creatures and/or blue creatures."
+          "text": "Intimidate looks at the current colors of a creature that has it. Normally, Bladetusk Boar can't be blocked except by artifact creatures and/or red creatures. If it's turned blue, then it can't be blocked except by artifact creatures and/or blue creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it’s blocked, changing its colors won’t change that."
+          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it's blocked, changing its colors won't change that."
         }
       ],
       "subtypes": [
@@ -14219,19 +14228,19 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Chandra’s second ability creates a delayed triggered ability that will copy the next instant or sorcery spell you cast that turn, regardless of whether that spell has targets."
+          "text": "Chandra's second ability creates a delayed triggered ability that will copy the next instant or sorcery spell you cast that turn, regardless of whether that spell has targets."
         },
         {
           "date": "2011-09-22",
-          "text": "When the delayed trigger resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When the delayed trigger resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2011-09-22",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2011-09-22",
-          "text": "If the spell Chandra copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Chandra copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2011-09-22",
@@ -14239,11 +14248,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you sacrifice a 3/3 creature to cast Fling after activating Chandra’s second ability, the copy of Fling will also deal 3 damage."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you sacrifice a 3/3 creature to cast Fling after activating Chandra's second ability, the copy of Fling will also deal 3 damage."
         },
         {
           "date": "2011-09-22",
-          "text": "When you activate Chandra’s last ability, you choose up to six target creatures and/or players. No damage is divided, and Chandra can’t deal more than 6 damage to any one target. Chandra deals 6 damage to each target that is still legal when the ability resolves."
+          "text": "When you activate Chandra's last ability, you choose up to six target creatures and/or players. No damage is divided, and Chandra can't deal more than 6 damage to any one target. Chandra deals 6 damage to each target that is still legal when the ability resolves."
         }
       ],
       "subtypes": [
@@ -14354,7 +14363,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Chandra’s Fury targets only the player, not any creature. Chandra’s Fury will deal 1 damage to a creature with hexproof, for example."
+          "text": "Chandra's Fury targets only the player, not any creature. Chandra's Fury will deal 1 damage to a creature with hexproof, for example."
         }
       ],
       "text": "Chandra's Fury deals 4 damage to target player and 1 damage to each creature that player controls.",
@@ -14460,7 +14469,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Cleaver Riot affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Cleaver Riot affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control gain double strike until end of turn. (They deal both first-strike and regular combat damage.)",
@@ -14478,7 +14487,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"‘Utterly' is my favorite way to destroy something.\"\n—Chandra Nalaar",
+      "flavor": "\"'Utterly' is my favorite way to destroy something.\"\n—Chandra Nalaar",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -14884,7 +14893,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If an attacking creature loses haste, perhaps because Fervor leaves the battlefield after attackers have been declared, it won’t be removed from combat."
+          "text": "If an attacking creature loses haste, perhaps because Fervor leaves the battlefield after attackers have been declared, it won't be removed from combat."
         }
       ],
       "text": "Creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
@@ -15104,7 +15113,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Firewing Phoenix’s ability can be activated only if Firewing Phoenix is in your graveyard."
+          "text": "Firewing Phoenix's ability can be activated only if Firewing Phoenix is in your graveyard."
         }
       ],
       "subtypes": [
@@ -15219,7 +15228,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "You can’t deal damage to both a player and a planeswalker controlled by that player with Flames of the Firebrand."
+          "text": "You can't deal damage to both a player and a planeswalker controlled by that player with Flames of the Firebrand."
         }
       ],
       "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
@@ -15750,6 +15759,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -15796,7 +15809,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn’t prevent that creature from dealing combat damage."
+          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn't prevent that creature from dealing combat damage."
         }
       ],
       "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
@@ -16122,7 +16135,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Magmaquake doesn’t target any creature or planeswalker. For example, it will deal damage to a creature without flying that has hexproof."
+          "text": "Magmaquake doesn't target any creature or planeswalker. For example, it will deal damage to a creature without flying that has hexproof."
         }
       ],
       "text": "Magmaquake deals X damage to each creature without flying and each planeswalker.",
@@ -16235,7 +16248,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target a creature you already control. You may target a creature that’s already untapped."
+          "text": "You may target a creature you already control. You may target a creature that's already untapped."
         },
         {
           "date": "2009-10-01",
@@ -16346,23 +16359,23 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Any player can respond to Mindclaw Shaman’s triggered ability. However, once that ability starts resolving and the target opponent reveals his or her hand, players can’t respond until after the ability finishes resolving. For example, the opponent can’t cast the instant or sorcery card you choose to cast in order to stop you from casting it."
+          "text": "Any player can respond to Mindclaw Shaman's triggered ability. However, once that ability starts resolving and the target opponent reveals his or her hand, players can't respond until after the ability finishes resolving. For example, the opponent can't cast the instant or sorcery card you choose to cast in order to stop you from casting it."
         },
         {
           "date": "2012-07-01",
-          "text": "You cast the card from the opponent’s hand immediately. Ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "You cast the card from the opponent's hand immediately. Ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2012-07-01",
-          "text": "The card goes to its owner’s graveyard after it resolves (or otherwise leaves the stack), not yours."
+          "text": "The card goes to its owner's graveyard after it resolves (or otherwise leaves the stack), not yours."
         },
         {
           "date": "2012-07-01",
-          "text": "If you can’t cast any instant or sorcery card (perhaps because there are no legal targets available) or if you choose not to cast one, then Mindclaw Shaman’s ability finishes resolving and the game moves on."
+          "text": "If you can't cast any instant or sorcery card (perhaps because there are no legal targets available) or if you choose not to cast one, then Mindclaw Shaman's ability finishes resolving and the game moves on."
         },
         {
           "date": "2012-07-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-07-01",
@@ -16495,7 +16508,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Although Mogg Flunkies can’t attack alone, other attacking creature(s) don’t have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
+          "text": "Although Mogg Flunkies can't attack alone, other attacking creature(s) don't have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
         },
         {
           "date": "2017-03-14",
@@ -16503,7 +16516,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player’s blocking creatures."
+          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player's blocking creatures."
         }
       ],
       "subtypes": [
@@ -16614,7 +16627,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Reckless Brute attacks only if it’s able to do so as the declare attackers step begins. If, at that time, it’s tapped, it’s affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having it attack, you’re not forced to pay that cost, so it doesn’t attack in that case either."
+          "text": "Reckless Brute attacks only if it's able to do so as the declare attackers step begins. If, at that time, it's tapped, it's affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having it attack, you're not forced to pay that cost, so it doesn't attack in that case either."
         },
         {
           "date": "2012-07-01",
@@ -16732,19 +16745,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Reverberate can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Reverberate can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2010-08-15",
-          "text": "When Reverberate resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When Reverberate resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2010-08-15",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2010-08-15",
-          "text": "If the spell Reverberate copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Reverberate copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2010-08-15",
@@ -16752,11 +16765,11 @@
         },
         {
           "date": "2010-08-15",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Reverberate, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Reverberate, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2010-08-15",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
@@ -16864,7 +16877,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Discarding a card is part of the cost to activate Rummaging Goblin’s ability. If you don’t have a card in your hand, you can’t pay this part of the cost and you can’t activate the ability."
+          "text": "Discarding a card is part of the cost to activate Rummaging Goblin's ability. If you don't have a card in your hand, you can't pay this part of the cost and you can't activate the ability."
         }
       ],
       "subtypes": [
@@ -17077,15 +17090,15 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Slumbering Dragon’s second ability counts all +1/+1 counters on it, not just the ones added by its third ability."
+          "text": "Slumbering Dragon's second ability counts all +1/+1 counters on it, not just the ones added by its third ability."
         },
         {
           "date": "2012-07-01",
-          "text": "The +1/+1 counter is put on Slumbering Dragon before blockers are declared. This may allow Slumbering Dragon to “wake up” and block the creature that attacked and caused its ability to trigger."
+          "text": "The +1/+1 counter is put on Slumbering Dragon before blockers are declared. This may allow Slumbering Dragon to \"wake up\" and block the creature that attacked and caused its ability to trigger."
         },
         {
           "date": "2012-07-01",
-          "text": "Slumbering Dragon’s third ability will trigger once for each creature that attacks you or a planeswalker you control."
+          "text": "Slumbering Dragon's third ability will trigger once for each creature that attacks you or a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -17535,7 +17548,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
@@ -17543,7 +17556,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you’ve declared attackers usually won’t do anything."
+          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you've declared attackers usually won't do anything."
         }
       ],
       "text": "Attacking creatures get +2/+0 until end of turn.",
@@ -18096,7 +18109,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Because discarding a card is an additional cost, you can’t cast Wild Guess if you have no other cards in hand."
+          "text": "Because discarding a card is an additional cost, you can't cast Wild Guess if you have no other cards in hand."
         }
       ],
       "text": "As an additional cost to cast Wild Guess, discard a card.\nDraw two cards.",
@@ -18202,7 +18215,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "These actions are performed in order, but no triggered abilities resolve in between them and no player may cast spells or activate abilities in between them. This means that if a permanent’s ability triggers on a player losing life, that permanent will be exiled first and won’t be on the battlefield when your life total becomes 1. Leaves-the-battlefield triggers won’t resolve until you’re done resolving Worldfire entirely."
+          "text": "These actions are performed in order, but no triggered abilities resolve in between them and no player may cast spells or activate abilities in between them. This means that if a permanent's ability triggers on a player losing life, that permanent will be exiled first and won't be on the battlefield when your life total becomes 1. Leaves-the-battlefield triggers won't resolve until you're done resolving Worldfire entirely."
         },
         {
           "date": "2012-07-01",
@@ -18210,7 +18223,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Worldfire won’t be exiled. It will go to your graveyard as the final part of its resolution."
+          "text": "Worldfire won't be exiled. It will go to your graveyard as the final part of its resolution."
         }
       ],
       "text": "Exile all permanents. Exile all cards from all hands and graveyards. Each player's life total becomes 1.",
@@ -19185,11 +19198,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Elderscale Wurm’s last ability doesn’t prevent damage. It only changes the result of damage dealt to you. For example, a creature will lifelink that deals damage to you will still cause its controller to gain life, even if that damage would reduce your life total to less than 7."
+          "text": "Elderscale Wurm's last ability doesn't prevent damage. It only changes the result of damage dealt to you. For example, a creature will lifelink that deals damage to you will still cause its controller to gain life, even if that damage would reduce your life total to less than 7."
         },
         {
           "date": "2012-07-01",
-          "text": "Elderscale Wurm’s last ability doesn’t affect the loss or payment of life."
+          "text": "Elderscale Wurm's last ability doesn't affect the loss or payment of life."
         },
         {
           "date": "2012-07-01",
@@ -19197,11 +19210,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If damage is dealt to you and Elderscale Wurm at the same time, and that damage is enough to destroy Elderscale Wurm and reduce your life total to 7 or less, Elderscale Wurm’s ability will still apply. For example, if you have 10 life and a spell deals 10 damage to you and 10 damage to Elderscale Wurm, you’ll end up at 7 life and Elderscale Wurm will be destroyed."
+          "text": "If damage is dealt to you and Elderscale Wurm at the same time, and that damage is enough to destroy Elderscale Wurm and reduce your life total to 7 or less, Elderscale Wurm's ability will still apply. For example, if you have 10 life and a spell deals 10 damage to you and 10 damage to Elderscale Wurm, you'll end up at 7 life and Elderscale Wurm will be destroyed."
         },
         {
           "date": "2012-07-01",
-          "text": "In a Commander game, combat damage you’re dealt by a commander is still tracked, even if it doesn’t change your life total."
+          "text": "In a Commander game, combat damage you're dealt by a commander is still tracked, even if it doesn't change your life total."
         }
       ],
       "subtypes": [
@@ -19317,11 +19330,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Elvish Archdruid’s first ability affects only other Elves you control. However, Elvish Archdruid’s second ability counts all Elves you control — including itself."
+          "text": "Elvish Archdruid's first ability affects only other Elves you control. However, Elvish Archdruid's second ability counts all Elves you control — including itself."
         },
         {
           "date": "2011-09-22",
-          "text": "Elvish Archdruid’s activated ability is a mana ability. It doesn’t use the stack and players can’t respond to it."
+          "text": "Elvish Archdruid's activated ability is a mana ability. It doesn't use the stack and players can't respond to it."
         }
       ],
       "subtypes": [
@@ -19894,7 +19907,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Fungal Sprouting doesn’t target any creature. The greatest power among creatures you control is determined when Fungal Sprouting resolves."
+          "text": "Fungal Sprouting doesn't target any creature. The greatest power among creatures you control is determined when Fungal Sprouting resolves."
         }
       ],
       "text": "Create X 1/1 green Saproling creature tokens, where X is the greatest power among creatures you control.",
@@ -20001,15 +20014,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "For Garruk’s second ability, the greatest power among creatures you control is determined when that ability begins resolving."
+          "text": "For Garruk's second ability, the greatest power among creatures you control is determined when that ability begins resolving."
         },
         {
           "date": "2011-09-22",
-          "text": "If the greatest power among creatures you control is 0 or less, you’ll draw no cards. You won’t discard any cards this way."
+          "text": "If the greatest power among creatures you control is 0 or less, you'll draw no cards. You won't discard any cards this way."
         },
         {
           "date": "2011-09-22",
-          "text": "For Garruk’s third ability, the number of Wurm tokens you put onto the battlefield is determined when that ability begins resolving."
+          "text": "For Garruk's third ability, the number of Wurm tokens you put onto the battlefield is determined when that ability begins resolving."
         }
       ],
       "subtypes": [
@@ -20121,15 +20134,15 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If Garruk’s Packleader and another creature with power 3 or greater enter the battlefield under your control at the same time, the ability will trigger."
+          "text": "If Garruk's Packleader and another creature with power 3 or greater enter the battlefield under your control at the same time, the ability will trigger."
         },
         {
           "date": "2012-07-01",
-          "text": "The ability checks the power of each creature as it enters the battlefield. It will take into account counters the permanent enters the battlefield with and static abilities that affect its power (such as Flinthoof Boar’s ability). After the creature is on the battlefield, raising its power with a spell (such as Titanic Growth), an activated ability, or a triggered ability won’t cause this ability to retroactively trigger."
+          "text": "The ability checks the power of each creature as it enters the battlefield. It will take into account counters the permanent enters the battlefield with and static abilities that affect its power (such as Flinthoof Boar's ability). After the creature is on the battlefield, raising its power with a spell (such as Titanic Growth), an activated ability, or a triggered ability won't cause this ability to retroactively trigger."
         },
         {
           "date": "2012-07-01",
-          "text": "The creature’s power is checked only to see if the ability triggers. It doesn’t matter what the creature’s power is when the ability resolves."
+          "text": "The creature's power is checked only to see if the ability triggers. It doesn't matter what the creature's power is when the ability resolves."
         }
       ],
       "subtypes": [
@@ -20248,7 +20261,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Only spells and abilities that target cards in graveyards will be affected. Abilities that don’t target cards in graveyards (like the one Tormod’s Crypt has) can still affect those cards."
+          "text": "Only spells and abilities that target cards in graveyards will be affected. Abilities that don't target cards in graveyards (like the one Tormod's Crypt has) can still affect those cards."
         }
       ],
       "text": "When Ground Seal enters the battlefield, draw a card.\nCards in graveyards can't be the targets of spells or abilities.",
@@ -20356,7 +20369,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The creature card must have one of the listed abilities, not an ability that grants one of the listed abilities to the creature. For example, you couldn’t put Prized Elephant, which has “{G}: Prized Elephant gains trample until end of turn,” on top of your library this way."
+          "text": "The creature card must have one of the listed abilities, not an ability that grants one of the listed abilities to the creature. For example, you couldn't put Prized Elephant, which has \"{G}: Prized Elephant gains trample until end of turn,\" on top of your library this way."
         }
       ],
       "subtypes": [
@@ -20729,15 +20742,15 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Each creature your opponents control blocks if able, even if that creature wasn’t on the battlefield or wasn’t controlled by an opponent when Predatory Rampage resolved."
+          "text": "Each creature your opponents control blocks if able, even if that creature wasn't on the battlefield or wasn't controlled by an opponent when Predatory Rampage resolved."
         },
         {
           "date": "2012-07-01",
-          "text": "Predatory Rampage doesn’t force any creature to attack."
+          "text": "Predatory Rampage doesn't force any creature to attack."
         },
         {
           "date": "2012-07-01",
-          "text": "Each creature controlled by an opponent blocks only if it’s able to do so as the declare blockers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can’t block, or no creatures are attacking that player or a planeswalker controlled by that player, then it doesn’t block. If there’s a cost associated with having the creature block, the player isn’t forced to pay that cost, so it doesn’t block in that case either."
+          "text": "Each creature controlled by an opponent blocks only if it's able to do so as the declare blockers step begins. If, at that time, the creature is tapped, is affected by a spell or ability that says it can't block, or no creatures are attacking that player or a planeswalker controlled by that player, then it doesn't block. If there's a cost associated with having the creature block, the player isn't forced to pay that cost, so it doesn't block in that case either."
         },
         {
           "date": "2012-07-01",
@@ -20745,7 +20758,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If there are multiple combat phases in a turn, each affected creature must block only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, each affected creature must block only in the first one in which it's able to."
         }
       ],
       "text": "Creatures you control get +3/+3 until end of turn. Each creature your opponents control blocks this turn if able.",
@@ -21085,7 +21098,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Consider only the number of +1/+1 counters on Primordial Hydra when determining if it has trample, not its power and toughness. For example, a Primordial Hydra with six +1/+1 counters on it that’s been the target of Titanic Growth (giving it +4/+4) would not have trample."
+          "text": "Consider only the number of +1/+1 counters on Primordial Hydra when determining if it has trample, not its power and toughness. For example, a Primordial Hydra with six +1/+1 counters on it that's been the target of Titanic Growth (giving it +4/+4) would not have trample."
         }
       ],
       "subtypes": [
@@ -21202,11 +21215,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Quirion Dryad’s ability will trigger only once per spell you cast, as long as that spell is at least one of the listed colors."
+          "text": "Quirion Dryad's ability will trigger only once per spell you cast, as long as that spell is at least one of the listed colors."
         },
         {
           "date": "2012-07-01",
-          "text": "Quirion Dryad’s ability will trigger if you cast a spell that’s green and at least one of the listed colors."
+          "text": "Quirion Dryad's ability will trigger if you cast a spell that's green and at least one of the listed colors."
         }
       ],
       "subtypes": [
@@ -21327,7 +21340,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -21645,11 +21658,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Roaring Primadox’s ability is mandatory. When it resolves, if Roaring Primadox is the only creature you control, you must return it to its owner’s hand."
+          "text": "Roaring Primadox's ability is mandatory. When it resolves, if Roaring Primadox is the only creature you control, you must return it to its owner's hand."
         },
         {
           "date": "2014-07-18",
-          "text": "The ability doesn’t target any creature. You choose which one to return when the ability resolves. No player can respond to this choice once the ability starts resolving."
+          "text": "The ability doesn't target any creature. You choose which one to return when the ability resolves. No player can respond to this choice once the ability starts resolving."
         }
       ],
       "subtypes": [
@@ -22187,7 +22200,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Thragtusk’s second ability will trigger no matter what zone Thragtusk goes to."
+          "text": "Thragtusk's second ability will trigger no matter what zone Thragtusk goes to."
         }
       ],
       "subtypes": [
@@ -22621,7 +22634,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Yeva’s ability applies to green creature cards in any zone, provided something is allowing you to cast them. For example, if the top card of your library is a green creature card and you control Garruk’s Horde, you can cast that card as though it had flash."
+          "text": "Yeva's ability applies to green creature cards in any zone, provided something is allowing you to cast them. For example, if the top card of your library is a green creature card and you control Garruk's Horde, you can cast that card as though it had flash."
         }
       ],
       "subtypes": [
@@ -22737,7 +22750,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Yeva’s Forcemage’s ability is mandatory, although you can choose Yeva’s Forcemage as the target."
+          "text": "Yeva's Forcemage's ability is mandatory, although you can choose Yeva's Forcemage as the target."
         }
       ],
       "subtypes": [
@@ -22863,7 +22876,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If the damage from Nicol Bolas’s third ability is prevented or redirected, the rest of the effect will still happen. Specifically, the number of cards discarded and permanents sacrificed isn’t tied to the amount of damage dealt."
+          "text": "If the damage from Nicol Bolas's third ability is prevented or redirected, the rest of the effect will still happen. Specifically, the number of cards discarded and permanents sacrificed isn't tied to the amount of damage dealt."
         },
         {
           "date": "2012-07-01",
@@ -23383,19 +23396,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Paying the activation cost of Elixir of Immortality’s ability doesn’t cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
+          "text": "Paying the activation cost of Elixir of Immortality's ability doesn't cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
         },
         {
           "date": "2011-09-22",
-          "text": "As the ability resolves, you’ll shuffle Elixir of Immortality into its owner’s library directly from the battlefield, if it’s still there."
+          "text": "As the ability resolves, you'll shuffle Elixir of Immortality into its owner's library directly from the battlefield, if it's still there."
         },
         {
           "date": "2011-09-22",
-          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you’ll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it’s anywhere else by that time, including in another player’s graveyard, it remains where it is and you shuffle just your graveyard into your library."
+          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you'll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it's anywhere else by that time, including in another player's graveyard, it remains where it is and you shuffle just your graveyard into your library."
         },
         {
           "date": "2011-09-22",
-          "text": "If you gain control of another player’s Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner’s library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
+          "text": "If you gain control of another player's Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner's library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
         }
       ],
       "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
@@ -23494,7 +23507,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You don’t have to find all three cards, even if they’re present in your library. For example, you can activate the ability just to find an Island card and a Swamp card."
+          "text": "You don't have to find all three cards, even if they're present in your library. For example, you can activate the ability just to find an Island card and a Swamp card."
         }
       ],
       "text": "{3}, {T}, Sacrifice Gem of Becoming: Search your library for an Island card, a Swamp card, and a Mountain card. Reveal those cards and put them into your hand. Then shuffle your library.",
@@ -24030,11 +24043,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         },
         {
           "date": "2012-07-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -25217,11 +25230,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don’t have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Swamp or Mountain, not for lands named Swamp or Mountain. The lands it checks for don't have to be basic lands. For example, if you control Stomping Ground (a nonbasic land with the land types Mountain and Forest), Dragonskull Summit will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
@@ -25326,11 +25339,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don’t have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Island or Swamp, not for lands named Island or Swamp. The lands it checks for don't have to be basic lands. For example, if you control Blood Crypt (a nonbasic land with the land types Swamp and Mountain), Drowned Catacomb will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
@@ -25572,11 +25585,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Plains or Island, not for lands named Plains or Island. The lands it checks for don’t have to be basic lands. For example, if you control Watery Grave (a nonbasic land with the land types Island and Swamp), Glacial Fortress will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Plains or Island, not for lands named Plains or Island. The lands it checks for don't have to be basic lands. For example, if you control Watery Grave (a nonbasic land with the land types Island and Swamp), Glacial Fortress will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
@@ -25777,7 +25790,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you’ll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Reliquary Tower onto the battlefield, you'll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\n{T}: Add {C} to your mana pool.",
@@ -25883,11 +25896,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don’t have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Mountain or Forest, not for lands named Mountain or Forest. The lands it checks for don't have to be basic lands. For example, if you control Temple Garden (a nonbasic land with the land types Forest and Plains), Rootbound Crag will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
@@ -25992,11 +26005,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don’t have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
+          "text": "This checks for lands you control with the land type Forest or Plains, not for lands named Forest or Plains. The lands it checks for don't have to be basic lands. For example, if you control Hallowed Fountain (a nonbasic land with the land types Plains and Island), Sunpetal Grove will enter the battlefield untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won’t see lands that are entering the battlefield at the same time (due to Warp World, for example)."
+          "text": "As this is entering the battlefield, it checks for lands that are already on the battlefield. It won't see lands that are entering the battlefield at the same time (due to Warp World, for example)."
         }
       ],
       "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
@@ -26072,9 +26085,29 @@
           "multiverseid": 332009
         },
         {
+          "language": "Japanese",
+          "name": "平地",
+          "multiverseid": 332756
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 330512
+        },
+        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 330513
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 330514
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 330515
         },
         {
           "language": "Portuguese (Brazil)",
@@ -26115,26 +26148,6 @@
           "language": "Russian",
           "name": "Равнина",
           "multiverseid": 331760
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332255
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332256
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332257
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332258
         }
       ],
       "id": "7a5040a4b18d09bf20bb4b0fee1db1749da81c66",
@@ -26453,9 +26466,29 @@
           "multiverseid": 332009
         },
         {
+          "language": "Japanese",
+          "name": "平地",
+          "multiverseid": 332756
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 330512
+        },
+        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 330513
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 330514
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 330515
         },
         {
           "language": "Portuguese (Brazil)",
@@ -26496,26 +26529,6 @@
           "language": "Russian",
           "name": "Равнина",
           "multiverseid": 331760
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332255
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332256
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332257
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332258
         }
       ],
       "id": "dcc91f8db182c5c2d59bc7761a0b4d34035b77d0",
@@ -27215,9 +27228,29 @@
           "multiverseid": 332009
         },
         {
+          "language": "Japanese",
+          "name": "平地",
+          "multiverseid": 332756
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 330512
+        },
+        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 330513
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 330514
+        },
+        {
+          "language": "Korean",
+          "name": "들",
+          "multiverseid": 330515
         },
         {
           "language": "Portuguese (Brazil)",
@@ -27258,26 +27291,6 @@
           "language": "Russian",
           "name": "Равнина",
           "multiverseid": 331760
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332255
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332256
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332257
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 332258
         }
       ],
       "id": "611e3d2d540cc994b6675b8a6cbae3fe11940d7a",
@@ -30648,9 +30661,29 @@
           "multiverseid": 332005
         },
         {
+          "language": "Japanese",
+          "name": "山",
+          "multiverseid": 332751
+        },
+        {
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 330508
+        },
+        {
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 330509
+        },
+        {
           "language": "Korean",
           "name": "산",
           "multiverseid": 330510
+        },
+        {
+          "language": "Korean",
+          "name": "산",
+          "multiverseid": 330511
         },
         {
           "language": "Portuguese (Brazil)",
@@ -30691,26 +30724,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 331756
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 332251
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 332252
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 332253
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 332254
         }
       ],
       "id": "00ee8693a4a785b3898a252d7950988590aee0f2",
@@ -32571,6 +32584,26 @@
           "multiverseid": 331996
         },
         {
+          "language": "Japanese",
+          "name": "森",
+          "multiverseid": 332742
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 330499
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 330500
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 330501
+        },
+        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 330502
@@ -32614,26 +32647,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 331747
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332242
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332243
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332244
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332245
         }
       ],
       "id": "d8ce1c5cbf5ed9b6157599b188646a71b46439de",
@@ -32954,6 +32967,26 @@
           "multiverseid": 331996
         },
         {
+          "language": "Japanese",
+          "name": "森",
+          "multiverseid": 332742
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 330499
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 330500
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 330501
+        },
+        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 330502
@@ -32997,26 +33030,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 331747
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332242
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332243
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332244
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332245
         }
       ],
       "id": "1f842563223d1965581cf8d27b7941038cf892c1",
@@ -33337,6 +33350,26 @@
           "multiverseid": 331996
         },
         {
+          "language": "Japanese",
+          "name": "森",
+          "multiverseid": 332742
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 330499
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 330500
+        },
+        {
+          "language": "Korean",
+          "name": "숲",
+          "multiverseid": 330501
+        },
+        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 330502
@@ -33380,26 +33413,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 331747
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332242
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332243
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332244
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 332245
         }
       ],
       "id": "f8a17ff359653555f765f59837831ac687ff84cf",

--- a/json/M14.json
+++ b/json/M14.json
@@ -140,7 +140,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can activate the first ability without a target. You’ll still put one loyalty counter on Ajani when you activate the ability."
+          "text": "You can activate the first ability without a target. You'll still put one loyalty counter on Ajani when you activate the ability."
         },
         {
           "date": "2012-07-01",
@@ -252,6 +252,24 @@
         "C15"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-07-01",
+          "text": "The ability doesn't trigger until the enchantment enters the battlefield. This means that, for example, you can't cast an Aura with enchant creature if there are no legal targets available, hoping to enchant the Cat token. Ajani's Chosen itself, however, may be a legal target for the Aura."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If you cast an Aura targeting an opponent or a permanent controlled by an opponent, you control that Aura when it enters the battlefield. The ability of Ajani's Chosen will trigger."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "You may attach the Aura to the token only if it can legally enchant that token. For example, if the enchantment that entered the battlefield is an Aura with \"enchant land,\" it won't move."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "You may attach the Aura to the Cat token only if the Aura and the token are both on the battlefield when the triggered ability resolves. If the Aura leaves the battlefield before the ability resolves, it won't become attached to the token. If the token leaves the battlefield before the ability resolves, the Aura won't move."
+        }
+      ],
       "subtypes": [
         "Cat",
         "Soldier"
@@ -360,15 +378,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Angelic Accord’s ability checks how much life you’ve gained during the turn, not what your life total is compared to what it was when the turn began. For example, if you start the turn at 10 life, gain 6 life during the turn, then lose 6 life later that turn, the ability will trigger."
+          "text": "Angelic Accord's ability checks how much life you've gained during the turn, not what your life total is compared to what it was when the turn began. For example, if you start the turn at 10 life, gain 6 life during the turn, then lose 6 life later that turn, the ability will trigger."
         },
         {
           "date": "2013-07-01",
-          "text": "If you haven’t gained 4 or more life during the turn when the end step begins, the ability won’t trigger at all. Gaining life during the end step won’t cause the ability to trigger."
+          "text": "If you haven't gained 4 or more life during the turn when the end step begins, the ability won't trigger at all. Gaining life during the end step won't cause the ability to trigger."
         },
         {
           "date": "2013-07-01",
-          "text": "In a Two-Headed Giant game, life gained by your teammate isn’t considered, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate isn't considered, even though it causes your team's life total to increase."
         }
       ],
       "text": "At the beginning of each end step, if you gained 4 or more life this turn, create a 4/4 white Angel creature token with flying.",
@@ -592,15 +610,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "The ability triggers just once from each life-gaining event, whether it’s 1 life from Soulmender or 5 life from Elixir of Immortality."
+          "text": "The ability triggers just once from each life-gaining event, whether it's 1 life from Soulmender or 5 life from Elixir of Immortality."
         },
         {
           "date": "2013-07-01",
-          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Archangel of Thune’s ability will trigger twice. However, if a single creature with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
+          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Archangel of Thune's ability will trigger twice. However, if a single creature with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
         },
         {
           "date": "2013-07-01",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -830,27 +848,27 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Banisher Priest’s ability causes a zone change with a duration, a new style of ability that’s somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Banisher Priest have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Banisher Priest leaves the battlefield."
+          "text": "Banisher Priest's ability causes a zone change with a duration, a new style of ability that's somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Banisher Priest have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Banisher Priest leaves the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "If Banisher Priest leaves the battlefield before its enters-the-battlefield ability resolves, the target creature won’t be exiled."
+          "text": "If Banisher Priest leaves the battlefield before its enters-the-battlefield ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2013-07-01",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "The exiled card returns to the battlefield immediately after Banisher Priest leaves the battlefield. Nothing happens between the two events, including state-based actions. The two creatures aren’t on the battlefield at the same time. For example, if the returning creature is a Clone, it can’t enter the battlefield as a copy of Banisher Priest."
+          "text": "The exiled card returns to the battlefield immediately after Banisher Priest leaves the battlefield. Nothing happens between the two events, including state-based actions. The two creatures aren't on the battlefield at the same time. For example, if the returning creature is a Clone, it can't enter the battlefield as a copy of Banisher Priest."
         },
         {
           "date": "2013-07-01",
-          "text": "In a multiplayer game, if Banisher Priest’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Banisher Priest's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "subtypes": [
@@ -1073,15 +1091,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If Bonescythe Sliver leaves the battlefield after other Sliver creatures you control have dealt first-strike damage but before regular combat damage, those Slivers won’t deal regular combat damage (unless they still have double strike for some other reason)."
+          "text": "If Bonescythe Sliver leaves the battlefield after other Sliver creatures you control have dealt first-strike damage but before regular combat damage, those Slivers won't deal regular combat damage (unless they still have double strike for some other reason)."
         },
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -1197,11 +1215,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You choose a color as Brave the Elements resolves. Once the color is chosen, it’s too late for players to respond."
+          "text": "You choose a color as Brave the Elements resolves. Once the color is chosen, it's too late for players to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "Only white creatures you control at the time Brave the Elements resolves gain the protection ability. Creatures that come under your control later in the turn, or that turn white later in the turn, won’t have it."
+          "text": "Only white creatures you control at the time Brave the Elements resolves gain the protection ability. Creatures that come under your control later in the turn, or that turn white later in the turn, won't have it."
         }
       ],
       "text": "Choose a color. White creatures you control gain protection from the chosen color until end of turn.",
@@ -1424,7 +1442,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the player sacrifices a blocking creature, any attacking creature it was blocking remains blocked. Unless that attacking creature has trample or is being blocked by another creature, it won’t assign or deal combat damage."
+          "text": "If the player sacrifices a blocking creature, any attacking creature it was blocking remains blocked. Unless that attacking creature has trample or is being blocked by another creature, it won't assign or deal combat damage."
         },
         {
           "date": "2013-07-01",
@@ -1971,7 +1989,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If the creature targeted by Divine Favor is an illegal target when Divine Favor tries to resolve, Divine Favor will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the creature targeted by Divine Favor is an illegal target when Divine Favor tries to resolve, Divine Favor will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -2081,7 +2099,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Fiendslayer Paladin can be affected by black or red spells that don’t target it. For example, a red spell that “deals 3 damage to each creature” would deal damage to Fiendslayer Paladin."
+          "text": "Fiendslayer Paladin can be affected by black or red spells that don't target it. For example, a red spell that \"deals 3 damage to each creature\" would deal damage to Fiendslayer Paladin."
         }
       ],
       "subtypes": [
@@ -2202,7 +2220,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Creatures that come under your control after Fortify resolves won’t get the chosen bonus."
+          "text": "Creatures that come under your control after Fortify resolves won't get the chosen bonus."
         }
       ],
       "text": "Choose one —\n• Creatures you control get +2/+0 until end of turn.\n• Creatures you control get +0/+2 until end of turn.",
@@ -2416,11 +2434,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "text": "Create two 1/1 colorless Sliver creature tokens.",
@@ -2632,15 +2650,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If an effect would simultaneously destroy Indestructibility and the creature it’s enchanting, only Indestructibility is destroyed."
+          "text": "If an effect would simultaneously destroy Indestructibility and the creature it's enchanting, only Indestructibility is destroyed."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage, damage from a source with deathtouch, and effects that say “destroy” won’t cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, if it’s a planeswalker and another planeswalker with the same subtype is controlled by the same player, if it’s a creature with toughness 0 or less, or if it’s an Aura that’s either unattached or attached to something illegal."
+          "text": "Lethal damage, damage from a source with deathtouch, and effects that say \"destroy\" won't cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, if it's a planeswalker and another planeswalker with the same subtype is controlled by the same player, if it's a creature with toughness 0 or less, or if it's an Aura that's either unattached or attached to something illegal."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted by Indestructibility is dealt lethal damage, the creature isn’t destroyed, but the damage remains marked on the creature. If Indestructibility stops enchanting that creature later in the turn, the creature will no longer have indestructible and will be destroyed."
+          "text": "If a creature enchanted by Indestructibility is dealt lethal damage, the creature isn't destroyed, but the damage remains marked on the creature. If Indestructibility stops enchanting that creature later in the turn, the creature will no longer have indestructible and will be destroyed."
         }
       ],
       "subtypes": [
@@ -3011,19 +3029,19 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Your starting life total is the life total you began the game with, keeping in mind the format you’re playing and, in some rare cases, anything that affects your starting life total (for example, a vanguard with a life modifier)."
+          "text": "Your starting life total is the life total you began the game with, keeping in mind the format you're playing and, in some rare cases, anything that affects your starting life total (for example, a vanguard with a life modifier)."
         },
         {
           "date": "2013-07-01",
-          "text": "In most games, your starting life total is 20. In a Commander game, your starting life total is 40 instead. In a Two-Headed Giant game, Path of Bravery compares your team’s life total to your team’s starting life total, which is 30."
+          "text": "In most games, your starting life total is 20. In a Commander game, your starting life total is 40 instead. In a Two-Headed Giant game, Path of Bravery compares your team's life total to your team's starting life total, which is 30."
         },
         {
           "date": "2013-07-01",
-          "text": "Path of Bravery’s triggered ability triggers only once, after attacking creatures are declared. For example, if you attack with five creatures, you’ll gain 5 life as a single life-gain event."
+          "text": "Path of Bravery's triggered ability triggers only once, after attacking creatures are declared. For example, if you attack with five creatures, you'll gain 5 life as a single life-gain event."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enters the battlefield attacking after attacking creatures have been declared, the ability won’t trigger again because you didn’t declare that creature as an attacking creature. However, if enters the battlefield before the ability resolves, it will be counted when determining how much life is gained."
+          "text": "If a creature enters the battlefield attacking after attacking creatures have been declared, the ability won't trigger again because you didn't declare that creature as an attacking creature. However, if enters the battlefield before the ability resolves, it will be counted when determining how much life is gained."
         }
       ],
       "text": "As long as your life total is greater than or equal to your starting life total, creatures you control get +1/+1.\nWhenever one or more creatures you control attack, you gain life equal to the number of attacking creatures.",
@@ -3135,7 +3153,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Pay No Heed doesn’t target anything. You can choose a source with hexproof, for example. You choose the damage source as Pay No Heed resolves."
+          "text": "Pay No Heed doesn't target anything. You can choose a source with hexproof, for example. You choose the damage source as Pay No Heed resolves."
         },
         {
           "date": "2013-07-01",
@@ -3457,11 +3475,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -3572,7 +3590,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If Seraph of the Sword blocks a creature with trample, that creature’s controller must assign 3 damage to Seraph of the Sword (assuming it’s blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
+          "text": "If Seraph of the Sword blocks a creature with trample, that creature's controller must assign 3 damage to Seraph of the Sword (assuming it's blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
         }
       ],
       "subtypes": [
@@ -4028,7 +4046,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Silence won’t affect spells that your opponents cast before you cast Silence. (In other words, it can’t be used as a retroactive Cancel.) Silence also won’t stop your opponents from casting spells after you cast Silence but before Silence resolves."
+          "text": "Silence won't affect spells that your opponents cast before you cast Silence. (In other words, it can't be used as a retroactive Cancel.) Silence also won't stop your opponents from casting spells after you cast Silence but before Silence resolves."
         },
         {
           "date": "2009-10-01",
@@ -4141,7 +4159,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted permanent is an illegal target by the time Solemn Offering would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted permanent is an illegal target by the time Solemn Offering would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Destroy target artifact or enchantment. You gain 4 life.",
@@ -4355,11 +4373,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -4470,7 +4488,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Multiple instances of vigilance and lifelink are redundant. There’s usually no reason to activate Stonehorn Chanter’s ability more than once in a single turn."
+          "text": "Multiple instances of vigilance and lifelink are redundant. There's usually no reason to activate Stonehorn Chanter's ability more than once in a single turn."
         }
       ],
       "subtypes": [
@@ -5140,6 +5158,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Time Spiral Block",
           "legality": "Legal"
         },
@@ -5292,7 +5314,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The enchanted creature can still be untapped in other ways. Claustrophobia will remain attached, and the creature will continue to not untap during its controller’s untap step."
+          "text": "The enchanted creature can still be untapped in other ways. Claustrophobia will remain attached, and the creature will continue to not untap during its controller's untap step."
         }
       ],
       "subtypes": [
@@ -5427,7 +5449,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -5435,11 +5457,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -5447,7 +5469,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -5558,31 +5580,31 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Colossal Whale’s triggered ability triggers and resolves during the declare attackers step, before blocking creatures are declared."
+          "text": "Colossal Whale's triggered ability triggers and resolves during the declare attackers step, before blocking creatures are declared."
         },
         {
           "date": "2013-07-01",
-          "text": "Colossal Whale’s ability causes a zone change with a duration, a new style of ability that’s somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Colossal Whale have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Colossal Whale leaves the battlefield."
+          "text": "Colossal Whale's ability causes a zone change with a duration, a new style of ability that's somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Colossal Whale have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Colossal Whale leaves the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "If Colossal Whale leaves the battlefield before its triggered ability resolves, the target creature won’t be exiled."
+          "text": "If Colossal Whale leaves the battlefield before its triggered ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2013-07-01",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "The exiled card returns to the battlefield immediately after Colossal Whale leaves the battlefield. Nothing happens between the two events, including state-based actions. The two creatures aren’t on the battlefield at the same time. For example, if the returning creature is a Clone, it can’t enter the battlefield as a copy of Colossal Whale."
+          "text": "The exiled card returns to the battlefield immediately after Colossal Whale leaves the battlefield. Nothing happens between the two events, including state-based actions. The two creatures aren't on the battlefield at the same time. For example, if the returning creature is a Clone, it can't enter the battlefield as a copy of Colossal Whale."
         },
         {
           "date": "2013-07-01",
-          "text": "In a multiplayer game, if Colossal Whale’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Colossal Whale's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "subtypes": [
@@ -6139,15 +6161,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Domestication’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability triggers only if the enchanted creature’s power is 4 or greater as your end step begins, and (2) the ability does nothing if the enchanted creature’s power is 3 or less by the time it resolves."
+          "text": "Domestication's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability triggers only if the enchanted creature's power is 4 or greater as your end step begins, and (2) the ability does nothing if the enchanted creature's power is 3 or less by the time it resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "Domestication can target, and can enchant, a creature with power 4 or greater. The enchanted creature’s power is checked only when the triggered ability triggers and resolves."
+          "text": "Domestication can target, and can enchant, a creature with power 4 or greater. The enchanted creature's power is checked only when the triggered ability triggers and resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "If an effect changes the enchanted creature’s power until end of turn, it will still have the modified power during your end step."
+          "text": "If an effect changes the enchanted creature's power until end of turn, it will still have the modified power during your end step."
         }
       ],
       "subtypes": [
@@ -6256,19 +6278,19 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "You don’t choose the value of {X} in the activation cost of Elite Arcanist’s ability. It’s defined by the converted mana cost of the exiled instant card."
+          "text": "You don't choose the value of {X} in the activation cost of Elite Arcanist's ability. It's defined by the converted mana cost of the exiled instant card."
         },
         {
           "date": "2013-07-01",
-          "text": "The copy is created in and cast from exile. You must still follow any timing restrictions, such as “Cast [this spell] only during combat.”"
+          "text": "The copy is created in and cast from exile. You must still follow any timing restrictions, such as \"Cast [this spell] only during combat.\""
         },
         {
           "date": "2013-07-01",
-          "text": "You can’t pay any alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the spell has any mandatory additional costs, you must pay those."
+          "text": "You can't pay any alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the spell has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2013-07-01",
-          "text": "If the copied card has {X} in its mana cost, you must choose 0 as its value when casting the copy. Don’t confuse that {X} with the {X} in the activation cost of Elite Arcanist’s ability."
+          "text": "If the copied card has {X} in its mana cost, you must choose 0 as its value when casting the copy. Don't confuse that {X} with the {X} in the activation cost of Elite Arcanist's ability."
         },
         {
           "date": "2013-07-01",
@@ -6276,7 +6298,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Elite Arcanist leaves the battlefield, you will no longer be able to copy the exiled card. If it returns to the battlefield, you’ll be able to exile another instant card from your hand, but Elite Arcanist will be a different permanent with no connection to the first exiled card."
+          "text": "If Elite Arcanist leaves the battlefield, you will no longer be able to copy the exiled card. If it returns to the battlefield, you'll be able to exile another instant card from your hand, but Elite Arcanist will be a different permanent with no connection to the first exiled card."
         }
       ],
       "subtypes": [
@@ -6373,6 +6395,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -6395,7 +6421,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -6502,11 +6528,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If a creature affected by Frost Breath changes controllers before its old controller’s next untap step, Frost Breath will prevent it from becoming untapped during its new controller’s next untap step."
+          "text": "If a creature affected by Frost Breath changes controllers before its old controller's next untap step, Frost Breath will prevent it from becoming untapped during its new controller's next untap step."
         },
         {
           "date": "2013-04-15",
-          "text": "This spell can target tapped creatures. If a targeted creature is already tapped when the spell resolves, that creature just remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "This spell can target tapped creatures. If a targeted creature is already tapped when the spell resolves, that creature just remains tapped and doesn't untap during its controller's next untap step."
         }
       ],
       "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
@@ -6613,11 +6639,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -6938,15 +6964,15 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you target yourself with Jace’s first ability, you’ll draw a card first, then put the top card of your library into your graveyard."
+          "text": "If you target yourself with Jace's first ability, you'll draw a card first, then put the top card of your library into your graveyard."
         },
         {
           "date": "2011-09-22",
-          "text": "If you activate Jace’s first ability, and the player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If you activate Jace's first ability, and the player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         },
         {
           "date": "2011-09-22",
-          "text": "If Jace’s third ability causes a player to draw more cards than are left in his or her library, that player loses the game as a state-based action. If this ability causes all players to do this, the game is a draw."
+          "text": "If Jace's third ability causes a player to draw more cards than are left in his or her library, that player loses the game as a state-based action. If this ability causes all players to do this, the game is a draw."
         }
       ],
       "subtypes": [
@@ -7053,6 +7079,32 @@
         "DDM"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-07-01",
+          "text": "If you cast an instant or sorcery card this way, you do so while the ability of Jace's Mindseeker is resolving. If you choose not to (or can't), you won't get a chance to cast one later."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "\"From among them\" means the five cards put into the graveyard, not all cards in that graveyard."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "When casting an instant or sorcery card this way, ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this spell] only during combat,\" must be followed."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If a card has {X} in its mana cost, you must choose 0 as its value."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If the five cards are put into a public zone such as exile instead of a graveyard (perhaps due to the ability of Rest in Peace), you can cast one of those instant or sorcery cards from that zone."
+        }
+      ],
       "subtypes": [
         "Fish",
         "Illusion"
@@ -7170,11 +7222,11 @@
         },
         {
           "date": "2010-08-15",
-          "text": "After the second ability resolves, the revealed card stops being revealed in its owner’s hand."
+          "text": "After the second ability resolves, the revealed card stops being revealed in its owner's hand."
         },
         {
           "date": "2010-08-15",
-          "text": "The next time Merfolk Spy deals combat damage to the same player, the card that’s revealed at random may be the same card or may be a different card."
+          "text": "The next time Merfolk Spy deals combat damage to the same player, the card that's revealed at random may be the same card or may be a different card."
         }
       ],
       "subtypes": [
@@ -7423,7 +7475,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -7874,11 +7926,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You don’t choose a sorcery card when Quicken resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a sorcery card, even if you cast that sorcery at a time you normally could."
+          "text": "You don't choose a sorcery card when Quicken resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a sorcery card, even if you cast that sorcery at a time you normally could."
         },
         {
           "date": "2006-02-01",
-          "text": "If you cast multiple Quickens on the same turn, they’ll all apply to the very next sorcery spell you cast."
+          "text": "If you cast multiple Quickens on the same turn, they'll all apply to the very next sorcery spell you cast."
         },
         {
           "date": "2006-09-25",
@@ -7886,7 +7938,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Casting a copy of a sorcery card won’t “use up” Quicken’s effect because the copy isn’t a card."
+          "text": "Casting a copy of a sorcery card won't \"use up\" Quicken's effect because the copy isn't a card."
         }
       ],
       "text": "The next sorcery card you cast this turn can be cast as though it had flash. (It can be cast any time you could cast an instant.)\nDraw a card.",
@@ -8339,11 +8391,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -8449,7 +8501,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you lose control of Tidebinder Mage between when it entered the battlefield and when the ability resolves, the target creature will become tapped. However, it won’t be affected by the other effect and will untap as normal during its controller’s untap step."
+          "text": "If you lose control of Tidebinder Mage between when it entered the battlefield and when the ability resolves, the target creature will become tapped. However, it won't be affected by the other effect and will untap as normal during its controller's untap step."
         },
         {
           "date": "2013-07-01",
@@ -8457,11 +8509,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If you gain control of the creature that’s being prevented from untapping, that creature won’t untap during your untap step for as long as you control Tidebinder Mage."
+          "text": "If you gain control of the creature that's being prevented from untapping, that creature won't untap during your untap step for as long as you control Tidebinder Mage."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability can target a tapped creature. If the targeted creature is already tapped when it resolves, that creature just remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "The ability can target a tapped creature. If the targeted creature is already tapped when it resolves, that creature just remains tapped and doesn't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -8685,7 +8737,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than five cards in the targeted player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than five cards in the targeted player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "text": "Target player puts the top five cards of his or her library into his or her graveyard.",
@@ -9018,11 +9070,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Frost’s ability tracks the creature, not the creature’s controller. That is, if the creature changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "Wall of Frost's ability tracks the creature, not the creature's controller. That is, if the creature changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-07-18",
-          "text": "If the creature isn’t tapped during its controller’s next untap step (perhaps because it was untapped by a spell), Wall of Frost’s ability has no effect at that time. It won’t try to keep the creature tapped on subsequent turns."
+          "text": "If the creature isn't tapped during its controller's next untap step (perhaps because it was untapped by a spell), Wall of Frost's ability has no effect at that time. It won't try to keep the creature tapped on subsequent turns."
         }
       ],
       "subtypes": [
@@ -9134,11 +9186,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A creature spell that doesn’t have flying won’t cost less even if the creature it will become will have flying once on the battlefield. For example, if you control an Island and Wonder is in your graveyard, creature spells won’t cost {1} less even though those creatures will have flying once they’re on the battlefield."
+          "text": "A creature spell that doesn't have flying won't cost less even if the creature it will become will have flying once on the battlefield. For example, if you control an Island and Wonder is in your graveyard, creature spells won't cost {1} less even though those creatures will have flying once they're on the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability can’t reduce the colored mana requirement of a creature spell with flying."
+          "text": "The ability can't reduce the colored mana requirement of a creature spell with flying."
         }
       ],
       "subtypes": [
@@ -9252,7 +9304,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You can activate Water Servant’s second ability even if doing so would cause Water Servant’s power to be less than 0."
+          "text": "You can activate Water Servant's second ability even if doing so would cause Water Servant's power to be less than 0."
         }
       ],
       "subtypes": [
@@ -9363,15 +9415,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "It doesn’t matter who controls the creature with flying or what player or planeswalker that creature is attacking."
+          "text": "It doesn't matter who controls the creature with flying or what player or planeswalker that creature is attacking."
         },
         {
           "date": "2013-07-01",
-          "text": "Windreader Sphinx’s ability will trigger when it itself attacks."
+          "text": "Windreader Sphinx's ability will trigger when it itself attacks."
         },
         {
           "date": "2013-07-01",
-          "text": "The creature must have flying when declared as an attacking creature in order for Windreader Sphinx’s ability to trigger. For example, attacking with Trained Condor (a creature with flying and “Whenever Trained Condor attacks, another target creature you control gains flying until end of turn.”) and a creature without flying will cause the ability to trigger only once."
+          "text": "The creature must have flying when declared as an attacking creature in order for Windreader Sphinx's ability to trigger. For example, attacking with Trained Condor (a creature with flying and \"Whenever Trained Condor attacks, another target creature you control gains flying until end of turn.\") and a creature without flying will cause the ability to trigger only once."
         }
       ],
       "subtypes": [
@@ -9813,6 +9865,24 @@
         "M14"
       ],
       "rarity": "Uncommon",
+      "rulings": [
+        {
+          "date": "2013-07-01",
+          "text": "The ability checks to see if the enchanted Equipment is attached to a creature as your upkeep begins. If it's not, the ability won't trigger at all. If it is, the ability will check again as it tries to resolve. If the enchanted Equipment isn't attached to a creature at that time, the ability won't do anything."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "This ability triggers at the beginning of the upkeep of the controller of Artificer's Hex, not the upkeep of the controller of the enchanted Equipment or the creature that Equipment is attached to."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "Players can't pay an Equipment's equip cost to unattach that Equipment to stop Artificer's Hex from destroying a creature."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "In some rare cases, the creature the enchanted Equipment is attached to as the ability resolves isn't the same one as the one it was attached to when it triggered. In such a case, the creature the Equipment is attached to when the ability resolves is destroyed."
+        }
+      ],
       "subtypes": [
         "Aura"
       ],
@@ -9921,15 +9991,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you are the only player who controls a creature when Blightcaster’s ability triggers, you must choose one as the target, although you can choose not to give it -2/-2."
+          "text": "If you are the only player who controls a creature when Blightcaster's ability triggers, you must choose one as the target, although you can choose not to give it -2/-2."
         },
         {
           "date": "2015-06-22",
-          "text": "Blightcaster’s ability will resolve before the enchantment spell that caused it to trigger."
+          "text": "Blightcaster's ability will resolve before the enchantment spell that caused it to trigger."
         },
         {
           "date": "2015-06-22",
-          "text": "If you are the only player who controls a creature when Blightcaster’s ability triggers, you must choose one of those creatures as the target, although you can choose to not give it -2/-2."
+          "text": "If you are the only player who controls a creature when Blightcaster's ability triggers, you must choose one of those creatures as the target, although you can choose to not give it -2/-2."
         }
       ],
       "subtypes": [
@@ -10148,7 +10218,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "You don’t have to declare which card you’re searching for when you activate the ability."
+          "text": "You don't have to declare which card you're searching for when you activate the ability."
         },
         {
           "date": "2013-07-01",
@@ -10506,7 +10576,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -10618,7 +10688,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If the creature targeted by Dark Favor is an illegal target when Dark Favor tries to resolve, Dark Favor will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the creature targeted by Dark Favor is an illegal target when Dark Favor tries to resolve, Dark Favor will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -11500,11 +11570,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "You can choose a creature card in any player’s graveyard as long as that card was put there from the battlefield during the turn. A creature card that was put into a graveyard from anywhere else, such as a card that was discarded, can’t be chosen as the target."
+          "text": "You can choose a creature card in any player's graveyard as long as that card was put there from the battlefield during the turn. A creature card that was put into a graveyard from anywhere else, such as a card that was discarded, can't be chosen as the target."
         },
         {
           "date": "2013-07-01",
-          "text": "Creature spells that are countered never entered the battlefield, so those cards can’t be chosen as the target of Grim Return."
+          "text": "Creature spells that are countered never entered the battlefield, so those cards can't be chosen as the target of Grim Return."
         }
       ],
       "text": "Choose target creature card in a graveyard that was put there from the battlefield this turn. Put that card onto the battlefield under your control.",
@@ -11717,25 +11787,25 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can activate Liliana’s first ability even if your library contains no Swamp cards (or you don’t want to find one). You’ll still search your library and shuffle it."
+          "text": "You can activate Liliana's first ability even if your library contains no Swamp cards (or you don't want to find one). You'll still search your library and shuffle it."
         },
         {
           "date": "2012-07-01",
-          "text": "When you activate Liliana’s second ability, you choose only the target creature. You choose whether that creature gets +X/+X or -X/-X when the ability resolves. The value of X is determined by the number of Swamps you control when the ability resolves."
+          "text": "When you activate Liliana's second ability, you choose only the target creature. You choose whether that creature gets +X/+X or -X/-X when the ability resolves. The value of X is determined by the number of Swamps you control when the ability resolves."
         },
         {
           "date": "2012-07-01",
-          "text": "Liliana’s emblem doesn’t remove any other abilities of Swamps you control."
+          "text": "Liliana's emblem doesn't remove any other abilities of Swamps you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Each of Liliana’s abilities refers to lands (or land cards) with the subtype Swamp, not just ones named Swamp."
+          "text": "Each of Liliana's abilities refers to lands (or land cards) with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
         "Liliana"
       ],
-      "text": "+1: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.\n−3: Target creature gets +X/+X or -X/-X until end of turn, where X is the number of Swamps you control.\n−6: You get an emblem with \"Swamps you control have ‘{T}: Add {B}{B}{B}{B} to your mana pool.'\"",
+      "text": "+1: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.\n−3: Target creature gets +X/+X or -X/-X until end of turn, where X is the number of Swamps you control.\n−6: You get an emblem with \"Swamps you control have '{T}: Add {B}{B}{B}{B} to your mana pool.'\"",
       "type": "Planeswalker — Liliana",
       "types": [
         "Planeswalker"
@@ -11836,6 +11906,12 @@
         "C14"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-07-01",
+          "text": "If the player's hand is empty when the triggered ability resolves, you'll still put a Zombie token onto the battlefield."
+        }
+      ],
       "subtypes": [
         "Zombie"
       ],
@@ -11943,11 +12019,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Liturgy of Blood isn’t a mana ability and uses the stack. Players can respond to it by casting spells and activating abilities."
+          "text": "Liturgy of Blood isn't a mana ability and uses the stack. Players can respond to it by casting spells and activating abilities."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target creature is an illegal target when Liturgy of Blood tries to resolve, it will be countered and none of its effects will happen. You won’t add mana to your mana pool."
+          "text": "If the target creature is an illegal target when Liturgy of Blood tries to resolve, it will be countered and none of its effects will happen. You won't add mana to your mana pool."
         }
       ],
       "text": "Destroy target creature. Add {B}{B}{B} to your mana pool.",
@@ -11965,7 +12041,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"My ‘condition' is a trial. The weak are consumed by it. The strong transcend it.\"\n—Sorin Markov",
+      "flavor": "\"My 'condition' is a trial. The weak are consumed by it. The strong transcend it.\"\n—Sorin Markov",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -12055,7 +12131,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Multiple instances of lifelink are redundant. If Mark of the Vampire enchants a creature that already has lifelink, damage that creature deals won’t cause you to gain additional life."
+          "text": "multiple instances of lifelink on the same creature are redundant. If Mark of the Vampire enchants a creature that already has lifelink, damage that creature deals won't cause you to gain additional life."
         }
       ],
       "subtypes": [
@@ -12425,19 +12501,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -12655,7 +12731,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "This ability counts the number of Swamps controlled by Quag Sickness’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability counts the number of Swamps controlled by Quag Sickness's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2010-08-15",
@@ -12874,7 +12950,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Sanguine Bond’s ability triggers just once for each life-gaining event, whether it’s 1 life from Soul Warden or 8 life from Tendrils of Corruption."
+          "text": "Sanguine Bond's ability triggers just once for each life-gaining event, whether it's 1 life from Soul Warden or 8 life from Tendrils of Corruption."
         }
       ],
       "text": "Whenever you gain life, target opponent loses that much life.",
@@ -13009,15 +13085,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -13127,15 +13203,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Shadowborn Apostle’s first ability lets you ignore only the “four-of” rule. It doesn’t let you ignore format legality."
+          "text": "Shadowborn Apostle's first ability lets you ignore only the \"four-of\" rule. It doesn't let you ignore format legality."
         },
         {
           "date": "2013-07-01",
-          "text": "You sacrifice the six creatures when you activate the ability. You can’t respond to that ability by activating the ability of one of the other Shadowborn Apostles you just sacrificed."
+          "text": "You sacrifice the six creatures when you activate the ability. You can't respond to that ability by activating the ability of one of the other Shadowborn Apostles you just sacrificed."
         },
         {
           "date": "2013-07-01",
-          "text": "You don’t have to sacrifice the Shadowborn Apostle whose ability you activated. It can be six other Shadowborn Apostles."
+          "text": "You don't have to sacrifice the Shadowborn Apostle whose ability you activated. It can be six other Shadowborn Apostles."
         }
       ],
       "subtypes": [
@@ -13246,11 +13322,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Shadowborn Demon’s enters-the-battlefield ability is mandatory. If you control the only non-Demon creature, you must choose it as the target."
+          "text": "Shadowborn Demon's enters-the-battlefield ability is mandatory. If you control the only non-Demon creature, you must choose it as the target."
         },
         {
           "date": "2013-07-01",
-          "text": "The last ability checks whether you have fewer than six creature cards in your graveyard when it would trigger. If you have six or more, it won’t trigger at all. The ability will check again when it tries to resolve. If at that time you have six or more, the ability won’t do anything."
+          "text": "The last ability checks whether you have fewer than six creature cards in your graveyard when it would trigger. If you have six or more, it won't trigger at all. The ability will check again when it tries to resolve. If at that time you have six or more, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -13473,11 +13549,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -13588,11 +13664,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "You decide whether to pay {1}{B} when the ability resolves. If you choose not to, you won’t get another chance later."
+          "text": "You decide whether to pay {1}{B} when the ability resolves. If you choose not to, you won't get another chance later."
         },
         {
           "date": "2013-07-01",
-          "text": "If you control a Tenacious Dead owned by another player when it dies, you’ll control the triggered ability. However, if you choose to pay {1}{B}, it will be put onto the battlefield under its owner’s control."
+          "text": "If you control a Tenacious Dead owned by another player when it dies, you'll control the triggered ability. However, if you choose to pay {1}{B}, it will be put onto the battlefield under its owner's control."
         }
       ],
       "subtypes": [
@@ -13808,7 +13884,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Activating Vampire Warlord’s ability causes a “regeneration shield” to be created for it. The next time that creature would be destroyed that turn, the regeneration shield is used up instead. This works only if the creature is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to “destroy” it. Other effects that cause the creature to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don’t destroy it, so regeneration won’t save it. If the regeneration shield isn’t used, it goes away as the turn ends."
+          "text": "Activating Vampire Warlord's ability causes a \"regeneration shield\" to be created for it. The next time that creature would be destroyed that turn, the regeneration shield is used up instead. This works only if the creature is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to \"destroy\" it. Other effects that cause the creature to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don't destroy it, so regeneration won't save it. If the regeneration shield isn't used, it goes away as the turn ends."
         },
         {
           "date": "2013-07-01",
@@ -13928,7 +14004,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If the creature card is an illegal target when Vile Rebirth tries to resolve, it will be countered and none of its effects will happen. You won’t put a Zombie token onto the battlefield."
+          "text": "If the creature card is an illegal target when Vile Rebirth tries to resolve, it will be countered and none of its effects will happen. You won't put a Zombie token onto the battlefield."
         }
       ],
       "text": "Exile target creature card from a graveyard. Create a 2/2 black Zombie creature token.",
@@ -14375,15 +14451,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Act of Treason can target any creature, even one that’s untapped or one you already control."
+          "text": "Act of Treason can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2013-07-01",
-          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you’ll choose one to remain on the battlefield and put the other into its owner’s graveyard."
+          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you'll choose one to remain on the battlefield and put the other into its owner's graveyard."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
@@ -14497,15 +14573,15 @@
         },
         {
           "date": "2013-07-01",
-          "text": "This doesn’t count as a creature entering the battlefield. The Mountain was already on the battlefield; it only changed types."
+          "text": "This doesn't count as a creature entering the battlefield. The Mountain was already on the battlefield; it only changed types."
         },
         {
           "date": "2013-07-01",
-          "text": "If the enchanted Mountain stops being a Mountain for any reason, Awaken the Ancient will be put into its owner’s graveyard as a state-based action."
+          "text": "If the enchanted Mountain stops being a Mountain for any reason, Awaken the Ancient will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2013-07-01",
-          "text": "Copies of the enchanted Mountain won’t be 7/7 red Giant creatures with haste. For example, if Awaken the Ancient is enchanting a basic Mountain, a copy of that creature would just be a basic Mountain."
+          "text": "Copies of the enchanted Mountain won't be 7/7 red Giant creatures with haste. For example, if Awaken the Ancient is enchanting a basic Mountain, a copy of that creature would just be a basic Mountain."
         }
       ],
       "subtypes": [
@@ -14725,11 +14801,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -14844,11 +14920,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -14958,7 +15034,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "To tap a land for mana is to activate one of that land’s mana abilities that has {T} in its activation cost and produces mana as it resolves."
+          "text": "To tap a land for mana is to activate one of that land's mana abilities that has {T} in its activation cost and produces mana as it resolves."
         },
         {
           "date": "2013-07-01",
@@ -14966,7 +15042,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If any nonbasic lands are tapped for mana while a player is casting a spell or activating an ability, Burning Earth’s ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, Burning Earth’s triggered abilities are put on the stack on top of it. Burning Earth’s abilities will resolve first."
+          "text": "If any nonbasic lands are tapped for mana while a player is casting a spell or activating an ability, Burning Earth's ability will trigger that many times and wait. When the player finishes casting that spell or activating that ability, Burning Earth's triggered abilities are put on the stack on top of it. Burning Earth's abilities will resolve first."
         },
         {
           "date": "2013-07-01",
@@ -15195,31 +15271,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If the first ability resolves but the damage is prevented or redirected, the target creature still won’t be able to block that turn."
+          "text": "If the first ability resolves but the damage is prevented or redirected, the target creature still won't be able to block that turn."
         },
         {
           "date": "2014-07-18",
-          "text": "The card exiled by the second ability is exiled face up. Playing it follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if it’s a creature card, you can cast it only during your main phase while the stack is empty."
+          "text": "The card exiled by the second ability is exiled face up. Playing it follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if it's a creature card, you can cast it only during your main phase while the stack is empty."
         },
         {
           "date": "2014-07-18",
-          "text": "If you exile a land card using the second ability, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven’t played a land yet that turn."
+          "text": "If you exile a land card using the second ability, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven't played a land yet that turn."
         },
         {
           "date": "2014-07-18",
-          "text": "In the third ability, “exiled this way” means the cards you just exiled because of that ability resolving. Cards exiled with the second ability or with previous activations of the third ability don’t count."
+          "text": "In the third ability, \"exiled this way\" means the cards you just exiled because of that ability resolving. Cards exiled with the second ability or with previous activations of the third ability don't count."
         },
         {
           "date": "2014-07-18",
-          "text": "While resolving the third ability, you create the copies of the card in exile and cast them from exile. You can cast zero, one, two, or all three copies. The card itself isn’t cast. It remains exiled."
+          "text": "While resolving the third ability, you create the copies of the card in exile and cast them from exile. You can cast zero, one, two, or all three copies. The card itself isn't cast. It remains exiled."
         },
         {
           "date": "2014-07-18",
-          "text": "While casting the copies created by the third ability, timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” are not."
+          "text": "While casting the copies created by the third ability, timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" are not."
         },
         {
           "date": "2014-07-18",
-          "text": "Because you’re casting the copies “without paying their mana costs,” you can’t pay any alternative costs for the copies. You can pay additional costs, such as kicker costs. If the copies have any mandatory additional costs, you must pay those."
+          "text": "Because you're casting the copies \"without paying their mana costs,\" you can't pay any alternative costs for the copies. You can pay additional costs, such as kicker costs. If the copies have any mandatory additional costs, you must pay those."
         },
         {
           "date": "2014-07-18",
@@ -15337,7 +15413,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target creature is an illegal target by the time Chandra’s Outrage resolves, the entire spell is countered. No player is dealt damage."
+          "text": "If the target creature is an illegal target by the time Chandra's Outrage resolves, the entire spell is countered. No player is dealt damage."
         }
       ],
       "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
@@ -15551,7 +15627,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If Cyclops Tyrant blocks a creature with power 3 or greater, and then that creature’s power becomes 2 or less, Cyclops Tyrant continues to block that creature."
+          "text": "If Cyclops Tyrant blocks a creature with power 3 or greater, and then that creature's power becomes 2 or less, Cyclops Tyrant continues to block that creature."
         }
       ],
       "subtypes": [
@@ -16012,7 +16088,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "You can’t deal damage to both a player and a planeswalker controlled by that player with Flames of the Firebrand."
+          "text": "You can't deal damage to both a player and a planeswalker controlled by that player with Flames of the Firebrand."
         }
       ],
       "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
@@ -16123,7 +16199,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the target creature’s toughness is greater than 2 when the ability tries to resolve, the ability will be countered and the creature won’t be destroyed."
+          "text": "If the target creature's toughness is greater than 2 when the ability tries to resolve, the ability will be countered and the creature won't be destroyed."
         }
       ],
       "subtypes": [
@@ -16243,7 +16319,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -16692,15 +16768,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Marauding Maulhorn can attack if you control a creature named Advocate of the Beast. It just isn’t forced to."
+          "text": "Marauding Maulhorn can attack if you control a creature named Advocate of the Beast. It just isn't forced to."
         },
         {
           "date": "2013-07-01",
-          "text": "Marauding Maulhorn checks whether you control a creature named Advocate of the Beast as attacking creatures are declared. At that time, if you don’t, Marauding Maulhorn attacks if able."
+          "text": "Marauding Maulhorn checks whether you control a creature named Advocate of the Beast as attacking creatures are declared. At that time, if you don't, Marauding Maulhorn attacks if able."
         },
         {
           "date": "2013-07-01",
-          "text": "If, during your declare attackers step, Marauding Maulhorn is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under your control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having Marauding Maulhorn attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Marauding Maulhorn is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under your control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having Marauding Maulhorn attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -16810,7 +16886,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Mindsparker’s ability will trigger whenever an opponent casts an instant or sorcery spell that’s white, blue, or both. If the spell is both white and blue, Mindsparker’s ability will trigger only once."
+          "text": "Mindsparker's ability will trigger whenever an opponent casts an instant or sorcery spell that's white, blue, or both. If the spell is both white and blue, Mindsparker's ability will trigger only once."
         },
         {
           "date": "2013-07-01",
@@ -16924,7 +17000,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you win the flip, Molten Birth goes directly from the stack to its owner’s hand. It never goes to a graveyard."
+          "text": "If you win the flip, Molten Birth goes directly from the stack to its owner's hand. It never goes to a graveyard."
         }
       ],
       "text": "Create two 1/1 red Elemental creature tokens. Then flip a coin. If you win the flip, return Molten Birth to its owner's hand.",
@@ -17577,11 +17653,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Only Shiv’s Embrace’s controller (who is not necessarily the enchanted creature’s controller) can activate its activated ability."
+          "text": "Only Shiv's Embrace's controller (who is not necessarily the enchanted creature's controller) can activate its activated ability."
         },
         {
           "date": "2010-08-15",
-          "text": "When Shiv’s Embrace’s activated ability resolves, the creature Shiv’s Embrace is enchanting at that time will get +1/+0 (regardless of what creature Shiv’s Embrace was enchanting when the ability was activated). If Shiv’s Embrace has left the battlefield by then, the creature it was enchanting at the time it left the battlefield will get +1/+0."
+          "text": "When Shiv's Embrace's activated ability resolves, the creature Shiv's Embrace is enchanting at that time will get +1/+0 (regardless of what creature Shiv's Embrace was enchanting when the ability was activated). If Shiv's Embrace has left the battlefield by then, the creature it was enchanting at the time it left the battlefield will get +1/+0."
         }
       ],
       "subtypes": [
@@ -18052,15 +18128,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If Striking Sliver leaves the battlefield after Sliver creatures you control have dealt first-strike damage but before regular combat damage, those Slivers won’t deal regular combat damage (unless they have double strike for some reason)."
+          "text": "If Striking Sliver leaves the battlefield after Sliver creatures you control have dealt first-strike damage but before regular combat damage, those Slivers won't deal regular combat damage (unless they have double strike for some reason)."
         },
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -18175,11 +18251,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -18294,7 +18370,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "If a creature doesn’t have first strike, granting it first strike after combat damage has been dealt in the first-strike combat damage step won’t prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
+          "text": "If a creature doesn't have first strike, granting it first strike after combat damage has been dealt in the first-strike combat damage step won't prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
         }
       ],
       "text": "Target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
@@ -18510,7 +18586,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Because discarding a card is an additional cost, you can’t cast Wild Guess if you have no other cards in hand."
+          "text": "Because discarding a card is an additional cost, you can't cast Wild Guess if you have no other cards in hand."
         }
       ],
       "text": "As an additional cost to cast Wild Guess, discard a card.\nDraw two cards.",
@@ -18623,19 +18699,19 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Wild Ricochet can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Wild Ricochet can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2013-07-01",
-          "text": "When Wild Ricochet resolves, it creates a copy of a spell. You control the copy. The controller of the original spell retains control of that spell. The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. The copy resolves before the original spell."
+          "text": "When Wild Ricochet resolves, it creates a copy of a spell. You control the copy. The controller of the original spell retains control of that spell. The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. The copy resolves before the original spell."
         },
         {
           "date": "2013-07-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2013-07-01",
-          "text": "If the spell Wild Ricochet copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Wild Ricochet copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2013-07-01",
@@ -18643,11 +18719,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Wild Ricochet, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Wild Ricochet, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2013-07-01",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
@@ -18756,7 +18832,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Young Pyromancer’s triggered ability will resolve before the spell that caused it to trigger, but after targets have been chosen for that spell."
+          "text": "Young Pyromancer's triggered ability will resolve before the spell that caused it to trigger, but after targets have been chosen for that spell."
         }
       ],
       "subtypes": [
@@ -18868,7 +18944,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you don’t control any Beast creatures as your end step begins, the ability will be removed from the stack and will have no effect."
+          "text": "If you don't control any Beast creatures as your end step begins, the ability will be removed from the stack and will have no effect."
         }
       ],
       "subtypes": [
@@ -19197,7 +19273,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking Brindle Boar during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but Brindle Boar is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking Brindle Boar during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but Brindle Boar is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -19759,7 +19835,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If you have Garruk’s emblem, the creature card you search for will be put onto the battlefield before the creature spell you cast resolves. The creature card you put onto the battlefield isn’t cast, so the ability of the emblem won’t retrigger."
+          "text": "If you have Garruk's emblem, the creature card you search for will be put onto the battlefield before the creature spell you cast resolves. The creature card you put onto the battlefield isn't cast, so the ability of the emblem won't retrigger."
         }
       ],
       "subtypes": [
@@ -19871,23 +19947,23 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Normally, Garruk’s Horde allows you to cast the top card of your library if it’s a creature card, it’s your main phase, and the stack is empty. If that creature card has flash, you’ll be able to cast it at the time you could cast an instant, even on an opponent’s turn."
+          "text": "Normally, Garruk's Horde allows you to cast the top card of your library if it's a creature card, it's your main phase, and the stack is empty. If that creature card has flash, you'll be able to cast it at the time you could cast an instant, even on an opponent's turn."
         },
         {
           "date": "2011-09-22",
-          "text": "You’ll still pay all costs for that spell, including additional costs. You may also pay alternative costs."
+          "text": "You'll still pay all costs for that spell, including additional costs. You may also pay alternative costs."
         },
         {
           "date": "2011-09-22",
-          "text": "If the top card of your library is Dryad Arbor (the only card that’s both a creature and a land), you can’t play it this way. Dryad Arbor can’t be cast as a spell."
+          "text": "If the top card of your library is Dryad Arbor (the only card that's both a creature and a land), you can't play it this way. Dryad Arbor can't be cast as a spell."
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -20124,6 +20200,10 @@
         },
         {
           "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -20383,11 +20463,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -20628,16 +20708,8 @@
       "rarity": "Common",
       "rulings": [
         {
-          "date": "2014-11-24",
-          "text": "If either target is an illegal target as Hunt the Weak tries to resolve, neither creature will deal or be dealt damage."
-        },
-        {
-          "date": "2014-11-24",
-          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won’t put a +1/+1 counter on it. If that creature is a legal target but the creature you don’t control isn’t, you’ll still put the counter on the creature you control."
-        },
-        {
           "date": "2016-09-20",
-          "text": "You can’t cast Hunt the Weak unless you choose both a creature you control and a creature you don’t control as targets."
+          "text": "You can't cast Hunt the Weak unless you choose both a creature you control and a creature you don't control as targets."
         },
         {
           "date": "2016-09-20",
@@ -20645,7 +20717,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won’t put a +1/+1 counter on it. If that creature is a legal target but the other creature isn’t, you’ll still put the counter on the creature you control."
+          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won't put a +1/+1 counter on it. If that creature is a legal target but the other creature isn't, you'll still put the counter on the creature you control."
         }
       ],
       "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
@@ -20751,11 +20823,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Putting a land onto the battlefield this way doesn’t count as playing a land. You’ll still be able to play a land during one of your main phases."
+          "text": "Putting a land onto the battlefield this way doesn't count as playing a land. You'll still be able to play a land during one of your main phases."
         },
         {
           "date": "2013-07-01",
-          "text": "If the card is not a land card, or you choose not to put it onto the battlefield, it will stay on top of your library. In most cases, you’ll then draw it during your draw step."
+          "text": "If the card is not a land card, or you choose not to put it onto the battlefield, it will stay on top of your library. In most cases, you'll then draw it during your draw step."
         }
       ],
       "text": "At the beginning of your upkeep, look at the top card of your library. If it's a land card, you may put it onto the battlefield.",
@@ -20863,7 +20935,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "To double the number of +1/+1 counters on a creature, determine how many +1/+1 counters are on the creature and put that many more on it. Effects that interact with counters (such as the one created by Corpsejack Menace’s ability) may change the number of counters ultimately put on the creature."
+          "text": "To double the number of +1/+1 counters on a creature, determine how many +1/+1 counters are on the creature and put that many more on it. Effects that interact with counters (such as the one created by Corpsejack Menace's ability) may change the number of counters ultimately put on the creature."
         }
       ],
       "subtypes": [
@@ -21082,7 +21154,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
@@ -21189,11 +21261,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -21305,11 +21377,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -21559,7 +21631,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If the enchantment that enters the battlefield is somehow also a creature, you may choose it as the target of Oath of the Ancient Wood’s ability."
+          "text": "If the enchantment that enters the battlefield is somehow also a creature, you may choose it as the target of Oath of the Ancient Wood's ability."
         }
       ],
       "text": "Whenever Oath of the Ancient Wood or another enchantment enters the battlefield under your control, you may put a +1/+1 counter on target creature.",
@@ -21784,11 +21856,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -22119,7 +22191,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -22331,15 +22403,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "You don’t choose a creature card when Savage Summoning resolves. Rather, it applies to the next creature card you cast that turn, even if you cast it at a time when you normally could cast a creature and even if you cast it from a zone other than your hand."
+          "text": "You don't choose a creature card when Savage Summoning resolves. Rather, it applies to the next creature card you cast that turn, even if you cast it at a time when you normally could cast a creature and even if you cast it from a zone other than your hand."
         },
         {
           "date": "2013-07-01",
-          "text": "If you cast multiple Savage Summonings in succession, they’ll apply to the next creature spell you cast. That creature will enter the battlefield with that many additional +1/+1 counters on it."
+          "text": "If you cast multiple Savage Summonings in succession, they'll apply to the next creature spell you cast. That creature will enter the battlefield with that many additional +1/+1 counters on it."
         },
         {
           "date": "2013-07-01",
-          "text": "Spells that would counter Savage Summoning or the relevant creature spell can still be cast. They won’t counter the spell, but any additional effects they have will happen."
+          "text": "Spells that would counter Savage Summoning or the relevant creature spell can still be cast. They won't counter the spell, but any additional effects they have will happen."
         }
       ],
       "text": "Savage Summoning can't be countered.\nThe next creature card you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.",
@@ -22450,7 +22522,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. No +1/+1 counter will be put on Scavenging Ooze and you won’t gain life. Notably, this means that if you activate Scavenging Ooze’s ability multiple times targeting the same creature card, only the first instance of the ability to resolve will have any effect."
+          "text": "If the target card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. No +1/+1 counter will be put on Scavenging Ooze and you won't gain life. Notably, this means that if you activate Scavenging Ooze's ability multiple times targeting the same creature card, only the first instance of the ability to resolve will have any effect."
         }
       ],
       "subtypes": [
@@ -22561,7 +22633,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Sporemound’s ability triggers whenever you play a land and also whenever a land enters the battlefield under your control for some other reason, such as the ability of Into the Wilds."
+          "text": "Sporemound's ability triggers whenever you play a land and also whenever a land enters the battlefield under your control for some other reason, such as the ability of Into the Wilds."
         }
       ],
       "subtypes": [
@@ -22671,7 +22743,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Activating the ability granted to the enchanted creature causes a “regeneration shield” to be created for it. The next time that creature would be destroyed that turn, the regeneration shield is used up instead. This works only if the creature is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to “destroy” it. Other effects that cause the creature to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don’t destroy it, so regeneration won’t save it. If it hasn’t been used, the regeneration shield goes away as the turn ends."
+          "text": "Activating the ability granted to the enchanted creature causes a \"regeneration shield\" to be created for it. The next time that creature would be destroyed that turn, the regeneration shield is used up instead. This works only if the creature is dealt lethal damage, dealt damage from a source with deathtouch, or affected by a spell or ability that says to \"destroy\" it. Other effects that cause the creature to be put into the graveyard (such as reducing its toughness to 0 or sacrificing it) don't destroy it, so regeneration won't save it. If it hasn't been used, the regeneration shield goes away as the turn ends."
         },
         {
           "date": "2011-09-22",
@@ -22792,7 +22864,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "The ability that triggers when Vastwood Hydra dies doesn’t target any of the creatures. You can choose to put counters on a creature with protection from green, for example."
+          "text": "The ability that triggers when Vastwood Hydra dies doesn't target any of the creatures. You can choose to put counters on a creature with protection from green, for example."
         },
         {
           "date": "2013-07-01",
@@ -22915,7 +22987,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If the land targeted by Verdant Haven is an illegal target when Verdan Haven tries to resolve, Verdant Haven will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the land targeted by Verdant Haven is an illegal target when Verdan Haven tries to resolve, Verdant Haven will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -23025,11 +23097,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Voracious Wurm’s ability checks how much life you’ve gained during the turn, not what your life total is compared to what it was when the turn began. For example, if you start the turn at 10 life, gain 6 life during the turn, then lose 6 life later that turn, Voracious Wurm will enter the battlefield with six +1/+1 counters."
+          "text": "Voracious Wurm's ability checks how much life you've gained during the turn, not what your life total is compared to what it was when the turn began. For example, if you start the turn at 10 life, gain 6 life during the turn, then lose 6 life later that turn, Voracious Wurm will enter the battlefield with six +1/+1 counters."
         },
         {
           "date": "2013-07-01",
-          "text": "In a Two-Headed Giant game, life gained by your teammate isn’t considered, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate isn't considered, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -23251,7 +23323,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If an opponent casts a copy of a card that’s blue or black during your turn (as opposed to putting a copy of such a spell directly on the stack), the ability will also trigger. Check for the word “cast” in the effect that creates the copy."
+          "text": "If an opponent casts a copy of a card that's blue or black during your turn (as opposed to putting a copy of such a spell directly on the stack), the ability will also trigger. Check for the word \"cast\" in the effect that creates the copy."
         }
       ],
       "subtypes": [
@@ -23974,19 +24046,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Paying the activation cost of Elixir of Immortality’s ability doesn’t cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
+          "text": "Paying the activation cost of Elixir of Immortality's ability doesn't cause it to leave the battlefield. If you have a way to untap it, you can activate the ability multiple times in response to itself."
         },
         {
           "date": "2011-09-22",
-          "text": "As the ability resolves, you’ll shuffle Elixir of Immortality into its owner’s library directly from the battlefield, if it’s still there."
+          "text": "As the ability resolves, you'll shuffle Elixir of Immortality into its owner's library directly from the battlefield, if it's still there."
         },
         {
           "date": "2011-09-22",
-          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you’ll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it’s anywhere else by that time, including in another player’s graveyard, it remains where it is and you shuffle just your graveyard into your library."
+          "text": "If Elixir of Immortality is in your graveyard at the time the ability resolves, you'll still wind up shuffling it into your library because you shuffle your entire graveyard into your library. If it's anywhere else by that time, including in another player's graveyard, it remains where it is and you shuffle just your graveyard into your library."
         },
         {
           "date": "2011-09-22",
-          "text": "If you gain control of another player’s Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner’s library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
+          "text": "If you gain control of another player's Elixir of Immortality and activate it, the Elixir of Immortality will be shuffled into its owner's library and the cards in your graveyard will be shuffled into your library. You are considered to have shuffled each affected library (even if, as a shortcut, each player physically shuffles his or her own library)."
         }
       ],
       "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
@@ -24189,7 +24261,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "The effect of Guardian of the Ages’s triggered ability doesn’t wear off as the turn ends. Losing defender and gaining trample last indefinitely."
+          "text": "The effect of Guardian of the Ages's triggered ability doesn't wear off as the turn ends. Losing defender and gaining trample last indefinitely."
         },
         {
           "date": "2013-07-01",
@@ -24298,15 +24370,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Although you must control no creatures to activate the “animation” ability, having a creature somehow come under your control in response to that ability won’t stop it from resolving."
+          "text": "Although you must control no creatures to activate the \"animation\" ability, having a creature somehow come under your control in response to that ability won't stop it from resolving."
         },
         {
           "date": "2014-07-18",
-          "text": "It’s possible to activate the first activated ability of Haunted Plate Mail in response to activating the first ability of another Haunted Plate Mail and have them both become creatures until end of turn."
+          "text": "It's possible to activate the first activated ability of Haunted Plate Mail in response to activating the first ability of another Haunted Plate Mail and have them both become creatures until end of turn."
         },
         {
           "date": "2014-07-18",
-          "text": "You can activate the equip ability of Haunted Plate Mail while it isn’t an Equipment, but the ability will have no effect. Haunted Plate Mail won’t become attached to any creature."
+          "text": "You can activate the equip ability of Haunted Plate Mail while it isn't an Equipment, but the ability will have no effect. Haunted Plate Mail won't become attached to any creature."
         }
       ],
       "subtypes": [
@@ -24523,6 +24595,20 @@
         "M14"
       ],
       "rarity": "Rare",
+      "rulings": [
+        {
+          "date": "2013-07-01",
+          "text": "Pyromancer's Gauntlet doesn't change the source or recipient of the damage."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If all damage from a source is prevented (because of Pay No Heed, for example) or if a source would deal 0 damage, the effect of Pyromancer's Gauntlet will not apply as that source is no longer dealing damage."
+        },
+        {
+          "date": "2013-07-01",
+          "text": "If damage is being dealt to multiple players and/or permanents at the same time, the damage being dealt to each one is increased by 2."
+        }
+      ],
       "text": "If a red instant or sorcery spell you control or a red planeswalker you control would deal damage to a permanent or player, it deals that much damage plus 2 to that permanent or player instead.",
       "type": "Artifact",
       "types": [
@@ -24625,23 +24711,23 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Ratchet Bomb’s last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
+          "text": "As Ratchet Bomb's last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
         },
         {
           "date": "2011-01-01",
-          "text": "Ratchet Bomb’s second ability destroys only those nonland permanents whose converted mana cost is exactly equal to the number of charge counters on Ratchet Bomb. It doesn’t matter who controls them."
+          "text": "Ratchet Bomb's second ability destroys only those nonland permanents whose converted mana cost is exactly equal to the number of charge counters on Ratchet Bomb. It doesn't matter who controls them."
         },
         {
           "date": "2011-01-01",
-          "text": "If Ratchet Bomb’s second ability is activated while it has no charge counters on it, it will destroy each nonland permanent with converted mana cost 0."
+          "text": "If Ratchet Bomb's second ability is activated while it has no charge counters on it, it will destroy each nonland permanent with converted mana cost 0."
         },
         {
           "date": "2011-01-01",
-          "text": "The converted mana cost of a permanent is determined solely by the mana symbols printed in its upper right corner, unless it’s copying something else (see below). The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {3}{U}{U} has converted mana cost 5."
+          "text": "The converted mana cost of a permanent is determined solely by the mana symbols printed in its upper right corner, unless it's copying something else (see below). The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {3}{U}{U} has converted mana cost 5."
         },
         {
           "date": "2011-01-01",
-          "text": "If a permanent is copying something else, its converted mana cost is the converted mana cost of whatever it’s copying."
+          "text": "If a permanent is copying something else, its converted mana cost is the converted mana cost of whatever it's copying."
         },
         {
           "date": "2011-01-01",
@@ -24653,7 +24739,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If a nonland permanent has no mana symbols in its upper right corner (because it’s a token that’s not copying something else, for example), its converted mana cost is 0."
+          "text": "If a nonland permanent has no mana symbols in its upper right corner (because it's a token that's not copying something else, for example), its converted mana cost is 0."
         }
       ],
       "text": "{T}: Put a charge counter on Ratchet Bomb.\n{T}, Sacrifice Ratchet Bomb: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Ratchet Bomb.",
@@ -24957,11 +25043,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         }
       ],
       "subtypes": [
@@ -25067,15 +25153,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a black spell or a Swamp enters the battlefield under your control, you gain 1 life.",
@@ -25176,15 +25262,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a red spell or a Mountain enters the battlefield under your control, you gain 1 life.",
@@ -25285,15 +25371,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a blue spell or an Island enters the battlefield under your control, you gain 1 life.",
@@ -25394,15 +25480,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a white spell or a Plains enters the battlefield under your control, you gain 1 life.",
@@ -25503,15 +25589,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a green spell or a Forest enters the battlefield under your control, you gain 1 life.",
@@ -25619,23 +25705,23 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the triggered ability is modal (that is, if it says “Choose one —” or similar), the mode is copied and can’t be changed."
+          "text": "If the triggered ability is modal (that is, if it says \"Choose one —\" or similar), the mode is copied and can't be changed."
         },
         {
           "date": "2013-07-01",
-          "text": "If the triggered ability divides damage or distributes counters among a number of targets (for example, the ability of Bogardan Hellkite), the division and number of targets can’t be changed. If you choose new targets, you must choose the same number of targets."
+          "text": "If the triggered ability divides damage or distributes counters among a number of targets (for example, the ability of Bogardan Hellkite), the division and number of targets can't be changed. If you choose new targets, you must choose the same number of targets."
         },
         {
           "date": "2013-07-01",
-          "text": "Any choices made when the triggered ability resolves won’t have been made yet when it’s copied. Any such choices will be made separately when the copy resolves. If the triggered ability asks you to pay a cost (for example, as the extort ability from the Return to Ravnica block does), you pay that cost for the copy."
+          "text": "Any choices made when the triggered ability resolves won't have been made yet when it's copied. Any such choices will be made separately when the copy resolves. If the triggered ability asks you to pay a cost (for example, as the extort ability from the Return to Ravnica block does), you pay that cost for the copy."
         },
         {
           "date": "2013-07-01",
-          "text": "If a triggered ability is linked to a second ability, copies of that triggered ability are also linked to that second ability. If the second ability refers to “the exiled card,” it refers to all cards exiled by the triggered ability and the copy. For example, if Exclusion Ritual’s enters-the-battlefield ability is copied and two nonland permanents are exiled, players can’t cast spells with the same name as either exiled card."
+          "text": "If a triggered ability is linked to a second ability, copies of that triggered ability are also linked to that second ability. If the second ability refers to \"the exiled card,\" it refers to all cards exiled by the triggered ability and the copy. For example, if Exclusion Ritual's enters-the-battlefield ability is copied and two nonland permanents are exiled, players can't cast spells with the same name as either exiled card."
         },
         {
           "date": "2013-07-01",
-          "text": "In some cases involving linked abilities, an ability requires information about “the exiled card.” When this happens, the ability gets multiple answers. If these answers are being used to determine the value of a variable, the sum is used. For example, if Elite Arcanist’s enters-the-battlefield ability is copied, two cards are exiled. The value of X in the activation cost of Elite Arcanist’s other ability is the sum of the two cards’ converted mana costs. As the ability resolves, you create copies of both cards and can cast none, one, or both of the copies in any order."
+          "text": "In some cases involving linked abilities, an ability requires information about \"the exiled card.\" When this happens, the ability gets multiple answers. If these answers are being used to determine the value of a variable, the sum is used. For example, if Elite Arcanist's enters-the-battlefield ability is copied, two cards are exiled. The value of X in the activation cost of Elite Arcanist's other ability is the sum of the two cards' converted mana costs. As the ability resolves, you create copies of both cards and can cast none, one, or both of the copies in any order."
         }
       ],
       "text": "{2}, {T}: Copy target triggered ability you control. You may choose new targets for the copy. (A triggered ability uses the words \"when,\" \"whenever,\" or \"at.\")",
@@ -26022,11 +26108,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Although Mutavault has all creature types while it’s animated, it does not have the changeling keyword ability."
+          "text": "Although Mutavault has all creature types while it's animated, it does not have the changeling keyword ability."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-07-01",
@@ -26152,11 +26238,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "平原",
-          "multiverseid": 370864
-        },
-        {
           "language": "Chinese Traditional",
           "name": "平原",
           "multiverseid": 371113
@@ -26242,21 +26323,6 @@
           "multiverseid": 372109
         },
         {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 372163
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 372173
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 372248
-        },
-        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 372358
@@ -26275,6 +26341,26 @@
           "language": "Korean",
           "name": "들",
           "multiverseid": 372497
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 373105
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 373159
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 373169
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 373244
         }
       ],
       "id": "54ed001196351b7de6ff5ae46a4fb01743165a04",
@@ -26533,11 +26619,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "平原",
-          "multiverseid": 370864
-        },
-        {
           "language": "Chinese Traditional",
           "name": "平原",
           "multiverseid": 371113
@@ -26623,21 +26704,6 @@
           "multiverseid": 372109
         },
         {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 372163
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 372173
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 372248
-        },
-        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 372358
@@ -26656,6 +26722,26 @@
           "language": "Korean",
           "name": "들",
           "multiverseid": 372497
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 373105
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 373159
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 373169
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 373244
         }
       ],
       "id": "7a5049d97b4d4495547300eca38c67cc667446d9",
@@ -31113,11 +31199,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "山脉",
-          "multiverseid": 370832
-        },
-        {
           "language": "Chinese Traditional",
           "name": "山脈",
           "multiverseid": 371081
@@ -31141,21 +31222,6 @@
           "language": "French",
           "name": "Montagne",
           "multiverseid": 371579
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 371584
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 371587
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 371721
         },
         {
           "language": "German",
@@ -31236,6 +31302,26 @@
           "language": "Korean",
           "name": "산",
           "multiverseid": 372468
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 373073
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 373078
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 373081
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 373215
         }
       ],
       "id": "77c4c40c3b918b2c0887503ab5fdf0d8781f7503",
@@ -32353,21 +32439,6 @@
           "multiverseid": 372092
         },
         {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 372223
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 372250
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 372265
-        },
-        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 372341
@@ -32391,6 +32462,21 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 373088
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 373219
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 373246
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 373261
         }
       ],
       "id": "5e785f572e6b75f6f945c8b9161c15cd49e6c0b4",
@@ -32771,9 +32857,9 @@
           "multiverseid": 372514
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 373088
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 372839
         }
       ],
       "id": "2706b17d8c0d9736b1112c4e0489121945f028b7",
@@ -33154,9 +33240,9 @@
           "multiverseid": 372514
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 373088
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 372839
         }
       ],
       "id": "c4e68c39ef4653d62f725e9d4bcf5232f0a275a8",
@@ -33502,21 +33588,6 @@
           "multiverseid": 372092
         },
         {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 372223
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 372250
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 372265
-        },
-        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 372341
@@ -33540,6 +33611,21 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 373088
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 373219
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 373246
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 373261
         }
       ],
       "id": "4c2f27035403ba5ecc9820783e53a2a56ab1473c",

--- a/json/M15.json
+++ b/json/M15.json
@@ -143,19 +143,19 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If a permanent you control is both a creature and a planeswalker, Ajani’s second ability will put both a +1/+1 counter and a loyalty counter on it."
+          "text": "If a permanent you control is both a creature and a planeswalker, Ajani's second ability will put both a +1/+1 counter and a loyalty counter on it."
         },
         {
           "date": "2014-07-18",
-          "text": "The emblem’s ability doesn’t consider who controls the source dealing damage to you or a planeswalker you control."
+          "text": "The emblem's ability doesn't consider who controls the source dealing damage to you or a planeswalker you control."
         },
         {
           "date": "2014-07-18",
-          "text": "Each attacking creature is a separate source of damage. For example, if two 3/3 creatures attack you and are unblocked, the emblem will prevent 2 damage from each creature. You’ll be dealt a total of 2 damage."
+          "text": "Each attacking creature is a separate source of damage. For example, if two 3/3 creatures attack you and are unblocked, the emblem will prevent 2 damage from each creature. You'll be dealt a total of 2 damage."
         },
         {
           "date": "2014-07-18",
-          "text": "If multiple effects modify how damage is dealt, the player being dealt damage or the controller of the permanent being dealt damage chooses the order to apply the effects. For example, Dictate of the Twin Gods says, “If a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.” Suppose you would be dealt 3 damage while Dictate of the Twin Gods is on the battlefield and you control Ajani’s emblem. You can either (a) prevent all but 1 damage first and then let Dictate of the Twin Gods’s effect double that, for a result of being dealt 2 damage, or (b) double the damage to 6 and then prevent all but 1 of that damage."
+          "text": "If multiple effects modify how damage is dealt, the player being dealt damage or the controller of the permanent being dealt damage chooses the order to apply the effects. For example, Dictate of the Twin Gods says, \"If a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.\" Suppose you would be dealt 3 damage while Dictate of the Twin Gods is on the battlefield and you control Ajani's emblem. You can either (a) prevent all but 1 damage first and then let Dictate of the Twin Gods's effect double that, for a result of being dealt 2 damage, or (b) double the damage to 6 and then prevent all but 1 of that damage."
         }
       ],
       "subtypes": [
@@ -268,11 +268,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Soulmender or 8 life from Meditation Puzzle."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Soulmender or 8 life from Meditation Puzzle."
         },
         {
           "date": "2014-07-18",
-          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Ajani’s Pridemate’s ability will trigger twice. However, if a single creature you control with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
+          "text": "A creature with lifelink dealing combat damage is a single life-gaining event. For example, if two creatures you control with lifelink deal combat damage at the same time, Ajani's Pridemate's ability will trigger twice. However, if a single creature you control with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), the ability will trigger only once."
         }
       ],
       "subtypes": [
@@ -383,11 +383,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The possible color choices are white, blue, black, red, and green. You can’t choose artifact, colorless, or any other word."
+          "text": "The possible color choices are white, blue, black, red, and green. You can't choose artifact, colorless, or any other word."
         },
         {
           "date": "2014-07-18",
-          "text": "For each activated ability, you choose the color as the ability resolves. However, the color of a source that would deal damage to the creature or player is checked only when it would deal that damage, not as Avacyn’s ability resolves. For example, if you choose blue, damage a blue creature would deal is prevented, even if that creature wasn’t blue (or wasn’t on the battlefield) when Avacyn’s ability resolved."
+          "text": "For each activated ability, you choose the color as the ability resolves. However, the color of a source that would deal damage to the creature or player is checked only when it would deal that damage, not as Avacyn's ability resolves. For example, if you choose blue, damage a blue creature would deal is prevented, even if that creature wasn't blue (or wasn't on the battlefield) when Avacyn's ability resolved."
         },
         {
           "date": "2014-07-18",
@@ -395,7 +395,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The second activated ability doesn’t prevent damage that would be dealt to planeswalkers the target player controls. If that player is you, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply the ability’s prevention effect to that damage first, and there won’t be any damage to redirect."
+          "text": "The second activated ability doesn't prevent damage that would be dealt to planeswalkers the target player controls. If that player is you, it can still prevent noncombat damage that your opponent would want to redirect from you to one of your planeswalkers. Just apply the ability's prevention effect to that damage first, and there won't be any damage to redirect."
         },
         {
           "date": "2014-07-18",
@@ -403,7 +403,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Neither activated ability has any effect on damage that’s already been dealt."
+          "text": "Neither activated ability has any effect on damage that's already been dealt."
         }
       ],
       "subtypes": [
@@ -527,7 +527,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If a creature loses double strike after dealing combat damage in the first combat damage step, it won’t assign combat damage in the second one."
+          "text": "If a creature loses double strike after dealing combat damage in the first combat damage step, it won't assign combat damage in the second one."
         }
       ],
       "subtypes": [
@@ -636,11 +636,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The Aura card must be able to legally enchant Boonweaver Giant. For example, you can’t put an Aura with enchant land onto the battlefield this way."
+          "text": "The Aura card must be able to legally enchant Boonweaver Giant. For example, you can't put an Aura with enchant land onto the battlefield this way."
         },
         {
           "date": "2014-07-18",
-          "text": "If Boonweaver Giant isn’t on the battlefield when its ability resolves, you can’t put any Aura onto the battlefield. You may still search the appropriate zones and shuffle your library, if applicable."
+          "text": "If Boonweaver Giant isn't on the battlefield when its ability resolves, you can't put any Aura onto the battlefield. You may still search the appropriate zones and shuffle your library, if applicable."
         }
       ],
       "subtypes": [
@@ -867,7 +867,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Constricting Sliver gives Slivers you control an ability that causes a zone change with a duration, a newer style of ability that’s somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring’s abilities, this ability creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after the Sliver leaves the battlefield."
+          "text": "Constricting Sliver gives Slivers you control an ability that causes a zone change with a duration, a newer style of ability that's somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring's abilities, this ability creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after the Sliver leaves the battlefield."
         },
         {
           "date": "2014-07-18",
@@ -879,15 +879,15 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards (unless they’re Theros block cards with the bestow ability). Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards (unless they're Theros block cards with the bestow ability). Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2014-07-18",
-          "text": "If a Sliver leaves the battlefield before its enters-the-battlefield ability resolves, the target creature won’t be exiled."
+          "text": "If a Sliver leaves the battlefield before its enters-the-battlefield ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2014-07-18",
@@ -895,31 +895,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The exiled card returns to the battlefield immediately after the Sliver leaves the battlefield. Nothing happens between the two events, including state-based actions. The two creatures aren’t on the battlefield at the same time. For example, if the returning creature is a Mercurial Pretender, it can’t enter the battlefield as a copy of the Sliver."
+          "text": "The exiled card returns to the battlefield immediately after the Sliver leaves the battlefield. Nothing happens between the two events, including state-based actions. The two creatures aren't on the battlefield at the same time. For example, if the returning creature is a Mercurial Pretender, it can't enter the battlefield as a copy of the Sliver."
         },
         {
           "date": "2014-07-18",
-          "text": "The exiled card will return to the battlefield under its owner’s control."
+          "text": "The exiled card will return to the battlefield under its owner's control."
         },
         {
           "date": "2014-07-18",
-          "text": "The exiled card will return even if the Sliver whose ability exiled it doesn’t have that ability at the time (perhaps because Constricting Sliver is no longer on the battlefield)."
+          "text": "The exiled card will return even if the Sliver whose ability exiled it doesn't have that ability at the time (perhaps because Constricting Sliver is no longer on the battlefield)."
         },
         {
           "date": "2014-07-18",
-          "text": "In a multiplayer game, if the Sliver’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if the Sliver's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         },
         {
           "date": "2014-07-18",
-          "text": "Slivers in this set affect only Sliver creatures you control. They don’t grant bonuses to your opponents’ Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
+          "text": "Slivers in this set affect only Sliver creatures you control. They don't grant bonuses to your opponents' Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
         },
         {
           "date": "2014-07-18",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2014-07-18",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         }
       ],
       "subtypes": [
@@ -1141,7 +1141,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You can tap untapped attacking or blocking creatures you control to help cast Devouring Light. This doesn’t remove those creatures from combat."
+          "text": "You can tap untapped attacking or blocking creatures you control to help cast Devouring Light. This doesn't remove those creatures from combat."
         },
         {
           "date": "2014-07-18",
@@ -1149,31 +1149,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nExile target attacking or blocking creature.",
@@ -1282,7 +1282,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If the creature targeted by Divine Favor is an illegal target when Divine Favor tries to resolve, Divine Favor will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the creature targeted by Divine Favor is an illegal target when Divine Favor tries to resolve, Divine Favor will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -1390,31 +1390,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
@@ -1524,11 +1524,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "First Response looks at the entire previous turn to determine whether its ability triggers or not. It doesn’t matter whether First Response was on the battlefield when you lost life."
+          "text": "First Response looks at the entire previous turn to determine whether its ability triggers or not. It doesn't matter whether First Response was on the battlefield when you lost life."
         },
         {
           "date": "2014-07-18",
-          "text": "First Response checks only if you lost life during the turn, not whether your life total decreased over the course of the turn. For example, if you lost 2 life and then gained 8 life last turn, First Response’s ability will trigger."
+          "text": "First Response checks only if you lost life during the turn, not whether your life total decreased over the course of the turn. For example, if you lost 2 life and then gained 8 life last turn, First Response's ability will trigger."
         },
         {
           "date": "2014-07-18",
@@ -1536,7 +1536,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The Soldier won’t be able to attack the turn it’s created (unless something gives it haste)."
+          "text": "The Soldier won't be able to attack the turn it's created (unless something gives it haste)."
         }
       ],
       "text": "At the beginning of each upkeep, if you lost life last turn, create a 1/1 white Soldier creature token.",
@@ -1748,7 +1748,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Enchantment creatures with bestow from the Theros block aren’t Aura cards in your library. You can’t find one with Heliod’s Pilgrim."
+          "text": "Enchantment creatures with bestow from the Theros block aren't Aura cards in your library. You can't find one with Heliod's Pilgrim."
         }
       ],
       "subtypes": [
@@ -1861,7 +1861,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Triggered abilities use the word “when,” “whenever,” or “at.” They’re often written as “[Trigger condition], [effect].”"
+          "text": "Triggered abilities use the word \"when,\" \"whenever,\" or \"at.\" They're often written as \"[Trigger condition], [effect].\""
         },
         {
           "date": "2014-07-18",
@@ -1869,19 +1869,19 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Abilities that apply “as [this creature] enters the battlefield,” such as choosing a creature to copy with Mercurial Pretender, are also unaffected."
+          "text": "Abilities that apply \"as [this creature] enters the battlefield,\" such as choosing a creature to copy with Mercurial Pretender, are also unaffected."
         },
         {
           "date": "2014-07-18",
-          "text": "Hushwing Gryff’s ability stops a creature’s own enters-the-battlefield triggered abilities as well as other triggered abilities that would trigger when a creature enters the battlefield."
+          "text": "Hushwing Gryff's ability stops a creature's own enters-the-battlefield triggered abilities as well as other triggered abilities that would trigger when a creature enters the battlefield."
         },
         {
           "date": "2014-07-18",
-          "text": "The trigger event doesn’t have to specify “creatures” entering the battlefield. For example, Amulet of Vigor says “Whenever a permanent enters the battlefield tapped and under your control, untap it.” If a creature enters the battlefield tapped and under your control, Amulet of Vigor’s ability would not trigger. If a land (that isn’t also a creature) enters the battlefield tapped and under your control, Amulet of Vigor’s ability would trigger."
+          "text": "The trigger event doesn't have to specify \"creatures\" entering the battlefield. For example, Amulet of Vigor says \"Whenever a permanent enters the battlefield tapped and under your control, untap it.\" If a creature enters the battlefield tapped and under your control, Amulet of Vigor's ability would not trigger. If a land (that isn't also a creature) enters the battlefield tapped and under your control, Amulet of Vigor's ability would trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "Look at the permanent as it exists on the battlefield, taking into account continuous effects, to determine whether any triggered abilities will trigger. For example, if you control March of the Machines, which says, in part, “Each noncreature artifact is an artifact creature,” each artifact will be a creature at the time it enters the battlefield and will not cause triggered abilities to trigger."
+          "text": "Look at the permanent as it exists on the battlefield, taking into account continuous effects, to determine whether any triggered abilities will trigger. For example, if you control March of the Machines, which says, in part, \"Each noncreature artifact is an artifact creature,\" each artifact will be a creature at the time it enters the battlefield and will not cause triggered abilities to trigger."
         },
         {
           "date": "2014-07-18",
@@ -2320,31 +2320,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nYou gain 8 life.",
@@ -2565,11 +2565,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The enchanted creature’s controller can choose to not attack or block with it even if it must attack or block if able. Players can’t be forced to pay a cost to attack or block."
+          "text": "The enchanted creature's controller can choose to not attack or block with it even if it must attack or block if able. Players can't be forced to pay a cost to attack or block."
         },
         {
           "date": "2014-07-18",
-          "text": "Activated abilities are written in the form “Cost: Effect.” Some keywords are activated abilities and will have colons in their reminder texts. Static and triggered abilities are unaffected by Oppressive Rays."
+          "text": "Activated abilities are written in the form \"Cost: Effect.\" Some keywords are activated abilities and will have colons in their reminder texts. Static and triggered abilities are unaffected by Oppressive Rays."
         }
       ],
       "subtypes": [
@@ -2997,11 +2997,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You choose what the Soldier you put onto the battlefield is attacking. It doesn’t have to attack the same player or planeswalker as Preeminent Captain."
+          "text": "You choose what the Soldier you put onto the battlefield is attacking. It doesn't have to attack the same player or planeswalker as Preeminent Captain."
         },
         {
           "date": "2014-07-18",
-          "text": "Any abilities of the Soldier creature card that trigger “Whenever [this creature] attacks” won’t trigger because the creature was never declared as an attacking creature."
+          "text": "Any abilities of the Soldier creature card that trigger \"Whenever [this creature] attacks\" won't trigger because the creature was never declared as an attacking creature."
         }
       ],
       "subtypes": [
@@ -3338,11 +3338,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Your starting life total is the life total you began the game with. For most two-player formats, this is 20. For Two-Headed Giant, it’s the life total your team started with, usually 30. In Commander games, your starting life total is 40."
+          "text": "Your starting life total is the life total you began the game with. For most two-player formats, this is 20. For Two-Headed Giant, it's the life total your team started with, usually 30. In Commander games, your starting life total is 40."
         },
         {
           "date": "2014-07-18",
-          "text": "If your life total is less than your starting life total, you actually gain the appropriate amount of life. Other effects that interact with life gain will interact with Resolute Archangel’s ability accordingly."
+          "text": "If your life total is less than your starting life total, you actually gain the appropriate amount of life. Other effects that interact with life gain will interact with Resolute Archangel's ability accordingly."
         }
       ],
       "subtypes": [
@@ -3451,31 +3451,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nReturn X target creature cards with converted mana cost 2 or less from your graveyard to the battlefield.",
@@ -3687,11 +3687,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can activate Selfless Cathar’s ability even if you control no other creatures."
+          "text": "You can activate Selfless Cathar's ability even if you control no other creatures."
         },
         {
           "date": "2011-09-22",
-          "text": "Only creatures you control when Selfless Cathar’s ability resolves will be affected. Creatures that enter the battlefield or that you gain control of later in the turn will not."
+          "text": "Only creatures you control when Selfless Cathar's ability resolves will be affected. Creatures that enter the battlefield or that you gain control of later in the turn will not."
         }
       ],
       "subtypes": [
@@ -3802,7 +3802,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The ability that defines Seraph of the Masses’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Seraph of the Masses's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2014-07-18",
@@ -3810,31 +3810,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -3947,7 +3947,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted permanent is an illegal target by the time Solemn Offering would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted permanent is an illegal target by the time Solemn Offering would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Destroy target artifact or enchantment. You gain 4 life.",
@@ -4057,7 +4057,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Exiling the Soul from your graveyard is part of the last ability’s activation cost. A player can’t remove the Soul in response to prevent you from activating the ability."
+          "text": "Exiling the Soul from your graveyard is part of the last ability's activation cost. A player can't remove the Soul in response to prevent you from activating the ability."
         }
       ],
       "subtypes": [
@@ -4273,11 +4273,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The protection granted by Spectra Ward won’t cause any Aura to be put into its owner’s graveyard, including Spectra Ward itself. However, if the enchanted creature gains protection from white in another way, Spectra Ward will be put into its owner’s graveyard as a state-based action."
+          "text": "The protection granted by Spectra Ward won't cause any Aura to be put into its owner's graveyard, including Spectra Ward itself. However, if the enchanted creature gains protection from white in another way, Spectra Ward will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-07-18",
-          "text": "Although Auras that are already attached to the creature aren’t affected by Spectra Ward, the enchanted creature can’t be the target of further Aura spells that have one or more colors."
+          "text": "Although Auras that are already attached to the creature aren't affected by Spectra Ward, the enchanted creature can't be the target of further Aura spells that have one or more colors."
         }
       ],
       "subtypes": [
@@ -4707,31 +4707,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate three 1/1 white Spirit creature tokens with flying. (They can't be blocked except by creatures with flying or reach.)",
@@ -4844,7 +4844,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Essence’s triggered ability will trigger even if it’s dealt lethal damage. For example, if it’s dealt 7 combat damage, its ability will trigger and you’ll gain 7 life."
+          "text": "Wall of Essence's triggered ability will trigger even if it's dealt lethal damage. For example, if it's dealt 7 combat damage, its ability will trigger and you'll gain 7 life."
         }
       ],
       "subtypes": [
@@ -4955,7 +4955,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Warden of the Beyond can’t get more than +2/+2 from its last ability, no matter how many opponents own a card in exile or how many exiled cards they own."
+          "text": "Warden of the Beyond can't get more than +2/+2 from its last ability, no matter how many opponents own a card in exile or how many exiled cards they own."
         }
       ],
       "subtypes": [
@@ -5176,7 +5176,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If an effect puts two or more cards on the top or bottom of a library at the same time, the owner of those cards may arrange them in any order. That library’s owner doesn’t reveal the order in which the cards go into his or her library."
+          "text": "If an effect puts two or more cards on the top or bottom of a library at the same time, the owner of those cards may arrange them in any order. That library's owner doesn't reveal the order in which the cards go into his or her library."
         }
       ],
       "text": "For each attacking creature, its owner puts it on the top or bottom of his or her library.",
@@ -5283,7 +5283,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Activating the ability after blockers have been declared won’t have any effect. It won’t change or undo any blocks."
+          "text": "Activating the ability after blockers have been declared won't have any effect. It won't change or undo any blocks."
         }
       ],
       "subtypes": [
@@ -5400,7 +5400,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If enough -1/-1 counters are put on Chasm Skulker at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got any -1/-1 counters will be used to determine how many Squid tokens you get. For example, if there are two +1/+1 counters on Chasm Skulker and it gets three -1/-1 counters, you’ll get two Squid tokens."
+          "text": "If enough -1/-1 counters are put on Chasm Skulker at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got any -1/-1 counters will be used to determine how many Squid tokens you get. For example, if there are two +1/+1 counters on Chasm Skulker and it gets three -1/-1 counters, you'll get two Squid tokens."
         }
       ],
       "subtypes": [
@@ -5518,31 +5518,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -5858,19 +5858,19 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The granted ability applies to any spell (including Aura spells), activated ability, or triggered ability that’s controlled by an opponent that targets a Sliver you control."
+          "text": "The granted ability applies to any spell (including Aura spells), activated ability, or triggered ability that's controlled by an opponent that targets a Sliver you control."
         },
         {
           "date": "2014-07-18",
-          "text": "Slivers in this set affect only Sliver creatures you control. They don’t grant bonuses to your opponents’ Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
+          "text": "Slivers in this set affect only Sliver creatures you control. They don't grant bonuses to your opponents' Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
         },
         {
           "date": "2014-07-18",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2014-07-18",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         }
       ],
       "subtypes": [
@@ -5996,7 +5996,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then it does not get exiled."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then it does not get exiled."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
@@ -6226,7 +6226,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -6335,19 +6335,19 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The artifact retains any types, subtypes, or supertypes it has. Notably, if an Equipment becomes an artifact creature, it can’t be attached to another creature. If it was attached to a creature, it becomes unattached."
+          "text": "The artifact retains any types, subtypes, or supertypes it has. Notably, if an Equipment becomes an artifact creature, it can't be attached to another creature. If it was attached to a creature, it becomes unattached."
         },
         {
           "date": "2014-07-18",
-          "text": "If the artifact was already a creature, its base power and toughness will each become 5. This overwrites any previous effects that set the creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Ensoul Artifact becomes attached to the artifact will overwrite this effect."
+          "text": "If the artifact was already a creature, its base power and toughness will each become 5. This overwrites any previous effects that set the creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Ensoul Artifact becomes attached to the artifact will overwrite this effect."
         },
         {
           "date": "2014-07-18",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the ones created by Titanic Growth or a +/1+1 counter, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch power and toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the ones created by Titanic Growth or a +/1+1 counter, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch power and toughness."
         },
         {
           "date": "2014-07-18",
-          "text": "The resulting artifact creature will be able to attack on your turn if it’s been under your control continuously since the turn began. That is, it doesn’t matter how long it’s been a creature, just how long it’s been on the battlefield."
+          "text": "The resulting artifact creature will be able to attack on your turn if it's been under your control continuously since the turn began. That is, it doesn't matter how long it's been a creature, just how long it's been on the battlefield."
         }
       ],
       "subtypes": [
@@ -6457,15 +6457,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Frost Lynx’s ability can target a creature that’s already tapped. That creature still won’t untap during its controller’s next untap step."
+          "text": "Frost Lynx's ability can target a creature that's already tapped. That creature still won't untap during its controller's next untap step."
         },
         {
           "date": "2014-07-18",
-          "text": "Frost Lynx’s ability tracks the creature, not the creature’s controller. That is, if the creature changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "Frost Lynx's ability tracks the creature, not the creature's controller. That is, if the creature changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-07-18",
-          "text": "If the creature isn’t tapped during its controller’s next untap step (perhaps because it was untapped by a spell), Frost Lynx’s ability has no effect at that time. It won’t try to keep the creature tapped on subsequent turns."
+          "text": "If the creature isn't tapped during its controller's next untap step (perhaps because it was untapped by a spell), Frost Lynx's ability has no effect at that time. It won't try to keep the creature tapped on subsequent turns."
         }
       ],
       "subtypes": [
@@ -6688,7 +6688,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "It doesn’t matter who controls the Mountain."
+          "text": "It doesn't matter who controls the Mountain."
         },
         {
           "date": "2014-07-18",
@@ -6906,11 +6906,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Notably, if you exile Illusory Angel because of a cascade ability of a spell with converted mana cost 4 or greater, you’ll be able to cast Illusory Angel."
+          "text": "Notably, if you exile Illusory Angel because of a cascade ability of a spell with converted mana cost 4 or greater, you'll be able to cast Illusory Angel."
         },
         {
           "date": "2014-07-18",
-          "text": "It doesn’t matter whether the other spell resolved. It could have been countered or, if you’ve somehow cast Illusory Angel as though it had flash, it could still be on the stack."
+          "text": "It doesn't matter whether the other spell resolved. It could have been countered or, if you've somehow cast Illusory Angel as though it had flash, it could still be on the stack."
         }
       ],
       "subtypes": [
@@ -6933,7 +6933,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"The cathars have their swords, the inquisitors their axes. I prefer the ‘diplomatic' approach.\"\n—Terhold, archmage of Drunau",
+      "flavor": "\"The cathars have their swords, the inquisitors their axes. I prefer the 'diplomatic' approach.\"\n—Terhold, archmage of Drunau",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -7238,11 +7238,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "When the first ability resolves, the card you don’t put into your graveyard stays on top of your library."
+          "text": "When the first ability resolves, the card you don't put into your graveyard stays on top of your library."
         },
         {
           "date": "2014-07-18",
-          "text": "If a player has no cards in his or her hand and no cards in his or her graveyard when the third ability resolves, that player won’t shuffle his or her library."
+          "text": "If a player has no cards in his or her hand and no cards in his or her graveyard when the third ability resolves, that player won't shuffle his or her library."
         }
       ],
       "subtypes": [
@@ -7455,7 +7455,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If your library has no nonlegendary creature cards in it, you’ll reveal all the cards in your library, then put them in a random order. Although this is not technically shuffling your library, no player is allowed to know the order of those cards."
+          "text": "If your library has no nonlegendary creature cards in it, you'll reveal all the cards in your library, then put them in a random order. Although this is not technically shuffling your library, no player is allowed to know the order of those cards."
         }
       ],
       "subtypes": [
@@ -7570,7 +7570,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Multiple instances of lifelink on a creature are redundant. Giving the same creature lifelink more than once won’t cause its controller to gain additional life."
+          "text": "Multiple instances of lifelink on a creature are redundant. Giving the same creature lifelink more than once won't cause its controller to gain additional life."
         }
       ],
       "subtypes": [
@@ -7796,11 +7796,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Although you may choose a land card in your hand, you won’t be able to play it even if the player guessed wrong."
+          "text": "Although you may choose a land card in your hand, you won't be able to play it even if the player guessed wrong."
         },
         {
           "date": "2014-07-18",
-          "text": "If you don’t cast the card, either because the player guessed right or because you choose not to cast it, you don’t have to reveal it. Your opponent won’t know the reason you didn’t cast the card."
+          "text": "If you don't cast the card, either because the player guessed right or because you choose not to cast it, you don't have to reveal it. Your opponent won't know the reason you didn't cast the card."
         },
         {
           "date": "2014-07-18",
@@ -7808,11 +7808,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "You cast the card in your hand as part of the resolution of the triggered ability. Timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other restrictions, such as “Cast [this card] only during combat,” are not."
+          "text": "You cast the card in your hand as part of the resolution of the triggered ability. Timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other restrictions, such as \"Cast [this card] only during combat,\" are not."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. Notably, you can’t cast a card with bestow as an Aura this way. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. Notably, you can't cast a card with bestow as an Aura this way. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2017-04-18",
@@ -7928,15 +7928,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Mercurial Pretender’s ability doesn’t target the chosen creature."
+          "text": "Mercurial Pretender's ability doesn't target the chosen creature."
         },
         {
           "date": "2014-07-18",
-          "text": "The activated ability Mercurial Pretender gives itself becomes part of its copiable values. Unless the ability is overwritten by another copy effect, a creature that’s a copy of Mercurial Pretender will have that ability."
+          "text": "The activated ability Mercurial Pretender gives itself becomes part of its copiable values. Unless the ability is overwritten by another copy effect, a creature that's a copy of Mercurial Pretender will have that ability."
         },
         {
           "date": "2014-07-18",
-          "text": "Mercurial Pretender copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, etc. For example, if Mercurial Pretender enters the battlefield as a copy of a Profane Memento with Ensoul Artifact attached to it, Mercurial Pretender will be a noncreature Profane Memento with Mercurial Pretender’s added activated ability."
+          "text": "Mercurial Pretender copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, etc. For example, if Mercurial Pretender enters the battlefield as a copy of a Profane Memento with Ensoul Artifact attached to it, Mercurial Pretender will be a noncreature Profane Memento with Mercurial Pretender's added activated ability."
         },
         {
           "date": "2014-07-18",
@@ -7952,11 +7952,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Mercurial Pretender enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Mercurial Pretender enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2014-07-18",
-          "text": "If Mercurial Pretender somehow enters the battlefield at the same time as another creature, Mercurial Pretender can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Mercurial Pretender somehow enters the battlefield at the same time as another creature, Mercurial Pretender can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2014-07-18",
@@ -8070,11 +8070,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The creatures don’t have to be attacking the same player or planeswalker."
+          "text": "The creatures don't have to be attacking the same player or planeswalker."
         },
         {
           "date": "2014-07-18",
-          "text": "Once the ability triggers, it doesn’t matter how many creatures are still attacking when the ability resolves."
+          "text": "Once the ability triggers, it doesn't matter how many creatures are still attacking when the ability resolves."
         }
       ],
       "text": "Whenever you attack with two or more creatures, draw a card.",
@@ -8181,7 +8181,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You can cast Mind Sculpt no matter how many cards are in the opponent’s library. If there are fewer than seven, the opponent will put all of them into his or her graveyard."
+          "text": "You can cast Mind Sculpt no matter how many cards are in the opponent's library. If there are fewer than seven, the opponent will put all of them into his or her graveyard."
         }
       ],
       "text": "Target opponent puts the top seven cards of his or her library into his or her graveyard.",
@@ -8320,7 +8320,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -8531,7 +8531,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Causing a creature to gain flying after it’s been blocked won’t change or undo that block."
+          "text": "Causing a creature to gain flying after it's been blocked won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -8753,7 +8753,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Creatures that enter the battlefield or come under the target player’s control after Polymorphist’s Jest resolves won’t be affected."
+          "text": "Creatures that enter the battlefield or come under the target player's control after Polymorphist's Jest resolves won't be affected."
         },
         {
           "date": "2014-07-18",
@@ -8761,23 +8761,23 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Polymorphist’s Jest overwrites all previous effects that set the creatures’ base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Polymorphist’s Jest resolves will overwrite this effect."
+          "text": "Polymorphist's Jest overwrites all previous effects that set the creatures' base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Polymorphist's Jest resolves will overwrite this effect."
         },
         {
           "date": "2014-07-18",
-          "text": "Polymorphist’s Jest doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature’s ability that says “At the beginning of your upkeep,” “When this creature enters the battlefield,” or similar from triggering."
+          "text": "Polymorphist's Jest doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature's ability that says \"At the beginning of your upkeep,\" \"When this creature enters the battlefield,\" or similar from triggering."
         },
         {
           "date": "2014-07-18",
-          "text": "If one of the affected creatures gains an ability after Polymorphist’s Jest resolves, it will keep that ability."
+          "text": "If one of the affected creatures gains an ability after Polymorphist's Jest resolves, it will keep that ability."
         },
         {
           "date": "2014-07-18",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the effect of Titanic Growth, will apply to the creatures no matter when they started to take effect. The same is true for any counters that change their power and/or toughness and effects that switch power and toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the effect of Titanic Growth, will apply to the creatures no matter when they started to take effect. The same is true for any counters that change their power and/or toughness and effects that switch power and toughness."
         },
         {
           "date": "2014-07-18",
-          "text": "If one of the Theros block Gods is affected by Polymorphist’s Jest, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God’s type-changing ability is applied before the effect that removes that ability is applied."
+          "text": "If one of the Theros block Gods is affected by Polymorphist's Jest, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God's type-changing ability is applied before the effect that removes that ability is applied."
         }
       ],
       "text": "Until end of turn, each creature target player controls loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
@@ -9105,11 +9105,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Exiling the Soul from your graveyard is part of the last ability’s activation cost. A player can’t remove the Soul in response to prevent you from activating the ability."
+          "text": "Exiling the Soul from your graveyard is part of the last ability's activation cost. A player can't remove the Soul in response to prevent you from activating the ability."
         },
         {
           "date": "2014-07-18",
-          "text": "To determine how many cards to draw, count the number of colors among permanents you control as either activated ability resolves. You’ll draw between zero and five cards."
+          "text": "To determine how many cards to draw, count the number of colors among permanents you control as either activated ability resolves. You'll draw between zero and five cards."
         }
       ],
       "subtypes": [
@@ -9219,7 +9219,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Whether you control a blue creature is checked only when Statute of Denial resolves. If you do, drawing and discarding a card is mandatory. You can’t choose to not do it."
+          "text": "Whether you control a blue creature is checked only when Statute of Denial resolves. If you do, drawing and discarding a card is mandatory. You can't choose to not do it."
         }
       ],
       "text": "Counter target spell. If you control a blue creature, draw a card, then discard a card.",
@@ -9327,15 +9327,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Stormtide Leviathan’s second ability causes each land on the battlefield to have the land type Island. Each land thus has the ability “{T}: Add {U} to your mana pool.” Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they’re legendary or basic."
+          "text": "Stormtide Leviathan's second ability causes each land on the battlefield to have the land type Island. Each land thus has the ability \"{T}: Add {U} to your mana pool.\" Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they're legendary or basic."
         },
         {
           "date": "2014-07-18",
-          "text": "If Stormtide Leviathan loses its abilities, all lands on the battlefield (including those that enter the battlefield later on) will still be Islands in addition to their other types and will still be able to tap to produce {U}. The way continuous effects work, Stormtide Leviathan’s type-changing ability is applied before the effect that removes that ability is applied."
+          "text": "If Stormtide Leviathan loses its abilities, all lands on the battlefield (including those that enter the battlefield later on) will still be Islands in addition to their other types and will still be able to tap to produce {U}. The way continuous effects work, Stormtide Leviathan's type-changing ability is applied before the effect that removes that ability is applied."
         },
         {
           "date": "2014-07-18",
-          "text": "Stormtide Leviathan’s third ability affects all creatures with neither flying nor islandwalk, regardless of who controls them. They can’t attack any player or planeswalker."
+          "text": "Stormtide Leviathan's third ability affects all creatures with neither flying nor islandwalk, regardless of who controls them. They can't attack any player or planeswalker."
         },
         {
           "date": "2014-07-18",
@@ -9456,11 +9456,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Turn to Frog overwrites all previous effects that set the creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Turn to Frog resolves will overwrite this effect."
+          "text": "Turn to Frog overwrites all previous effects that set the creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Turn to Frog resolves will overwrite this effect."
         },
         {
           "date": "2014-07-18",
-          "text": "Turn to Frog doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature’s ability that says “At the beginning of your upkeep,” “When this creature enters the battlefield,” or similar from triggering."
+          "text": "Turn to Frog doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature's ability that says \"At the beginning of your upkeep,\" \"When this creature enters the battlefield,\" or similar from triggering."
         },
         {
           "date": "2014-07-18",
@@ -9468,11 +9468,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
         },
         {
           "date": "2014-07-18",
-          "text": "If one of the Theros block Gods is affected by Turn to Frog, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God’s type-changing ability is applied before the effect that removes that ability is applied."
+          "text": "If one of the Theros block Gods is affected by Turn to Frog, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God's type-changing ability is applied before the effect that removes that ability is applied."
         }
       ],
       "text": "Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
@@ -9685,11 +9685,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Frost’s ability tracks the creature, not the creature’s controller. That is, if the creature changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "Wall of Frost's ability tracks the creature, not the creature's controller. That is, if the creature changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-07-18",
-          "text": "If the creature isn’t tapped during its controller’s next untap step (perhaps because it was untapped by a spell), Wall of Frost’s ability has no effect at that time. It won’t try to keep the creature tapped on subsequent turns."
+          "text": "If the creature isn't tapped during its controller's next untap step (perhaps because it was untapped by a spell), Wall of Frost's ability has no effect at that time. It won't try to keep the creature tapped on subsequent turns."
         }
       ],
       "subtypes": [
@@ -10128,7 +10128,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If Blood Host isn’t on the battlefield when its ability resolves, you won’t put a +1/+1 counter on it but you’ll still gain 2 life."
+          "text": "If Blood Host isn't on the battlefield when its ability resolves, you won't put a +1/+1 counter on it but you'll still gain 2 life."
         }
       ],
       "subtypes": [
@@ -10562,35 +10562,35 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If the target creature or player is an illegal target when Covenant of Blood tries to resolve, it will be countered and none of its effects will happen. You won’t gain any life. (Any creatures you tapped to cast Covenant of Blood remain tapped.)"
+          "text": "If the target creature or player is an illegal target when Covenant of Blood tries to resolve, it will be countered and none of its effects will happen. You won't gain any life. (Any creatures you tapped to cast Covenant of Blood remain tapped.)"
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCovenant of Blood deals 4 damage to target creature or player and you gain 4 life.",
@@ -10911,31 +10911,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPut target creature card from a graveyard onto the battlefield under your control.",
@@ -11147,11 +11147,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Feast on the Fallen looks at the entire previous turn to determine whether its ability triggers or not. It doesn’t matter whether Feast on the Fallen was on the battlefield when the opponent lost life."
+          "text": "Feast on the Fallen looks at the entire previous turn to determine whether its ability triggers or not. It doesn't matter whether Feast on the Fallen was on the battlefield when the opponent lost life."
         },
         {
           "date": "2014-07-18",
-          "text": "Feast on the Fallen checks only if an opponent lost life during the turn, not whether that player’s life total decreased over the course of the turn. For example, if an opponent lost 2 life and then gained 8 life last turn, Feast on the Fallen’s ability will trigger."
+          "text": "Feast on the Fallen checks only if an opponent lost life during the turn, not whether that player's life total decreased over the course of the turn. For example, if an opponent lost 2 life and then gained 8 life last turn, Feast on the Fallen's ability will trigger."
         },
         {
           "date": "2014-07-18",
@@ -11453,6 +11453,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -11495,7 +11499,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -11710,11 +11714,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The opponent chooses whether he or she sacrifices a creature, pays 3 life, or allows you to draw a card. That player can’t make an impossible choice, such as sacrificing a creature while he or she controls no creatures."
+          "text": "The opponent chooses whether he or she sacrifices a creature, pays 3 life, or allows you to draw a card. That player can't make an impossible choice, such as sacrificing a creature while he or she controls no creatures."
         },
         {
           "date": "2014-07-18",
-          "text": "If there are no legal targets to choose, perhaps because all your opponents have hexproof, the ability is removed from the stack with no effect. You won’t draw a card. This is also true if the target opponent becomes an illegal target in response to the ability."
+          "text": "If there are no legal targets to choose, perhaps because all your opponents have hexproof, the ability is removed from the stack with no effect. You won't draw a card. This is also true if the target opponent becomes an illegal target in response to the ability."
         }
       ],
       "subtypes": [
@@ -11825,15 +11829,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Slivers in this set affect only Sliver creatures you control. They don’t grant bonuses to your opponents’ Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
+          "text": "Slivers in this set affect only Sliver creatures you control. They don't grant bonuses to your opponents' Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
         },
         {
           "date": "2014-07-18",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2014-07-18",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         }
       ],
       "subtypes": [
@@ -11953,7 +11957,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -12728,7 +12732,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Ob Nixilis’s first triggered ability won’t trigger if you search an opponent’s library or if an opponent searches another player’s library."
+          "text": "Ob Nixilis's first triggered ability won't trigger if you search an opponent's library or if an opponent searches another player's library."
         },
         {
           "date": "2014-07-18",
@@ -12736,7 +12740,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The first triggered ability won’t be put on the stack until after the spell or ability causing the opponent to search his or her library finishes resolving. Notably, if that spell or ability causes any other abilities to trigger (for example, if the opponent searched for a creature card and put it onto the battlefield), those abilities and Ob Nixilis’s triggered ability will go on the stack together. The active player puts all of his or her abilities on the stack in any order, then each other player in turn order does the same. The last ability put onto the stack this way will be the first to resolve, and so on."
+          "text": "The first triggered ability won't be put on the stack until after the spell or ability causing the opponent to search his or her library finishes resolving. Notably, if that spell or ability causes any other abilities to trigger (for example, if the opponent searched for a creature card and put it onto the battlefield), those abilities and Ob Nixilis's triggered ability will go on the stack together. The active player puts all of his or her abilities on the stack in any order, then each other player in turn order does the same. The last ability put onto the stack this way will be the first to resolve, and so on."
         }
       ],
       "subtypes": [
@@ -12955,7 +12959,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Rotfeaster Maggot’s ability is mandatory. If you are the only player with creature cards in your graveyard, you must target one of them."
+          "text": "Rotfeaster Maggot's ability is mandatory. If you are the only player with creature cards in your graveyard, you must target one of them."
         }
       ],
       "subtypes": [
@@ -13284,7 +13288,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Exiling the Soul from your graveyard is part of the last ability’s activation cost. A player can’t remove the Soul in response to prevent you from activating the ability."
+          "text": "Exiling the Soul from your graveyard is part of the last ability's activation cost. A player can't remove the Soul in response to prevent you from activating the ability."
         }
       ],
       "subtypes": [
@@ -13501,35 +13505,35 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You can leave any cards with that name in the zone they’re in. You don’t have to exile them."
+          "text": "You can leave any cards with that name in the zone they're in. You don't have to exile them."
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose a nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
@@ -13751,7 +13755,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The loss of life isn’t a cost. If the target creature is an illegal target when Ulcerate tries to resolve, it will be countered and none of its effects will happen. You won’t lose any life."
+          "text": "The loss of life isn't a cost. If the target creature is an illegal target when Ulcerate tries to resolve, it will be countered and none of its effects will happen. You won't lose any life."
         }
       ],
       "text": "Target creature gets -3/-3 until end of turn. You lose 3 life.",
@@ -13857,31 +13861,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nReturn up to two target creature cards from your graveyard to your hand.",
@@ -13987,15 +13991,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The ability triggers just once for each life-gaining event, whether it’s 1 life from Soulmender or 8 life from Meditation Puzzle."
+          "text": "The ability triggers just once for each life-gaining event, whether it's 1 life from Soulmender or 8 life from Meditation Puzzle."
         },
         {
           "date": "2014-07-18",
-          "text": "Use Wall of Limbs’s power as it last existed on the battlefield, including any +1/+1 counters it had, to determine the value of X."
+          "text": "Use Wall of Limbs's power as it last existed on the battlefield, including any +1/+1 counters it had, to determine the value of X."
         },
         {
           "date": "2014-07-18",
-          "text": "If you gain life at the same time Wall of Limbs is dealt lethal damage (probably because you control a blocking creature with lifelink), Wall of Limbs’s triggered ability will trigger, but Wall of Limbs will be destroyed before the ability resolves."
+          "text": "If you gain life at the same time Wall of Limbs is dealt lethal damage (probably because you control a blocking creature with lifelink), Wall of Limbs's triggered ability will trigger, but Wall of Limbs will be destroyed before the ability resolves."
         }
       ],
       "subtypes": [
@@ -14534,11 +14538,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Under normal circumstances, you can play a land card exiled with Act on Impulse only if you haven’t played a land yet that turn."
+          "text": "Under normal circumstances, you can play a land card exiled with Act on Impulse only if you haven't played a land yet that turn."
         },
         {
           "date": "2014-07-18",
-          "text": "Any cards you don’t play will remain exiled."
+          "text": "Any cards you don't play will remain exiled."
         }
       ],
       "text": "Exile the top three cards of your library. Until end of turn, you may play cards exiled this way. (If you cast a spell this way, you still pay its costs. You can play a land this way only if you have an available land play remaining.)",
@@ -14644,11 +14648,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You can activate the ability once on each player’s turn, not just your own."
+          "text": "You can activate the ability once on each player's turn, not just your own."
         },
         {
           "date": "2014-07-18",
-          "text": "Aggressive Mining doesn’t stop lands from being put onto the battlefield by a spell or ability. It only stops the special action of playing a land."
+          "text": "Aggressive Mining doesn't stop lands from being put onto the battlefield by a spell or ability. It only stops the special action of playing a land."
         }
       ],
       "text": "You can't play lands.\nSacrifice a land: Draw two cards. Activate this ability only once each turn.",
@@ -14754,7 +14758,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If a combat phase has two combat damage steps (because there’s an attacker or blocker with first strike or double strike), Altac Bloodseeker may gain first strike during the first one. If this happens, it will assign combat damage in the second combat damage step along with other creatures that haven’t assigned combat damage during that combat."
+          "text": "If a combat phase has two combat damage steps (because there's an attacker or blocker with first strike or double strike), Altac Bloodseeker may gain first strike during the first one. If this happens, it will assign combat damage in the second combat damage step along with other creatures that haven't assigned combat damage during that combat."
         },
         {
           "date": "2014-07-18",
@@ -14870,15 +14874,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Slivers in this set affect only Sliver creatures you control. They don’t grant bonuses to your opponents’ Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
+          "text": "Slivers in this set affect only Sliver creatures you control. They don't grant bonuses to your opponents' Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
         },
         {
           "date": "2014-07-18",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2014-07-18",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         }
       ],
       "subtypes": [
@@ -14988,7 +14992,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Blastfire Bolt can target any creature, not just one with Equipment attached to it. The damage will be dealt to the creature even if it doesn’t have any Equipment attached to it."
+          "text": "Blastfire Bolt can target any creature, not just one with Equipment attached to it. The damage will be dealt to the creature even if it doesn't have any Equipment attached to it."
         },
         {
           "date": "2014-07-18",
@@ -15211,7 +15215,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Brood Keeper’s ability triggers both whenever an Aura enters the battlefield attached to Brood Keeper and whenever an Aura on the battlefield attached to a different object becomes attached to Brood Keeper."
+          "text": "Brood Keeper's ability triggers both whenever an Aura enters the battlefield attached to Brood Keeper and whenever an Aura on the battlefield attached to a different object becomes attached to Brood Keeper."
         },
         {
           "date": "2014-07-18",
@@ -15326,7 +15330,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Use the power of the enchanted creature as the activated ability resolves to determine how much damage is dealt. If the creature isn’t on the battlefield at that time, use its power as it last existed on the battlefield. Note that this works differently than the fight keyword, which requires both creatures be on the battlefield for any damage to be dealt."
+          "text": "Use the power of the enchanted creature as the activated ability resolves to determine how much damage is dealt. If the creature isn't on the battlefield at that time, use its power as it last existed on the battlefield. Note that this works differently than the fight keyword, which requires both creatures be on the battlefield for any damage to be dealt."
         },
         {
           "date": "2014-07-18",
@@ -15446,31 +15450,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If the first ability resolves but the damage is prevented or redirected, the target creature still won’t be able to block that turn."
+          "text": "If the first ability resolves but the damage is prevented or redirected, the target creature still won't be able to block that turn."
         },
         {
           "date": "2014-07-18",
-          "text": "The card exiled by the second ability is exiled face up. Playing it follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if it’s a creature card, you can cast it only during your main phase while the stack is empty."
+          "text": "The card exiled by the second ability is exiled face up. Playing it follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if it's a creature card, you can cast it only during your main phase while the stack is empty."
         },
         {
           "date": "2014-07-18",
-          "text": "If you exile a land card using the second ability, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven’t played a land yet that turn."
+          "text": "If you exile a land card using the second ability, you may play that land only if you have any available land plays. Normally, this means you can play the land only if you haven't played a land yet that turn."
         },
         {
           "date": "2014-07-18",
-          "text": "In the third ability, “exiled this way” means the cards you just exiled because of that ability resolving. Cards exiled with the second ability or with previous activations of the third ability don’t count."
+          "text": "In the third ability, \"exiled this way\" means the cards you just exiled because of that ability resolving. Cards exiled with the second ability or with previous activations of the third ability don't count."
         },
         {
           "date": "2014-07-18",
-          "text": "While resolving the third ability, you create the copies of the card in exile and cast them from exile. You can cast zero, one, two, or all three copies. The card itself isn’t cast. It remains exiled."
+          "text": "While resolving the third ability, you create the copies of the card in exile and cast them from exile. You can cast zero, one, two, or all three copies. The card itself isn't cast. It remains exiled."
         },
         {
           "date": "2014-07-18",
-          "text": "While casting the copies created by the third ability, timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other restrictions, such as “Cast [this spell] only during combat,” are not."
+          "text": "While casting the copies created by the third ability, timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other restrictions, such as \"Cast [this spell] only during combat,\" are not."
         },
         {
           "date": "2014-07-18",
-          "text": "Because you’re casting the copies “without paying their mana costs,” you can’t pay any alternative costs for the copies. You can pay additional costs, such as kicker costs. If the copies have any mandatory additional costs, you must pay those."
+          "text": "Because you're casting the copies \"without paying their mana costs,\" you can't pay any alternative costs for the copies. You can pay additional costs, such as kicker costs. If the copies have any mandatory additional costs, you must pay those."
         },
         {
           "date": "2014-07-18",
@@ -15585,7 +15589,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Circle of Flame’s ability triggers only if a creature without flying is declared as an attacker during the declare attackers step. If a creature with flying attacks you or a planeswalker you control and then loses flying, or if a creature without flying is put onto the battlefield attacking you or a planeswalker you control, the ability won’t trigger."
+          "text": "Circle of Flame's ability triggers only if a creature without flying is declared as an attacker during the declare attackers step. If a creature with flying attacks you or a planeswalker you control and then loses flying, or if a creature without flying is put onto the battlefield attacking you or a planeswalker you control, the ability won't trigger."
         }
       ],
       "text": "Whenever a creature without flying attacks you or a planeswalker you control, Circle of Flame deals 1 damage to that creature.",
@@ -15810,11 +15814,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of the three targets must be different. If there aren’t three different legal targets available, you can’t cast the spell."
+          "text": "Each of the three targets must be different. If there aren't three different legal targets available, you can't cast the spell."
         },
         {
           "date": "2014-07-18",
-          "text": "If one or two of Cone of Flame’s targets are illegal when it resolves, you can’t change how much damage will be dealt to the remaining legal targets."
+          "text": "If one or two of Cone of Flame's targets are illegal when it resolves, you can't change how much damage will be dealt to the remaining legal targets."
         }
       ],
       "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
@@ -15919,31 +15923,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +1/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
@@ -16160,7 +16164,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Forge Devil’s ability is mandatory. If it’s the only creature on the battlefield, you’ll have to choose it as the target and have it deal 1 damage to itself and 1 damage to you."
+          "text": "Forge Devil's ability is mandatory. If it's the only creature on the battlefield, you'll have to choose it as the target and have it deal 1 damage to itself and 1 damage to you."
         }
       ],
       "subtypes": [
@@ -16729,11 +16733,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Although Goblin Rabblemaster doesn’t force itself to attack, if you control two of them, they’ll force each other to attack if able."
+          "text": "Although Goblin Rabblemaster doesn't force itself to attack, if you control two of them, they'll force each other to attack if able."
         },
         {
           "date": "2014-07-18",
-          "text": "If, during your declare attackers step, a creature that must attack if able is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under your control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, you’re not forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, a creature that must attack if able is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under your control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, you're not forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2014-07-18",
@@ -17176,11 +17180,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If Hoarding Dragon is put into a graveyard before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve. If you choose to find an artifact card from your library, it will be exiled for the rest of the game."
-        },
-        {
-          "date": "2014-07-18",
-          "text": "Hoarding Dragon’s two abilities are linked. The second ability refers only to the card exiled by that Hoarding Dragon’s first ability. In other words, each Dragon has its own hoard."
+          "text": "Hoarding Dragon's two abilities are linked. The second ability refers only to the card exiled by that Hoarding Dragon's first ability. In other words, each Dragon has its own hoard."
         },
         {
           "date": "2014-07-18",
@@ -17294,11 +17294,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "As soon as Inferno Fist leaves the battlefield, its power bonus stops applying. This means that if you sacrifice Inferno Fist before combat damage is dealt, perhaps to destroy a potential blocker, the creature that was enchanted won’t have the bonus when it deals combat damage."
+          "text": "As soon as Inferno Fist leaves the battlefield, its power bonus stops applying. This means that if you sacrifice Inferno Fist before combat damage is dealt, perhaps to destroy a potential blocker, the creature that was enchanted won't have the bonus when it deals combat damage."
         },
         {
           "date": "2014-07-18",
-          "text": "If another player gains control of the enchanted creature, or if Inferno Fist becomes attached to a creature another player controls, Inferno Fist will be put into its owner’s graveyard as a state-based action."
+          "text": "If another player gains control of the enchanted creature, or if Inferno Fist becomes attached to a creature another player controls, Inferno Fist will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -17619,19 +17619,19 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Activated abilities are written in the form “Cost: Effect.” Some keywords are activated abilities and will have colons in their reminder texts."
+          "text": "Activated abilities are written in the form \"Cost: Effect.\" Some keywords are activated abilities and will have colons in their reminder texts."
         },
         {
           "date": "2014-07-18",
-          "text": "A mana ability is an ability that (1) could put mana into a player’s mana pool when it resolves, (2) isn’t a loyalty ability, and (3) doesn’t target."
+          "text": "A mana ability is an ability that (1) could put mana into a player's mana pool when it resolves, (2) isn't a loyalty ability, and (3) doesn't target."
         },
         {
           "date": "2014-07-18",
-          "text": "The copy will have the same targets as the ability it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the ability it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2014-07-18",
-          "text": "If the ability is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the ability is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2014-07-18",
@@ -17639,7 +17639,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If paying the activation cost of the ability includes sacrificing Kurkesh, the ability won’t be copied. At the time the ability is considered activated (after all costs are paid), Kurkesh is no longer on the battlefield."
+          "text": "If paying the activation cost of the ability includes sacrificing Kurkesh, the ability won't be copied. At the time the ability is considered activated (after all costs are paid), Kurkesh is no longer on the battlefield."
         }
       ],
       "subtypes": [
@@ -17977,23 +17977,23 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "“Each creature on the battlefield with the greatest power” may be a single creature if each other creature has less power."
+          "text": "\"Each creature on the battlefield with the greatest power\" may be a single creature if each other creature has less power."
         },
         {
           "date": "2014-07-18",
-          "text": "The ability will trigger only if you control each creature on the battlefield with the greatest power as the beginning of combat step begins. If another player controls a creature with the greatest power or tied for the greatest power at that time, the ability won’t trigger at all."
+          "text": "The ability will trigger only if you control each creature on the battlefield with the greatest power as the beginning of combat step begins. If another player controls a creature with the greatest power or tied for the greatest power at that time, the ability won't trigger at all."
         },
         {
           "date": "2014-07-18",
-          "text": "The ability will check its condition again as it tries to resolve. If, at that time, another player controls a creature with the greatest power or tied for the greatest power, the ability won’t do anything."
+          "text": "The ability will check its condition again as it tries to resolve. If, at that time, another player controls a creature with the greatest power or tied for the greatest power, the ability won't do anything."
         },
         {
           "date": "2014-07-18",
-          "text": "The ability can target any creature an opponent controls, not just one that’s tapped."
+          "text": "The ability can target any creature an opponent controls, not just one that's tapped."
         },
         {
           "date": "2014-07-18",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "text": "At the beginning of combat on your turn, if you control each creature on the battlefield with the greatest power, gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
@@ -18311,7 +18311,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Discarding a card is part of the cost to activate Rummaging Goblin’s ability. If you don’t have a card in your hand, you can’t pay this part of the cost and you can’t activate the ability."
+          "text": "Discarding a card is part of the cost to activate Rummaging Goblin's ability. If you don't have a card in your hand, you can't pay this part of the cost and you can't activate the ability."
         }
       ],
       "subtypes": [
@@ -18534,7 +18534,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You must sacrifice exactly one artifact to cast this spell; you can’t cast it without sacrificing an artifact, and you can’t sacrifice additional artifacts."
+          "text": "You must sacrifice exactly one artifact to cast this spell; you can't cast it without sacrificing an artifact, and you can't sacrifice additional artifacts."
         },
         {
           "date": "2014-07-18",
@@ -18753,7 +18753,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Exiling the Soul from your graveyard is part of the last ability’s activation cost. A player can’t remove the Soul in response to prevent you from activating the ability."
+          "text": "Exiling the Soul from your graveyard is part of the last ability's activation cost. A player can't remove the Soul in response to prevent you from activating the ability."
         },
         {
           "date": "2014-07-18",
@@ -18867,31 +18867,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nStoke the Flames deals 4 damage to target creature or player.",
@@ -19776,31 +19776,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nSearch your library for a creature card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.",
@@ -20016,31 +20016,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate three 3/3 green Beast creature tokens.",
@@ -20150,31 +20150,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +2/+2 until end of turn.",
@@ -20282,19 +20282,19 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Genesis Hydra’s first ability will resolve before Genesis Hydra does. Notably, if you put an Aura card onto the battlefield this way, it can’t enchant Genesis Hydra."
+          "text": "Genesis Hydra's first ability will resolve before Genesis Hydra does. Notably, if you put an Aura card onto the battlefield this way, it can't enchant Genesis Hydra."
         },
         {
           "date": "2014-07-18",
-          "text": "If you put an Aura onto the battlefield this way, you choose what it enchants as it enters the battlefield. This doesn’t target any permanent or player. For example, you could put an Aura onto the battlefield enchanting a creature with hexproof controlled by an opponent."
+          "text": "If you put an Aura onto the battlefield this way, you choose what it enchants as it enters the battlefield. This doesn't target any permanent or player. For example, you could put an Aura onto the battlefield enchanting a creature with hexproof controlled by an opponent."
         },
         {
           "date": "2014-07-18",
-          "text": "If there’s an {X} in the mana cost of the nonland permanent card, X is 0."
+          "text": "If there's an {X} in the mana cost of the nonland permanent card, X is 0."
         },
         {
           "date": "2014-07-18",
-          "text": "If “the rest” is zero cards, either because X was 0 or because X was 1 and that card was put onto the battlefield, the library is still shuffled."
+          "text": "If \"the rest\" is zero cards, either because X was 0 or because X was 1 and that card was put onto the battlefield, the library is still shuffled."
         }
       ],
       "subtypes": [
@@ -20405,7 +20405,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Hornet Nest’s triggered ability will trigger even if it’s dealt lethal damage. For example, if it’s dealt 7 damage, its ability will trigger and you’ll put seven Insect creature tokens onto the battlefield."
+          "text": "Hornet Nest's triggered ability will trigger even if it's dealt lethal damage. For example, if it's dealt 7 damage, its ability will trigger and you'll put seven Insect creature tokens onto the battlefield."
         }
       ],
       "subtypes": [
@@ -20634,16 +20634,8 @@
       "rarity": "Common",
       "rulings": [
         {
-          "date": "2014-11-24",
-          "text": "If either target is an illegal target as Hunt the Weak tries to resolve, neither creature will deal or be dealt damage."
-        },
-        {
-          "date": "2014-11-24",
-          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won’t put a +1/+1 counter on it. If that creature is a legal target but the creature you don’t control isn’t, you’ll still put the counter on the creature you control."
-        },
-        {
           "date": "2016-09-20",
-          "text": "You can’t cast Hunt the Weak unless you choose both a creature you control and a creature you don’t control as targets."
+          "text": "You can't cast Hunt the Weak unless you choose both a creature you control and a creature you don't control as targets."
         },
         {
           "date": "2016-09-20",
@@ -20651,7 +20643,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won’t put a +1/+1 counter on it. If that creature is a legal target but the other creature isn’t, you’ll still put the counter on the creature you control."
+          "text": "If the creature you control is an illegal target as Hunt the Weak tries to resolve, you won't put a +1/+1 counter on it. If that creature is a legal target but the other creature isn't, you'll still put the counter on the creature you control."
         }
       ],
       "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
@@ -20757,7 +20749,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The prevention effect will apply to any combat damage that would be dealt this turn by a nongreen creature, even if that creature was green or wasn’t on the battlefield when Hunter’s Ambush resolved."
+          "text": "The prevention effect will apply to any combat damage that would be dealt this turn by a nongreen creature, even if that creature was green or wasn't on the battlefield when Hunter's Ambush resolved."
         }
       ],
       "text": "Prevent all combat damage that would be dealt by nongreen creatures this turn.",
@@ -20864,7 +20856,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The ability doesn’t target any permanent. You choose which one to return when the ability resolves. No player can respond to this choice once the ability starts resolving."
+          "text": "The ability doesn't target any permanent. You choose which one to return when the ability resolves. No player can respond to this choice once the ability starts resolving."
         }
       ],
       "subtypes": [
@@ -20974,7 +20966,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The ability that defines Kalonian Twingrove’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Kalonian Twingrove's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2014-07-18",
@@ -21089,7 +21081,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You must sacrifice exactly one creature to cast this spell; you can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast this spell; you can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2014-07-18",
@@ -21199,31 +21191,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -21592,11 +21584,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The type-changing effects of the first and third abilities don’t have a duration. They last indefinitely."
+          "text": "The type-changing effects of the first and third abilities don't have a duration. They last indefinitely."
         },
         {
           "date": "2014-07-18",
-          "text": "If the land targeted by the first ability entered the battlefield this turn, it won’t be able to attack and its activated abilities with {T} in the cost (including its mana ability) can’t be activated (unless something gives it haste). The same is true for the lands put onto the battlefield with the third ability."
+          "text": "If the land targeted by the first ability entered the battlefield this turn, it won't be able to attack and its activated abilities with {T} in the cost (including its mana ability) can't be activated (unless something gives it haste). The same is true for the lands put onto the battlefield with the third ability."
         }
       ],
       "subtypes": [
@@ -21704,31 +21696,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nSearch your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
@@ -21840,31 +21832,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreatures you control get +3/+3 until end of turn.",
@@ -22077,7 +22069,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Phytotitan’s ability will return it to the battlefield only if it’s still in the graveyard when the delayed triggered ability resolves. If it’s not, it won’t return to the battlefield."
+          "text": "Phytotitan's ability will return it to the battlefield only if it's still in the graveyard when the delayed triggered ability resolves. If it's not, it won't return to the battlefield."
         }
       ],
       "subtypes": [
@@ -22628,11 +22620,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Roaring Primadox’s ability is mandatory. When it resolves, if Roaring Primadox is the only creature you control, you must return it to its owner’s hand."
+          "text": "Roaring Primadox's ability is mandatory. When it resolves, if Roaring Primadox is the only creature you control, you must return it to its owner's hand."
         },
         {
           "date": "2014-07-18",
-          "text": "The ability doesn’t target any creature. You choose which one to return when the ability resolves. No player can respond to this choice once the ability starts resolving."
+          "text": "The ability doesn't target any creature. You choose which one to return when the ability resolves. No player can respond to this choice once the ability starts resolving."
         }
       ],
       "subtypes": [
@@ -23073,31 +23065,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -23212,7 +23204,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Exiling the Soul from your graveyard is part of the last ability’s activation cost. A player can’t remove the Soul in response to prevent you from activating the ability."
+          "text": "Exiling the Soul from your graveyard is part of the last ability's activation cost. A player can't remove the Soul in response to prevent you from activating the ability."
         }
       ],
       "subtypes": [
@@ -23645,15 +23637,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Slivers in this set affect only Sliver creatures you control. They don’t grant bonuses to your opponents’ Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
+          "text": "Slivers in this set affect only Sliver creatures you control. They don't grant bonuses to your opponents' Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
         },
         {
           "date": "2014-07-18",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2014-07-18",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         }
       ],
       "subtypes": [
@@ -23768,7 +23760,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If the land targeted by Verdant Haven is an illegal target when Verdan Haven tries to resolve, Verdant Haven will be countered. It won’t enter the battlefield and its enters-the-battlefield ability won’t trigger."
+          "text": "If the land targeted by Verdant Haven is an illegal target when Verdan Haven tries to resolve, Verdant Haven will be countered. It won't enter the battlefield and its enters-the-battlefield ability won't trigger."
         }
       ],
       "subtypes": [
@@ -24103,7 +24095,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If Yisan isn’t on the battlefield when its ability resolves, use the number of verse counters on it when it left the battlefield to determine which creature cards may be put onto the battlefield. This number will include the counter you put on Yisan to activate the ability."
+          "text": "If Yisan isn't on the battlefield when its ability resolves, use the number of verse counters on it when it left the battlefield to determine which creature cards may be put onto the battlefield. This number will include the counter you put on Yisan to activate the ability."
         }
       ],
       "subtypes": [
@@ -24224,15 +24216,15 @@
         },
         {
           "date": "2014-07-18",
-          "text": "If you activate the third ability, and the target creature is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t gain any life."
+          "text": "If you activate the third ability, and the target creature is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't gain any life."
         },
         {
           "date": "2014-07-18",
-          "text": "The emblem’s ability won’t trigger if a creature attacks a planeswalker."
+          "text": "The emblem's ability won't trigger if a creature attacks a planeswalker."
         },
         {
           "date": "2014-07-18",
-          "text": "The emblem is owned and controlled by the target of the ability that created it. In a multiplayer game, if Garruk’s owner leaves the game, the emblem does not."
+          "text": "The emblem is owned and controlled by the target of the ability that created it. In a multiplayer game, if Garruk's owner leaves the game, the emblem does not."
         }
       ],
       "subtypes": [
@@ -24354,15 +24346,15 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Slivers in this set affect only Sliver creatures you control. They don’t grant bonuses to your opponents’ Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
+          "text": "Slivers in this set affect only Sliver creatures you control. They don't grant bonuses to your opponents' Slivers. This is the same way Slivers from the Magic 2014 core set worked, while Slivers in earlier sets granted bonuses to all Slivers."
         },
         {
           "date": "2014-07-18",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like indestructible and the ability granted by Belligerent Sliver, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2014-07-18",
-          "text": "If you change the creature type of a Sliver you control so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
+          "text": "If you change the creature type of a Sliver you control so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures you control."
         }
       ],
       "subtypes": [
@@ -24766,7 +24758,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "For the first ability, it doesn’t matter whether the planeswalker is still on the battlefield as your end step begins. If you activated one of its loyalty abilities that turn, The Chain Veil’s triggered ability won’t trigger."
+          "text": "For the first ability, it doesn't matter whether the planeswalker is still on the battlefield as your end step begins. If you activated one of its loyalty abilities that turn, The Chain Veil's triggered ability won't trigger."
         },
         {
           "date": "2014-07-18",
@@ -24774,15 +24766,15 @@
         },
         {
           "date": "2014-07-18",
-          "text": "After the last ability resolves, you’ll essentially be able to activate a loyalty ability of each planeswalker you control a total of twice during your turn. The timing rules for when you can activate loyalty abilities apply each time; it must be your main phase and the stack must be empty."
+          "text": "After the last ability resolves, you'll essentially be able to activate a loyalty ability of each planeswalker you control a total of twice during your turn. The timing rules for when you can activate loyalty abilities apply each time; it must be your main phase and the stack must be empty."
         },
         {
           "date": "2014-07-18",
-          "text": "The second loyalty ability you activate doesn’t have to be the same as the first ability. For example, you could activate a planeswalker’s first ability twice, or you could activate a planeswalker’s first ability, then activate its second ability."
+          "text": "The second loyalty ability you activate doesn't have to be the same as the first ability. For example, you could activate a planeswalker's first ability twice, or you could activate a planeswalker's first ability, then activate its second ability."
         },
         {
           "date": "2014-07-18",
-          "text": "Each additional time The Chain Veil’s last ability resolves will allow you to activate a loyalty ability of each planeswalker you control an additional time. For example, if you activate The Chain Veil’s last ability, untap it, then activate it again, you can activate a loyalty ability of a planeswalker you control three times that turn."
+          "text": "Each additional time The Chain Veil's last ability resolves will allow you to activate a loyalty ability of each planeswalker you control an additional time. For example, if you activate The Chain Veil's last ability, untap it, then activate it again, you can activate a loyalty ability of a planeswalker you control three times that turn."
         }
       ],
       "supertypes": [
@@ -24991,7 +24983,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If Grindclock isn’t on the battlefield when its last ability resolves, use the number of charge counters on it when it left the battlefield to determine how many cards to put into the graveyard."
+          "text": "If Grindclock isn't on the battlefield when its last ability resolves, use the number of charge counters on it when it left the battlefield to determine how many cards to put into the graveyard."
         }
       ],
       "text": "{T}: Put a charge counter on Grindclock.\n{T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of charge counters on Grindclock.",
@@ -25091,15 +25083,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Although you must control no creatures to activate the “animation” ability, having a creature somehow come under your control in response to that ability won’t stop it from resolving."
+          "text": "Although you must control no creatures to activate the \"animation\" ability, having a creature somehow come under your control in response to that ability won't stop it from resolving."
         },
         {
           "date": "2014-07-18",
-          "text": "It’s possible to activate the first activated ability of Haunted Plate Mail in response to activating the first ability of another Haunted Plate Mail and have them both become creatures until end of turn."
+          "text": "It's possible to activate the first activated ability of Haunted Plate Mail in response to activating the first ability of another Haunted Plate Mail and have them both become creatures until end of turn."
         },
         {
           "date": "2014-07-18",
-          "text": "You can activate the equip ability of Haunted Plate Mail while it isn’t an Equipment, but the ability will have no effect. Haunted Plate Mail won’t become attached to any creature."
+          "text": "You can activate the equip ability of Haunted Plate Mail while it isn't an Equipment, but the ability will have no effect. Haunted Plate Mail won't become attached to any creature."
         }
       ],
       "subtypes": [
@@ -25318,11 +25310,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -25525,35 +25517,35 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The choice of creature type is made as Obelisk of Urd enters the battlefield. Players can’t respond to this choice. The bonus starts applying immediately."
+          "text": "The choice of creature type is made as Obelisk of Urd enters the battlefield. Players can't respond to this choice. The bonus starts applying immediately."
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nAs Obelisk of Urd enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +2/+2.",
@@ -25877,11 +25869,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Activated abilities are written in the form “Cost: Effect.” Some keywords are activated abilities and will have colons in their reminder texts. Static and triggered abilities of sources with the chosen name are unaffected."
+          "text": "Activated abilities are written in the form \"Cost: Effect.\" Some keywords are activated abilities and will have colons in their reminder texts. Static and triggered abilities of sources with the chosen name are unaffected."
         },
         {
           "date": "2014-07-18",
-          "text": "Phyrexian Revoker’s ability affects sources with the chosen name no matter what zone they are in. For example, if Soul of Ravnica is the chosen name, the ability that exiles it from a player’s graveyard can’t be activated."
+          "text": "Phyrexian Revoker's ability affects sources with the chosen name no matter what zone they are in. For example, if Soul of Ravnica is the chosen name, the ability that exiles it from a player's graveyard can't be activated."
         }
       ],
       "subtypes": [
@@ -25986,15 +25978,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Token creatures dying won’t cause Profane Memento’s ability to trigger."
+          "text": "Token creatures dying won't cause Profane Memento's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "Profane Memento’s ability will trigger when a nontoken creature you control but an opponent owns dies."
+          "text": "Profane Memento's ability will trigger when a nontoken creature you control but an opponent owns dies."
         },
         {
           "date": "2014-07-18",
-          "text": "If Profane Memento is put into your graveyard at the same time as a creature card is put into an opponent’s graveyard, its ability won’t trigger."
+          "text": "If Profane Memento is put into your graveyard at the same time as a creature card is put into an opponent's graveyard, its ability won't trigger."
         }
       ],
       "text": "Whenever a creature card is put into an opponent's graveyard from anywhere, you gain 1 life.",
@@ -26286,7 +26278,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Once Scuttling Doom Engine has been blocked by a creature, reducing that creature’s power to 2 or less won’t change or undo that block."
+          "text": "Once Scuttling Doom Engine has been blocked by a creature, reducing that creature's power to 2 or less won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -26391,11 +26383,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "To determine how much damage to prevent, use the number of creatures you control when damage would be dealt, including the equipped creature. Notably, if damage would be dealt to multiple creatures at the same time, you’ll count the number of creatures you control before any of that damage is dealt."
+          "text": "To determine how much damage to prevent, use the number of creatures you control when damage would be dealt, including the equipped creature. Notably, if damage would be dealt to multiple creatures at the same time, you'll count the number of creatures you control before any of that damage is dealt."
         },
         {
           "date": "2014-07-18",
-          "text": "If multiple effects modify how damage is dealt, the player being dealt damage or the controller of the permanent being dealt damage chooses the order to apply the effects. For example, Dictate of the Twin Gods says, “If a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.” Suppose the equipped creature would be dealt 3 damage while Dictate of the Twin Gods is on the battlefield and you control two creatures. You can either (a) prevent 2 damage first and then let Dictate of the Twin Gods’s effect apply, for a result of the equipped creature being dealt 2 damage, or (b) double the damage to 6 and then prevent 2 damage, for a result of the creature being dealt 4 damage."
+          "text": "If multiple effects modify how damage is dealt, the player being dealt damage or the controller of the permanent being dealt damage chooses the order to apply the effects. For example, Dictate of the Twin Gods says, \"If a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.\" Suppose the equipped creature would be dealt 3 damage while Dictate of the Twin Gods is on the battlefield and you control two creatures. You can either (a) prevent 2 damage first and then let Dictate of the Twin Gods's effect apply, for a result of the equipped creature being dealt 2 damage, or (b) double the damage to 6 and then prevent 2 damage, for a result of the creature being dealt 4 damage."
         }
       ],
       "subtypes": [
@@ -26503,7 +26495,7 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Exiling the Soul from your graveyard is part of the last ability’s activation cost. A player can’t remove the Soul in response to prevent you from activating the ability."
+          "text": "Exiling the Soul from your graveyard is part of the last ability's activation cost. A player can't remove the Soul in response to prevent you from activating the ability."
         }
       ],
       "subtypes": [
@@ -26609,15 +26601,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a black spell or a Swamp enters the battlefield under your control, you gain 1 life.",
@@ -26718,15 +26710,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a red spell or a Mountain enters the battlefield under your control, you gain 1 life.",
@@ -26827,15 +26819,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a blue spell or an Island enters the battlefield under your control, you gain 1 life.",
@@ -26936,15 +26928,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a white spell or a Plains enters the battlefield under your control, you gain 1 life.",
@@ -27045,15 +27037,15 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus’s ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
+          "text": "Each of these artifacts cares about any land with the appropriate basic land type. For example, Staff of the Sun Magus's ability triggers when any land with the subtype Plains enters the battlefield under your control, not just lands named Plains."
         },
         {
           "date": "2014-07-18",
-          "text": "Most nonbasic lands don’t have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won’t cause Staff of the Sun Magus’s ability to trigger."
+          "text": "Most nonbasic lands don't have basic land types, even if they produce colored mana. For example, Caves of Koilos is neither a Plains nor a Swamp. Having one enter the battlefield under your control won't cause Staff of the Sun Magus's ability to trigger."
         },
         {
           "date": "2014-07-18",
-          "text": "If you cast a copy of a card that’s a certain color, the appropriate Staff’s ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
+          "text": "If you cast a copy of a card that's a certain color, the appropriate Staff's ability will trigger. However, if you copy a spell on the stack without casting that copy, it will not."
         }
       ],
       "text": "Whenever you cast a green spell or a Forest enters the battlefield under your control, you gain 1 life.",
@@ -27352,31 +27344,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -27490,7 +27482,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -27605,7 +27597,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -27716,7 +27708,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Although Darksteel Citadel is an artifact, it can’t be cast as a spell. Playing it follows the normal rules for playing a land."
+          "text": "Although Darksteel Citadel is an artifact, it can't be cast as a spell. Playing it follows the normal rules for playing a land."
         }
       ],
       "text": "Indestructible\n{T}: Add {C} to your mana pool.",
@@ -27964,7 +27956,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -28169,7 +28161,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -28270,7 +28262,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Whether you control a Sliver is checked only when you activate the last ability, not as that ability resolves. If you control no Slivers at the time the ability resolves, you’ll still get a Sliver token."
+          "text": "Whether you control a Sliver is checked only when you activate the last ability, not as that ability resolves. If you control no Slivers at the time the ability resolves, you'll still get a Sliver token."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a Sliver spell.\n{5}, {T}: Create a 1/1 colorless Sliver creature token. Activate this ability only if you control a Sliver.",
@@ -28374,19 +28366,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If Urborg, Tomb of Yawgmoth and either Blood Moon or Magus of the Moon are on the battlefield, all nonbasic lands will be Mountains, not Swamps. Urborg, Tomb of Yawgmoth will be a Mountain as well. It will have “{T}: Add {R} to your mana pool” and no other abilities."
+          "text": "If Urborg, Tomb of Yawgmoth and either Blood Moon or Magus of the Moon are on the battlefield, all nonbasic lands will be Mountains, not Swamps. Urborg, Tomb of Yawgmoth will be a Mountain as well. It will have \"{T}: Add {R} to your mana pool\" and no other abilities."
         },
         {
           "date": "2014-07-18",
-          "text": "Urborg, Tomb of Yawgmoth isn’t a Swamp while it’s not on the battlefield."
+          "text": "Urborg, Tomb of Yawgmoth isn't a Swamp while it's not on the battlefield."
         },
         {
           "date": "2014-07-18",
-          "text": "Urborg’s ability causes each land on the battlefield to have the land type Swamp. Each land thus has the ability “{T}: Add {B} to your mana pool.” Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they’re legendary or basic."
+          "text": "Urborg's ability causes each land on the battlefield to have the land type Swamp. Each land thus has the ability \"{T}: Add {B} to your mana pool.\" Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they're legendary or basic."
         },
         {
           "date": "2014-07-18",
-          "text": "If Urborg loses its abilities (for example, if it becomes a creature and then Turn to Frog targets it), all lands on the battlefield, including Urborg, will still be Swamps, but Urborg won’t have the ability “Each land is a Swamp in addition to its other land types.” Urborg also won’t be able to tap to produce {B}, but other lands (including those that enter the battlefield later in the turn) will. The way continuous effects work, Urborg’s type-changing ability is applied before the effect that removes both the type-changing ability and its own mana ability."
+          "text": "If Urborg loses its abilities (for example, if it becomes a creature and then Turn to Frog targets it), all lands on the battlefield, including Urborg, will still be Swamps, but Urborg won't have the ability \"Each land is a Swamp in addition to its other land types.\" Urborg also won't be able to tap to produce {B}, but other lands (including those that enter the battlefield later in the turn) will. The way continuous effects work, Urborg's type-changing ability is applied before the effect that removes both the type-changing ability and its own mana ability."
         }
       ],
       "supertypes": [
@@ -28498,7 +28490,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -28517,11 +28509,6 @@
         "W"
       ],
       "foreignNames": [
-        {
-          "language": "Chinese Simplified",
-          "name": "平原",
-          "multiverseid": 383630
-        },
         {
           "language": "Chinese Traditional",
           "name": "平原",
@@ -28608,21 +28595,6 @@
           "multiverseid": 385050
         },
         {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 385051
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 385052
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 385053
-        },
-        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 385334
@@ -28641,6 +28613,26 @@
           "language": "Korean",
           "name": "들",
           "multiverseid": 385337
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386186
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386187
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386188
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386189
         }
       ],
       "id": "dec8380db34752f51cd8a6fe1fedc6d17c570cdf",
@@ -28899,11 +28891,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "平原",
-          "multiverseid": 383630
-        },
-        {
           "language": "Chinese Traditional",
           "name": "平原",
           "multiverseid": 383914
@@ -28989,21 +28976,6 @@
           "multiverseid": 385050
         },
         {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 385051
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 385052
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 385053
-        },
-        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 385334
@@ -29022,6 +28994,26 @@
           "language": "Korean",
           "name": "들",
           "multiverseid": 385337
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386186
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386187
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386188
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386189
         }
       ],
       "id": "eb24d98fc680316042403bc104e54bf71c1d1df3",
@@ -29661,11 +29653,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "平原",
-          "multiverseid": 383630
-        },
-        {
           "language": "Chinese Traditional",
           "name": "平原",
           "multiverseid": 383914
@@ -29751,21 +29738,6 @@
           "multiverseid": 385050
         },
         {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 385051
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 385052
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 385053
-        },
-        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 385334
@@ -29784,6 +29756,26 @@
           "language": "Korean",
           "name": "들",
           "multiverseid": 385337
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386186
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386187
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386188
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 386189
         }
       ],
       "id": "af88e66bd3c3d671fd7f7b67d9dbc6c8e1badf0c",
@@ -33479,11 +33471,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "山脉",
-          "multiverseid": 383599
-        },
-        {
           "language": "Chinese Traditional",
           "name": "山脈",
           "multiverseid": 383883
@@ -33507,21 +33494,6 @@
           "language": "French",
           "name": "Montagne",
           "multiverseid": 384451
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 384452
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 384453
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 384454
         },
         {
           "language": "German",
@@ -33602,6 +33574,26 @@
           "language": "Korean",
           "name": "산",
           "multiverseid": 385306
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 386155
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 386156
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 386157
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 386158
         }
       ],
       "id": "76865a4949afc8292d7a9ab29948568ac4d5e0cd",
@@ -34249,11 +34241,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "山脉",
-          "multiverseid": 383599
-        },
-        {
           "language": "Chinese Traditional",
           "name": "山脈",
           "multiverseid": 383883
@@ -34277,21 +34264,6 @@
           "language": "French",
           "name": "Montagne",
           "multiverseid": 384451
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 384452
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 384453
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 384454
         },
         {
           "language": "German",
@@ -34372,6 +34344,26 @@
           "language": "Korean",
           "name": "산",
           "multiverseid": 385306
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 386155
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 386156
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 386157
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 386158
         }
       ],
       "id": "79b83e19e68e58c231590348bd39470de2150b29",
@@ -34754,9 +34746,9 @@
           "multiverseid": 385232
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 386081
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 385797
         }
       ],
       "id": "105d678e4c2b76ad2a15ae28c9bca8f964234b9e",
@@ -35137,9 +35129,9 @@
           "multiverseid": 385232
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 386081
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 385797
         }
       ],
       "id": "6a0d569aede12c94f1a27d2533ee9ca086639407",
@@ -35485,21 +35477,6 @@
           "multiverseid": 384945
         },
         {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 384946
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 384947
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 384948
-        },
-        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 385229
@@ -35523,6 +35500,21 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 386081
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 386082
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 386083
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 386084
         }
       ],
       "id": "4dc1f2c554d461d73f4dc9acb043a719cabb513d",
@@ -35903,9 +35895,9 @@
           "multiverseid": 385232
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 386081
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 385797
         }
       ],
       "id": "666c74d32a590296bbf53a19f9bec352bc0f0aa5",
@@ -36392,15 +36384,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         },
         {
           "date": "2012-07-01",
-          "text": "Destroying a blocking creature won’t cause any of the creatures it was blocking to become unblocked. They won’t deal combat damage to the defending player or planeswalker (unless they have trample)."
+          "text": "Destroying a blocking creature won't cause any of the creatures it was blocking to become unblocked. They won't deal combat damage to the defending player or planeswalker (unless they have trample)."
         }
       ],
       "starter": true,
@@ -36526,7 +36518,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "The set of creatures affected by Inspired Charge is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won’t get +2/+1."
+          "text": "The set of creatures affected by Inspired Charge is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get +2/+1."
         }
       ],
       "starter": true,
@@ -36766,6 +36758,10 @@
         },
         {
           "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -37055,19 +37051,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "starter": true,
@@ -37208,15 +37204,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "starter": true,
@@ -37906,15 +37902,15 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If Garruk’s Packleader and another creature with power 3 or greater enter the battlefield under your control at the same time, the ability will trigger."
+          "text": "If Garruk's Packleader and another creature with power 3 or greater enter the battlefield under your control at the same time, the ability will trigger."
         },
         {
           "date": "2012-07-01",
-          "text": "The ability checks the power of each creature as it enters the battlefield. It will take into account counters the permanent enters the battlefield with and static abilities that affect its power (such as Flinthoof Boar’s ability). After the creature is on the battlefield, raising its power with a spell (such as Titanic Growth), an activated ability, or a triggered ability won’t cause this ability to retroactively trigger."
+          "text": "The ability checks the power of each creature as it enters the battlefield. It will take into account counters the permanent enters the battlefield with and static abilities that affect its power (such as Flinthoof Boar's ability). After the creature is on the battlefield, raising its power with a spell (such as Titanic Growth), an activated ability, or a triggered ability won't cause this ability to retroactively trigger."
         },
         {
           "date": "2012-07-01",
-          "text": "The creature’s power is checked only to see if the ability triggers. It doesn’t matter what the creature’s power is when the ability resolves."
+          "text": "The creature's power is checked only to see if the ability triggers. It doesn't matter what the creature's power is when the ability resolves."
         }
       ],
       "starter": true,
@@ -38032,7 +38028,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Terra Stomper can be targeted by spells that try to counter it (such as Cancel). Those spells will resolve, but the part of their effect that would counter Terra Stomper won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Terra Stomper can be targeted by spells that try to counter it (such as Cancel). Those spells will resolve, but the part of their effect that would counter Terra Stomper won't do anything. Any other effects those spells have will work as normal."
         }
       ],
       "starter": true,

--- a/json/MBS.json
+++ b/json/MBS.json
@@ -562,7 +562,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you’ll still gain the life."
+          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you'll still gain the life."
         }
       ],
       "text": "Destroy target artifact. You gain life equal to its converted mana cost.",
@@ -672,7 +672,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "You can cast this with zero targets. If you do, you’ll get to draw a card. However, if you cast this with at least one target and all of those targets become illegal (because another effect has removed them from the graveyard, perhaps), the spell will be countered and you won’t get to draw a card."
+          "text": "You can cast this with zero targets. If you do, you'll get to draw a card. However, if you cast this with at least one target and all of those targets become illegal (because another effect has removed them from the graveyard, perhaps), the spell will be countered and you won't get to draw a card."
         }
       ],
       "text": "Put any number of target artifact cards from your graveyard on top of your library.\nDraw a card.",
@@ -779,15 +779,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You can activate Gore Vassal’s ability targeting itself, but it won’t get a -1/-1 counter or regenerate because it’ll be an illegal target when the ability resolves."
+          "text": "You can activate Gore Vassal's ability targeting itself, but it won't get a -1/-1 counter or regenerate because it'll be an illegal target when the ability resolves."
         },
         {
           "date": "2011-06-01",
-          "text": "The regeneration shield will last until the turn ends or until it’s used."
+          "text": "The regeneration shield will last until the turn ends or until it's used."
         },
         {
           "date": "2011-06-01",
-          "text": "Let’s say you activate Gore Vassal’s ability targeting a creature with 3 toughness and 2 damage marked on it. The regeneration shield will be created just before the creature is destroyed for having damage marked on it equal to or greater than its toughness. The creature will then regenerate. That is, all damage will be removed from it and it will become tapped; any counters on the creature, including the -1/-1 counter put on by this ability, remain."
+          "text": "Let's say you activate Gore Vassal's ability targeting a creature with 3 toughness and 2 damage marked on it. The regeneration shield will be created just before the creature is destroyed for having damage marked on it equal to or greater than its toughness. The creature will then regenerate. That is, all damage will be removed from it and it will become tapped; any counters on the creature, including the -1/-1 counter put on by this ability, remain."
         }
       ],
       "subtypes": [
@@ -1018,7 +1018,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The number of creatures Kemba’s Legion can block is calculated when blocking creatures are declared. Take into account the number of Equipment attached to Kemba’s Legion at that time, as well as any other effects that increase the number of creatures Kemba’s Legion can block."
+          "text": "The number of creatures Kemba's Legion can block is calculated when blocking creatures are declared. Take into account the number of Equipment attached to Kemba's Legion at that time, as well as any other effects that increase the number of creatures Kemba's Legion can block."
         }
       ],
       "subtypes": [
@@ -1670,11 +1670,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Any triggered abilities that trigger because a creature was destroyed won’t be put onto the stack until after Phyrexian Rebirth finishes resolving. This means the Horror creature token can be targeted by those abilities, if applicable."
+          "text": "Any triggered abilities that trigger because a creature was destroyed won't be put onto the stack until after Phyrexian Rebirth finishes resolving. This means the Horror creature token can be targeted by those abilities, if applicable."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature regenerates or has indestructible, it won’t be counted when determining the value of X."
+          "text": "If a creature regenerates or has indestructible, it won't be counted when determining the value of X."
         }
       ],
       "text": "Destroy all creatures, then create an X/X colorless Horror artifact creature token, where X is the number of creatures destroyed this way.",
@@ -1997,7 +1997,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Victory’s Herald also gains flying (which will likely be redundant) and lifelink if it’s still attacking when the ability resolves."
+          "text": "Victory's Herald also gains flying (which will likely be redundant) and lifelink if it's still attacking when the ability resolves."
         }
       ],
       "subtypes": [
@@ -2108,7 +2108,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         }
       ],
       "text": "Create X 2/2 white Cat creature tokens. Shuffle White Sun's Zenith into its owner's library.",
@@ -2217,11 +2217,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         },
         {
           "date": "2011-06-01",
-          "text": "You follow the instructions in order. You won’t be able to draw the same Blue Sun’s Zenith that you cast."
+          "text": "You follow the instructions in order. You won't be able to draw the same Blue Sun's Zenith that you cast."
         }
       ],
       "text": "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.",
@@ -2329,7 +2329,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You may either draw two cards or not draw at all. You can’t choose to draw only one card."
+          "text": "You may either draw two cards or not draw at all. You can't choose to draw only one card."
         },
         {
           "date": "2011-06-01",
@@ -2565,11 +2565,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If the creature is an illegal target when the ability tries to resolve, it will be countered. Cryptoplasm won’t become a copy of that creature; it remains whatever it was before."
+          "text": "If the creature is an illegal target when the ability tries to resolve, it will be countered. Cryptoplasm won't become a copy of that creature; it remains whatever it was before."
         },
         {
           "date": "2011-06-01",
-          "text": "If another creature becomes a copy of Cryptoplasm, it will become a copy of whatever Cryptoplasm is currently copying (if anything), plus it will have Cryptoplasm’s triggered ability."
+          "text": "If another creature becomes a copy of Cryptoplasm, it will become a copy of whatever Cryptoplasm is currently copying (if anything), plus it will have Cryptoplasm's triggered ability."
         }
       ],
       "subtypes": [
@@ -2793,11 +2793,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You must be able to target another spell in order to cast Fuel for the Cause. You can’t just cast it in order to proliferate, and it can’t target itself."
+          "text": "You must be able to target another spell in order to cast Fuel for the Cause. You can't just cast it in order to proliferate, and it can't target itself."
         },
         {
           "date": "2011-06-01",
-          "text": "If the spell is an illegal target when Fuel for the Cause tries to resolve, it will be countered. You won’t proliferate."
+          "text": "If the spell is an illegal target when Fuel for the Cause tries to resolve, it will be countered. You won't proliferate."
         }
       ],
       "text": "Counter target spell, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -3008,7 +3008,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "“The same name as a permanent” means the same name as a permanent currently on the battlefield as Mitotic Manipulation resolves."
+          "text": "\"The same name as a permanent\" means the same name as a permanent currently on the battlefield as Mitotic Manipulation resolves."
         },
         {
           "date": "2011-06-01",
@@ -3016,7 +3016,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "You don’t reveal any of the other cards or the order in which they go to the bottom of your library."
+          "text": "You don't reveal any of the other cards or the order in which they go to the bottom of your library."
         }
       ],
       "text": "Look at the top seven cards of your library. You may put one of those cards onto the battlefield if it has the same name as a permanent. Put the rest on the bottom of your library in any order.",
@@ -4097,7 +4097,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You may target and put a charge counter on any artifact, even if it doesn’t have an ability that references charge counters."
+          "text": "You may target and put a charge counter on any artifact, even if it doesn't have an ability that references charge counters."
         }
       ],
       "subtypes": [
@@ -4320,7 +4320,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         }
       ],
       "text": "Put X -1/-1 counters on each creature. Shuffle Black Sun's Zenith into its owner's library.",
@@ -5270,7 +5270,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Nested Ghoul’s ability will trigger if a source with infect deals damage to it."
+          "text": "Nested Ghoul's ability will trigger if a source with infect deals damage to it."
         }
       ],
       "subtypes": [
@@ -5490,7 +5490,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If Phyrexian Crusader blocks or is blocked by a creature without first strike or double strike, the damage dealt by Phyrexian Crusader results in -1/-1 counters that will affect how much damage the other creature assigns (if it’s still on the battlefield)."
+          "text": "If Phyrexian Crusader blocks or is blocked by a creature without first strike or double strike, the damage dealt by Phyrexian Crusader results in -1/-1 counters that will affect how much damage the other creature assigns (if it's still on the battlefield)."
         }
       ],
       "subtypes": [
@@ -5824,7 +5824,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If one or more creatures an opponent controls are put into the graveyard at the same time as Sangromancer, Sangromancer’s first ability will trigger that many times."
+          "text": "If one or more creatures an opponent controls are put into the graveyard at the same time as Sangromancer, Sangromancer's first ability will trigger that many times."
         }
       ],
       "subtypes": [
@@ -6155,11 +6155,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the creature is an illegal target when Spread the Sickness tries to resolve, the spell is countered. You won’t proliferate."
+          "text": "If the creature is an illegal target when Spread the Sickness tries to resolve, the spell is countered. You won't proliferate."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature regenerates or has indestructible when Spread the Sickness resolves, you’ll still proliferate."
+          "text": "If the creature regenerates or has indestructible when Spread the Sickness resolves, you'll still proliferate."
         }
       ],
       "text": "Destroy target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -6265,7 +6265,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the creature is not put into a graveyard on the turn Virulent Wound resolves, its controller won’t get a poison counter."
+          "text": "If the creature is not put into a graveyard on the turn Virulent Wound resolves, its controller won't get a poison counter."
         }
       ],
       "text": "Put a -1/-1 counter on target creature. When that creature dies this turn, its controller gets a poison counter.",
@@ -6583,7 +6583,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The number of artifacts you control is checked only once: when Concussive Bolt resolves. If you don’t control three or more artifacts at that time, creatures will be able to block that turn, even if you gain control of more artifacts later in the turn."
+          "text": "The number of artifacts you control is checked only once: when Concussive Bolt resolves. If you don't control three or more artifacts at that time, creatures will be able to block that turn, even if you gain control of more artifacts later in the turn."
         },
         {
           "date": "2011-06-01",
@@ -6591,7 +6591,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you controlled three or more artifacts as Concussive Bolt resolved, the targeted player won’t be able to block with any creatures this turn. That is, the set of affected creatures isn’t locked in as the spell resolves."
+          "text": "If you controlled three or more artifacts as Concussive Bolt resolved, the targeted player won't be able to block with any creatures this turn. That is, the set of affected creatures isn't locked in as the spell resolves."
         }
       ],
       "text": "Concussive Bolt deals 4 damage to target player.\nMetalcraft — If you control three or more artifacts, creatures that player controls can't block this turn.",
@@ -6805,7 +6805,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the card you look at isn’t an instant or sorcery card, it remains on top of your library. You don’t reveal it."
+          "text": "If the card you look at isn't an instant or sorcery card, it remains on top of your library. You don't reveal it."
         },
         {
           "date": "2011-06-01",
@@ -7250,11 +7250,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The power of each creature is checked only when blocking creatures are declared. If a creature has power 1 or less at that time, it can’t block, even if its power was greater than 1 when the last ability resolved."
+          "text": "The power of each creature is checked only when blocking creatures are declared. If a creature has power 1 or less at that time, it can't block, even if its power was greater than 1 when the last ability resolved."
         },
         {
           "date": "2011-06-01",
-          "text": "Creatures with power 1 or less can’t block even if they weren’t on the battlefield when the last ability resolved."
+          "text": "Creatures with power 1 or less can't block even if they weren't on the battlefield when the last ability resolved."
         }
       ],
       "subtypes": [
@@ -7577,11 +7577,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Kuldotha Flamefiend’s ability may target up to four creatures and/or players. Each must be chosen to receive at least 1 damage."
+          "text": "Kuldotha Flamefiend's ability may target up to four creatures and/or players. Each must be chosen to receive at least 1 damage."
         },
         {
           "date": "2011-06-01",
-          "text": "You choose the target(s) and how the damage will be divided when you put the triggered ability on the stack. You don’t choose whether to sacrifice an artifact or which artifact you’re sacrificing until the ability resolves. Once you decide to sacrifice an artifact (or not), it’s too late for players to respond."
+          "text": "You choose the target(s) and how the damage will be divided when you put the triggered ability on the stack. You don't choose whether to sacrifice an artifact or which artifact you're sacrificing until the ability resolves. Once you decide to sacrifice an artifact (or not), it's too late for players to respond."
         }
       ],
       "subtypes": [
@@ -8004,7 +8004,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If Rally the Forces is cast before attackers are declared or after combat ends, it won’t do anything."
+          "text": "If Rally the Forces is cast before attackers are declared or after combat ends, it won't do anything."
         }
       ],
       "text": "Attacking creatures get +1/+0 and gain first strike until end of turn.",
@@ -8109,7 +8109,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         }
       ],
       "text": "Red Sun's Zenith deals X damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead. Shuffle Red Sun's Zenith into its owner's library.",
@@ -8632,7 +8632,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If Fangren Marauder has itself become an artifact for some reason, you’ll gain 5 life when it is put into a graveyard from the battlefield."
+          "text": "If Fangren Marauder has itself become an artifact for some reason, you'll gain 5 life when it is put into a graveyard from the battlefield."
         }
       ],
       "subtypes": [
@@ -8849,19 +8849,19 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         },
         {
           "date": "2016-06-08",
-          "text": "If Green Sun’s Zenith is countered, none of its effects will happen. Notably, it will be put into its owner’s graveyard rather than shuffled into its owner’s library."
+          "text": "If Green Sun's Zenith is countered, none of its effects will happen. Notably, it will be put into its owner's graveyard rather than shuffled into its owner's library."
         },
         {
           "date": "2016-06-08",
-          "text": "In most cases, if you own Green Sun’s Zenith and cast it, you’ll shuffle your library twice. In practice, shuffling once is sufficient, but effects that care about you shuffling your library (like Psychogenic Probe, for example) will see that you’ve shuffled twice."
+          "text": "In most cases, if you own Green Sun's Zenith and cast it, you'll shuffle your library twice. In practice, shuffling once is sufficient, but effects that care about you shuffling your library (like Psychogenic Probe, for example) will see that you've shuffled twice."
         },
         {
           "date": "2016-06-08",
-          "text": "If you own Green Sun’s Zenith, but an opponent casts it (due to Knowledge Pool’s effect, for example), that opponent searches his or her library for an appropriate creature card, then shuffles that library. That opponent then shuffles Green Sun’s Zenith into your library. You won’t shuffle any library in this case."
+          "text": "If you own Green Sun's Zenith, but an opponent casts it (due to Knowledge Pool's effect, for example), that opponent searches his or her library for an appropriate creature card, then shuffles that library. That opponent then shuffles Green Sun's Zenith into your library. You won't shuffle any library in this case."
         }
       ],
       "text": "Search your library for a green creature card with converted mana cost X or less, put it onto the battlefield, then shuffle your library. Shuffle Green Sun's Zenith into its owner's library.",
@@ -9069,19 +9069,19 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Melira’s Keepers can’t have any kind of counters placed on it, not just -1/-1 counters."
+          "text": "Melira's Keepers can't have any kind of counters placed on it, not just -1/-1 counters."
         },
         {
           "date": "2011-06-01",
-          "text": "Damage from a source with infect has no effect on Melira’s Keepers. No -1/-1 counters are placed on it, and no damage is marked on it. The damage is still dealt for purposes of effects that care about damage, such as lifelink."
+          "text": "Damage from a source with infect has no effect on Melira's Keepers. No -1/-1 counters are placed on it, and no damage is marked on it. The damage is still dealt for purposes of effects that care about damage, such as lifelink."
         },
         {
           "date": "2011-06-01",
-          "text": "If Melira’s Keepers would enter the battlefield with a counter on it, it simply enters the battlefield without that counter."
+          "text": "If Melira's Keepers would enter the battlefield with a counter on it, it simply enters the battlefield without that counter."
         },
         {
           "date": "2011-06-01",
-          "text": "If a creature with a counter on it becomes a copy of Melira’s Keepers, those counters will remain."
+          "text": "If a creature with a counter on it becomes a copy of Melira's Keepers, those counters will remain."
         }
       ],
       "subtypes": [
@@ -9292,11 +9292,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If multiple damage prevention effects, including Phyrexian Hydra’s, are attempting to prevent damage that would be dealt to Phyrexian Hydra, its controller chooses which to apply."
+          "text": "If multiple damage prevention effects, including Phyrexian Hydra's, are attempting to prevent damage that would be dealt to Phyrexian Hydra, its controller chooses which to apply."
         },
         {
           "date": "2011-06-01",
-          "text": "If damage dealt to Phyrexian Hydra can’t be prevented (due to Leyline of Punishment, for example), it will be dealt as normal and won’t cause Phyrexian Hydra to put -1/-1 counters on itself."
+          "text": "If damage dealt to Phyrexian Hydra can't be prevented (due to Leyline of Punishment, for example), it will be dealt as normal and won't cause Phyrexian Hydra to put -1/-1 counters on itself."
         }
       ],
       "subtypes": [
@@ -9633,11 +9633,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then resolve Praetor’s Counsel, you have no maximum hand size. However, if those events happened in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then resolve Praetor's Counsel, you have no maximum hand size. However, if those events happened in the opposite order, your maximum hand size would be two."
         },
         {
           "date": "2011-06-01",
-          "text": "Later effects that modify your maximum hand size, but don’t set it to a specific number, will have no effect."
+          "text": "Later effects that modify your maximum hand size, but don't set it to a specific number, will have no effect."
         }
       ],
       "text": "Return all cards from your graveyard to your hand. Exile Praetor's Counsel. You have no maximum hand size for the rest of the game.",
@@ -9846,7 +9846,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If Rot Wolf and a creature dealt damage by Rot Wolf go to the graveyard at the same time, Rot Wolf’s ability will trigger."
+          "text": "If Rot Wolf and a creature dealt damage by Rot Wolf go to the graveyard at the same time, Rot Wolf's ability will trigger."
         }
       ],
       "subtypes": [
@@ -10498,7 +10498,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If an artifact you own and a creature an opponent controls go to the graveyard at the same time, you may choose that artifact card as the target of Glissa, the Traitor’s ability (even if they’re the same card: an artifact creature you own that an opponent controlled)."
+          "text": "If an artifact you own and a creature an opponent controls go to the graveyard at the same time, you may choose that artifact card as the target of Glissa, the Traitor's ability (even if they're the same card: an artifact creature you own that an opponent controlled)."
         }
       ],
       "subtypes": [
@@ -10614,15 +10614,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The artifact targeted by the second ability will retain any types, subtypes, or supertypes it has. Notably, if an Equipment becomes an artifact creature, it can’t be attached to another creature. If it was attached to a creature, it becomes unattached."
+          "text": "The artifact targeted by the second ability will retain any types, subtypes, or supertypes it has. Notably, if an Equipment becomes an artifact creature, it can't be attached to another creature. If it was attached to a creature, it becomes unattached."
         },
         {
           "date": "2011-06-01",
-          "text": "If the target of the second ability is already an artifact creature, its power and toughness will each become 5. This overwrites all previous effects that set the creature’s power and toughness to specific values. Any power- or toughness-setting effects that start to apply after this ability resolves will overwrite this effect."
+          "text": "If the target of the second ability is already an artifact creature, its power and toughness will each become 5. This overwrites all previous effects that set the creature's power and toughness to specific values. Any power- or toughness-setting effects that start to apply after this ability resolves will overwrite this effect."
         },
         {
           "date": "2011-06-01",
-          "text": "Effects that modify that creature’s power or toughness, such as the effects of Giant Growth, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as -1/-1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify that creature's power or toughness, such as the effects of Giant Growth, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as -1/-1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2011-06-01",
@@ -10831,7 +10831,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed or if its toughness is 0 or less. (In these cases, of course, Blightsteel Colossus would be shuffled into its owner’s library instead of being put into its owner’s graveyard.)"
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed or if its toughness is 0 or less. (In these cases, of course, Blightsteel Colossus would be shuffled into its owner's library instead of being put into its owner's graveyard.)"
         }
       ],
       "subtypes": [
@@ -10943,15 +10943,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If there are no creature cards in any graveyard when Bonehoard’s living weapon ability resolves, the Germ will be 0/0 and put into its owner’s graveyard."
+          "text": "If there are no creature cards in any graveyard when Bonehoard's living weapon ability resolves, the Germ will be 0/0 and put into its owner's graveyard."
         },
         {
           "date": "2011-06-01",
-          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won’t increase the bonus granted by Bonehoard, however briefly."
+          "text": "Although creature tokens go to the graveyard before ceasing to exist, they never count as creature cards and won't increase the bonus granted by Bonehoard, however briefly."
         },
         {
           "date": "2011-06-01",
-          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won’t get an additional bonus from the other creature."
+          "text": "If lethal damage is dealt simultaneously to the equipped creature and another creature, both creatures are put into the graveyard at the same time. The equipped creature won't get an additional bonus from the other creature."
         }
       ],
       "subtypes": [
@@ -11055,11 +11055,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If one of the targets is illegal when the activated ability resolves, nothing will happen and the Equipment won’t move. Notably, if an opponent gains control of either target in response, the Equipment won’t move."
+          "text": "If one of the targets is illegal when the activated ability resolves, nothing will happen and the Equipment won't move. Notably, if an opponent gains control of either target in response, the Equipment won't move."
         },
         {
           "date": "2011-06-01",
-          "text": "Unlike the equip ability, Brass Squire’s ability can be activated whenever you could cast an instant."
+          "text": "Unlike the equip ability, Brass Squire's ability can be activated whenever you could cast an instant."
         }
       ],
       "subtypes": [
@@ -11959,7 +11959,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The ability will trigger when Ichor Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn’t resolved yet."
+          "text": "The ability will trigger when Ichor Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn't resolved yet."
         }
       ],
       "text": "When Ichor Wellspring enters the battlefield or is put into a graveyard from the battlefield, draw a card.",
@@ -12058,15 +12058,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You may cast any other card exiled by Knowledge Pool, including one owned by an opponent. Any card exiled by Knowledge Pool’s enters-the-battlefield ability or its other triggered ability may be cast."
+          "text": "You may cast any other card exiled by Knowledge Pool, including one owned by an opponent. Any card exiled by Knowledge Pool's enters-the-battlefield ability or its other triggered ability may be cast."
         },
         {
           "date": "2011-06-01",
-          "text": "The spell a player casts from his or her hand won’t resolve if it’s exiled, even if that spell can’t be countered by spells or abilities."
+          "text": "The spell a player casts from his or her hand won't resolve if it's exiled, even if that spell can't be countered by spells or abilities."
         },
         {
           "date": "2011-06-01",
-          "text": "If the original spell isn’t exiled (perhaps because it’s countered by another spell or ability before Knowledge Pool’s second triggered ability resolves), the rest of the ability does nothing. The player doesn’t get to cast an exiled card."
+          "text": "If the original spell isn't exiled (perhaps because it's countered by another spell or ability before Knowledge Pool's second triggered ability resolves), the rest of the ability does nothing. The player doesn't get to cast an exiled card."
         },
         {
           "date": "2011-06-01",
@@ -12082,7 +12082,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Timing restrictions based on the card’s type are ignored. For example, you can cast an exiled creature card this way. Other restrictions, such as Spinal Embrace’s “Cast Spinal Embrace only during combat” are not ignored."
+          "text": "Timing restrictions based on the card's type are ignored. For example, you can cast an exiled creature card this way. Other restrictions, such as Spinal Embrace's \"Cast Spinal Embrace only during combat\" are not ignored."
         },
         {
           "date": "2011-06-01",
@@ -12397,15 +12397,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "As the token is created, it checks the printed values of the artifact it’s copying, as well as any copy effects that have been applied to it."
+          "text": "As the token is created, it checks the printed values of the artifact it's copying, as well as any copy effects that have been applied to it."
         },
         {
           "date": "2011-06-01",
-          "text": "The copiable values of the token’s characteristics are the same as the copiable values of the characteristics of the artifact it’s copying."
+          "text": "The copiable values of the token's characteristics are the same as the copiable values of the characteristics of the artifact it's copying."
         },
         {
           "date": "2011-06-01",
-          "text": "If the artifact that caused Mirrorworks’s ability to trigger has already left the battlefield by the time the ability resolves, you can still pay {2}. If you do, you’ll still put a token onto the battlefield. That token has the copiable values of the characteristics of that nontoken artifact as it last existed on the battlefield."
+          "text": "If the artifact that caused Mirrorworks's ability to trigger has already left the battlefield by the time the ability resolves, you can still pay {2}. If you do, you'll still put a token onto the battlefield. That token has the copiable values of the characteristics of that nontoken artifact as it last existed on the battlefield."
         }
       ],
       "text": "Whenever another nontoken artifact enters the battlefield under your control, you may pay {2}. If you do, create a token that's a copy of that artifact.",
@@ -12708,7 +12708,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You can tap a Myr that hasn’t been under your control since your most recent turn began to pay for the cost of the second activated ability."
+          "text": "You can tap a Myr that hasn't been under your control since your most recent turn began to pay for the cost of the second activated ability."
         }
       ],
       "text": "{T}: Create a 1/1 colorless Myr artifact creature token.\n{T}, Tap five untapped Myr you control: Search your library for a Myr creature card, put it onto the battlefield, then shuffle your library.",
@@ -12809,15 +12809,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Myr Welder has only the activated abilities of cards it exiles. It doesn’t gain triggered abilities or static abilities."
+          "text": "Myr Welder has only the activated abilities of cards it exiles. It doesn't gain triggered abilities or static abilities."
         },
         {
           "date": "2011-06-01",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities; they have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities; they have colons in their reminder text."
         },
         {
           "date": "2011-06-01",
-          "text": "If an activated ability of a card exiled with Myr Welder references the card it’s printed on by name, treat Myr Welder’s version of that ability as though it referenced Myr Welder by name instead. For example, if Lux Cannon (which says, in part, “{T}: Put a charge counter on Lux Cannon.”) has been exiled by Myr Welder, Myr Welder has the ability “{T}: Put a charge counter on Myr Welder.”"
+          "text": "If an activated ability of a card exiled with Myr Welder references the card it's printed on by name, treat Myr Welder's version of that ability as though it referenced Myr Welder by name instead. For example, if Lux Cannon (which says, in part, \"{T}: Put a charge counter on Lux Cannon.\") has been exiled by Myr Welder, Myr Welder has the ability \"{T}: Put a charge counter on Myr Welder.\""
         }
       ],
       "subtypes": [
@@ -13225,11 +13225,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Activated abilities are written in the form “Cost: Effect.” Some keywords are activated abilities and will have colons in their reminder texts. Static and triggered abilities of sources with the chosen name are unaffected."
+          "text": "Activated abilities are written in the form \"Cost: Effect.\" Some keywords are activated abilities and will have colons in their reminder texts. Static and triggered abilities of sources with the chosen name are unaffected."
         },
         {
           "date": "2014-07-18",
-          "text": "Phyrexian Revoker’s ability affects sources with the chosen name no matter what zone they are in. For example, if Soul of Ravnica is the chosen name, the ability that exiles it from a player’s graveyard can’t be activated."
+          "text": "Phyrexian Revoker's ability affects sources with the chosen name no matter what zone they are in. For example, if Soul of Ravnica is the chosen name, the ability that exiles it from a player's graveyard can't be activated."
         }
       ],
       "subtypes": [
@@ -13438,7 +13438,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "You can sacrifice Piston Sledge to pay its own equip cost. It won’t become attached as it will be in your graveyard."
+          "text": "You can sacrifice Piston Sledge to pay its own equip cost. It won't become attached as it will be in your graveyard."
         }
       ],
       "subtypes": [
@@ -13852,7 +13852,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You may sacrifice Rusted Slasher to pay for its own regeneration ability. If you do, however, it won’t regenerate. It’ll just end up in its owner’s graveyard as a result of the sacrifice."
+          "text": "You may sacrifice Rusted Slasher to pay for its own regeneration ability. If you do, however, it won't regenerate. It'll just end up in its owner's graveyard as a result of the sacrifice."
         }
       ],
       "subtypes": [
@@ -13959,7 +13959,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Because the artifact lands of the original _Mirrodin_(R) block aren’t cast, Shimmer Myr’s ability doesn’t affect them."
+          "text": "Because the artifact lands of the original _Mirrodin_(R) block aren't cast, Shimmer Myr's ability doesn't affect them."
         }
       ],
       "subtypes": [
@@ -14258,7 +14258,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The equipped creature will remain whatever color(s) it was previously. Becoming an artifact doesn’t make the creature colorless."
+          "text": "The equipped creature will remain whatever color(s) it was previously. Becoming an artifact doesn't make the creature colorless."
         }
       ],
       "subtypes": [
@@ -14655,7 +14655,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Spine of Ish Sah’s last ability doesn’t allow you to sacrifice it. You must find another way to get Spine of Ish Sah into the graveyard."
+          "text": "Spine of Ish Sah's last ability doesn't allow you to sacrifice it. You must find another way to get Spine of Ish Sah into the graveyard."
         }
       ],
       "text": "When Spine of Ish Sah enters the battlefield, destroy target permanent.\nWhen Spine of Ish Sah is put into a graveyard from the battlefield, return Spine of Ish Sah to its owner's hand.",
@@ -14853,7 +14853,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You’ll untap all lands you control even if the player doesn’t discard a card."
+          "text": "You'll untap all lands you control even if the player doesn't discard a card."
         }
       ],
       "subtypes": [
@@ -15259,7 +15259,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If Training Drone has been declared as an attacking or blocking creature, and it stops being equipped later in combat, it won’t stop attacking or blocking."
+          "text": "If Training Drone has been declared as an attacking or blocking creature, and it stops being equipped later in combat, it won't stop attacking or blocking."
         }
       ],
       "subtypes": [
@@ -15462,11 +15462,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "The word “you” in a permanent’s trigger condition always refers to the permanent’s current controller."
+          "text": "The word \"you\" in a permanent's trigger condition always refers to the permanent's current controller."
         },
         {
           "date": "2011-06-01",
-          "text": "Gaining control of Contested War Zone doesn’t cause it to tap or untap."
+          "text": "Gaining control of Contested War Zone doesn't cause it to tap or untap."
         },
         {
           "date": "2011-06-01",
@@ -15567,11 +15567,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If Inkmoth Nexus entered the battlefield this turn and it’s not a creature, it can be tapped for mana. If it becomes a creature that turn, it can’t attack or be tapped for mana."
+          "text": "If Inkmoth Nexus entered the battlefield this turn and it's not a creature, it can be tapped for mana. If it becomes a creature that turn, it can't attack or be tapped for mana."
         },
         {
           "date": "2011-06-01",
-          "text": "If you’ve controlled Inkmoth Nexus continuously since your most recent turn began and it becomes a creature, it can attack or be tapped for mana."
+          "text": "If you've controlled Inkmoth Nexus continuously since your most recent turn began and it becomes a creature, it can attack or be tapped for mana."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Inkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying and infect until end of turn. It's still a land. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",

--- a/json/MD1.json
+++ b/json/MD1.json
@@ -73,7 +73,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other’s ability to trigger."
+          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other's ability to trigger."
         },
         {
           "date": "2005-08-01",
@@ -216,11 +216,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature’s controller won’t search for a basic land card."
+          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature's controller won't search for a basic land card."
         },
         {
           "date": "2017-03-14",
-          "text": "The controller of the exiled creature isn’t required to search his or her library for a basic land. If that player doesn’t, the player won’t shuffle his or her library."
+          "text": "The controller of the exiled creature isn't required to search his or her library for a basic land. If that player doesn't, the player won't shuffle his or her library."
         }
       ],
       "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
@@ -605,7 +605,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You’ll untap all lands you control even if the player doesn’t discard a card."
+          "text": "You'll untap all lands you control even if the player doesn't discard a card."
         }
       ],
       "subtypes": [
@@ -727,7 +727,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -800,11 +800,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren’t permanents and don’t exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
+          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren't permanents and don't exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s a creature whose toughness is 0 or less, or if it’s an Aura that’s either unattached or attached to something illegal."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's a creature whose toughness is 0 or less, or if it's an Aura that's either unattached or attached to something illegal."
         }
       ],
       "subtypes": [
@@ -866,7 +866,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -929,7 +929,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass’s triggered ability is put on the stack on top of it. City of Brass’s ability will resolve first."
+          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass's triggered ability is put on the stack on top of it. City of Brass's ability will resolve first."
         },
         {
           "date": "2004-10-04",
@@ -1037,7 +1037,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Vault of the Archangel’s last ability affects only creatures you control when that ability resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Vault of the Archangel's last ability affects only creatures you control when that ability resolves. It won't affect creatures that come under your control later in the turn."
         },
         {
           "date": "2011-01-22",
@@ -1096,7 +1096,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "At the time the ability resolves, you’ll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered the battlefield attacking (such as a token created by Militia’s Pride) doesn’t count because you never attacked with it."
+          "text": "At the time the ability resolves, you'll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered the battlefield attacking (such as a token created by Militia's Pride) doesn't count because you never attacked with it."
         }
       ],
       "text": "Hideaway (This land enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\n{T}: Add {W} to your mana pool.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",
@@ -1655,11 +1655,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If you activate Relic of Progenitus’s first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
+          "text": "If you activate Relic of Progenitus's first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "You can activate Relic of Progenitus’s second ability even if no players have any cards in their graveyards. You’ll still draw a card."
+          "text": "You can activate Relic of Progenitus's second ability even if no players have any cards in their graveyards. You'll still draw a card."
         }
       ],
       "text": "{T}: Target player exiles a card from his or her graveyard.\n{1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.",
@@ -1719,7 +1719,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "If the red source you chose changes colors before the damage is dealt, the damage-prevention effect doesn’t apply."
+          "text": "If the red source you chose changes colors before the damage is dealt, the damage-prevention effect doesn't apply."
         }
       ],
       "subtypes": [
@@ -1929,11 +1929,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({B/P} can be paid with either {B} or 2 life.)\nTarget creature gets -5/-5 until end of turn.",
@@ -1992,15 +1992,15 @@
       "rulings": [
         {
           "date": "2006-05-01",
-          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won’t get to search for a land card."
+          "text": "If you target Ghost Quarter with its own ability, the ability will be countered because its target is no longer on the battlefield. You won't get to search for a land card."
         },
         {
           "date": "2011-09-22",
-          "text": "If the targeted land is an illegal target by the time Ghost Quarter’s ability resolves, it will be countered and none of its effects will happen. The land’s controller won’t get to search for a basic land card."
+          "text": "If the targeted land is an illegal target by the time Ghost Quarter's ability resolves, it will be countered and none of its effects will happen. The land's controller won't get to search for a basic land card."
         },
         {
           "date": "2013-07-01",
-          "text": "The target land’s controller gets to search for a basic land card even if that land wasn’t destroyed by Ghost Quarter’s ability. This may happen because the land has indestructible or because it was regenerated."
+          "text": "The target land's controller gets to search for a basic land card even if that land wasn't destroyed by Ghost Quarter's ability. This may happen because the land has indestructible or because it was regenerated."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it onto the battlefield, then shuffle his or her library.",

--- a/json/ME2.json
+++ b/json/ME2.json
@@ -117,11 +117,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If Angel of Fury is removed from the graveyard after the ability triggers but before it resolves, it will remain in its zone when its owner shuffles his or her library. Similarly, if a replacement effect has it move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If Angel of Fury is removed from the graveyard after the ability triggers but before it resolves, it will remain in its zone when its owner shuffles his or her library. Similarly, if a replacement effect has it move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         },
         {
           "date": "2008-10-01",
-          "text": "Angel of Fury’s second ability is a leaves-the-battlefield ability. Because it works only from on the battlefield, it behaves differently than the _Lorwyn_ Incarnations. When Angel of Fury is put into a graveyard from the battlefield, it will look back in time (to the point just before it left the battlefield) to see if its ability triggers. That means the following: — If Angel of Fury lost its triggered ability while on the battlefield (due to Snakeform, for example) and then was destroyed, the ability would not trigger. Angel of Fury would stay in its owner’s graveyard. — If Angel of Fury had its triggered ability when it left the battlefield, but lost it when it was put into the graveyard (due to Yixlid Jailer, for example), the ability would still trigger. Angel of Fury would be shuffled into its owner’s library."
+          "text": "Angel of Fury's second ability is a leaves-the-battlefield ability. Because it works only from on the battlefield, it behaves differently than the _Lorwyn_ Incarnations. When Angel of Fury is put into a graveyard from the battlefield, it will look back in time (to the point just before it left the battlefield) to see if its ability triggers. That means the following: — If Angel of Fury lost its triggered ability while on the battlefield (due to Snakeform, for example) and then was destroyed, the ability would not trigger. Angel of Fury would stay in its owner's graveyard. — If Angel of Fury had its triggered ability when it left the battlefield, but lost it when it was put into the graveyard (due to Yixlid Jailer, for example), the ability would still trigger. Angel of Fury would be shuffled into its owner's library."
         }
       ],
       "subtypes": [
@@ -389,7 +389,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Aysen Crusader’s ability counts the number of permanents you control that are Soldiers and/or Warriors. A permanent with both creature types is counted only once."
+          "text": "Aysen Crusader's ability counts the number of permanents you control that are Soldiers and/or Warriors. A permanent with both creature types is counted only once."
         }
       ],
       "subtypes": [
@@ -713,7 +713,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -775,27 +775,27 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you put this on your opponent’s creature, they decide whether or not to make their creature deal no damage to you."
+          "text": "If you put this on your opponent's creature, they decide whether or not to make their creature deal no damage to you."
         },
         {
           "date": "2008-10-01",
-          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won’t be around to deal its combat damage."
+          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won't be around to deal its combat damage."
         },
         {
           "date": "2008-10-01",
-          "text": "If the same creature is enchanted with more than one Farrel’s Mantle, they’ll each trigger if that creature attacks and isn’t blocked. The creature’s controller may have it deal damage multiple times. As long as the enchanted creature’s controller chooses to use Farrel’s Mantle’s ability at least once to deal damage, the enchanted creature will deal no combat damage."
+          "text": "If the same creature is enchanted with more than one Farrel's Mantle, they'll each trigger if that creature attacks and isn't blocked. The creature's controller may have it deal damage multiple times. As long as the enchanted creature's controller chooses to use Farrel's Mantle's ability at least once to deal damage, the enchanted creature will deal no combat damage."
         },
         {
           "date": "2008-10-01",
-          "text": "If the enchanted creature’s controller chooses to have it deal no combat damage, that combat damage is not prevented. It’s simply not dealt. A creature whose damage can’t be prevented (such as Excruciator) would deal no combat damage this way."
+          "text": "If the enchanted creature's controller chooses to have it deal no combat damage, that combat damage is not prevented. It's simply not dealt. A creature whose damage can't be prevented (such as Excruciator) would deal no combat damage this way."
         },
         {
           "date": "2011-01-25",
-          "text": "The enchanted creature’s controller cannot choose to have the enchanted creature deal damage to itself. If there are no other creatures on the battlefield, then a legal target cannot be chosen so the ability does nothing."
+          "text": "The enchanted creature's controller cannot choose to have the enchanted creature deal damage to itself. If there are no other creatures on the battlefield, then a legal target cannot be chosen so the ability does nothing."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -854,15 +854,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won’t be around to deal its combat damage."
+          "text": "This ability resolves during the declare blockers step. If the damage dealt this way is enough to destroy an attacking or blocking creature, that other creature won't be around to deal its combat damage."
         },
         {
           "date": "2008-10-01",
-          "text": "If there are no other creatures on the battlefield, Farrel’s Zealot will have to target itself. Of course, you can choose not to use the ability when it resolves."
+          "text": "If there are no other creatures on the battlefield, Farrel's Zealot will have to target itself. Of course, you can choose not to use the ability when it resolves."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -981,7 +981,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1106,7 +1106,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If Inheritance and a creature are each put into a graveyard from the battlefield at the same time, Inheritance’s ability will trigger."
+          "text": "If Inheritance and a creature are each put into a graveyard from the battlefield at the same time, Inheritance's ability will trigger."
         }
       ],
       "text": "Whenever a creature dies, you may pay {3}. If you do, draw a card.",
@@ -1162,7 +1162,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The player who controlled Ivory Gargoyle when it was put into a graveyard will skip his or her next draw step even if Ivory Gargoyle is returned to the battlefield under a different player’s control (because it’s owned by someone else) or isn’t returned to the battlefield at all (because it left the graveyard before the end of the turn, for example)."
+          "text": "The player who controlled Ivory Gargoyle when it was put into a graveyard will skip his or her next draw step even if Ivory Gargoyle is returned to the battlefield under a different player's control (because it's owned by someone else) or isn't returned to the battlefield at all (because it left the graveyard before the end of the turn, for example)."
         },
         {
           "date": "2008-10-01",
@@ -1343,11 +1343,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The ability will trigger only if Kjeldoran Home Guard is still on the battlefield at end of combat. If it’s been dealt lethal combat damage and destroyed during that combat (or has left the battlefield during that combat by any other means), its ability won’t trigger and you won’t get a token."
+          "text": "The ability will trigger only if Kjeldoran Home Guard is still on the battlefield at end of combat. If it's been dealt lethal combat damage and destroyed during that combat (or has left the battlefield during that combat by any other means), its ability won't trigger and you won't get a token."
         },
         {
           "date": "2008-10-01",
-          "text": "You put the Deserter token onto the battlefield even if you can’t put a -0/-1 counter on Kjeldoran Home Guard (because it left the battlefield after its ability triggered but before it resolved, for example)."
+          "text": "You put the Deserter token onto the battlefield even if you can't put a -0/-1 counter on Kjeldoran Home Guard (because it left the battlefield after its ability triggered but before it resolved, for example)."
         }
       ],
       "subtypes": [
@@ -1409,7 +1409,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1858,7 +1858,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Royal Decree’s ability will trigger a maximum of once for each permanent that becomes tapped, even if that permanent meets multiple criteria. (For example, Badlands is both a Swamp and a Mountain.)"
+          "text": "Royal Decree's ability will trigger a maximum of once for each permanent that becomes tapped, even if that permanent meets multiple criteria. (For example, Badlands is both a Swamp and a Mountain.)"
         }
       ],
       "text": "Cumulative upkeep {W} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever a Swamp, Mountain, black permanent, or red permanent becomes tapped, Royal Decree deals 1 damage to that permanent's controller.",
@@ -2065,7 +2065,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -2143,15 +2143,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         },
         {
           "date": "2008-10-01",
-          "text": "The second ability applies only if your life total is being reduced by damage. Other effects or costs (such as “lose 1 life” or “pay 1 life”) can reduce your life total below 1 as normal."
+          "text": "The second ability applies only if your life total is being reduced by damage. Other effects or costs (such as \"lose 1 life\" or \"pay 1 life\") can reduce your life total below 1 as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "If an effect asks you to pay life, you can’t pay more life than you have."
+          "text": "If an effect asks you to pay life, you can't pay more life than you have."
         },
         {
           "date": "2008-10-01",
@@ -2159,11 +2159,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The ability doesn’t change how much damage is dealt; it just changes how much life that damage makes you lose. An effect such as Spirit Link will see the full amount of damage being dealt."
+          "text": "The ability doesn't change how much damage is dealt; it just changes how much life that damage makes you lose. An effect such as Spirit Link will see the full amount of damage being dealt."
         },
         {
           "date": "2008-10-01",
-          "text": "Sustaining Spirit won’t prevent you from losing the game if your life total is 0 or less or some other effect causes you to lose the game."
+          "text": "Sustaining Spirit won't prevent you from losing the game if your life total is 0 or less or some other effect causes you to lose the game."
         }
       ],
       "subtypes": [
@@ -2246,7 +2246,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -2350,7 +2350,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Affects any spell with the type creature, including those with other types such as artifact or enchantment. This includes older cards with “summon” on their type line."
+          "text": "Affects any spell with the type creature, including those with other types such as artifact or enchantment. This includes older cards with \"summon\" on their type line."
         }
       ],
       "text": "Creature spells can't be cast.\nPay 4 life: Destroy Aether Storm. It can't be regenerated. Any player may activate this ability.",
@@ -2406,11 +2406,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2008-10-01",
-          "text": "If an affected land later loses the supertype snow, Balduvian Conjurer’s effect doesn’t end. The land will remain a creature until end of turn."
+          "text": "If an affected land later loses the supertype snow, Balduvian Conjurer's effect doesn't end. The land will remain a creature until end of turn."
         }
       ],
       "subtypes": [
@@ -2780,11 +2780,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with Dreams of the Dead would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence."
+          "text": "If a creature returned to the battlefield with Dreams of the Dead would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence."
         },
         {
           "date": "2013-04-15",
@@ -3113,7 +3113,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Shuffling a card from your hand into your library is mandatory. The effect says “if you do” because performing that action might have been impossible. If you fail to shuffle a card into your library because your hand was empty, you won’t draw any cards."
+          "text": "Shuffling a card from your hand into your library is mandatory. The effect says \"if you do\" because performing that action might have been impossible. If you fail to shuffle a card into your library because your hand was empty, you won't draw any cards."
         }
       ],
       "text": "Shuffle a card from your hand into your library. If you do, draw two cards at the beginning of the next turn's upkeep.",
@@ -3177,11 +3177,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the artifact when you lose control of it for any reason — because Magus of the Unseen’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the artifact when you lose control of it for any reason — because Magus of the Unseen's effect ends, or because a spell or ability causes another player to gain control of it."
         },
         {
           "date": "2008-10-01",
-          "text": "The artifact will gain haste whether or not it’s a creature. Of course, if it’s not a creature, haste will have no particular effect."
+          "text": "The artifact will gain haste whether or not it's a creature. Of course, if it's not a creature, haste will have no particular effect."
         }
       ],
       "subtypes": [
@@ -3348,11 +3348,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         },
         {
           "date": "2008-10-01",
-          "text": "This ability has no duration. An affected creature will retain the triggered ability until the game ends, it leaves the battlefield, or some other effect causes it to lose its abilities. It doesn’t matter if Musician is still on the battlefield or not."
+          "text": "This ability has no duration. An affected creature will retain the triggered ability until the game ends, it leaves the battlefield, or some other effect causes it to lose its abilities. It doesn't matter if Musician is still on the battlefield or not."
         },
         {
           "date": "2008-10-01",
@@ -3360,7 +3360,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If a music counter is put on a creature by some other means (Fate Transfer, for example), but that creature has never been affected by Musician’s ability, that creature won’t have the triggered ability and its controller won’t have to pay mana. The music counters will stay on that creature but won’t do anything."
+          "text": "If a music counter is put on a creature by some other means (Fate Transfer, for example), but that creature has never been affected by Musician's ability, that creature won't have the triggered ability and its controller won't have to pay mana. The music counters will stay on that creature but won't do anything."
         }
       ],
       "subtypes": [
@@ -3466,7 +3466,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -3521,7 +3521,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the ability resolves, then the targeted creature’s toughness becomes greater than 2 later, Phantasmal Mount’s effect will not end. (The ability checks whether the creature has toughness 2 or less only at the time you activate it and the time it resolves.)"
+          "text": "If the ability resolves, then the targeted creature's toughness becomes greater than 2 later, Phantasmal Mount's effect will not end. (The ability checks whether the creature has toughness 2 or less only at the time you activate it and the time it resolves.)"
         }
       ],
       "subtypes": [
@@ -3649,11 +3649,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The creature returns to the opponent when the “until end of turn” effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
+          "text": "The creature returns to the opponent when the \"until end of turn\" effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command's effect ends, or because a spell or ability causes another player to gain control of it."
         }
       ],
       "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature gains haste until end of turn. When you lose control of the creature, tap it.",
@@ -3805,7 +3805,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, if one of the lands has become an illegal target (because it’s no longer on the battlefield, for example), you return the other one to your hand. If both of the lands have become illegal targets, the ability is countered. This has no effect on Sea Drake."
+          "text": "When the ability resolves, if one of the lands has become an illegal target (because it's no longer on the battlefield, for example), you return the other one to your hand. If both of the lands have become illegal targets, the ability is countered. This has no effect on Sea Drake."
         }
       ],
       "subtypes": [
@@ -3921,11 +3921,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Shyft’s ability won’t let you make it colorless. Colorless is not a color."
+          "text": "Shyft's ability won't let you make it colorless. Colorless is not a color."
         },
         {
           "date": "2008-10-01",
-          "text": "The ability’s effect has no duration. Shyft will remain the chosen color or colors until the game ends, it leaves the battlefield, or some other effect (such as the next time its ability resolves) changes its colors."
+          "text": "The ability's effect has no duration. Shyft will remain the chosen color or colors until the game ends, it leaves the battlefield, or some other effect (such as the next time its ability resolves) changes its colors."
         }
       ],
       "subtypes": [
@@ -3987,7 +3987,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Your opponent does not have to draw a card if they don’t want to."
+          "text": "Your opponent does not have to draw a card if they don't want to."
         }
       ],
       "subtypes": [
@@ -4047,11 +4047,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Even though the two activated abilities have the same cost, they’re separate. You choose which one you’re activating before you exile the top card of your library (and see what it is)."
+          "text": "Even though the two activated abilities have the same cost, they're separate. You choose which one you're activating before you exile the top card of your library (and see what it is)."
         },
         {
           "date": "2008-10-01",
-          "text": "If you activate Storm Elemental’s third ability and the exiled card is not a snow land, the ability has no effect."
+          "text": "If you activate Storm Elemental's third ability and the exiled card is not a snow land, the ability has no effect."
         }
       ],
       "subtypes": [
@@ -4106,7 +4106,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one.",
@@ -4161,11 +4161,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you don’t pay Thought Lash’s cumulative upkeep, you’ll sacrifice Thought Lash as normal, then, when its triggered ability resolves, you’ll exile all cards in your library."
+          "text": "If you don't pay Thought Lash's cumulative upkeep, you'll sacrifice Thought Lash as normal, then, when its triggered ability resolves, you'll exile all cards in your library."
         },
         {
           "date": "2008-10-01",
-          "text": "If your library has no cards in it, you can’t activate the last ability."
+          "text": "If your library has no cards in it, you can't activate the last ability."
         }
       ],
       "text": "Cumulative upkeep—Exile the top card of your library. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen a player doesn't pay Thought Lash's cumulative upkeep, that player exiles all cards from his or her library.\nExile the top card of your library: Prevent the next 1 damage that would be dealt to you this turn.",
@@ -4598,7 +4598,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "A card is “above” another card in your graveyard if it was put into that graveyard later."
+          "text": "A card is \"above\" another card in your graveyard if it was put into that graveyard later."
         },
         {
           "date": "2008-10-01",
@@ -4610,11 +4610,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -4675,7 +4675,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the ability is activated during a turn’s Ending phase (after any “at the beginning of the End step” triggers would have triggered that turn), the Graveborn token will remain on the battlefield until the following turn’s End step."
+          "text": "If the ability is activated during a turn's Ending phase (after any \"at the beginning of the End step\" triggers would have triggered that turn), the Graveborn token will remain on the battlefield until the following turn's End step."
         }
       ],
       "subtypes": [
@@ -4736,7 +4736,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -4852,7 +4852,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -4917,15 +4917,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Once the creature is returned to the battlefield, Dance of the Dead can’t be attached to anything other than it (unless Dance of the Dead somehow manages to put a different creature onto the battlefield). Attempting to move Dance of the Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Dance of the Dead can't be attached to anything other than it (unless Dance of the Dead somehow manages to put a different creature onto the battlefield). Attempting to move Dance of the Dead to another creature won't work."
         },
         {
           "date": "2008-04-01",
-          "text": "If the creature card put onto the battlefield has protection from black (or anything that prevents this from legally being attached), this won’t be able to attach to it. Then this will go to the graveyard as a state-based action, causing the creature to be sacrificed."
+          "text": "If the creature card put onto the battlefield has protection from black (or anything that prevents this from legally being attached), this won't be able to attach to it. Then this will go to the graveyard as a state-based action, causing the creature to be sacrificed."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -5053,7 +5053,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "There is no way to make this card affect your opponent. It affects “you”, and “you” means the controller of the spell. It has no targets."
+          "text": "There is no way to make this card affect your opponent. It affects \"you\", and \"you\" means the controller of the spell. It has no targets."
         },
         {
           "date": "2004-10-04",
@@ -5061,11 +5061,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You don’t name a card until Demonic Consultation resolves."
+          "text": "You don't name a card until Demonic Consultation resolves."
         },
         {
           "date": "2008-10-01",
-          "text": "If you don’t reveal the named card (perhaps because it was in the top six cards of your library), you’ll end up exiling your entire library. You don’t lose the game at that point, but will lose the next time you’re instructed to draw a card."
+          "text": "If you don't reveal the named card (perhaps because it was in the top six cards of your library), you'll end up exiling your entire library. You don't lose the game at that point, but will lose the next time you're instructed to draw a card."
         }
       ],
       "text": "Choose a card name. Exile the top six cards of your library, then reveal cards from the top of your library until you reveal a card with the chosen name. Put that card into your hand and exile all other cards revealed this way.",
@@ -5553,7 +5553,7 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "Checks only on resolution to see if the land has the supertype snow; it’s not part of the targeting condition."
+          "text": "Checks only on resolution to see if the land has the supertype snow; it's not part of the targeting condition."
         }
       ],
       "text": "Destroy target land. If that land was a snow land, Icequake deals 1 damage to that land's controller.",
@@ -5708,7 +5708,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This effect changes the type of mana produced, but not the amount. For example, if a land that’s tapped for mana would add {W}{W} to its controller’s mana pool, it adds {B}{B} to that player’s mana pool instead."
+          "text": "This effect changes the type of mana produced, but not the amount. For example, if a land that's tapped for mana would add {W}{W} to its controller's mana pool, it adds {B}{B} to that player's mana pool instead."
         }
       ],
       "text": "Cumulative upkeep—Pay {B} and 1 life. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nIf a land is tapped for mana, it produces {B} instead of any other type.",
@@ -5771,7 +5771,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "When Kjeldoran Dead’s enters-the-battlefield ability resolves, if you don’t control any other creatures, you must sacrifice Kjeldoran Dead itself."
+          "text": "When Kjeldoran Dead's enters-the-battlefield ability resolves, if you don't control any other creatures, you must sacrifice Kjeldoran Dead itself."
         }
       ],
       "subtypes": [
@@ -6005,19 +6005,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "At the beginning of each end step, the game checks all creatures that died that turn to see if Krovikan Vampire had dealt damage to them during the turn. It doesn’t matter whether the damage was combat damage, and it doesn’t matter whether the damage was what caused the creatures to die."
+          "text": "At the beginning of each end step, the game checks all creatures that died that turn to see if Krovikan Vampire had dealt damage to them during the turn. It doesn't matter whether the damage was combat damage, and it doesn't matter whether the damage was what caused the creatures to die."
         },
         {
           "date": "2004-10-04",
-          "text": "If a creature Krovikan Vampire dealt damage to dies, then leaves the graveyard by some means, the game loses track of it. Krovikan Vampire’s ability won’t be able to return it to the battlefield, even if it’s put back into the graveyard before the end step."
+          "text": "If a creature Krovikan Vampire dealt damage to dies, then leaves the graveyard by some means, the game loses track of it. Krovikan Vampire's ability won't be able to return it to the battlefield, even if it's put back into the graveyard before the end step."
         },
         {
           "date": "2008-08-01",
-          "text": "Whoever controls Krovikan Vampire when the ability triggers will return the applicable cards to the battlefield under his or her control. It doesn’t matter who controlled it at the time the damage was dealt."
+          "text": "Whoever controls Krovikan Vampire when the ability triggers will return the applicable cards to the battlefield under his or her control. It doesn't matter who controlled it at the time the damage was dealt."
         },
         {
           "date": "2008-08-01",
-          "text": "If Krovikan Vampire isn’t on the battlefield at the beginning of the end step, its ability won’t trigger. No cards will be returned to the battlefield, even if Krovikan Vampire dealt damage to some creatures that died that turn."
+          "text": "If Krovikan Vampire isn't on the battlefield at the beginning of the end step, its ability won't trigger. No cards will be returned to the battlefield, even if Krovikan Vampire dealt damage to some creatures that died that turn."
         },
         {
           "date": "2008-10-01",
@@ -6135,11 +6135,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you don’t sacrifice a creature at the beginning of your upkeep (either by choice or because you can’t), but you somehow prevent all the damage Minion of Leshrac would deal to you, then you don’t tap Minion of Leshrac."
+          "text": "If you don't sacrifice a creature at the beginning of your upkeep (either by choice or because you can't), but you somehow prevent all the damage Minion of Leshrac would deal to you, then you don't tap Minion of Leshrac."
         },
         {
           "date": "2008-10-01",
-          "text": "Minion of Leshrac can’t target itself with its activated ability because it has protection from black."
+          "text": "Minion of Leshrac can't target itself with its activated ability because it has protection from black."
         }
       ],
       "subtypes": [
@@ -6203,7 +6203,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "You don’t need to show the opponent what order you put the cards on top of his or her library."
+          "text": "You don't need to show the opponent what order you put the cards on top of his or her library."
         }
       ],
       "text": "Put up to three target cards from an opponent's graveyard on top of his or her library in any order.",
@@ -6256,7 +6256,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6319,11 +6319,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Necropotence’s last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
+          "text": "Necropotence's last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
         },
         {
           "date": "2016-06-08",
-          "text": "If the discarded card isn’t put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won’t be exiled."
+          "text": "If the discarded card isn't put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won't be exiled."
         }
       ],
       "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
@@ -6381,11 +6381,11 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Note that the wording “Effects that alter the creature’s power alter its toughness instead, and vice versa, this turn” has been removed."
+          "text": "Note that the wording \"Effects that alter the creature's power alter its toughness instead, and vice versa, this turn\" has been removed."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that switch power and toughness are always applied last when determining a creature’s power and toughness, even if other power/toughness-changing effects are created later in the turn. For example, if you activate Phantasmal Fiend’s first ability, it will become 2/4. Then if you activate its second ability, it will become 4/2. Then if you activate its first ability again, it will become 3/3."
+          "text": "Effects that switch power and toughness are always applied last when determining a creature's power and toughness, even if other power/toughness-changing effects are created later in the turn. For example, if you activate Phantasmal Fiend's first ability, it will become 2/4. Then if you activate its second ability, it will become 4/2. Then if you activate its first ability again, it will become 3/3."
         },
         {
           "date": "2013-04-15",
@@ -6393,7 +6393,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -6512,7 +6512,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Add {B} to your mana pool for each creature card in your graveyard.",
@@ -6566,11 +6566,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You exile exactly one creature. You can’t exile more than one in an attempt to get a larger effect."
+          "text": "You exile exactly one creature. You can't exile more than one in an attempt to get a larger effect."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "As an additional cost to cast Soul Exchange, exile a creature you control.\nReturn target creature card from your graveyard to the battlefield. Put a +2/+2 counter on that creature if the exiled creature was a Thrull.",
@@ -6732,15 +6732,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Withering Wisps’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless there are no creatures on the battlefield when a turn’s end step begins, and (2) the ability will do nothing if there are any creatures on the battlefield by the time the ability resolves."
+          "text": "Withering Wisps's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless there are no creatures on the battlefield when a turn's end step begins, and (2) the ability will do nothing if there are any creatures on the battlefield by the time the ability resolves."
         },
         {
           "date": "2008-10-01",
-          "text": "If all creatures leave the battlefield during a turn’s End step (after any “at the beginning of the end step” triggers would have triggered that turn), Withering Wisps will remain on the battlefield because the trigger condition has already passed."
+          "text": "If all creatures leave the battlefield during a turn's End step (after any \"at the beginning of the end step\" triggers would have triggered that turn), Withering Wisps will remain on the battlefield because the trigger condition has already passed."
         },
         {
           "date": "2008-10-01",
-          "text": "The number of snow Swamps you control and the number of times Withering Wisps’s ability has been activated so far that turn are checked each time you attempt to activate the ability."
+          "text": "The number of snow Swamps you control and the number of times Withering Wisps's ability has been activated so far that turn are checked each time you attempt to activate the ability."
         }
       ],
       "text": "At the beginning of the end step, if no creatures are on the battlefield, sacrifice Withering Wisps.\n{B}: Withering Wisps deals 1 damage to each creature and each player. Activate this ability no more times each turn than the number of snow Swamps you control.",
@@ -7096,7 +7096,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target any instant spell with Burnout. If it’s blue at the time Burnout resolves, that spell will be countered and you’ll draw a card at the beginning of the next turn’s upkeep. If it’s not blue at the time Burnout resolves, that spell won’t be countered, but you’ll still draw a card at the beginning of the next turn’s upkeep."
+          "text": "You may target any instant spell with Burnout. If it's blue at the time Burnout resolves, that spell will be countered and you'll draw a card at the beginning of the next turn's upkeep. If it's not blue at the time Burnout resolves, that spell won't be countered, but you'll still draw a card at the beginning of the next turn's upkeep."
         }
       ],
       "text": "Counter target instant spell if it's blue.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -7206,7 +7206,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "A card is “directly above” another card in your graveyard if it was put into that graveyard later and there are no cards in between the two."
+          "text": "A card is \"directly above\" another card in your graveyard if it was put into that graveyard later and there are no cards in between the two."
         },
         {
           "date": "2008-10-01",
@@ -7218,11 +7218,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "text": "Death Spark deals 1 damage to target creature or player.\nAt the beginning of your upkeep, if Death Spark is in your graveyard with a creature card directly above it, you may pay {1}. If you do, return Death Spark to your hand.",
@@ -7278,11 +7278,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Can only attack alone” means the enchanted creature can’t be declared as an attacker during the declare attackers step unless no other creatures are declared as attackers at that time (either by you or your Two-Headed Giant teammate)."
+          "text": "\"Can only attack alone\" means the enchanted creature can't be declared as an attacker during the declare attackers step unless no other creatures are declared as attackers at that time (either by you or your Two-Headed Giant teammate)."
         },
         {
           "date": "2008-10-01",
-          "text": "If the enchanted creature attacks alone, then a spell or ability causes another creature to be put onto the battlefield attacking, that’s fine."
+          "text": "If the enchanted creature attacks alone, then a spell or ability causes another creature to be put onto the battlefield attacking, that's fine."
         }
       ],
       "subtypes": [
@@ -7504,7 +7504,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Goblin Ski Patrol’s ability may be activated only once in the entire game. If its ability is activated and then it changes controllers, its ability may not be activated again, and its new controller will still have to sacrifice it at the beginning of the End step."
+          "text": "Goblin Ski Patrol's ability may be activated only once in the entire game. If its ability is activated and then it changes controllers, its ability may not be activated again, and its new controller will still have to sacrifice it at the beginning of the End step."
         }
       ],
       "subtypes": [
@@ -7622,11 +7622,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature card has “*” in its power, the ability that defines its power works in all zones."
+          "text": "If a creature card has \"*\" in its power, the ability that defines its power works in all zones."
         }
       ],
       "subtypes": [
@@ -7649,7 +7649,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Yes, I think ‘toast' is an appropriate description.\"\n—Jaya Ballard, task mage",
+      "flavor": "\"Yes, I think 'toast' is an appropriate description.\"\n—Jaya Ballard, task mage",
       "id": "702db8d45d0d0b5435b4ecaa7fee16c3a14bcaca",
       "imageName": "incinerate",
       "layout": "normal",
@@ -7705,7 +7705,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Regeneration abilities that would affect that creature can still be activated; they just won’t do anything. The creature can’t be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
+          "text": "Regeneration abilities that would affect that creature can still be activated; they just won't do anything. The creature can't be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
         }
       ],
       "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
@@ -7932,7 +7932,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose to do fractional damage to a target."
+          "text": "You can't choose to do fractional damage to a target."
         },
         {
           "date": "2008-10-01",
@@ -7995,7 +7995,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "First the player chooses all the tapped creatures he or she would like to untap this way. Then the entire payment is made at once, then all of those creatures untap at the same time. If the entire payment can’t be paid (because the player chose too many creatures, for example), none of it is paid and none of those creatures untap."
+          "text": "First the player chooses all the tapped creatures he or she would like to untap this way. Then the entire payment is made at once, then all of those creatures untap at the same time. If the entire payment can't be paid (because the player chose too many creatures, for example), none of it is paid and none of those creatures untap."
         }
       ],
       "text": "Creatures without flying don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, that player may choose any number of tapped creatures without flying he or she controls and pay {2} for each creature chosen this way. If the player does, untap those creatures.",
@@ -8155,7 +8155,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You choose the target when you activate the ability. You don’t flip a coin until the ability resolves."
+          "text": "You choose the target when you activate the ability. You don't flip a coin until the ability resolves."
         }
       ],
       "subtypes": [
@@ -8271,7 +8271,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This ability changes the targeted land’s land types. It doesn’t affect its name, its supertypes (such as whether or not it’s legendary, snow, or basic), or its other types (if it’s also a creature, for example). The ability will cause the land to lose all of its printed abilities and gain the ability “{T}: Add {B} to your mana pool.”"
+          "text": "This ability changes the targeted land's land types. It doesn't affect its name, its supertypes (such as whether or not it's legendary, snow, or basic), or its other types (if it's also a creature, for example). The ability will cause the land to lose all of its printed abilities and gain the ability \"{T}: Add {B} to your mana pool.\""
         }
       ],
       "subtypes": [
@@ -8393,11 +8393,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you lose control of Orcish Squatters before its ability resolves, you won’t gain control of the targeted land at all."
+          "text": "If you lose control of Orcish Squatters before its ability resolves, you won't gain control of the targeted land at all."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -8507,7 +8507,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Panic only during combat before blockers are declared.\nTarget creature can't block this turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -8733,11 +8733,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "No choices are made when this ability triggers. After the wage counter is put on Rogue Skycaptain, then you choose whether to pay mana and, if you don’t, which opponent gains control of it."
+          "text": "No choices are made when this ability triggers. After the wage counter is put on Rogue Skycaptain, then you choose whether to pay mana and, if you don't, which opponent gains control of it."
         },
         {
           "date": "2008-10-01",
-          "text": "If you can’t pay the entire payment, none of it is paid."
+          "text": "If you can't pay the entire payment, none of it is paid."
         }
       ],
       "subtypes": [
@@ -8800,7 +8800,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don’t actually have Flying."
+          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don't actually have Flying."
         }
       ],
       "subtypes": [
@@ -9079,7 +9079,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won’t be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
+          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won't be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
         }
       ],
       "subtypes": [
@@ -9184,15 +9184,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target any creature with this ability. It doesn’t have to be tapped."
+          "text": "You may target any creature with this ability. It doesn't have to be tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "If the targeted creature is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when the targeted creature is tapped."
+          "text": "If the targeted creature is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when the targeted creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Elvish Hunter doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, Elvish Hunter will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Elvish Hunter doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, Elvish Hunter will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -9519,7 +9519,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Forbidden Lore grants an activated ability to the enchanted land. Only that land’s controller can activate the ability."
+          "text": "Forbidden Lore grants an activated ability to the enchanted land. Only that land's controller can activate the ability."
         }
       ],
       "subtypes": [
@@ -9577,7 +9577,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You target an opponent when you cast Forgotten Lore. The opponent chooses a card in your graveyard as Forgotten Lore resolves. After that choice is made, you’re given the option to pay {G}. If you do, the targeted opponent must choose a different card, if there is one. (If there isn’t one, this part is skipped.) Then you’re given the option to pay {G} again. As long as you keep paying {G}, the process continues. As soon as you decline to pay {G}, the last card that was chosen by the opponent is put into your hand."
+          "text": "You target an opponent when you cast Forgotten Lore. The opponent chooses a card in your graveyard as Forgotten Lore resolves. After that choice is made, you're given the option to pay {G}. If you do, the targeted opponent must choose a different card, if there is one. (If there isn't one, this part is skipped.) Then you're given the option to pay {G} again. As long as you keep paying {G}, the process continues. As soon as you decline to pay {G}, the last card that was chosen by the opponent is put into your hand."
         },
         {
           "date": "2008-10-01",
@@ -9872,15 +9872,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "The second ability will trigger only if Joven’s Ferrets is still on the battlefield at end of combat. If it’s been dealt lethal combat damage and destroyed during that combat (or has left the battlefield during that combat by any other means), its ability won’t trigger and the creatures that blocked it won’t be affected."
+          "text": "The second ability will trigger only if Joven's Ferrets is still on the battlefield at end of combat. If it's been dealt lethal combat damage and destroyed during that combat (or has left the battlefield during that combat by any other means), its ability won't trigger and the creatures that blocked it won't be affected."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature affected by the second ability is untapped at the time its controller’s next untap step begins, the “doesn’t untap” effect doesn’t do anything. It won’t apply at some later time when that creature is tapped."
+          "text": "If a creature affected by the second ability is untapped at the time its controller's next untap step begins, the \"doesn't untap\" effect doesn't do anything. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "The second ability doesn’t track the creatures’ controllers. If an affected creature changes controllers before its old controller’s next untap step, Joven’s Ferrets will prevent it from being untapped during its new controller’s next untap step."
+          "text": "The second ability doesn't track the creatures' controllers. If an affected creature changes controllers before its old controller's next untap step, Joven's Ferrets will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -9941,7 +9941,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Kaysa’s ability affects itself."
+          "text": "Kaysa's ability affects itself."
         }
       ],
       "subtypes": [
@@ -10058,7 +10058,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Nature’s Wrath cares about who puts the permanent onto the battlefield, not under whose control the permanent enters the battlefield under."
+          "text": "Nature's Wrath cares about who puts the permanent onto the battlefield, not under whose control the permanent enters the battlefield under."
         }
       ],
       "text": "At the beginning of your upkeep, sacrifice Nature's Wrath unless you pay {G}.\nWhenever a player puts an Island or blue permanent onto the battlefield, he or she sacrifices an Island or blue permanent.\nWhenever a player puts a Swamp or black permanent onto the battlefield, he or she sacrifices a Swamp or black permanent.",
@@ -10110,11 +10110,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-10-01",
-          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can’t be paid."
+          "text": "The two creature cards are exiled as a cost. No one can respond to this. If no graveyard has two creature cards in it, the cost can't be paid."
         }
       ],
       "text": "{1}, Exile two creature cards from a single graveyard: Create a 1/1 green Saproling creature token.",
@@ -10170,7 +10170,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This effect changes the type of mana produced, but not the amount. For example, if a land that’s tapped for mana would add {W}{W} to its controller’s mana pool, it adds {C}{C} to that player’s mana pool instead."
+          "text": "This effect changes the type of mana produced, but not the amount. For example, if a land that's tapped for mana would add {W}{W} to its controller's mana pool, it adds {C}{C} to that player's mana pool instead."
         }
       ],
       "text": "Cumulative upkeep {2} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nIf a land is tapped for mana, it produces colorless mana instead of any other type.",
@@ -10270,11 +10270,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature affected by Spore Cloud is untapped at the time its controller’s next untap step begins, the “doesn’t untap” effect doesn’t do anything. It won’t apply at some later time when that creature is tapped."
+          "text": "If a creature affected by Spore Cloud is untapped at the time its controller's next untap step begins, the \"doesn't untap\" effect doesn't do anything. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Spore Cloud doesn’t track the creatures’ controllers. If an affected creature changes controllers before its old controller’s next untap step, Spore Cloud will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Spore Cloud doesn't track the creatures' controllers. If an affected creature changes controllers before its old controller's next untap step, Spore Cloud will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "text": "Tap all blocking creatures. Prevent all combat damage that would be dealt this turn. Each attacking creature and each blocking creature doesn't untap during its controller's next untap step.",
@@ -10597,7 +10597,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -10866,11 +10866,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -10878,7 +10878,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -11264,7 +11264,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Fumarole can’t be cast unless you can target both a creature and a land. If there’s a permanent on the battlefield that’s both a creature and a land, it can be both targets."
+          "text": "Fumarole can't be cast unless you can target both a creature and a land. If there's a permanent on the battlefield that's both a creature and a land, it can be both targets."
         }
       ],
       "text": "As an additional cost to cast Fumarole, pay 3 life.\nDestroy target creature and target land.",
@@ -11623,15 +11623,15 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a land affected by Winter’s Night is untapped at the time its controller’s next untap step begins, the “doesn’t untap” effect doesn’t do anything. It won’t apply at some later time when that land is tapped."
+          "text": "If a land affected by Winter's Night is untapped at the time its controller's next untap step begins, the \"doesn't untap\" effect doesn't do anything. It won't apply at some later time when that land is tapped."
         },
         {
           "date": "2008-10-01",
-          "text": "Winter’s Night doesn’t track the lands’ controllers. If an affected land changes controllers before its old controller’s next untap step, Winter’s Night will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Winter's Night doesn't track the lands' controllers. If an affected land changes controllers before its old controller's next untap step, Winter's Night will prevent it from being untapped during its new controller's next untap step."
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -11872,7 +11872,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "When Clockwork Steed’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "When Clockwork Steed's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         },
         {
           "date": "2008-10-01",
@@ -11930,11 +11930,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You own a nontoken permanent if it started the game in your deck. If it started the game in no one’s deck (for example, it was brought into the game by Living Wish), you own it if you brought it into the game."
+          "text": "You own a nontoken permanent if it started the game in your deck. If it started the game in no one's deck (for example, it was brought into the game by Living Wish), you own it if you brought it into the game."
         },
         {
           "date": "2012-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         }
       ],
       "text": "{T}: Destroy target permanent you own. It can't be regenerated.",
@@ -11988,15 +11988,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the Bottle leaves the battlefield or your control, the cards remain waiting until played or until the beginning of your next upkeep. The card is in the “Exile” zone."
+          "text": "If the Bottle leaves the battlefield or your control, the cards remain waiting until played or until the beginning of your next upkeep. The card is in the \"Exile\" zone."
         },
         {
           "date": "2004-10-04",
-          "text": "The card is not part of your hand in any way. You can’t be forced to discard it due to a discard from hand effect, and you can’t discard it to pay a cost."
+          "text": "The card is not part of your hand in any way. You can't be forced to discard it due to a discard from hand effect, and you can't discard it to pay a cost."
         },
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2008-08-01",
@@ -12004,7 +12004,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The exiled card is played using the normal timing rules for its card type, as well as any other applicable restrictions such as “Cast [this card] only during combat.” For example, you can’t play the card during an opponent’s turn unless it’s an instant or has flash. Similarly, if the exiled card is a land, you can’t play it if you’ve already played a land that turn. If it’s a nonland card, you’ll have to pay its mana cost. The only thing that’s different is you’re playing it from the Exile zone."
+          "text": "The exiled card is played using the normal timing rules for its card type, as well as any other applicable restrictions such as \"Cast [this card] only during combat.\" For example, you can't play the card during an opponent's turn unless it's an instant or has flash. Similarly, if the exiled card is a land, you can't play it if you've already played a land that turn. If it's a nonland card, you'll have to pay its mana cost. The only thing that's different is you're playing it from the Exile zone."
         }
       ],
       "text": "{3}, {T}: Exile the top card of your library. Until the beginning of your next upkeep, you may play that card.",
@@ -12093,7 +12093,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The last ability will trigger when a different player gains control of Gustha’s Scepter, as well as when Gustha’s Scepter leaves the battlefield."
+          "text": "The last ability will trigger when a different player gains control of Gustha's Scepter, as well as when Gustha's Scepter leaves the battlefield."
         }
       ],
       "text": "{T}: Exile a card from your hand face down. You may look at it for as long as it remains exiled.\n{T}: Return a card you own exiled with Gustha's Scepter to your hand.\nWhen you lose control of Gustha's Scepter, put all cards exiled with Gustha's Scepter into their owner's graveyard.",
@@ -12142,11 +12142,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You put the creature card onto the battlefield even if you can’t sacrifice Helm of Obedience (because it’s left the battlefield by the time its ability resolves, for example)."
+          "text": "You put the creature card onto the battlefield even if you can't sacrifice Helm of Obedience (because it's left the battlefield by the time its ability resolves, for example)."
         },
         {
           "date": "2008-10-01",
-          "text": "If an effect like that of Leyline of the Void prevents cards from being put into your opponent’s graveyard, the process described in the first sentence of Helm of Obedience’s effect will never stop. Your opponent’s entire library will be exiled, even if X is 1."
+          "text": "If an effect like that of Leyline of the Void prevents cards from being put into your opponent's graveyard, the process described in the first sentence of Helm of Obedience's effect will never stop. Your opponent's entire library will be exiled, even if X is 1."
         }
       ],
       "text": "{X}, {T}: Target opponent puts cards from the top of his or her library into his or her graveyard until a creature card or X cards are put into that graveyard this way, whichever comes first. If a creature card is put into that graveyard this way, sacrifice Helm of Obedience and put that card onto the battlefield under your control. X can't be 0.",
@@ -12241,7 +12241,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Charge counters are indistinguishable from one another. If some other spell or ability (such as Power Conduit’s ability) puts a charge counter on Jeweled Amulet, activating Jeweled Amulet’s second ability will still check the type of mana last noted by its first ability. If there is no type of mana noted by its first ability (because it hasn’t been activated by that point), the second ability will produce no mana."
+          "text": "Charge counters are indistinguishable from one another. If some other spell or ability (such as Power Conduit's ability) puts a charge counter on Jeweled Amulet, activating Jeweled Amulet's second ability will still check the type of mana last noted by its first ability. If there is no type of mana noted by its first ability (because it hasn't been activated by that point), the second ability will produce no mana."
         }
       ],
       "text": "{1}, {T}: Put a charge counter on Jeweled Amulet. Note the type of mana spent to pay this activation cost. Activate this ability only if there are no charge counters on Jeweled Amulet.\n{T}, Remove a charge counter from Jeweled Amulet: Add one mana of Jeweled Amulet's last noted type to your mana pool.",
@@ -12290,7 +12290,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Up to four” means zero, one, two, three, or four. If you choose zero targets, you still choose a player. That player will draw a card at the beginning of the next turn’s upkeep."
+          "text": "\"Up to four\" means zero, one, two, three, or four. If you choose zero targets, you still choose a player. That player will draw a card at the beginning of the next turn's upkeep."
         }
       ],
       "text": "{1}, {T}, Sacrifice Lodestone Bauble: Put up to four target basic land cards from a player's graveyard on top of his or her library in any order. That player draws a card at the beginning of the next turn's upkeep.",
@@ -12387,11 +12387,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2008-10-01",
-          "text": "The ability’s effect has no duration. The affected land will remain an artifact, creature, and land until the game ends, it leaves the battlefield, or some other effect changes its types."
+          "text": "The ability's effect has no duration. The affected land will remain an artifact, creature, and land until the game ends, it leaves the battlefield, or some other effect changes its types."
         }
       ],
       "text": "{T}, Sacrifice Mishra's Groundbreaker: Target land becomes a 3/3 artifact creature that's still a land. (This effect lasts indefinitely.)",
@@ -12441,7 +12441,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Phyrexian Devourer’s first ability continually checks its power as a state trigger. Once it triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again. If the ability resolves, you’ll have to sacrifice Phyrexian Devourer even if its power has been reduced to 6 or less by then."
+          "text": "Phyrexian Devourer's first ability continually checks its power as a state trigger. Once it triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again. If the ability resolves, you'll have to sacrifice Phyrexian Devourer even if its power has been reduced to 6 or less by then."
         }
       ],
       "subtypes": [
@@ -12495,7 +12495,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two piles don’t have to have the same number of cards in them. One of the piles may have zero cards."
+          "text": "The two piles don't have to have the same number of cards in them. One of the piles may have zero cards."
         }
       ],
       "text": "{3}: If your library has ten or more cards in it, target opponent looks at the top ten cards of your library and separates them into two face-down piles. Exile one of those piles. Search the other pile for a card, put it into your hand, then shuffle the rest of that pile into your library.",
@@ -12728,7 +12728,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -12825,7 +12825,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If your library has fewer than two cards in it, you can’t activate the ability."
+          "text": "If your library has fewer than two cards in it, you can't activate the ability."
         }
       ],
       "text": "{2}, Exile the top two cards of your library: Whirling Catapult deals 1 damage to each creature with flying and each player.",
@@ -12878,7 +12878,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land type changing effects that change a dual land’s land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
+          "text": "Land type changing effects that change a dual land's land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
         },
         {
           "date": "2004-10-04",
@@ -12890,7 +12890,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -13080,7 +13080,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "When Glacial Chasm’s enters-the-battlefield ability resolves, if you don’t control any other lands, you must sacrifice Glacial Chasm itself."
+          "text": "When Glacial Chasm's enters-the-battlefield ability resolves, if you don't control any other lands, you must sacrifice Glacial Chasm itself."
         }
       ],
       "text": "Cumulative upkeep—Pay 2 life. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Glacial Chasm enters the battlefield, sacrifice a land.\nCreatures you control can't attack.\nPrevent all damage that would be dealt to you.",
@@ -13221,7 +13221,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "You may target a tapped creature with Ice Floe’s activated ability."
+          "text": "You may target a tapped creature with Ice Floe's activated ability."
         },
         {
           "date": "2008-10-01",
@@ -13229,19 +13229,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the ability resolves, then the creature gains flying later, Ice Floe’s effect will not end. (The ability checks whether the creature has flying only at the time you activate it and the time it resolves.)"
+          "text": "If the ability resolves, then the creature gains flying later, Ice Floe's effect will not end. (The ability checks whether the creature has flying only at the time you activate it and the time it resolves.)"
         },
         {
           "date": "2008-10-01",
-          "text": "If the affected creature is untapped by some other spell or ability, Ice Floe’s effect will not end. If you keep Ice Floe tapped, and that creature becomes tapped again, Ice Floe will continue to prevent it from being untapped during its controller’s untap step."
+          "text": "If the affected creature is untapped by some other spell or ability, Ice Floe's effect will not end. If you keep Ice Floe tapped, and that creature becomes tapped again, Ice Floe will continue to prevent it from being untapped during its controller's untap step."
         },
         {
           "date": "2008-10-01",
-          "text": "Ice Floe doesn’t track the creature’s controller. If the affected creature changes controllers, Ice Floe will prevent it from being untapped during its new controller’s untap step."
+          "text": "Ice Floe doesn't track the creature's controller. If the affected creature changes controllers, Ice Floe will prevent it from being untapped during its new controller's untap step."
         },
         {
           "date": "2008-10-01",
-          "text": "If Ice Floe untaps or leaves the battlefield, its effect will end. This has no immediate visible affect on the creature. (It doesn’t untap immediately, for example.) The creature will just untap as normal during its controller’s next untap step."
+          "text": "If Ice Floe untaps or leaves the battlefield, its effect will end. This has no immediate visible affect on the creature. (It doesn't untap immediately, for example.) The creature will just untap as normal during its controller's next untap step."
         }
       ],
       "text": "You may choose not to untap Ice Floe during your untap step.\n{T}: Tap target creature without flying that's attacking you. It doesn't untap during its controller's untap step for as long as Ice Floe remains tapped.",
@@ -13390,7 +13390,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -13543,7 +13543,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -13604,7 +13604,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -13665,7 +13665,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -13723,7 +13723,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -13731,11 +13731,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -13796,7 +13796,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -13804,11 +13804,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -13869,7 +13869,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -13877,11 +13877,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -13942,7 +13942,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -13950,11 +13950,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [
@@ -14015,7 +14015,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "“Snow” has no particular meaning or rules associated with it."
+          "text": "\"Snow\" has no particular meaning or rules associated with it."
         },
         {
           "date": "2008-10-01",
@@ -14023,11 +14023,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In Limited events, you can’t add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
+          "text": "In Limited events, you can't add basic snow lands to your deck from outside your card pool. You may add only lands named Plains, Island, Swamp, Mountain, and Forest, as normal."
         },
         {
           "date": "2008-10-01",
-          "text": "Effects that target nonbasic lands can’t target basic snow lands."
+          "text": "Effects that target nonbasic lands can't target basic snow lands."
         }
       ],
       "subtypes": [

--- a/json/ME3.json
+++ b/json/ME3.json
@@ -175,7 +175,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A creature with power 3 or greater can’t be declared as a blocker for Amrou Kithkin. If the power of a creature that’s already blocking Amrou Kithkin is increased to 3 or greater, it will continue to block Amrou Kithkin."
+          "text": "A creature with power 3 or greater can't be declared as a blocker for Amrou Kithkin. If the power of a creature that's already blocking Amrou Kithkin is increased to 3 or greater, it will continue to block Amrou Kithkin."
         }
       ],
       "subtypes": [
@@ -234,7 +234,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose “colorless” as a color."
+          "text": "You can't choose \"colorless\" as a color."
         },
         {
           "date": "2009-10-01",
@@ -242,15 +242,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Call to Arms changes controllers, it will continue to check the nontoken permanents controlled by the player chosen as it entered the battlefield, even if that player isn’t an opponent of its current controller."
+          "text": "If Call to Arms changes controllers, it will continue to check the nontoken permanents controlled by the player chosen as it entered the battlefield, even if that player isn't an opponent of its current controller."
         },
         {
           "date": "2009-10-01",
-          "text": "The game continually counts the number of nontoken permanents of each color the chosen player controls. Multicolored ones are counted for each of their colors; colorless ones are ignored. The moment the number of nontoken permanents of the chosen color that player controls is less than or equal to the number of permanents of one of the other colors that player controls, Call to Arms’s second ability stops giving white creatures +1/+1 and its third ability triggers. Call to Arms will be sacrificed when the third ability resolves, even if those numbers have changed by then."
+          "text": "The game continually counts the number of nontoken permanents of each color the chosen player controls. Multicolored ones are counted for each of their colors; colorless ones are ignored. The moment the number of nontoken permanents of the chosen color that player controls is less than or equal to the number of permanents of one of the other colors that player controls, Call to Arms's second ability stops giving white creatures +1/+1 and its third ability triggers. Call to Arms will be sacrificed when the third ability resolves, even if those numbers have changed by then."
         },
         {
           "date": "2009-10-01",
-          "text": "Call to Arms’s third ability is a “state trigger.” Once a state trigger triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "Call to Arms's third ability is a \"state trigger.\" Once a state trigger triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         }
       ],
       "text": "As Call to Arms enters the battlefield, choose a color and an opponent.\nWhite creatures get +1/+1 as long as the chosen color is the most common color among nontoken permanents the chosen player controls but isn't tied for most common.\nWhen the chosen color isn't the most common color among nontoken permanents the chosen player controls or is tied for most common, sacrifice Call to Arms.",
@@ -505,15 +505,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "When Divine Intervention’s third ability resolves, the game ends immediately. The game is a draw, meaning neither player wins and neither player loses."
+          "text": "When Divine Intervention's third ability resolves, the game ends immediately. The game is a draw, meaning neither player wins and neither player loses."
         },
         {
           "date": "2009-10-01",
-          "text": "Divine Intervention’s third ability triggers only if its controller removes the last intervention counter from it. It doesn’t matter how that happens. For example, if you control Divine Intervention and the last intervention counter is removed as a result of a Clockspinning you control, the ability will trigger. On the other hand, if the last intervention counter is removed as a result of a Clockspinning another player controls, the ability won’t trigger (and won’t ever be able to)."
+          "text": "Divine Intervention's third ability triggers only if its controller removes the last intervention counter from it. It doesn't matter how that happens. For example, if you control Divine Intervention and the last intervention counter is removed as a result of a Clockspinning you control, the ability will trigger. On the other hand, if the last intervention counter is removed as a result of a Clockspinning another player controls, the ability won't trigger (and won't ever be able to)."
         },
         {
           "date": "2009-10-01",
-          "text": "In a multiplayer game played with the limited range of influence option, Divine Intervention won’t necessarily end the entire game when its third ability resolves. All players within range of Divine Intervention will leave the game. They’ll neither win nor lose; as far as they’re concerned, the result of the game is a draw. All other players will continue playing."
+          "text": "In a multiplayer game played with the limited range of influence option, Divine Intervention won't necessarily end the entire game when its third ability resolves. All players within range of Divine Intervention will leave the game. They'll neither win nor lose; as far as they're concerned, the result of the game is a draw. All other players will continue playing."
         }
       ],
       "text": "Divine Intervention enters the battlefield with two intervention counters on it.\nAt the beginning of your upkeep, remove an intervention counter from Divine Intervention.\nWhen you remove the last intervention counter from Divine Intervention, the game is a draw.",
@@ -563,11 +563,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If all the attacking creatures attack your planeswalkers, you can’t cast Eightfold Maze. To cast it, a creature needs to have attacked _you_."
+          "text": "If all the attacking creatures attack your planeswalkers, you can't cast Eightfold Maze. To cast it, a creature needs to have attacked _you_."
         },
         {
           "date": "2009-10-01",
-          "text": "If you’re able to cast Eightfold Maze, it can target any attacking creature (including one attacking a planeswalker)."
+          "text": "If you're able to cast Eightfold Maze, it can target any attacking creature (including one attacking a planeswalker)."
         }
       ],
       "text": "Cast Eightfold Maze only during the declare attackers step and only if you've been attacked this step.\nDestroy target attacking creature.",
@@ -715,15 +715,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "If Guan Yu, Sainted Warrior is removed from the graveyard after the ability triggers but before it resolves, it won’t get shuffled into your library."
+          "text": "If Guan Yu, Sainted Warrior is removed from the graveyard after the ability triggers but before it resolves, it won't get shuffled into your library."
         },
         {
           "date": "2009-10-01",
-          "text": "If a replacement effect has Guan Yu move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If a replacement effect has Guan Yu move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -833,7 +833,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You draw a card at the beginning of the next turn’s upkeep after Heal resolves, regardless of whether 1 damage was actually prevented."
+          "text": "You draw a card at the beginning of the next turn's upkeep after Heal resolves, regardless of whether 1 damage was actually prevented."
         }
       ],
       "text": "Prevent the next 1 damage that would be dealt to target creature or player this turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -1008,15 +1008,15 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "You can fetch any of the “Snow-Covered” lands, since they all also have the supertype basic."
+          "text": "You can fetch any of the \"Snow-Covered\" lands, since they all also have the supertype basic."
         },
         {
           "date": "2009-10-01",
-          "text": "This ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
+          "text": "This ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "You shuffle your library if you search, even if you don’t put any basic land cards into your hand."
+          "text": "You shuffle your library if you search, even if you don't put any basic land cards into your hand."
         }
       ],
       "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, and put them into your hand. If you do, shuffle your library.",
@@ -1072,11 +1072,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target any creature, not just one that doesn’t have first strike. If the targeted creature already has first strike as Lightning Blow resolves, Lightning Blow won’t affect it (since multiple instances of first strike are redundant), but you’ll still draw a card at the beginning of the next turn’s upkeep."
+          "text": "You may target any creature, not just one that doesn't have first strike. If the targeted creature already has first strike as Lightning Blow resolves, Lightning Blow won't affect it (since multiple instances of first strike are redundant), but you'll still draw a card at the beginning of the next turn's upkeep."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature doesn’t have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won’t prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
+          "text": "If the targeted creature doesn't have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won't prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
         }
       ],
       "text": "Target creature gains first strike until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -1128,7 +1128,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -1245,11 +1245,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The creature’s *owner* gains the life, regardless of who happens to control it."
+          "text": "The creature's *owner* gains the life, regardless of who happens to control it."
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         }
       ],
       "text": "Destroy target creature. Its owner gains 4 life.",
@@ -1351,7 +1351,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -1408,7 +1408,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -1464,7 +1464,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -1622,7 +1622,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -1691,7 +1691,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Untapping a tapped land an opponent controls is part of the cost of Benthic Explorers’s ability. If no opponent controls a tapped land, the ability can’t be activated."
+          "text": "Untapping a tapped land an opponent controls is part of the cost of Benthic Explorers's ability. If no opponent controls a tapped land, the ability can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -1699,15 +1699,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Benthic Explorers checks the effects of all mana-producing abilities of the land untapped to pay its cost, but it doesn’t check the costs of those abilities. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If you untap a tapped Vivid Crag an opponent controls while paying for Benthic Explorers’s ability, you can add one mana of any color to your mana pool. It doesn’t matter whether that Vivid Crag has a charge counter on it."
+          "text": "Benthic Explorers checks the effects of all mana-producing abilities of the land untapped to pay its cost, but it doesn't check the costs of those abilities. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If you untap a tapped Vivid Crag an opponent controls while paying for Benthic Explorers's ability, you can add one mana of any color to your mana pool. It doesn't matter whether that Vivid Crag has a charge counter on it."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what types of mana an opponent’s land could produce, take into account any applicable replacement effects that would apply to that land’s mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what types of mana an opponent's land could produce, take into account any applicable replacement effects that would apply to that land's mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Benthic Explorers doesn’t care about any restrictions or riders an opponent’s land (such as Ancient Ziggurat or Hall of the Bandit Lord) puts on the mana it produces. It just cares about types of mana."
+          "text": "Benthic Explorers doesn't care about any restrictions or riders an opponent's land (such as Ancient Ziggurat or Hall of the Bandit Lord) puts on the mana it produces. It just cares about types of mana."
         }
       ],
       "subtypes": [
@@ -1985,7 +1985,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Dance of Many leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and put a token onto the battlefield. That token won’t have any connection to a Dance of Many permanent, so it won’t be exiled when a Dance of Many leaves the battlefield."
+          "text": "If Dance of Many leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and put a token onto the battlefield. That token won't have any connection to a Dance of Many permanent, so it won't be exiled when a Dance of Many leaves the battlefield."
         }
       ],
       "text": "When Dance of Many enters the battlefield, create a token that's a copy of target nontoken creature.\nWhen Dance of Many leaves the battlefield, exile the token.\nWhen the token leaves the battlefield, sacrifice Dance of Many.\nAt the beginning of your upkeep, sacrifice Dance of Many unless you pay {U}{U}.",
@@ -2185,7 +2185,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target any artifact, creature, or land, not just a tapped one. If the targeted permanent is already untapped as Infuse resolves, Infuse won’t affect it, but you’ll still draw a card at the beginning of the next turn’s upkeep."
+          "text": "You may target any artifact, creature, or land, not just a tapped one. If the targeted permanent is already untapped as Infuse resolves, Infuse won't affect it, but you'll still draw a card at the beginning of the next turn's upkeep."
         }
       ],
       "text": "Untap target artifact, creature, or land.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -2238,11 +2238,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the creature Labyrinth Minotaur blocked is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when that creature is tapped."
+          "text": "If the creature Labyrinth Minotaur blocked is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when that creature is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Labyrinth Minotaur doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Labyrinth Minotaur doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -2297,15 +2297,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This effect applies no matter how the land would enter the battlefield: because an opponent plays it, or because a spell or ability allows that opponent to put it onto the battlefield. Note that it doesn’t matter whose control the land enters the battlefield under. If the opponent would put the land onto the battlefield under someone else’s control (as a result of Yavimaya Dryad’s ability, for example), that opponent will still have to sacrifice a land."
+          "text": "This effect applies no matter how the land would enter the battlefield: because an opponent plays it, or because a spell or ability allows that opponent to put it onto the battlefield. Note that it doesn't matter whose control the land enters the battlefield under. If the opponent would put the land onto the battlefield under someone else's control (as a result of Yavimaya Dryad's ability, for example), that opponent will still have to sacrifice a land."
         },
         {
           "date": "2009-10-01",
-          "text": "If an opponent puts a land onto the battlefield under his or her own control, he or she may sacrifice that same land. The player won’t be able to tap that land for mana before sacrificing it."
+          "text": "If an opponent puts a land onto the battlefield under his or her own control, he or she may sacrifice that same land. The player won't be able to tap that land for mana before sacrificing it."
         },
         {
           "date": "2009-10-01",
-          "text": "If a land that would enter the battlefield has its own “If [this land] would enter the battlefield” replacement effect, the player who will control that land chooses which replacement effect to apply. After applying one, if the other one would still be applicable, it’s then applied."
+          "text": "If a land that would enter the battlefield has its own \"If [this land] would enter the battlefield\" replacement effect, the player who will control that land chooses which replacement effect to apply. After applying one, if the other one would still be applicable, it's then applied."
         }
       ],
       "text": "If an opponent who controls at least as many lands as you do would put a land onto the battlefield, that player instead puts that land onto the battlefield then sacrifices a land.",
@@ -2357,7 +2357,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -2418,11 +2418,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "Lu Xun’s second ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Lu Xun's second ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -2482,15 +2482,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell “can’t be countered,” it remains on the stack. Mana Drain continues to resolve. At the beginning of your next main phase, the delayed triggered ability will still add the mana to your mana pool."
+          "text": "If the targeted spell \"can't be countered,\" it remains on the stack. Mana Drain continues to resolve. At the beginning of your next main phase, the delayed triggered ability will still add the mana to your mana pool."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell is an illegal target by the time Mana Drain resolves, Mana Drain is countered. You won’t get any mana later."
+          "text": "If the targeted spell is an illegal target by the time Mana Drain resolves, Mana Drain is countered. You won't get any mana later."
         },
         {
           "date": "2009-10-01",
-          "text": "Mana Drain’s delayed triggered ability will usually trigger at the beginning of your precombat main phase. However, if you cast Mana Drain during your precombat main phase or during your combat phase, its delayed triggered ability will trigger at the beginning of that turn’s postcombat main phase."
+          "text": "Mana Drain's delayed triggered ability will usually trigger at the beginning of your precombat main phase. However, if you cast Mana Drain during your precombat main phase or during your combat phase, its delayed triggered ability will trigger at the beginning of that turn's postcombat main phase."
         }
       ],
       "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} to your mana pool equal to that spell's converted mana cost.",
@@ -2545,7 +2545,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Mana Vortex’s third ability is a “state trigger.” Once a state trigger triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "Mana Vortex's third ability is a \"state trigger.\" Once a state trigger triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         }
       ],
       "text": "When you cast Mana Vortex, counter it unless you sacrifice a land.\nAt the beginning of each player's upkeep, that player sacrifices a land.\nWhen there are no lands on the battlefield, sacrifice Mana Vortex.",
@@ -2601,15 +2601,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Old Man of the Sea stops being tapped before its ability resolves — even if it becomes tapped again right away — you won’t gain control of the targeted creature at all. The same is true if the targeted creature’s power becomes greater than Old Man of the Sea’s power before the ability resolves."
+          "text": "If Old Man of the Sea stops being tapped before its ability resolves — even if it becomes tapped again right away — you won't gain control of the targeted creature at all. The same is true if the targeted creature's power becomes greater than Old Man of the Sea's power before the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "The ability doesn’t care whether Old Man of the Sea remains under your control, only that Old Man of the Sea remains tapped and its power remains large enough. If an opponent gains control of Old Man of the Sea, you’ll keep control of the affected creature (until Old Man of the Sea stops being tapped or it no longer has enough power)."
+          "text": "The ability doesn't care whether Old Man of the Sea remains under your control, only that Old Man of the Sea remains tapped and its power remains large enough. If an opponent gains control of Old Man of the Sea, you'll keep control of the affected creature (until Old Man of the Sea stops being tapped or it no longer has enough power)."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the targeted permanent remains a legal target for the ability, only that it’s on the battlefield and its power remains small enough. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason. If it stops being a creature, its power is considered to be 0."
+          "text": "Once the ability resolves, it doesn't care whether the targeted permanent remains a legal target for the ability, only that it's on the battlefield and its power remains small enough. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason. If it stops being a creature, its power is considered to be 0."
         }
       ],
       "subtypes": [
@@ -2666,11 +2666,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t discard cards until Recall resolves. If you don’t have X cards in your hand at that time, you discard all the cards in your hand."
+          "text": "You don't discard cards until Recall resolves. If you don't have X cards in your hand at that time, you discard all the cards in your hand."
         },
         {
           "date": "2009-10-01",
-          "text": "You don’t choose which cards in your graveyard you’ll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
+          "text": "You don't choose which cards in your graveyard you'll return to your hand until after you discard cards. You choose a card in your graveyard for each card you discarded, then you put all cards chosen this way into your hand at the same time. You may choose to return some or all of the cards you just discarded."
         }
       ],
       "text": "Discard X cards, then return a card from your graveyard to your hand for each card discarded this way. Exile Recall.",
@@ -2734,7 +2734,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -2831,7 +2831,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Reveka’s effect causes it not to untap during _your_ next untap step. If another player gains control of it, it will untap during that player’s next untap step."
+          "text": "Reveka's effect causes it not to untap during _your_ next untap step. If another player gains control of it, it will untap during that player's next untap step."
         }
       ],
       "subtypes": [
@@ -2894,15 +2894,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Spiny Starfish’s first ability creates a regeneration shield for it. Spiny Starfish’s second ability checks whether it _used_ any regeneration shields that turn, not whether any regeneration shields were created for it."
+          "text": "Spiny Starfish's first ability creates a regeneration shield for it. Spiny Starfish's second ability checks whether it _used_ any regeneration shields that turn, not whether any regeneration shields were created for it."
         },
         {
           "date": "2009-10-01",
-          "text": "The second ability doesn’t care where the regeneration shields Spiny Starfish used that turn came from. If it regenerated due to a regeneration shield from Refresh, for example, the ability will still put a Starfish token onto the battlefield."
+          "text": "The second ability doesn't care where the regeneration shields Spiny Starfish used that turn came from. If it regenerated due to a regeneration shield from Refresh, for example, the ability will still put a Starfish token onto the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "The second ability has an “intervening ‘if’ clause,” so it won’t trigger at all unless Spiny Starfish had regenerated that turn. However, the number of tokens that are created isn’t determined until the ability resolves (in case it regenerates again before that time)."
+          "text": "The second ability has an \"intervening 'if' clause,\" so it won't trigger at all unless Spiny Starfish had regenerated that turn. However, the number of tokens that are created isn't determined until the ability resolves (in case it regenerates again before that time)."
         },
         {
           "date": "2009-10-01",
@@ -2934,11 +2934,19 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
           "legality": "Legal"
         },
         {
@@ -3018,7 +3026,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -3079,11 +3087,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "Sun Quan’s ability affects Sun Quan itself."
+          "text": "Sun Quan's ability affects Sun Quan itself."
         }
       ],
       "subtypes": [
@@ -3143,7 +3151,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -3307,27 +3315,27 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since you can respond to triggered abilities, it is legal to sacrifice creatures using some spell or ability prior to resolving the ability that removes the final counter from All Hallow’s Eve."
+          "text": "Since you can respond to triggered abilities, it is legal to sacrifice creatures using some spell or ability prior to resolving the ability that removes the final counter from All Hallow's Eve."
         },
         {
           "date": "2007-02-01",
-          "text": "This card is once again a sorcery, and its ability looks very much like suspend (although it doesn’t have the suspend ability."
+          "text": "This card is once again a sorcery, and its ability looks very much like suspend (although it doesn't have the suspend ability."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "The only thing that happens when All Hallow’s Eve resolves is that it’s exiled with two scream counters on it."
+          "text": "The only thing that happens when All Hallow's Eve resolves is that it's exiled with two scream counters on it."
         },
         {
           "date": "2009-10-01",
-          "text": "All Hallow’s Eve’s triggered ability functions from the exile zone. This ability has an “intervening ‘if’ clause.” It won’t trigger at all unless All Hallow’s Eve is exiled and has a scream counter on it (which can happen only if it resolves as a spell)."
+          "text": "All Hallow's Eve's triggered ability functions from the exile zone. This ability has an \"intervening 'if' clause.\" It won't trigger at all unless All Hallow's Eve is exiled and has a scream counter on it (which can happen only if it resolves as a spell)."
         },
         {
           "date": "2009-10-01",
-          "text": "Each creature returned to the battlefield by All Hallow’s Eve enters the battlefield under its owner’s control."
+          "text": "Each creature returned to the battlefield by All Hallow's Eve enters the battlefield under its owner's control."
         }
       ],
       "text": "Exile All Hallow's Eve with two scream counters on it.\nAt the beginning of your upkeep, if All Hallow's Eve is exiled with a scream counter on it, remove a scream counter from it. If there are no more scream counters on it, put it into your graveyard and each player returns all creature cards from his or her graveyard to the battlefield.",
@@ -3384,7 +3392,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If both of the targeted creatures are illegal targets by the time Ashes to Ashes resolves, it’s countered. It doesn’t deal 5 damage to you."
+          "text": "If both of the targeted creatures are illegal targets by the time Ashes to Ashes resolves, it's countered. It doesn't deal 5 damage to you."
         }
       ],
       "text": "Exile two target nonartifact creatures. Ashes to Ashes deals 5 damage to you.",
@@ -3437,7 +3445,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Banshee’s ability resolves, the ability is countered. You won’t be dealt damage."
+          "text": "If the targeted creature or player is an illegal target by the time Banshee's ability resolves, the ability is countered. You won't be dealt damage."
         }
       ],
       "subtypes": [
@@ -3459,7 +3467,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"‘War is no picnic,' my father liked to say. But the ants seemed to disagree.\"\n—General Chanek Valteroth",
+      "flavor": "\"'War is no picnic,' my father liked to say. But the ants seemed to disagree.\"\n—General Chanek Valteroth",
       "id": "321679a09e3715bcc48bf28e0975faa230fa9532",
       "imageName": "carrion ants",
       "layout": "normal",
@@ -3546,7 +3554,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you choose not to pay Cosmic Horror’s upkeep cost, it deals 7 damage to you only if it’s actually destroyed. If it regenerates or an effect has given it indestructible, it deals no damage."
+          "text": "If you choose not to pay Cosmic Horror's upkeep cost, it deals 7 damage to you only if it's actually destroyed. If it regenerates or an effect has given it indestructible, it deals no damage."
         }
       ],
       "subtypes": [
@@ -3648,7 +3656,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Desperate Charge affects only creatures you control at the time it resolves. A creature that enters the battlefield later in the turn won’t get +2/+0."
+          "text": "Desperate Charge affects only creatures you control at the time it resolves. A creature that enters the battlefield later in the turn won't get +2/+0."
         }
       ],
       "text": "Creatures you control get +2/+0 until end of turn.",
@@ -3714,7 +3722,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability “{T}: Add {B} to your mana pool.” Evil Presence doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability \"{T}: Add {B} to your mana pool.\" Evil Presence doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         }
       ],
       "subtypes": [
@@ -4005,15 +4013,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Hellfire checks the number of creatures put into graveyards as the result of its effect, not the number of creatures destroyed as a result of its effect. For example, a replacement effect that says “If a creature would be put into a graveyard from the battlefield, exile it instead” won’t affect whether a creature is destroyed or not, but will affect whether it’s put into a graveyard or not."
+          "text": "Hellfire checks the number of creatures put into graveyards as the result of its effect, not the number of creatures destroyed as a result of its effect. For example, a replacement effect that says \"If a creature would be put into a graveyard from the battlefield, exile it instead\" won't affect whether a creature is destroyed or not, but will affect whether it's put into a graveyard or not."
         },
         {
           "date": "2009-10-01",
-          "text": "A creature that regenerates instead of being destroyed doesn’t leave the battlefield, so it’s not put into a graveyard."
+          "text": "A creature that regenerates instead of being destroyed doesn't leave the battlefield, so it's not put into a graveyard."
         },
         {
           "date": "2009-10-01",
-          "text": "A token creature that’s destroyed is put into its owner’s graveyard, and will be counted by Hellfire’s effect. (Immediately after Hellfire finishes resolving, the token will cease to exist.)"
+          "text": "A token creature that's destroyed is put into its owner's graveyard, and will be counted by Hellfire's effect. (Immediately after Hellfire finishes resolving, the token will cease to exist.)"
         }
       ],
       "text": "Destroy all nonblack creatures. Hellfire deals X plus 3 damage to you, where X is the number of creatures that died this way.",
@@ -4064,7 +4072,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may activate Lesser Werewolf’s ability no matter what its power is. However, if Lesser Werewolf’s power is 0 or less at the time the ability resolves, the ability won’t do anything."
+          "text": "You may activate Lesser Werewolf's ability no matter what its power is. However, if Lesser Werewolf's power is 0 or less at the time the ability resolves, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -4175,7 +4183,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
@@ -4233,7 +4241,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Spirit Shackle’s ability triggers only when the enchanted creature changes from untapped to tapped. If Spirit Shackle enters the battlefield attached to an already tapped creature, it won’t do anything (until that creature untaps and becomes tapped again, that is)."
+          "text": "Spirit Shackle's ability triggers only when the enchanted creature changes from untapped to tapped. If Spirit Shackle enters the battlefield attached to an already tapped creature, it won't do anything (until that creature untaps and becomes tapped again, that is)."
         }
       ],
       "subtypes": [
@@ -4287,7 +4295,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted opponent is an illegal target by the time Stolen Grain resolves, the ability is countered. You won’t gain life."
+          "text": "If the targeted opponent is an illegal target by the time Stolen Grain resolves, the ability is countered. You won't gain life."
         }
       ],
       "text": "Stolen Grain deals 5 damage to target opponent. You gain 5 life.",
@@ -4338,19 +4346,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the creature leaves the battlefield without going to the graveyard, Takklemaggot is simply put into its owner’s graveyard."
+          "text": "If the creature leaves the battlefield without going to the graveyard, Takklemaggot is simply put into its owner's graveyard."
         },
         {
           "date": "2008-05-01",
-          "text": "Takklemaggot’s controller no longer changes as it returns to the battlefield. The player who controlled it when it left the battlefield is the same player that controls it when it returns to the battlefield, even though a different player may be choosing what it will be attached to after returning onto the battlefield."
+          "text": "Takklemaggot's controller no longer changes as it returns to the battlefield. The player who controlled it when it left the battlefield is the same player that controls it when it returns to the battlefield, even though a different player may be choosing what it will be attached to after returning onto the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "When the enchanted creature is put into a graveyard, Takklemaggot’s second ability triggers, then Takklemaggot is put into its owner’s graveyard as a state-based action. When the ability resolves, if Takklemaggot is still in that graveyard, it’s returned to the battlefield."
+          "text": "When the enchanted creature is put into a graveyard, Takklemaggot's second ability triggers, then Takklemaggot is put into its owner's graveyard as a state-based action. When the ability resolves, if Takklemaggot is still in that graveyard, it's returned to the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "The player who controlled the creature that went to the graveyard (and caused Takklemaggot’s second ability to trigger) chooses what creature Takklemaggot will return to the battlefield attached to. The creature isn’t chosen until the ability resolves, so no player can respond between the time the creature is chosen and the time Takklemaggot returns to the battlefield attached to it. The ability doesn’t target a creature, so a creature with shroud, for example, can be chosen. However, only a creature that can be legally enchanted by Takklemaggot can be chosen, so a creature with protection from black, for example, can’t be chosen. If the player can choose a creature, he or she must do so, no matter who controls it. If the player can’t choose a creature, Takklemaggot returns to the battlefield as a non-Aura enchantment, and that player is the player that Takklemaggot will deal damage to."
+          "text": "The player who controlled the creature that went to the graveyard (and caused Takklemaggot's second ability to trigger) chooses what creature Takklemaggot will return to the battlefield attached to. The creature isn't chosen until the ability resolves, so no player can respond between the time the creature is chosen and the time Takklemaggot returns to the battlefield attached to it. The ability doesn't target a creature, so a creature with shroud, for example, can be chosen. However, only a creature that can be legally enchanted by Takklemaggot can be chosen, so a creature with protection from black, for example, can't be chosen. If the player can choose a creature, he or she must do so, no matter who controls it. If the player can't choose a creature, Takklemaggot returns to the battlefield as a non-Aura enchantment, and that player is the player that Takklemaggot will deal damage to."
         }
       ],
       "subtypes": [
@@ -4409,7 +4417,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -4469,15 +4477,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "Any blocking creatures that regenerated during combat will have been removed from combat. Since such creatures are no longer in combat, they cannot be blocking The Wretched, which means you won’t be able to gain control of them."
+          "text": "Any blocking creatures that regenerated during combat will have been removed from combat. Since such creatures are no longer in combat, they cannot be blocking The Wretched, which means you won't be able to gain control of them."
         },
         {
           "date": "2009-05-01",
-          "text": "If The Wretched itself regenerated during combat, then it will have been removed from combat. Since it is no longer in combat, there cannot be any creatures blocking it, which means you won’t be able to gain control of any creatures."
+          "text": "If The Wretched itself regenerated during combat, then it will have been removed from combat. Since it is no longer in combat, there cannot be any creatures blocking it, which means you won't be able to gain control of any creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "The Wretched’s ability triggers only if it’s still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it’s blocked by a 7/7 creature and is destroyed, its ability won’t trigger at all."
+          "text": "The Wretched's ability triggers only if it's still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it's blocked by a 7/7 creature and is destroyed, its ability won't trigger at all."
         },
         {
           "date": "2009-10-01",
@@ -4485,11 +4493,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you lose control of The Wretched before its ability resolves, you won’t gain control of the creatures blocking it at all."
+          "text": "If you lose control of The Wretched before its ability resolves, you won't gain control of the creatures blocking it at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the permanents you gained control of remain creatures, only that they remain on the battlefield."
+          "text": "Once the ability resolves, it doesn't care whether the permanents you gained control of remain creatures, only that they remain on the battlefield."
         }
       ],
       "subtypes": [
@@ -4545,7 +4553,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -4650,11 +4658,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "Wei Night Raiders’s second ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Wei Night Raiders's second ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -4711,7 +4719,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -4768,11 +4776,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t activate Xiahou Dun’s ability to return Xiahou Dun itself to your hand. You must choose a target before you sacrifice Xiahou Dun, so it’s not a black card in your graveyard yet."
+          "text": "You can't activate Xiahou Dun's ability to return Xiahou Dun itself to your hand. You must choose a target before you sacrifice Xiahou Dun, so it's not a black card in your graveyard yet."
         },
         {
           "date": "2013-09-20",
@@ -4985,7 +4993,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Anaba Spirit Crafter’s ability affects all Minotaurs, including Anaba Spirit Crafter itself."
+          "text": "Anaba Spirit Crafter's ability affects all Minotaurs, including Anaba Spirit Crafter itself."
         }
       ],
       "subtypes": [
@@ -5098,11 +5106,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The lands that will be destroyed aren’t chosen until Burning of Xinye resolves."
+          "text": "The lands that will be destroyed aren't chosen until Burning of Xinye resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye’s destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
+          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye's destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
         },
         {
           "date": "2009-10-01",
@@ -5176,7 +5184,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who’s copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
+          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who's copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
         },
         {
           "date": "2016-06-08",
@@ -5184,11 +5192,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The copy of Chain Lightning is created on the stack, so it’s not cast. Abilities that trigger when a player casts a spell won’t trigger. Players may respond to that spell before it resolves."
+          "text": "The copy of Chain Lightning is created on the stack, so it's not cast. Abilities that trigger when a player casts a spell won't trigger. Players may respond to that spell before it resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can’t be copied."
+          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can't be copied."
         }
       ],
       "text": "Chain Lightning deals 3 damage to target creature or player. Then that player or that creature's controller may pay {R}{R}. If the player does, he or she may copy this spell and may choose a new target for that copy.",
@@ -5341,7 +5349,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -5463,11 +5471,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you cast Disharmony during an opponent’s turn, you may then block with the creature you gain control of (assuming there’s an attacking creature it can block)."
+          "text": "If you cast Disharmony during an opponent's turn, you may then block with the creature you gain control of (assuming there's an attacking creature it can block)."
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Disharmony only during combat before blockers are declared.\nUntap target attacking creature and remove it from combat. Gain control of that creature until end of turn.",
@@ -5674,11 +5682,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The “rebirth” is a replacement effect."
+          "text": "The \"rebirth\" is a replacement effect."
         },
         {
           "date": "2009-10-01",
-          "text": "The Firestorm Phoenix you return to your hand is tracked by its ability. As long as it remains in your hand, that particular card can’t be played before your next turn begins, but a different Firestorm Phoenix in your hand can."
+          "text": "The Firestorm Phoenix you return to your hand is tracked by its ability. As long as it remains in your hand, that particular card can't be played before your next turn begins, but a different Firestorm Phoenix in your hand can."
         }
       ],
       "subtypes": [
@@ -6098,7 +6106,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -6154,7 +6162,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -6310,11 +6318,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
-          "text": "If the player whose turn it is has four or more cards in his or her hand as Storm World’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the player whose turn it is has four or more cards in his or her hand as Storm World's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "supertypes": [
@@ -6369,11 +6377,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If Zodiac Dragon is removed from the graveyard after the ability triggers but before it resolves, you can’t return it to your hand. Similarly, if a replacement effect has Zodiac Dragon move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If Zodiac Dragon is removed from the graveyard after the ability triggers but before it resolves, you can't return it to your hand. Similarly, if a replacement effect has Zodiac Dragon move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Even though Zodiac Dragon is a Dragon, it doesn’t have flying."
+          "text": "Even though Zodiac Dragon is a Dragon, it doesn't have flying."
         }
       ],
       "subtypes": [
@@ -6431,19 +6439,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
-          "text": "Arboria doesn’t stop creatures from attacking planeswalkers, regardless of what their controllers did or didn’t do during their last turns."
+          "text": "Arboria doesn't stop creatures from attacking planeswalkers, regardless of what their controllers did or didn't do during their last turns."
         },
         {
           "date": "2009-10-01",
-          "text": "Arboria’s effect cares whether a player put a nontoken permanent onto the battlefield. It’s unusual for an ability to care who did the putting (as opposed to whose control the permanent entered the battlefield under), and requires careful reading of spells and abilities to see which player is instructed to put something onto the battlefield. For example, Exhume causes each player to return a creature card from his or her graveyard to the battlefield. If Exhume’s controller has no creature cards in his or her graveyard, but another player does, only that other player puts a permanent onto the battlefield. It doesn’t matter who controls the effect."
+          "text": "Arboria's effect cares whether a player put a nontoken permanent onto the battlefield. It's unusual for an ability to care who did the putting (as opposed to whose control the permanent entered the battlefield under), and requires careful reading of spells and abilities to see which player is instructed to put something onto the battlefield. For example, Exhume causes each player to return a creature card from his or her graveyard to the battlefield. If Exhume's controller has no creature cards in his or her graveyard, but another player does, only that other player puts a permanent onto the battlefield. It doesn't matter who controls the effect."
         },
         {
           "date": "2009-10-01",
-          "text": "Arboria’s effect cares about the actions taken by players, not their results. If a player cast a spell during his or her last turn but that spell was countered, that player may still be attacked. The same is true if a player put a nontoken permanent onto the battlefield during his or her last turn, even if it’s no longer on the battlefield by the time that player is attacked."
+          "text": "Arboria's effect cares about the actions taken by players, not their results. If a player cast a spell during his or her last turn but that spell was countered, that player may still be attacked. The same is true if a player put a nontoken permanent onto the battlefield during his or her last turn, even if it's no longer on the battlefield by the time that player is attacked."
         }
       ],
       "supertypes": [
@@ -6497,7 +6505,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
@@ -6641,7 +6649,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"Faeries talk all in riddles and tricky bits, ‘cept the Nobles. Now, there's some straight talkers.\"\n—Joskun, An-Havva Constable",
+      "flavor": "\"Faeries talk all in riddles and tricky bits, 'cept the Nobles. Now, there's some straight talkers.\"\n—Joskun, An-Havva Constable",
       "id": "8fccc239b26fa512f8b6c07bfa517b193d49e219",
       "imageName": "faerie noble",
       "layout": "normal",
@@ -6778,7 +6786,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "During your untap step, first you determine which of your permanents will untap, then you untap them. If you control a permanent that says “You may choose not to untap [this permanent] during your untap step” and you decide not to untap it, no wind counters will be removed from it because it wouldn’t untap. The same is true for a permanent you control that wouldn’t untap due to a spell or ability (such as the one from Barl’s Cage)."
+          "text": "During your untap step, first you determine which of your permanents will untap, then you untap them. If you control a permanent that says \"You may choose not to untap [this permanent] during your untap step\" and you decide not to untap it, no wind counters will be removed from it because it wouldn't untap. The same is true for a permanent you control that wouldn't untap due to a spell or ability (such as the one from Barl's Cage)."
         }
       ],
       "text": "Whenever a permanent becomes tapped, put a wind counter on it.\nIf a permanent with a wind counter on it would untap during its controller's untap step, remove all wind counters from it instead.",
@@ -6828,7 +6836,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The land enters the battlefield directly from your hand, but it is not “played”. This means it does not count towards the number of lands played this turn and doesn’t trigger abilities that would trigger if the Forest had been played."
+          "text": "The land enters the battlefield directly from your hand, but it is not \"played\". This means it does not count towards the number of lands played this turn and doesn't trigger abilities that would trigger if the Forest had been played."
         }
       ],
       "text": "{0}: You may put a basic Forest card from your hand onto the battlefield. Activate this ability only any time you could cast a sorcery and only once each turn.\nSacrifice Gaea's Touch: Add {G}{G} to your mana pool.",
@@ -6966,15 +6974,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If all the attacking creatures attack your planeswalkers, you can’t cast Heavy Fog. To cast it, a creature needs to have attacked _you_."
+          "text": "If all the attacking creatures attack your planeswalkers, you can't cast Heavy Fog. To cast it, a creature needs to have attacked _you_."
         },
         {
           "date": "2009-10-01",
-          "text": "Heavy Fog prevents only damage that would be dealt to you by attacking creatures. It won’t prevent damage attacking creatures would deal to creatures or planeswalkers you control."
+          "text": "Heavy Fog prevents only damage that would be dealt to you by attacking creatures. It won't prevent damage attacking creatures would deal to creatures or planeswalkers you control."
         },
         {
           "date": "2009-10-01",
-          "text": "Heavy Fog prevents all damage attacking creatures would deal to you this turn, not just combat damage. Noncombat damage from those creatures is prevented only if they’re still attacking at the time that damage would be dealt or, if the creature has left the battlefield by then, if it was an attacking creature at the time it left."
+          "text": "Heavy Fog prevents all damage attacking creatures would deal to you this turn, not just combat damage. Noncombat damage from those creatures is prevented only if they're still attacking at the time that damage would be dealt or, if the creature has left the battlefield by then, if it was an attacking creature at the time it left."
         }
       ],
       "text": "Cast Heavy Fog only during the declare attackers step and only if you've been attacked this step.\nPrevent all damage that would be dealt to you this turn by attacking creatures.",
@@ -7084,11 +7092,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2009-10-01",
-          "text": "Hunting Cheetah’s ability allows you to search your library for any card with the land type Forest, not just a card with the name Forest."
+          "text": "Hunting Cheetah's ability allows you to search your library for any card with the land type Forest, not just a card with the name Forest."
         }
       ],
       "subtypes": [
@@ -7245,11 +7253,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         }
       ],
       "supertypes": [
@@ -7407,19 +7415,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "All Reincarnation does when it resolves is set up a delayed triggered ability. If the targeted creature isn’t put into a graveyard this turn, that ability never triggers. If the targeted creature is put into a graveyard this turn, that ability triggers and resolves like any other triggered ability."
+          "text": "All Reincarnation does when it resolves is set up a delayed triggered ability. If the targeted creature isn't put into a graveyard this turn, that ability never triggers. If the targeted creature is put into a graveyard this turn, that ability triggers and resolves like any other triggered ability."
         },
         {
           "date": "2009-10-01",
-          "text": "The creature card that will be returned to the battlefield isn’t chosen until the delayed triggered ability resolves. The player who chooses is the player who controlled Reincarnation. The player under whose control the chosen creature card enters the battlefield is the player who owned the targeted creature (in other words, the player into whose graveyard it went), not necessarily the controller of that creature."
+          "text": "The creature card that will be returned to the battlefield isn't chosen until the delayed triggered ability resolves. The player who chooses is the player who controlled Reincarnation. The player under whose control the chosen creature card enters the battlefield is the player who owned the targeted creature (in other words, the player into whose graveyard it went), not necessarily the controller of that creature."
         },
         {
           "date": "2009-10-01",
-          "text": "The creature that’s returned to the battlefield may be the same one that was put into the graveyard (assuming it’s still in the graveyard when the delayed triggered ability resolves). If so, it returns to the battlefield as a brand-new creature."
+          "text": "The creature that's returned to the battlefield may be the same one that was put into the graveyard (assuming it's still in the graveyard when the delayed triggered ability resolves). If so, it returns to the battlefield as a brand-new creature."
         }
       ],
       "text": "Choose target creature. When that creature dies this turn, return a creature card from its owner's graveyard to the battlefield under the control of that creature's owner.",
@@ -7470,7 +7478,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The spell’s effect has no duration. The targeted creature gets +2/+2 until the game ends or it leaves the battlefield. It has horsemanship until the game ends, it leaves the battlefield, or some other effect causes it to lose horsemanship."
+          "text": "The spell's effect has no duration. The targeted creature gets +2/+2 until the game ends or it leaves the battlefield. It has horsemanship until the game ends, it leaves the battlefield, or some other effect causes it to lose horsemanship."
         }
       ],
       "text": "Target creature gets +2/+2 and gains horsemanship. (It can't be blocked except by creatures with horsemanship. This effect lasts indefinitely.)",
@@ -7638,7 +7646,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2009-10-01",
@@ -7693,7 +7701,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2009-10-01",
@@ -7920,11 +7928,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Willow Satyr stops being tapped before its ability resolves — even if it becomes tapped again right away — you won’t gain control of the targeted creature at all. The same is true if you lose control of Willow Satyr before the ability resolves."
+          "text": "If Willow Satyr stops being tapped before its ability resolves — even if it becomes tapped again right away — you won't gain control of the targeted creature at all. The same is true if you lose control of Willow Satyr before the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the targeted permanent remains a legal target for the ability, only that it’s on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, stops being legendary, or would no longer be a legal target for any other reason."
+          "text": "Once the ability resolves, it doesn't care whether the targeted permanent remains a legal target for the ability, only that it's on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, stops being legendary, or would no longer be a legal target for any other reason."
         }
       ],
       "subtypes": [
@@ -7981,7 +7989,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Causing Wormwood Treefolk to gain forestwalk or swampwalk is useful only during the declare attackers step or earlier. Once it becomes blocked, giving it a landwalk ability won’t change that."
+          "text": "Causing Wormwood Treefolk to gain forestwalk or swampwalk is useful only during the declare attackers step or earlier. Once it becomes blocked, giving it a landwalk ability won't change that."
         }
       ],
       "subtypes": [
@@ -8100,7 +8108,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As long as Arcades Sabboth is untapped and isn’t attacking, it’ll get +0/+2 from its own third ability."
+          "text": "As long as Arcades Sabboth is untapped and isn't attacking, it'll get +0/+2 from its own third ability."
         }
       ],
       "subtypes": [
@@ -8162,15 +8170,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Each time a creature is put into a graveyard from play, check whether Axelrod Gunnarson had dealt any damage to it at any time during that turn. (This includes combat damage.) If so, Axelrod Gunnarson’s second ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from play, check whether Axelrod Gunnarson had dealt any damage to it at any time during that turn. (This includes combat damage.) If so, Axelrod Gunnarson's second ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2009-10-01",
-          "text": "If Axelrod Gunnarson and a creature it dealt damage to are both put into a graveyard at the same time, Axelrod Gunnarson’s second ability will trigger."
+          "text": "If Axelrod Gunnarson and a creature it dealt damage to are both put into a graveyard at the same time, Axelrod Gunnarson's second ability will trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "The player you target with Axelrod Gunnarson’s ability doesn’t have to be the player that controlled the creature that was put into a graveyard."
+          "text": "The player you target with Axelrod Gunnarson's ability doesn't have to be the player that controlled the creature that was put into a graveyard."
         }
       ],
       "subtypes": [
@@ -8292,7 +8300,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This card can be enchanted by moving Auras onto it. The “can’t be the target” text is different from “can’t be enchanted” in that it only applies to Aura spells when they are being cast."
+          "text": "This card can be enchanted by moving Auras onto it. The \"can't be the target\" text is different from \"can't be enchanted\" in that it only applies to Aura spells when they are being cast."
         }
       ],
       "subtypes": [
@@ -8591,11 +8599,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         },
         {
           "date": "2009-10-01",
-          "text": "Note that the duration of Halfdane’s ability is until the end of your next upkeep. If Halfdane’s ability doesn’t get a chance to resolve (because there are no legal targets when it triggers, or because it’s countered), then the effect from the previous turn’s ability will continue to work through the rest of that upkeep step. Then that effect will wear off, and Halfdane will revert to being 3/3, its printed power and toughness (unless some other effect is modifying what its power and toughness is)."
+          "text": "Note that the duration of Halfdane's ability is until the end of your next upkeep. If Halfdane's ability doesn't get a chance to resolve (because there are no legal targets when it triggers, or because it's countered), then the effect from the previous turn's ability will continue to work through the rest of that upkeep step. Then that effect will wear off, and Halfdane will revert to being 3/3, its printed power and toughness (unless some other effect is modifying what its power and toughness is)."
         }
       ],
       "subtypes": [
@@ -8658,11 +8666,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "When Hazezon Tamar’s second ability resolves, all permanents with both the Sand and Warrior creature types are exiled, not just the Sand Warrior creature tokens it created. Permanents that have just one of those types are unaffected."
+          "text": "When Hazezon Tamar's second ability resolves, all permanents with both the Sand and Warrior creature types are exiled, not just the Sand Warrior creature tokens it created. Permanents that have just one of those types are unaffected."
         },
         {
           "date": "2009-10-01",
-          "text": "The first ability creates a delayed triggered ability that triggers at the beginning of your next upkeep. It doesn’t matter who controls Hazezon Tamar at that time, or even if it’s on the battlefield. The player who put Hazezon onto the battlefield gets the Sand Warriors."
+          "text": "The first ability creates a delayed triggered ability that triggers at the beginning of your next upkeep. It doesn't matter who controls Hazezon Tamar at that time, or even if it's on the battlefield. The player who put Hazezon onto the battlefield gets the Sand Warriors."
         },
         {
           "date": "2009-10-01",
@@ -8952,11 +8960,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Kjeldoran Frostbeast’s ability triggers only if it’s still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it blocks a 7/7 creature and is destroyed, its ability won’t trigger at all. The 7/7 will remain on the battlefield."
+          "text": "Kjeldoran Frostbeast's ability triggers only if it's still on the battlefield when the end of combat step begins (after the combat damage step). For example, if it blocks a 7/7 creature and is destroyed, its ability won't trigger at all. The 7/7 will remain on the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "Its ability will destroy all creatures it’s currently blocking or blocked by, not necessarily the creatures it had blocked or become blocked by during that combat phase. For example, if Kjeldoran Frostbeast is dealt lethal combat damage and regenerates, it’s removed from combat. Its ability will trigger at end of combat, but since it’s no longer blocking or blocked by any creatures, the ability won’t do anything."
+          "text": "Its ability will destroy all creatures it's currently blocking or blocked by, not necessarily the creatures it had blocked or become blocked by during that combat phase. For example, if Kjeldoran Frostbeast is dealt lethal combat damage and regenerates, it's removed from combat. Its ability will trigger at end of combat, but since it's no longer blocking or blocked by any creatures, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -9185,7 +9193,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "“Legendary landwalk” means “This creature is can’t be blocked as long as defending player controls a legendary land.”"
+          "text": "\"Legendary landwalk\" means \"This creature is can't be blocked as long as defending player controls a legendary land.\""
         }
       ],
       "subtypes": [
@@ -9304,11 +9312,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t name a card until the ability resolves. Once you name a card, it’s too late for the targeted opponent to respond."
+          "text": "You don't name a card until the ability resolves. Once you name a card, it's too late for the targeted opponent to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "You may activate the ability only during your turn, but you may do so any time you have priority. (In other words, it’s not restricted to only the times you could cast a sorcery.)"
+          "text": "You may activate the ability only during your turn, but you may do so any time you have priority. (In other words, it's not restricted to only the times you could cast a sorcery.)"
         }
       ],
       "subtypes": [
@@ -9382,7 +9390,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Nicol Bolas’s third ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Nicol Bolas's third ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -9727,7 +9735,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "A creature is “enchanted” if it has any Auras attached to it."
+          "text": "A creature is \"enchanted\" if it has any Auras attached to it."
         }
       ],
       "subtypes": [
@@ -9789,7 +9797,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The fourth ability has an “intervening ‘if’ clause,” so it won’t trigger at all unless Rasputin Dreamweaver started the turn untapped."
+          "text": "The fourth ability has an \"intervening 'if' clause,\" so it won't trigger at all unless Rasputin Dreamweaver started the turn untapped."
         },
         {
           "date": "2009-10-01",
@@ -9915,11 +9923,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rohgahh’s first ability isn’t targeted. You don’t choose the opponent that will gain control of the creatures until the ability resolves."
+          "text": "Rohgahh's first ability isn't targeted. You don't choose the opponent that will gain control of the creatures until the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "If you don’t pay {R}{R}{R} as the first ability resolves, all creatures named Kobolds of Kher Keep become tapped (even the ones you don’t control), as does Rohgahh. The chosen opponent gains control of Rohgahh and all creatures named Kobolds of Kher Keep regardless of whether you control them or whether they were tapped by the ability."
+          "text": "If you don't pay {R}{R}{R} as the first ability resolves, all creatures named Kobolds of Kher Keep become tapped (even the ones you don't control), as does Rohgahh. The chosen opponent gains control of Rohgahh and all creatures named Kobolds of Kher Keep regardless of whether you control them or whether they were tapped by the ability."
         }
       ],
       "subtypes": [
@@ -9988,11 +9996,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won’t gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
+          "text": "If Rubinia Soulsinger stops being tapped before its ability resolves — even if it becomes tapped again right away — you won't gain control of the targeted creature at all. The same is true if you lose control of Rubinia Soulsinger before the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the ability resolves, it doesn’t care whether the targeted permanent remains a legal target for the ability, only that it’s on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
+          "text": "Once the ability resolves, it doesn't care whether the targeted permanent remains a legal target for the ability, only that it's on the battlefield. The effect will continue to apply to it even if it gains shroud, stops being a creature, or would no longer be a legal target for any other reason."
         }
       ],
       "subtypes": [
@@ -10221,11 +10229,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Stangg’s delayed triggered abilities track only the token created by that particular Stangg."
+          "text": "Stangg's delayed triggered abilities track only the token created by that particular Stangg."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stangg leaves the battlefield before its ability has resolved, that ability will still create a Stangg Twin token, but its delayed triggered abilities will never have a chance to trigger. That token will remain on the battlefield indefinitely (until it’s dealt lethal damage, or anything else causes it to leave the battlefield)."
+          "text": "If Stangg leaves the battlefield before its ability has resolved, that ability will still create a Stangg Twin token, but its delayed triggered abilities will never have a chance to trigger. That token will remain on the battlefield indefinitely (until it's dealt lethal damage, or anything else causes it to leave the battlefield)."
         }
       ],
       "subtypes": [
@@ -10345,7 +10353,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card can be enchanted by moving Auras onto it. The “can’t be the target” text is different from “can’t be enchanted” in that it only applies to Aura spells when they are being cast."
+          "text": "This card can be enchanted by moving Auras onto it. The \"can't be the target\" text is different from \"can't be enchanted\" in that it only applies to Aura spells when they are being cast."
         },
         {
           "date": "2009-10-01",
@@ -10750,11 +10758,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The second ability checks that the targeted creature is a Cleric or Wizard only at the time the ability is activated and at the time it resolves. It doesn’t check at the time the damage is actually prevented."
+          "text": "The second ability checks that the targeted creature is a Cleric or Wizard only at the time the ability is activated and at the time it resolves. It doesn't check at the time the damage is actually prevented."
         },
         {
           "date": "2009-10-01",
-          "text": "If you activate Wandering Mage’s third ability, you put the -1/-1 counter on a creature you control as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the only creature you control to have 0 toughness, it’s put into the graveyard before you can pay the cost again."
+          "text": "If you activate Wandering Mage's third ability, you put the -1/-1 counter on a creature you control as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the only creature you control to have 0 toughness, it's put into the graveyard before you can pay the cost again."
         }
       ],
       "subtypes": [
@@ -10947,19 +10955,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Does not prevent a creature from untapping at other times. It just stops the “normal” untap during the untap step."
+          "text": "Does not prevent a creature from untapping at other times. It just stops the \"normal\" untap during the untap step."
         },
         {
           "date": "2009-10-01",
-          "text": "You may target any creature with this ability. It doesn’t have to be tapped."
+          "text": "You may target any creature with this ability. It doesn't have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is untapped at the time its controller’s next untap step begins, this ability has no effect. It won’t apply at some later time when the targeted creature is tapped."
+          "text": "If the targeted creature is untapped at the time its controller's next untap step begins, this ability has no effect. It won't apply at some later time when the targeted creature is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Barl’s Cage doesn’t track the creature’s controller. If the affected creature changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "Barl's Cage doesn't track the creature's controller. If the affected creature changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "text": "{3}: Target creature doesn't untap during its controller's next untap step.",
@@ -11015,7 +11023,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "text": "As Black Vise enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, Black Vise deals X damage to that player, where X is the number of cards in his or her hand minus 4.",
@@ -11060,7 +11068,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The ability affects only creatures on the battlefield at the time it resolves. A creature that enters the battlefield later in the turn won’t get -1/-0."
+          "text": "The ability affects only creatures on the battlefield at the time it resolves. A creature that enters the battlefield later in the turn won't get -1/-0."
         }
       ],
       "text": "{2}, {T}: All creatures get -1/-0 until end of turn.",
@@ -11213,7 +11221,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This works even if the opponent’s lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
+          "text": "This works even if the opponent's lands are tapped. It only checks what kinds of mana can be produced, not if the abilities that produce them are usable right now."
         },
         {
           "date": "2004-10-04",
@@ -11221,19 +11229,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Fellwar Stone can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Fellwar Stone checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Fellwar Stone, you can tap Fellwar Stone for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, take into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there is more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, take into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there is more than one, consider them in any possible order."
         },
         {
           "date": "2009-10-01",
-          "text": "Fellwar Stone doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Fellwar Stone doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -11279,11 +11287,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As you activate the ability, the targets you choose must be two artifacts, two creatures, or two lands. As the ability resolves, both targets will be legal only if they are two artifacts, two creatures, or two lands at that time as well, though they may be a different type than they were at the time the ability was activated. For example, if the targets were a creature and an artifact creature when the ability was activated, but the first target became a noncreature artifact by the time the ability resolves, both targets will still be legal (since they’re both artifacts)."
+          "text": "As you activate the ability, the targets you choose must be two artifacts, two creatures, or two lands. As the ability resolves, both targets will be legal only if they are two artifacts, two creatures, or two lands at that time as well, though they may be a different type than they were at the time the ability was activated. For example, if the targets were a creature and an artifact creature when the ability was activated, but the first target became a noncreature artifact by the time the ability resolves, both targets will still be legal (since they're both artifacts)."
         },
         {
           "date": "2009-10-01",
-          "text": "If one of the targets is illegal by the time the ability resolves (because the wrong player controls it, or it’s the wrong card type, or for any other reason), the exchange doesn’t happen. The target that’s still legal will remain under its controller’s control. Since the exchange doesn’t happen, no Auras are destroyed. (If both targets are illegal, the ability is countered.)"
+          "text": "If one of the targets is illegal by the time the ability resolves (because the wrong player controls it, or it's the wrong card type, or for any other reason), the exchange doesn't happen. The target that's still legal will remain under its controller's control. Since the exchange doesn't happen, no Auras are destroyed. (If both targets are illegal, the ability is countered.)"
         }
       ],
       "text": "{5}, Sacrifice Gauntlets of Chaos: Exchange control of target artifact, creature, or land you control and target permanent an opponent controls that shares one of those types with it. If those permanents are exchanged this way, destroy all Auras attached to them.",
@@ -11332,11 +11340,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature enters the battlefield face down, so none of its “enters the battlefield” abilities will trigger or have any effect. Also none of its “As this enters the battlefield” abilities apply."
+          "text": "The creature enters the battlefield face down, so none of its \"enters the battlefield\" abilities will trigger or have any effect. Also none of its \"As this enters the battlefield\" abilities apply."
         },
         {
           "date": "2004-10-04",
-          "text": "The creature’s “enters the battlefield” abilities (and any other abilities relating to the creature entering the battlefield) do not trigger when it turns face up."
+          "text": "The creature's \"enters the battlefield\" abilities (and any other abilities relating to the creature entering the battlefield) do not trigger when it turns face up."
         },
         {
           "date": "2004-10-04",
@@ -11344,11 +11352,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the ability to cast a creature card face down, you must keep track of the amount and types of mana you spent on {X}. If that creature spell is moved from the stack to anywhere other than the battlefield, the resulting creature leaves the battlefield, or the game ends, the face-down card is revealed. If its mana cost couldn’t be paid by some amount of, or all of, the mana you spent on {X}, all applicable penalties for casting a card illegally are assessed."
+          "text": "If you use the ability to cast a creature card face down, you must keep track of the amount and types of mana you spent on {X}. If that creature spell is moved from the stack to anywhere other than the battlefield, the resulting creature leaves the battlefield, or the game ends, the face-down card is revealed. If its mana cost couldn't be paid by some amount of, or all of, the mana you spent on {X}, all applicable penalties for casting a card illegally are assessed."
         },
         {
           "date": "2009-10-01",
@@ -11356,19 +11364,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect that turns it face-up is a replacement effect. It doesn’t use the stack and can’t be responded to."
+          "text": "The effect that turns it face-up is a replacement effect. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2009-10-01",
-          "text": "You may not turn a face-down spell face up. You may not turn a face-down permanent face up unless it would have morph while face up or an effect specifically allows you to turn it face up. Illusionary Mask’s ability has you turn a face-down creature face up if it would assign damage, deal damage, be dealt damage, or become tapped, but not for any other reason. For example, if you use Illusionary Mask’s ability to cast a black creature face down, you can’t turn it face up just because it’s being targeted by Terror."
+          "text": "You may not turn a face-down spell face up. You may not turn a face-down permanent face up unless it would have morph while face up or an effect specifically allows you to turn it face up. Illusionary Mask's ability has you turn a face-down creature face up if it would assign damage, deal damage, be dealt damage, or become tapped, but not for any other reason. For example, if you use Illusionary Mask's ability to cast a black creature face down, you can't turn it face up just because it's being targeted by Terror."
         },
         {
           "date": "2009-10-01",
-          "text": "Both the amount and types of mana you spend on {X} are taken into account while you’re choosing a creature card from your hand. For example, if you spent {U}{U} on {X}, you can choose a creature card with mana cost {U}{U}, {1}{U}, {2}, or {W/U}{W/U}, among other possibilities, but not one that costs {2}{U} or one that costs {G}."
+          "text": "Both the amount and types of mana you spend on {X} are taken into account while you're choosing a creature card from your hand. For example, if you spent {U}{U} on {X}, you can choose a creature card with mana cost {U}{U}, {1}{U}, {2}, or {W/U}{W/U}, among other possibilities, but not one that costs {2}{U} or one that costs {G}."
         },
         {
           "date": "2009-10-01",
-          "text": "While the creature card is face down, it’s a 2/2 creature with no name, mana cost, color, creature type, abilities, or expansion symbol. Since it has no mana cost, its converted mana cost is 0."
+          "text": "While the creature card is face down, it's a 2/2 creature with no name, mana cost, color, creature type, abilities, or expansion symbol. Since it has no mana cost, its converted mana cost is 0."
         },
         {
           "date": "2009-10-01",
@@ -11376,11 +11384,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You can turn a face-down permanent face up if it would have morph while face up. This applies to creatures you cast face down as a result of Illusionary Mask’s effect. The rest of Illusionary Mask’s effect applies to it as well."
+          "text": "You can turn a face-down permanent face up if it would have morph while face up. This applies to creatures you cast face down as a result of Illusionary Mask's effect. The rest of Illusionary Mask's effect applies to it as well."
         },
         {
           "date": "2009-10-01",
-          "text": "Illusionary Mask’s ability will continue to apply to creatures cast face down with it, even if Illusionary Mask has left the battlefield."
+          "text": "Illusionary Mask's ability will continue to apply to creatures cast face down with it, even if Illusionary Mask has left the battlefield."
         }
       ],
       "text": "{X}: You may choose a creature card in your hand whose mana cost could be paid by some amount of, or all of, the mana you spent on {X}. If you do, you may cast that card face down as a 2/2 creature spell without paying its mana cost. If the creature that spell becomes as it resolves has not been turned face up and would assign or deal damage, be dealt damage, or become tapped, instead it's turned face up and assigns or deals damage, is dealt damage, or becomes tapped. Activate this ability only any time you could cast a sorcery.",
@@ -11429,11 +11437,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You don’t get to look at the cards exiled with Knowledge Vault."
+          "text": "You don't get to look at the cards exiled with Knowledge Vault."
         },
         {
           "date": "2009-10-01",
-          "text": "If you activate Knowledge Vault’s second ability, all that happens at that time is that you pay a cost of {0}. As the ability resolves, you must sacrifice Knowledge Vault. This is mandatory. If you are able to do so, you discard your hand and put all cards exiled with Knowledge Vault into their owners’ hands. If you aren’t able to do so because Knowledge Vault left the battlefield or changed controllers before the ability resolves, nothing happens."
+          "text": "If you activate Knowledge Vault's second ability, all that happens at that time is that you pay a cost of {0}. As the ability resolves, you must sacrifice Knowledge Vault. This is mandatory. If you are able to do so, you discard your hand and put all cards exiled with Knowledge Vault into their owners' hands. If you aren't able to do so because Knowledge Vault left the battlefield or changed controllers before the ability resolves, nothing happens."
         }
       ],
       "text": "{2}, {T}: Exile the top card of your library face down.\n{0}: Sacrifice Knowledge Vault. If you do, discard your hand, then put all cards exiled with Knowledge Vault into their owner's hand.\nWhen Knowledge Vault leaves the battlefield, put all cards exiled with Knowledge Vault into their owner's graveyard.",
@@ -11520,7 +11528,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "As you activate the ability, you choose an opponent, then that opponent chooses a creature for the ability to target. It doesn’t have to be a creature that opponent controls. If there are no creatures that can be targeted with the ability, it can’t be activated."
+          "text": "As you activate the ability, you choose an opponent, then that opponent chooses a creature for the ability to target. It doesn't have to be a creature that opponent controls. If there are no creatures that can be targeted with the ability, it can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -11528,7 +11536,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The next time damage from the chosen source would be dealt to you this turn, that damage is dealt to the targeted creature instead. Whether it’s still a legal target is not checked at this time. However, if it’s not able to be dealt damage because it’s neither a creature nor a planeswalker, or it’s no longer on the battlefield, then the damage is not redirected and is dealt to you as normal."
+          "text": "The next time damage from the chosen source would be dealt to you this turn, that damage is dealt to the targeted creature instead. Whether it's still a legal target is not checked at this time. However, if it's not able to be dealt damage because it's neither a creature nor a planeswalker, or it's no longer on the battlefield, then the damage is not redirected and is dealt to you as normal."
         }
       ],
       "text": "{3}, {T}: The next time a source of your choice would deal damage to you this turn, that damage is dealt to target creature of an opponent's choice instead.",
@@ -11661,15 +11669,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Voodoo Doll’s second ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless Voodoo Doll is untapped, and (2) the ability will do nothing if Voodoo Doll is tapped by the time it resolves. If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see if it was tapped or untapped."
+          "text": "Voodoo Doll's second ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless Voodoo Doll is untapped, and (2) the ability will do nothing if Voodoo Doll is tapped by the time it resolves. If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see if it was tapped or untapped."
         },
         {
           "date": "2009-10-01",
-          "text": "Each X in the cost of Voodoo Doll’s third ability is the number of pin counters on Voodoo Doll at the time you activate the ability. The X in the ability’s effect is the number of pin counters on Voodoo Doll at the time it resolves, which may not be the same number (if a spell or ability put counters on it or removed counters from it in the meantime). If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see how many pin counters were on it."
+          "text": "Each X in the cost of Voodoo Doll's third ability is the number of pin counters on Voodoo Doll at the time you activate the ability. The X in the ability's effect is the number of pin counters on Voodoo Doll at the time it resolves, which may not be the same number (if a spell or ability put counters on it or removed counters from it in the meantime). If Voodoo Doll is no longer on the battlefield as the ability resolves, its last existence on the battlefield is checked to see how many pin counters were on it."
         },
         {
           "date": "2011-01-01",
-          "text": "Voodoo Doll’s second ability causes it to be destroyed regardless of whether it actually deals damage to you or not. Voodoo Doll is destroyed even if all the damage is prevented or redirected."
+          "text": "Voodoo Doll's second ability causes it to be destroyed regardless of whether it actually deals damage to you or not. Voodoo Doll is destroyed even if all the damage is prevented or redirected."
         }
       ],
       "text": "At the beginning of your upkeep, put a pin counter on Voodoo Doll.\nAt the beginning of your end step, if Voodoo Doll is untapped, destroy Voodoo Doll and it deals damage to you equal to the number of pin counters on it.\n{X}{X}, {T}: Voodoo Doll deals damage equal to the number of pin counters on it to target creature or player. X is the number of pin counters on Voodoo Doll.",
@@ -11726,7 +11734,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -11774,7 +11782,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t cast spells or activate mana abilities before discarding the extra cards."
+          "text": "You can't cast spells or activate mana abilities before discarding the extra cards."
         }
       ],
       "text": "{T}: Draw two cards, then discard three cards.",
@@ -11817,11 +11825,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The storage counters aren’t removed when you activate the mana ability."
+          "text": "The storage counters aren't removed when you activate the mana ability."
         },
         {
           "date": "2009-10-01",
-          "text": "You can activate City of Shadows’s second ability while it has no storage counters on it, though it won’t add any mana to your mana pool in this case. You did not tap it for mana, though, in case any abilities (such as the ability of a Fertile Ground enchanting it) care about that."
+          "text": "You can activate City of Shadows's second ability while it has no storage counters on it, though it won't add any mana to your mana pool in this case. You did not tap it for mana, though, in case any abilities (such as the ability of a Fertile Ground enchanting it) care about that."
         }
       ],
       "text": "{T}, Exile a creature you control: Put a storage counter on City of Shadows.\n{T}: Add {C} to your mana pool for each storage counter on City of Shadows.",
@@ -11835,7 +11843,7 @@
       "colorIdentity": [
         "R"
       ],
-      "flavor": "\"‘Tis distance lends enchantment to the view,/ And robes the mountain in its azure hue.\" —Thomas Campbell, \"Pleasures of Hope\"",
+      "flavor": "\"'Tis distance lends enchantment to the view,/ And robes the mountain in its azure hue.\" —Thomas Campbell, \"Pleasures of Hope\"",
       "id": "608b5ec24e78c09b01f04b56335dcbcdfb3ae0fa",
       "imageName": "hammerheim",
       "layout": "normal",
@@ -11871,7 +11879,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Causing a creature to lose landwalk abilities is useful only during the declare attackers step or earlier. Once the declare blockers step begins, it’s too late to block the creature."
+          "text": "Causing a creature to lose landwalk abilities is useful only during the declare attackers step or earlier. Once the declare blockers step begins, it's too late to block the creature."
         }
       ],
       "supertypes": [
@@ -11976,7 +11984,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -12037,7 +12045,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -12088,15 +12096,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two blocking creatures a single opponent controls. Whether those creatures could block all creatures the other is blocking isn’t determined until the ability resolves."
+          "text": "The first ability can target any two blocking creatures a single opponent controls. Whether those creatures could block all creatures the other is blocking isn't determined until the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
         },
         {
           "date": "2009-10-01",
-          "text": "When Sorrow’s Path’s first ability is activated, its second ability triggers and goes on the stack on top of the first ability. The second ability resolves first, and may cause some of the attacking creatures to be dealt lethal damage."
+          "text": "When Sorrow's Path's first ability is activated, its second ability triggers and goes on the stack on top of the first ability. The second ability resolves first, and may cause some of the attacking creatures to be dealt lethal damage."
         },
         {
           "date": "2009-10-01",
@@ -12104,11 +12112,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "When the first ability resolves, if all the creatures that one of the targeted creatures was blocking have left combat, then the other targeted creature is considered to be able to block all creatures the first creature is blocking. If the ability has its full effect, the second creature will be removed from combat but not returned to combat; it doesn’t block anything."
+          "text": "When the first ability resolves, if all the creatures that one of the targeted creatures was blocking have left combat, then the other targeted creature is considered to be able to block all creatures the first creature is blocking. If the ability has its full effect, the second creature will be removed from combat but not returned to combat; it doesn't block anything."
         },
         {
           "date": "2009-10-01",
-          "text": "Abilities that trigger whenever one of the targeted creatures blocks will trigger when the first ability resolves, because those creatures will change from not blocking (since they’re removed from combat) to blocking. It doesn’t matter if those abilities triggered when those creatures blocked the first time. Abilities that trigger whenever one of the attacking creatures becomes blocked will not trigger again, because they never stopped being blocked creatures. Abilities that trigger whenever a creature blocks one of the attacking creatures will trigger again, though; those kinds of abilities trigger once for each creature that blocks."
+          "text": "Abilities that trigger whenever one of the targeted creatures blocks will trigger when the first ability resolves, because those creatures will change from not blocking (since they're removed from combat) to blocking. It doesn't matter if those abilities triggered when those creatures blocked the first time. Abilities that trigger whenever one of the attacking creatures becomes blocked will not trigger again, because they never stopped being blocked creatures. Abilities that trigger whenever a creature blocks one of the attacking creatures will trigger again, though; those kinds of abilities trigger once for each creature that blocks."
         }
       ],
       "text": "{T}: Choose two target blocking creatures an opponent controls. If each of those creatures could block all creatures that the other is blocking, remove both of them from combat. Each one then blocks all creatures the other was blocking.\nWhenever Sorrow's Path becomes tapped, it deals 2 damage to you and each creature you control.",
@@ -12205,7 +12213,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -12259,7 +12267,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If a creature loses first strike after first strike combat damage has been assigned, it won’t deal damage during the second combat damage step."
+          "text": "If a creature loses first strike after first strike combat damage has been assigned, it won't deal damage during the second combat damage step."
         },
         {
           "date": "2009-10-01",
@@ -12267,11 +12275,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Causing a creature to lose swampwalk is useful only during the declare attackers step or earlier. Once the declare blockers step begins, it’s too late to block the creature."
+          "text": "Causing a creature to lose swampwalk is useful only during the declare attackers step or earlier. Once the declare blockers step begins, it's too late to block the creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Urborg’s second ability affects only the first strike ability, not the part of the double strike ability that acts like first strike."
+          "text": "Urborg's second ability affects only the first strike ability, not the part of the double strike ability that acts like first strike."
         }
       ],
       "supertypes": [
@@ -12330,7 +12338,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [

--- a/json/ME4.json
+++ b/json/ME4.json
@@ -235,7 +235,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘O miserable of happy! Is this the end\nOf this new glorious world . . . ?'\"\n—John Milton, Paradise Lost",
+      "flavor": "\"'O miserable of happy! Is this the end\nOf this new glorious world . . . ?'\"\n—John Milton, Paradise Lost",
       "id": "edfcd892f4f98e45d649ec99c5e527fa7bc78cb5",
       "imageName": "armageddon",
       "layout": "normal",
@@ -278,7 +278,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -342,7 +343,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Balance doesn’t have targets, so permanents that can’t be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
+          "text": "Balance doesn't have targets, so permanents that can't be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
         },
         {
           "date": "2016-06-08",
@@ -405,7 +406,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Blaze of Glory only during combat before blockers are declared.\nTarget creature defending player controls can block any number of creatures this turn. It blocks each attacking creature this turn if able.",
@@ -586,7 +587,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you’ll still gain the life."
+          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you'll still gain the life."
         }
       ],
       "text": "Destroy target artifact. You gain life equal to its converted mana cost.",
@@ -878,7 +879,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Since the draw is replaced, you can’t use the same draw to do other things."
+          "text": "Since the draw is replaced, you can't use the same draw to do other things."
         }
       ],
       "text": "If you would draw a card during your draw step, instead you may skip that draw. If you do, until your next turn, you can't be attacked except by creatures with flying and/or islandwalk.",
@@ -987,7 +988,7 @@
           "text": "Does not affect cards that phase in."
         }
       ],
-      "text": "Artifacts, creatures, and lands played by your opponents enter the battlefield tapped.",
+      "text": "Artifacts, creatures, and lands your opponents control enter the battlefield tapped.",
       "type": "Enchantment",
       "types": [
         "Enchantment"
@@ -1256,7 +1257,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent’s Incarnation you can let it die to make them lose life."
+          "text": "The owner of the Incarnation loses life when it is destroyed, not the controller. So if you control your opponent's Incarnation you can let it die to make them lose life."
         },
         {
           "date": "2007-02-01",
@@ -1523,7 +1524,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -1581,7 +1582,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -1768,7 +1769,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -1878,7 +1879,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can’t be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
+          "text": "If a creature is blocked but Trample damage is still done to a player, this damage can't be redirected to the Bodyguard because the Bodyguard only takes damage from unblocked creatures."
         },
         {
           "date": "2004-10-04",
@@ -2251,11 +2252,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that’s already a creature, it won’t change its power and toughness."
+          "text": "This card has been returned to its original functionality. If it is enchanting an artifact that's already a creature, it won't change its power and toughness."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -2315,7 +2316,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         }
       ],
       "text": "Choose one —\n• Counter target red spell.\n• Destroy target red permanent.",
@@ -2537,7 +2538,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -2755,7 +2756,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "text": "Target player activates a mana ability of each land he or she controls. Then put all mana from that player's mana pool into yours.",
@@ -3011,7 +3012,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -3134,7 +3135,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -3370,11 +3371,11 @@
         },
         {
           "date": "2006-07-15",
-          "text": "Can’t reduce Snow mana costs."
+          "text": "Can't reduce Snow mana costs."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -3721,7 +3722,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Mana from the ability can only be spent on activation costs for abilities from artifacts. It can’t be spent on artifact spells, or on costs resulting from triggered abilities."
+          "text": "Mana from the ability can only be spent on activation costs for abilities from artifacts. It can't be spent on artifact spells, or on costs resulting from triggered abilities."
         }
       ],
       "subtypes": [
@@ -3784,7 +3785,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since there is no untap step, Phasing in/out won’t happen."
+          "text": "Since there is no untap step, Phasing in/out won't happen."
         },
         {
           "date": "2004-10-04",
@@ -4051,7 +4052,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t sacrifice more than one artifact to this spell."
+          "text": "You can't sacrifice more than one artifact to this spell."
         },
         {
           "date": "2004-10-04",
@@ -4059,7 +4060,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2011-01-01",
@@ -4552,7 +4553,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t reveal the card to your opponent."
+          "text": "You don't reveal the card to your opponent."
         },
         {
           "date": "2004-10-04",
@@ -4873,7 +4874,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "White spells cost {3} more to cast.\nActivated abilities of white enchantments cost {3} more to activate.",
@@ -5205,15 +5206,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life, just like any player at less than one life can’t pay life. You can pay zero life if you want."
+          "text": "You can't pay life, just like any player at less than one life can't pay life. You can pay zero life if you want."
         },
         {
           "date": "2004-10-04",
-          "text": "If an opponent steals control of Lich and no other effect prevents you from losing with a life total of zero, you will lose the game due to a zero life total as a State-Based Action before you can take any actions. The last sentence doesn’t apply in this case since the Lich didn’t leave the battlefield."
+          "text": "If an opponent steals control of Lich and no other effect prevents you from losing with a life total of zero, you will lose the game due to a zero life total as a State-Based Action before you can take any actions. The last sentence doesn't apply in this case since the Lich didn't leave the battlefield."
         },
         {
           "date": "2004-10-04",
-          "text": "If an opponent steals control of Lich, their life total does not change. The life total changes for a player only when it enters the battlefield under that player’s control."
+          "text": "If an opponent steals control of Lich, their life total does not change. The life total changes for a player only when it enters the battlefield under that player's control."
         },
         {
           "date": "2004-10-04",
@@ -5221,7 +5222,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich leaves the battlefield or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can’t lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
+          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich leaves the battlefield or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can't lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
         },
         {
           "date": "2010-08-15",
@@ -5229,7 +5230,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich is put into the graveyard or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can’t lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
+          "text": "The last ability will cause you to lose the game even if you somehow manage to have a life total greater than 0 at the time the Lich is put into the graveyard or if some other effect would prevent you from losing for having 0 life. If, on the other hand, some effect such as that from Platinum Angel says that you can't lose the game then even the last ability of the Lich cannot cause you to do so. The ability will just resolve and the game will continue as normal."
         }
       ],
       "text": "As Lich enters the battlefield, you lose life equal to your life total.\nYou don't lose the game for having 0 or less life.\nIf you would gain life, draw that many cards instead.\nWhenever you're dealt damage, sacrifice that many nontoken permanents. If you can't, you lose the game.\nWhen Lich is put into a graveyard from the battlefield, you lose the game.",
@@ -5621,15 +5622,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -6016,7 +6017,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2009-10-01",
@@ -6024,15 +6025,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Word of Command can’t be used to force a player to play a card that isn’t in his or her hand."
+          "text": "Word of Command can't be used to force a player to play a card that isn't in his or her hand."
         },
         {
           "date": "2011-01-01",
-          "text": "You control the player while this spell is resolving, which means you get to see anything he or she can see. If that player is required to search his or her library as part of playing the card or as part of its resolution if it’s cast as a spell, then you can see the cards in that player’s library as well."
+          "text": "You control the player while this spell is resolving, which means you get to see anything he or she can see. If that player is required to search his or her library as part of playing the card or as part of its resolution if it's cast as a spell, then you can see the cards in that player's library as well."
         },
         {
           "date": "2011-01-01",
-          "text": "Your opponent can’t counter the Word of Command after letting you look at his or her hand, but they can attempt to counter the spell you force them to cast."
+          "text": "Your opponent can't counter the Word of Command after letting you look at his or her hand, but they can attempt to counter the spell you force them to cast."
         },
         {
           "date": "2011-01-01",
@@ -6048,7 +6049,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Since this spell is an instant, your opponent gets a chance to respond to it as normal. Once this spell resolves, you look at your opponent’s hand and choose a card. Note that it is common practice to respond to Word of Command by using up any spells or mana you have prior to letting it resolve."
+          "text": "Since this spell is an instant, your opponent gets a chance to respond to it as normal. Once this spell resolves, you look at your opponent's hand and choose a card. Note that it is common practice to respond to Word of Command by using up any spells or mana you have prior to letting it resolve."
         },
         {
           "date": "2011-01-01",
@@ -6056,11 +6057,11 @@
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "text": "Look at target opponent's hand and choose a card from it. You control that player until Word of Command finishes resolving. The player plays that card if able. While doing so, the player can activate mana abilities only if they're from lands he or she controls and only if mana they produce is spent to activate other mana abilities of lands he or she controls and/or play that card. If the chosen card is cast as a spell, you control the player while that spell is resolving.",
@@ -6117,7 +6118,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -6231,7 +6232,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Aladdin’s ability can take control of more than one artifact, although only one each time the ability is used."
+          "text": "Aladdin's ability can take control of more than one artifact, although only one each time the ability is used."
         },
         {
           "date": "2008-08-01",
@@ -6747,7 +6748,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -6759,7 +6760,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -6819,7 +6820,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When a spell with additional costs is copied, you don’t have to pay those costs again."
+          "text": "When a spell with additional costs is copied, you don't have to pay those costs again."
         },
         {
           "date": "2004-10-04",
@@ -6847,7 +6848,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy’s target will be illegal when it resolves."
+          "text": "If the spell being copied targets a spell on the stack, it is possible to target Fork itself since Fork is still on the stack when you pick the target(s) for the copy. Note that the copy's target will be illegal when it resolves."
         },
         {
           "date": "2004-10-04",
@@ -6855,7 +6856,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The copy that is placed on the stack is not considered to have been “cast”."
+          "text": "The copy that is placed on the stack is not considered to have been \"cast\"."
         },
         {
           "date": "2004-10-04",
@@ -7022,7 +7023,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Works even if placed on one of your opponent’s Mountains."
+          "text": "Works even if placed on one of your opponent's Mountains."
         },
         {
           "date": "2004-10-04",
@@ -7188,7 +7189,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Works even if placed on one of your opponent’s Mountains."
+          "text": "Works even if placed on one of your opponent's Mountains."
         }
       ],
       "subtypes": [
@@ -7299,7 +7300,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s before the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's before the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Gorilla War Cry only during combat before blockers are declared.\nAll creatures gain menace until end of turn. (They can't be blocked except by two or more creatures.)\nDraw a card at the beginning of the next turn's upkeep.",
@@ -7619,7 +7620,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Primitive Justice can’t target the same artifact more than once."
+          "text": "Primitive Justice can't target the same artifact more than once."
         }
       ],
       "text": "As an additional cost to cast Primitive Justice, you may pay {1}{R} and/or {1}{G} any number of times.\nDestroy target artifact. For each additional {1}{R} you paid, destroy another target artifact. For each additional {1}{G} you paid, destroy another target artifact, and you gain 1 life.",
@@ -7793,7 +7794,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If damage that would be dealt to Rock Hydra can’t be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
+          "text": "If damage that would be dealt to Rock Hydra can't be prevented, you still remove a +1/+1 counter from it for each 1 damage dealt."
         }
       ],
       "subtypes": [
@@ -8441,7 +8442,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life you don’t have. In other words, you can’t Channel yourself below zero life."
+          "text": "You can't pay life you don't have. In other words, you can't Channel yourself below zero life."
         }
       ],
       "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
@@ -8647,11 +8648,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -8659,7 +8660,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -8714,7 +8715,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "This card’s ability is not targeted, so even untargetable creatures or those with Protection can be chosen."
+          "text": "This card's ability is not targeted, so even untargetable creatures or those with Protection can be chosen."
         },
         {
           "date": "2013-07-01",
@@ -8722,7 +8723,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If there are multiple creatures tied for least power and some but not all of them have indestructible, the ones with indestructible can’t be chosen."
+          "text": "If there are multiple creatures tied for least power and some but not all of them have indestructible, the ones with indestructible can't be chosen."
         }
       ],
       "text": "At the beginning of your upkeep, destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them.\nWhen there are no creatures on the battlefield, sacrifice Drop of Honey.",
@@ -8830,11 +8831,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You take damage when you play a land using the “play a land” action. Such an action can be your regular “play a land”, one enabled by Fastbond, or ones enabled through other effects."
+          "text": "You take damage when you play a land using the \"play a land\" action. Such an action can be your regular \"play a land\", one enabled by Fastbond, or ones enabled through other effects."
         },
         {
           "date": "2004-10-04",
-          "text": "You do not take damage when you “put a land onto the battlefield” through the effect of a spell or ability."
+          "text": "You do not take damage when you \"put a land onto the battlefield\" through the effect of a spell or ability."
         }
       ],
       "text": "You may play any number of lands on each of your turns.\nWhenever you play a land, if it wasn't the first land you played this turn, Fastbond deals 1 damage to you.",
@@ -9168,15 +9169,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If attached to an opponent’s creature, you can untap their creature during your turn."
+          "text": "If attached to an opponent's creature, you can untap their creature during your turn."
         },
         {
           "date": "2004-10-04",
-          "text": "Instill Energy’s untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
+          "text": "Instill Energy's untap ability will not untap the creature until it resolves. This means other spells and abilities can be used before it actually becomes untapped."
         },
         {
           "date": "2005-08-01",
-          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card’s ability to untap once during the turn."
+          "text": "Any Auras (or other effects) which are on the creature that would cause it to not be untapped (or have a cost to be untapped) during untap step do not in any way hinder or imply a cost to use this card's ability to untap once during the turn."
         }
       ],
       "subtypes": [
@@ -9285,7 +9286,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can move it to any other player’s land whenever you get to move it."
+          "text": "You can move it to any other player's land whenever you get to move it."
         },
         {
           "date": "2005-08-01",
@@ -9297,7 +9298,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Because the ability isn’t targeted, the controller of the destroyed land may attach it to a land that can’t be the target of abilities."
+          "text": "Because the ability isn't targeted, the controller of the destroyed land may attach it to a land that can't be the target of abilities."
         }
       ],
       "subtypes": [
@@ -9409,7 +9410,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Forests are 1/1 creatures that are still lands.",
@@ -9825,7 +9826,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a creature card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -9878,7 +9879,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Each noncreature artifact loses all abilities and becomes an artifact creature with power and toughness each equal to its converted mana cost. If Titania's Song leaves the battlefield, this effect continues until end of turn.",
@@ -10498,7 +10499,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t spend yourself to below zero life. You can’t spend life you don’t have."
+          "text": "You can't spend yourself to below zero life. You can't spend life you don't have."
         }
       ],
       "text": "{2}, Pay 2 life: Draw a card.",
@@ -10689,7 +10690,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You may untap your opponent’s lands if desired."
+          "text": "You may untap your opponent's lands if desired."
         },
         {
           "date": "2004-10-04",
@@ -11101,7 +11102,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "After leaving the battlefield, the ability triggers during each of your upkeeps for the rest of the game. As it resolves, you must remove a mire counter from a land that had a mire counter put on it by that instance of Cyclopean Tomb, but it doesn’t matter where the mire counter you remove came from. For instance, you could remove mire counters that were put on the land by Gilder Bairn."
+          "text": "After leaving the battlefield, the ability triggers during each of your upkeeps for the rest of the game. As it resolves, you must remove a mire counter from a land that had a mire counter put on it by that instance of Cyclopean Tomb, but it doesn't matter where the mire counter you remove came from. For instance, you could remove mire counters that were put on the land by Gilder Bairn."
         },
         {
           "date": "2008-08-01",
@@ -11616,11 +11617,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The Cauldron counts only mana spent on it. It doesn’t see the value of X, so isn’t affected by cost reductions. Thus, if you spent {C}{C}{R}{R} on X, you get {C}{C}{R}{R} later even if X was 6."
+          "text": "The Cauldron counts only mana spent on it. It doesn't see the value of X, so isn't affected by cost reductions. Thus, if you spent {C}{C}{R}{R} on X, you get {C}{C}{R}{R} later even if X was 6."
         },
         {
           "date": "2004-10-04",
-          "text": "Cards which are not actually in your hand can’t be exiled by the Ice Cauldron."
+          "text": "Cards which are not actually in your hand can't be exiled by the Ice Cauldron."
         },
         {
           "date": "2004-10-04",
@@ -11632,7 +11633,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You do not have to use any mana from the Cauldron when casting the spell if you don’t want to. You don’t even have to tap the Cauldron and draw the mana, you can just cast the spell using mana from somewhere else."
+          "text": "You do not have to use any mana from the Cauldron when casting the spell if you don't want to. You don't even have to tap the Cauldron and draw the mana, you can just cast the spell using mana from somewhere else."
         },
         {
           "date": "2004-10-04",
@@ -11652,7 +11653,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can only cast the spell when you could legally cast it normally. So no casting a sorcery on your opponent’s turn."
+          "text": "You can only cast the spell when you could legally cast it normally. So no casting a sorcery on your opponent's turn."
         },
         {
           "date": "2004-10-04",
@@ -11735,19 +11736,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player’s pool."
+          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player's pool."
         },
         {
           "date": "2004-10-04",
-          "text": "Icy Manipulator can’t be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
+          "text": "Icy Manipulator can't be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger “if the card becomes tapped” effects."
+          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger \"if the card becomes tapped\" effects."
         },
         {
           "date": "2004-10-04",
-          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use the Icy Manipulator."
+          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use the Icy Manipulator."
         },
         {
           "date": "2004-10-04",
@@ -11864,11 +11865,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or you haven’t controlled it continuously since the beginning of your turn, then it doesn’t attack. If there’s a cost associated with having Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or you haven't controlled it continuously since the beginning of your turn, then it doesn't attack. If there's a cost associated with having Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-06-08",
-          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Juggernaut must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -11931,7 +11932,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All Swamps are 1/1 black creatures that are still lands.",
@@ -11982,11 +11983,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not “discarded”."
+          "text": "This effect has no effect on the cards being put into the graveyard from a library, because they are not \"discarded\"."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren’t effects."
+          "text": "You can't use the Library of Leng ability to place a discarded card on top of your library when you discard a card as a cost, because costs aren't effects."
         },
         {
           "date": "2004-10-04",
@@ -12014,7 +12015,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Library of Leng onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\nIf an effect causes you to discard a card, discard it, but you may put it on top of your library instead of into your graveyard.",
@@ -12121,7 +12122,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Only reduces the generic mana portion of a spell’s cost. If the cost does not include generic mana or includes less than {2}, you get a reduced or null effect from this card."
+          "text": "Only reduces the generic mana portion of a spell's cost. If the cost does not include generic mana or includes less than {2}, you get a reduced or null effect from this card."
         }
       ],
       "text": "Instant and enchantment spells you cast cost up to {2} less to cast.",
@@ -12516,7 +12517,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Only reduces the generic mana portion of a spell’s cost. If the cost does not include generic mana or includes less than {2}, you get a reduced or null effect from this card."
+          "text": "Only reduces the generic mana portion of a spell's cost. If the cost does not include generic mana or includes less than {2}, you get a reduced or null effect from this card."
         },
         {
           "date": "2008-04-01",
@@ -12578,11 +12579,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         },
         {
           "date": "2012-07-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Clay, it copies the power, toughness, and abilities that were chosen for Primal Clay when it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -13109,7 +13110,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Only Tetravites from this specific Tetravus may be used for the ability. Ones from a different Tetravus can’t."
+          "text": "Only Tetravites from this specific Tetravus may be used for the ability. Ones from a different Tetravus can't."
         },
         {
           "date": "2008-08-01",
@@ -13168,7 +13169,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         },
         {
           "date": "2008-10-01",
@@ -13225,7 +13226,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "{3}, {T}: Put a hatchling counter on Triassic Egg.\nSacrifice Triassic Egg: Choose one —\n• You may put a creature card from your hand onto the battlefield. Activate this ability only if two or more hatchling counters are on Triassic Egg.\n• Return target creature card from your graveyard to the battlefield. Activate this ability only if two or more hatchling counters are on Triassic Egg.",
@@ -13513,7 +13514,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land type changing effects that change a dual land’s land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
+          "text": "Land type changing effects that change a dual land's land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
         },
         {
           "date": "2004-10-04",
@@ -13525,7 +13526,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -13586,7 +13587,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -13648,7 +13649,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass’s triggered ability is put on the stack on top of it. City of Brass’s ability will resolve first."
+          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass's triggered ability is put on the stack on top of it. City of Brass's ability will resolve first."
         },
         {
           "date": "2004-10-04",
@@ -13782,11 +13783,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The creature isn’t removed from combat; it just has its damage prevented. It’s still an attacking creature until the combat phase is complete."
+          "text": "The creature isn't removed from combat; it just has its damage prevented. It's still an attacking creature until the combat phase is complete."
         },
         {
           "date": "2016-06-08",
-          "text": "You can activate Maze of Ith’s ability targeting an attacking creature you control during the combat damage step or the end of combat step. It’ll be untapped and the damage it had already dealt won’t be undone."
+          "text": "You can activate Maze of Ith's ability targeting an attacking creature you control during the combat damage step or the end of combat step. It'll be untapped and the damage it had already dealt won't be undone."
         }
       ],
       "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
@@ -13831,11 +13832,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can spend the mana on costs on the spell’s text."
+          "text": "You can spend the mana on costs on the spell's text."
         },
         {
           "date": "2004-10-04",
-          "text": "The mana can’t be used to pay Echo costs."
+          "text": "The mana can't be used to pay Echo costs."
         },
         {
           "date": "2004-10-04",
@@ -13937,7 +13938,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -13998,7 +13999,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -14059,7 +14060,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -14162,7 +14163,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -14223,7 +14224,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -14284,7 +14285,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -14345,7 +14346,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -14399,7 +14400,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -14458,7 +14459,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -14517,7 +14518,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -14576,7 +14577,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -14635,7 +14636,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -14694,7 +14695,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -14753,7 +14754,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -14812,7 +14813,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have at least one of each of the three Urza’s lands on the battlefield, you must take the 2 mana instead of just one."
+          "text": "If you have at least one of each of the three Urza's lands on the battlefield, you must take the 2 mana instead of just one."
         }
       ],
       "subtypes": [
@@ -15089,7 +15090,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [

--- a/json/MED.json
+++ b/json/MED.json
@@ -239,7 +239,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -298,7 +299,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1037,7 +1038,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1115,7 +1116,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1282,7 +1283,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the targeted player’s library is empty, that player still names a card, but nothing further happens. That player will not lose the game."
+          "text": "If the targeted player's library is empty, that player still names a card, but nothing further happens. That player will not lose the game."
         }
       ],
       "subtypes": [
@@ -1338,11 +1339,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The target of the ability is a creature the chosen opponent controls. As the ability resolves, if the target isn’t a creature controlled by the chosen opponent, the ability will be countered. If the ability’s target is changed somehow, the new target must be a creature controlled by the chosen opponent."
+          "text": "The target of the ability is a creature the chosen opponent controls. As the ability resolves, if the target isn't a creature controlled by the chosen opponent, the ability will be countered. If the ability's target is changed somehow, the new target must be a creature controlled by the chosen opponent."
         },
         {
           "date": "2007-09-16",
-          "text": "Whether Preacher is tapped is checked continually, starting when the ability is activated. If, before the ability resolves, there’s any point at which Preacher is untapped, the ability has no effect — even if Preacher is tapped again by the time the ability resolves."
+          "text": "Whether Preacher is tapped is checked continually, starting when the ability is activated. If, before the ability resolves, there's any point at which Preacher is untapped, the ability has no effect — even if Preacher is tapped again by the time the ability resolves."
         },
         {
           "date": "2007-09-16",
@@ -1462,19 +1463,19 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If Seraph isn’t on the battlefield at the time the other creature is put into a graveyard, the ability won’t trigger. However, the ability does trigger if Seraph and the other creature are put into the graveyard at the same time."
+          "text": "If Seraph isn't on the battlefield at the time the other creature is put into a graveyard, the ability won't trigger. However, the ability does trigger if Seraph and the other creature are put into the graveyard at the same time."
         },
         {
           "date": "2007-09-16",
-          "text": "If the other creature is a token, it will cease to exist after being exiled. It won’t be returned to the battlefield."
+          "text": "If the other creature is a token, it will cease to exist after being exiled. It won't be returned to the battlefield."
         },
         {
           "date": "2007-09-16",
-          "text": "If the other creature ceases to be a creature card after it leaves the battlefield (it’s an animated Mishra’s Factory, for example), it will be returned to the battlefield by this ability and you will have to sacrifice it when you lose control of Seraph."
+          "text": "If the other creature ceases to be a creature card after it leaves the battlefield (it's an animated Mishra's Factory, for example), it will be returned to the battlefield by this ability and you will have to sacrifice it when you lose control of Seraph."
         },
         {
           "date": "2007-09-16",
-          "text": "Once the ability triggers, you’ll return the card to the battlefield under your control at the end of the turn even if you no longer control Seraph at that time. In fact, if Seraph leaves the battlefield before the card is returned to the battlefield, you’ll never have to sacrifice it as a result of this ability. If Seraph remains on the battlefield but changes controllers before the card is returned, you’ll still get the returned card. However, in that scenario, you’ll still have to sacrifice it if you later regain control Seraph and then lose control of it once more."
+          "text": "Once the ability triggers, you'll return the card to the battlefield under your control at the end of the turn even if you no longer control Seraph at that time. In fact, if Seraph leaves the battlefield before the card is returned to the battlefield, you'll never have to sacrifice it as a result of this ability. If Seraph remains on the battlefield but changes controllers before the card is returned, you'll still get the returned card. However, in that scenario, you'll still have to sacrifice it if you later regain control Seraph and then lose control of it once more."
         }
       ],
       "subtypes": [
@@ -1732,7 +1733,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "The controller of the countered spell doesn’t choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
+          "text": "The controller of the countered spell doesn't choose how many cards to draw until the relevant ability resolves. The player may draw 0, 1, or 2 cards. He or she chooses the number before drawing any cards."
         }
       ],
       "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
@@ -1792,11 +1793,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Diminishing Returns won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "Diminishing Returns won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         },
         {
           "date": "2016-06-08",
-          "text": "The exiled cards are exiled face up. You’ll see them before you choose how many cards to draw."
+          "text": "The exiled cards are exiled face up. You'll see them before you choose how many cards to draw."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library. You exile the top ten cards of your library. Then each player draws up to seven cards.",
@@ -2064,7 +2065,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         },
         {
           "date": "2016-06-08",
@@ -2124,7 +2125,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -2291,7 +2292,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "First creatures are exchanged, then artifacts are exchanged. It’s possible that the same artifact creature may be involved in both exchanges."
+          "text": "First creatures are exchanged, then artifacts are exchanged. It's possible that the same artifact creature may be involved in both exchanges."
         },
         {
           "date": "2007-09-16",
@@ -2299,7 +2300,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If one of the players doesn’t control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn’t control an artifact at the time the exchange would be made, that part of the effect does nothing."
+          "text": "If one of the players doesn't control a creature at the time the exchange would be made, that part of the effect does nothing, but the exchange of artifacts will still happen. Similarly, if one of the players doesn't control an artifact at the time the exchange would be made, that part of the effect does nothing."
         }
       ],
       "text": "You and target player exchange control of the creature you each control with the highest converted mana cost. Then exchange control of artifacts the same way. If two or more permanents a player controls are tied for highest cost, their controller chooses one of them.",
@@ -2353,11 +2354,11 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "First the opponent chooses whether or not to pay {4}. Then, if he or she doesn’t pay, you choose whether or not to draw a card."
+          "text": "First the opponent chooses whether or not to pay {4}. Then, if he or she doesn't pay, you choose whether or not to draw a card."
         },
         {
           "date": "2008-04-01",
-          "text": "A “noncreature spell” is any spell that doesn’t have the type Creature. Artifact Creatures, Enchantment Creatures, and older cards of type Summon are all creature spells."
+          "text": "A \"noncreature spell\" is any spell that doesn't have the type Creature. Artifact Creatures, Enchantment Creatures, and older cards of type Summon are all creature spells."
         }
       ],
       "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever an opponent casts a noncreature spell, you may draw a card unless that player pays {4}.",
@@ -2473,7 +2474,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -2527,7 +2528,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The loss of life can’t be prevented by any means. It is not damage."
+          "text": "The loss of life can't be prevented by any means. It is not damage."
         },
         {
           "date": "2004-10-04",
@@ -2750,11 +2751,11 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If a creature’s controller doesn’t control an Island, that creature is an illegal target. Whether that player controls an Island is checked both when Seasinger’s ability is activated and when it resolves. However, targeting restrictions aren’t checked continually while a spell or ability is on the stack."
+          "text": "If a creature's controller doesn't control an Island, that creature is an illegal target. Whether that player controls an Island is checked both when Seasinger's ability is activated and when it resolves. However, targeting restrictions aren't checked continually while a spell or ability is on the stack."
         },
         {
           "date": "2007-09-16",
-          "text": "Whether you control Seasinger is checked continually, starting when the ability is activated. If, before the ability resolves, there’s any point at which you don’t control Seasinger, the ability has no effect — even if you control Seasinger again by the time the ability resolves. The same is true regarding whether Seasinger remains tapped."
+          "text": "Whether you control Seasinger is checked continually, starting when the ability is activated. If, before the ability resolves, there's any point at which you don't control Seasinger, the ability has no effect — even if you control Seasinger again by the time the ability resolves. The same is true regarding whether Seasinger remains tapped."
         }
       ],
       "subtypes": [
@@ -2907,7 +2908,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "Telekinesis’ ability doesn’t lock in who the creature’s controller is when it resolves. If the creature changes controllers, it won’t untap during its controller’s untap step until it has not done so twice, regardless of who its controller was during any of those untap steps."
+          "text": "Telekinesis' ability doesn't lock in who the creature's controller is when it resolves. If the creature changes controllers, it won't untap during its controller's untap step until it has not done so twice, regardless of who its controller was during any of those untap steps."
         }
       ],
       "text": "Tap target creature. Prevent all combat damage that would be dealt by that creature this turn. It doesn't untap during its controller's next two untap steps.",
@@ -2964,11 +2965,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A “permanent that isn’t enchanted” is a permanent with no Auras on it."
+          "text": "A \"permanent that isn't enchanted\" is a permanent with no Auras on it."
         },
         {
           "date": "2007-09-16",
-          "text": "If Time Elemental attacks or blocks, but you no longer control it at end of combat, you can’t sacrifice it. However, it will still deal 5 damage to you."
+          "text": "If Time Elemental attacks or blocks, but you no longer control it at end of combat, you can't sacrifice it. However, it will still deal 5 damage to you."
         }
       ],
       "subtypes": [
@@ -3049,23 +3050,23 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both “sides” of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
+          "text": "If a Doppelganger is flipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the flipped side. If a Doppelganger is unflipped, and it copies a flip card in any state, it will copy both \"sides\" of that card but use the unflipped side. In the second case, if it ever meets the flip conditions of its new ability, it will flip and used the flipped side of what it is copying."
         },
         {
           "date": "2007-09-16",
-          "text": "When Vesuvan Doppelganger’s triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
+          "text": "When Vesuvan Doppelganger's triggered ability triggers, you must choose a target for it. You determine whether to have the Doppelganger become a copy of that target when the ability resolves."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger copies the mana cost of the creature it’s copying but doesn’t copy its color."
+          "text": "Vesuvan Doppelganger copies the mana cost of the creature it's copying but doesn't copy its color."
         },
         {
           "date": "2007-09-16",
-          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger’s color, and will gain Vesuvan Doppelganger’s triggered ability."
+          "text": "If another creature copies Vesuvan Doppelganger, the new creature will become a copy of whatever Vesuvan Doppelganger is copying except for its color, will copy Vesuvan Doppelganger's color, and will gain Vesuvan Doppelganger's triggered ability."
         },
         {
           "date": "2007-09-16",
-          "text": "Vesuvan Doppelganger’s triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller’s upkeep. They’ll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger’s characteristics for the rest of the turn."
+          "text": "Vesuvan Doppelganger's triggered ability may cause it to become a copy of itself. A Vesuvan Doppelganger that becomes a copy of a Vesuvan Doppelganger (either itself or a different one) will gain another instance of its triggered ability. Each instance of that ability will trigger during its controller's upkeep. They'll all be put on the stack and resolve one at a time. The last one to resolve determines the Doppelganger's characteristics for the rest of the turn."
         },
         {
           "date": "2007-09-16",
@@ -3073,7 +3074,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Although Vesuvan Doppelganger’s triggered ability is targeted, its “as enters the battlefield” ability is not."
+          "text": "Although Vesuvan Doppelganger's triggered ability is targeted, its \"as enters the battlefield\" ability is not."
         }
       ],
       "subtypes": [
@@ -3242,7 +3243,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -3250,11 +3251,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -3310,11 +3311,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The Baron’s ability will only regenerate creatures with type “Vampire,” regardless of whether the creature has “Vampire” in its name."
+          "text": "The Baron's ability will only regenerate creatures with type \"Vampire,\" regardless of whether the creature has \"Vampire\" in its name."
         },
         {
           "date": "2007-09-16",
-          "text": "Although Baron Sengir is now a Vampire, it still can’t regenerate itself."
+          "text": "Although Baron Sengir is now a Vampire, it still can't regenerate itself."
         }
       ],
       "subtypes": [
@@ -3593,7 +3594,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The effect is cumulative. If there are two of these on the battlefield, each of them will modify each draw (after the first one if during the draw step), and will cause the player to discard or to “mill” a card from their library. As they resolve in order, the player must discard if possible. Once the player fails to discard and instead “mills” a card, all further effects of additional Chains of Mephistopheles will not do anything. This is because the “mill” also replaces the draw effect and the player is no longer drawing a card. You handle them in order. Each one makes you discard first and then continue or else mill a card and lose the draw."
+          "text": "The effect is cumulative. If there are two of these on the battlefield, each of them will modify each draw (after the first one if during the draw step), and will cause the player to discard or to \"mill\" a card from their library. As they resolve in order, the player must discard if possible. Once the player fails to discard and instead \"mills\" a card, all further effects of additional Chains of Mephistopheles will not do anything. This is because the \"mill\" also replaces the draw effect and the player is no longer drawing a card. You handle them in order. Each one makes you discard first and then continue or else mill a card and lose the draw."
         },
         {
           "date": "2004-10-04",
@@ -3601,15 +3602,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If a spell or ability would cause a player to draw multiple cards, this is treated as a number of individual “draw one card” actions. Apply the effect of Chains of Mephistopheles to each one."
+          "text": "If a spell or ability would cause a player to draw multiple cards, this is treated as a number of individual \"draw one card\" actions. Apply the effect of Chains of Mephistopheles to each one."
         },
         {
           "date": "2007-09-16",
-          "text": "A player’s normal card draw on his or her turn is exempt from this effect. All other draws will be affected."
+          "text": "A player's normal card draw on his or her turn is exempt from this effect. All other draws will be affected."
         },
         {
           "date": "2007-09-16",
-          "text": "Here’s what happens when Chains of Mephistopheles replaces a player’s draw: — If that player has at least one card in his or her hand, he or she discards a card and then draws a card. — If that player’s hand is empty, he or she puts the top card of his or her library into his or her graveyard. The player doesn’t draw a card at all."
+          "text": "Here's what happens when Chains of Mephistopheles replaces a player's draw: — If that player has at least one card in his or her hand, he or she discards a card and then draws a card. — If that player's hand is empty, he or she puts the top card of his or her library into his or her graveyard. The player doesn't draw a card at all."
         }
       ],
       "text": "If a player would draw a card except the first one he or she draws in his or her draw step each turn, that player discards a card instead. If the player discards a card this way, he or she draws a card. If the player doesn't discard a card this way, he or she puts the top card of his or her library into his or her graveyard.",
@@ -3711,7 +3712,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different opposing player each time it is used. You also don’t have to choose the same player that you targeted with the effect (or whose creature you targeted)."
+          "text": "In multiplayer games you can choose a different opposing player each time it is used. You also don't have to choose the same player that you targeted with the effect (or whose creature you targeted)."
         },
         {
           "date": "2004-10-04",
@@ -3836,11 +3837,11 @@
         },
         {
           "date": "2007-09-16",
-          "text": "You can activate the ability whether or not Eater of the Dead is tapped. However, if Eater of the Dead is untapped when the ability resolves, the ability won’t do anything."
+          "text": "You can activate the ability whether or not Eater of the Dead is tapped. However, if Eater of the Dead is untapped when the ability resolves, the ability won't do anything."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -3958,11 +3959,11 @@
         },
         {
           "date": "2007-09-16",
-          "text": "The Fallen’s ability causes it to deal damage only to opponents of its current controller. If The Fallen has dealt damage to you, and then you gain control of it, you won’t be damaged during your upkeep."
+          "text": "The Fallen's ability causes it to deal damage only to opponents of its current controller. If The Fallen has dealt damage to you, and then you gain control of it, you won't be damaged during your upkeep."
         },
         {
           "date": "2007-09-16",
-          "text": "The effect isn’t cumulative. When it resolves, The Fallen deals 1 damage to each opponent previously dealt damage by it, regardless of how many times The Fallen dealt damage to that opponent before."
+          "text": "The effect isn't cumulative. When it resolves, The Fallen deals 1 damage to each opponent previously dealt damage by it, regardless of how many times The Fallen dealt damage to that opponent before."
         }
       ],
       "subtypes": [
@@ -4346,7 +4347,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -4408,7 +4409,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can’t be countered with something that counters spells."
+          "text": "Note that bringing the Shadow back onto the battlefield from the graveyard is not a spell, it is an ability. It can't be countered with something that counters spells."
         },
         {
           "date": "2004-10-04",
@@ -4416,7 +4417,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "A card is “above” another card in your graveyard if it was put into that graveyard later."
+          "text": "A card is \"above\" another card in your graveyard if it was put into that graveyard later."
         },
         {
           "date": "2008-10-01",
@@ -4428,11 +4429,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-10-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -4544,7 +4545,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can’t be enchanted by an Aura that was also exiled by Oubliette, that Aura will remain exiled."
+          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can't be enchanted by an Aura that was also exiled by Oubliette, that Aura will remain exiled."
         }
       ],
       "text": "When Oubliette enters the battlefield, exile target creature and all Auras attached to it. Note the number and kind of counters that were on that creature.\nWhen Oubliette leaves the battlefield, return that exiled card to the battlefield under its owner's control tapped with the noted number and kind of counters on it. If you do, return the other exiled cards to the battlefield under their owner's control attached to that permanent.",
@@ -4728,15 +4729,15 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "The losses, discards, and sacrifices are rounded up. For example, if you have 5 life, you’ll lose 2 life, leaving you at 3 life. (Five divided by three is one and two-thirds. Rounding that up to the nearest whole number gives you two.)"
+          "text": "The losses, discards, and sacrifices are rounded up. For example, if you have 5 life, you'll lose 2 life, leaving you at 3 life. (Five divided by three is one and two-thirds. Rounding that up to the nearest whole number gives you two.)"
         },
         {
           "date": "2007-09-16",
-          "text": "Each part of Pox’s effect is processed separately. For each part, first the player whose turn it is makes all necessary choices (such as which cards to discard), then each other player in turn order chooses, then the actions happen at the same time. Then Pox’s effect moves to the next stage."
+          "text": "Each part of Pox's effect is processed separately. For each part, first the player whose turn it is makes all necessary choices (such as which cards to discard), then each other player in turn order chooses, then the actions happen at the same time. Then Pox's effect moves to the next stage."
         },
         {
           "date": "2007-09-16",
-          "text": "The number you need to lose, discard, or sacrifice isn’t calculated until it’s time to perform that part of the effect. For example, if your opponent casts Pox and you discard Dodecapod as part of Pox’s discard effect, Dodecapod will be put onto the battlefield instead of into your graveyard. Then, when determining how many creatures you need to sacrifice, the Dodecapod is taken into account."
+          "text": "The number you need to lose, discard, or sacrifice isn't calculated until it's time to perform that part of the effect. For example, if your opponent casts Pox and you discard Dodecapod as part of Pox's discard effect, Dodecapod will be put onto the battlefield instead of into your graveyard. Then, when determining how many creatures you need to sacrifice, the Dodecapod is taken into account."
         }
       ],
       "text": "Each player loses a third of his or her life, then discards a third of the cards in his or her hand, then sacrifices a third of the creatures he or she controls, then sacrifices a third of the lands he or she controls. Round up each time.",
@@ -4797,7 +4798,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Unlike many similar creatures, Thrull Champion untaps as normal during your untap step. Whether it’s tapped or untapped has no bearing on the control-change effect."
+          "text": "Unlike many similar creatures, Thrull Champion untaps as normal during your untap step. Whether it's tapped or untapped has no bearing on the control-change effect."
         }
       ],
       "subtypes": [
@@ -4853,7 +4854,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won’t be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
+          "text": "This leaves the battlefield when you activate its activated ability, but the enchanted creature won't be regenerated until the ability resolves. In the intervening time, the creature will no longer have the bonus that this had been giving it. This may cause the creature to be destroyed before the regeneration shield is created."
         }
       ],
       "subtypes": [
@@ -5188,7 +5189,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -5467,7 +5468,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t sacrifice more than one Goblin to get a greater effect."
+          "text": "You can't sacrifice more than one Goblin to get a greater effect."
         },
         {
           "date": "2011-09-22",
@@ -5475,7 +5476,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn’t have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
+          "text": "The Goblin you sacrifice to cast Goblin Grenade doesn't have to be a creature. For example, you could sacrifice Boggart Shenanigans (a tribal enchantment with the subtype Goblin)."
         }
       ],
       "text": "As an additional cost to cast Goblin Grenade, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to target creature or player.",
@@ -5806,7 +5807,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never “locked in”."
+          "text": "This is a Characteristic-Defining Ability. It checks the number of non-Wall creatures you control continuously, and applies in all zones. It is never \"locked in\"."
         }
       ],
       "subtypes": [
@@ -5931,7 +5932,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare’s ability."
+          "text": "If the land produces more than one color of mana at a single time, its controller chooses which of those types is produced by Mana Flare's ability."
         },
         {
           "date": "2004-10-04",
@@ -5939,7 +5940,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can’t give a mana of a color that wasn’t produced."
+          "text": "When used with lands that can produce multiple colors, Mana Flare produces one additional mana of the same color that was produced. It can't give a mana of a color that wasn't produced."
         },
         {
           "date": "2004-10-04",
@@ -5955,7 +5956,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Does not copy any restrictions on the mana, such as with Mishra’s Workshop or Pillar of the Paruns."
+          "text": "Does not copy any restrictions on the mana, such as with Mishra's Workshop or Pillar of the Paruns."
         },
         {
           "date": "2007-09-16",
@@ -6175,7 +6176,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can’t be changed, so only targets of the selected type are valid."
+          "text": "The decision to counter a spell or destroy a permanent is a decision made on announcement before the target is selected. If the spell is redirected, this mode can't be changed, so only targets of the selected type are valid."
         },
         {
           "date": "2016-06-08",
@@ -6295,19 +6296,19 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the Giant’s power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
+          "text": "If the Giant's power and/or toughness change so that its toughness is less than its power, you can have the ability target the Giant itself."
         },
         {
           "date": "2009-10-01",
-          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "To work as an evasion ability, an attacking creature must already have flying when the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "If Stone Giant’s ability is activated during a turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. The targeted creature will be destroyed at that time."
+          "text": "If Stone Giant's ability is activated during a turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. The targeted creature will be destroyed at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it’s no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant’s power at that time."
+          "text": "When the delayed triggered ability resolves, the targeted creature is destroyed, even if it's no longer a creature, no longer under your control, or no longer has toughness less than Stone Giant's power at that time."
         }
       ],
       "subtypes": [
@@ -6372,7 +6373,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -6763,11 +6764,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The cards are put onto the battlefield and will not trigger effects which trigger on such cards being “cast” or “played”."
+          "text": "The cards are put onto the battlefield and will not trigger effects which trigger on such cards being \"cast\" or \"played\"."
         },
         {
           "date": "2004-10-04",
-          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn’t end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
+          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn't end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
         },
         {
           "date": "2004-10-04",
@@ -6779,7 +6780,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "A “permanent card” is a card that would be a permanent once it’s on the battlefield. Specifically, it’s an artifact, creature, enchantment, land, or planeswalker card."
+          "text": "A \"permanent card\" is a card that would be a permanent once it's on the battlefield. Specifically, it's an artifact, creature, enchantment, land, or planeswalker card."
         }
       ],
       "text": "Starting with you, each player may put a permanent card from his or her hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.",
@@ -7163,7 +7164,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -7488,11 +7489,11 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Changes creature’s current power to zero (as opposed to giving it -X/-0, like before) but does not prevent raising it after the Tree has been used on it."
+          "text": "Changes creature's current power to zero (as opposed to giving it -X/-0, like before) but does not prevent raising it after the Tree has been used on it."
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -7549,7 +7550,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The checks for black cards is made both at the time you declare attackers and as the ability resolves. If there are any at the time attackers are declared, it won’t trigger at all. If there are any at the time it resolves, the ability will do nothing."
+          "text": "The checks for black cards is made both at the time you declare attackers and as the ability resolves. If there are any at the time attackers are declared, it won't trigger at all. If there are any at the time it resolves, the ability will do nothing."
         }
       ],
       "subtypes": [
@@ -7654,19 +7655,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player’s draw step."
+          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player's draw step."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library’s ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
+          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library's ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
         },
         {
           "date": "2016-06-08",
-          "text": "Any cards drawn prior to Sylvan Library’s ability resolving, including in your upkeep or in response to Sylvan Library’s triggered ability, can be chosen to be put back using this effect. Sylvan Library’s controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
+          "text": "Any cards drawn prior to Sylvan Library's ability resolving, including in your upkeep or in response to Sylvan Library's triggered ability, can be chosen to be put back using this effect. Sylvan Library's controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don’t get to draw all the cards at once and then put them all back at once."
+          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don't get to draw all the cards at once and then put them all back at once."
         },
         {
           "date": "2016-06-08",
@@ -7674,11 +7675,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library’s ability still happens. If you’ve actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven’t actually drawn any cards that turn, the rest of the ability has no effect."
+          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library's ability still happens. If you've actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven't actually drawn any cards that turn, the rest of the ability has no effect."
         },
         {
           "date": "2016-06-08",
-          "text": "It’s not possible to take any actions between drawing the cards and choosing two cards. You can’t cast the cards you drew to avoid having two cards to choose."
+          "text": "It's not possible to take any actions between drawing the cards and choosing two cards. You can't cast the cards you drew to avoid having two cards to choose."
         }
       ],
       "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
@@ -7738,7 +7739,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Protection from Green does not stop the Basilisk’s ability because the ability is not targeted."
+          "text": "Protection from Green does not stop the Basilisk's ability because the ability is not targeted."
         },
         {
           "date": "2004-10-04",
@@ -7958,7 +7959,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Checks if the creatures are Flying on resolution and not on announcement. It’s not a targeting restriction."
+          "text": "Checks if the creatures are Flying on resolution and not on announcement. It's not a targeting restriction."
         }
       ],
       "text": "Tap X target creatures. Winter Blast deals 2 damage to each of those creatures with flying.",
@@ -8067,7 +8068,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -8128,7 +8129,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -8373,7 +8374,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "You divide the damage as you cast the spell. You can’t redistribute the damage if any of the target creatures becomes illegal before the spell resolves."
+          "text": "You divide the damage as you cast the spell. You can't redistribute the damage if any of the target creatures becomes illegal before the spell resolves."
         }
       ],
       "text": "As an additional cost to cast Fire Covenant, pay X life.\nFire Covenant deals X damage divided as you choose among any number of target creatures.",
@@ -8430,7 +8431,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control.",
@@ -8552,7 +8553,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "In other words: — Step 1: Look at the top five cards of your library. — Step 2: If you like them, proceed to step 3a. If you don’t like them, proceed to step 3b. — Step 3a: Shuffle the rest of your library, then put those five cards back on top of your library in the order you want. The spell has finished resolving. — Step 3b: Put those five cards on the bottom of your library in the order you want. Pay 1 life. Return to step 1."
+          "text": "In other words: — Step 1: Look at the top five cards of your library. — Step 2: If you like them, proceed to step 3a. If you don't like them, proceed to step 3b. — Step 3a: Shuffle the rest of your library, then put those five cards back on top of your library in the order you want. The spell has finished resolving. — Step 3b: Put those five cards on the bottom of your library in the order you want. Pay 1 life. Return to step 1."
         },
         {
           "date": "2007-09-16",
@@ -8560,7 +8561,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If you have five or fewer cards in your library, you can pay 1 life as many times as you like, but you’ll keep seeing the same cards."
+          "text": "If you have five or fewer cards in your library, you can pay 1 life as many times as you like, but you'll keep seeing the same cards."
         }
       ],
       "text": "Look at the top five cards of your library. As many times as you choose, you may pay 1 life, put those cards on the bottom of your library in any order, then look at the top five cards of your library. Then shuffle your library and put the last cards you looked at this way on top of it in any order.",
@@ -8620,7 +8621,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When Lord of Tresserhorn enters the battlefield, if you have zero or one other creature on the battlefield, Lord of Tresserhorn itself will be sacrificed as part of its ability’s effect. Regeneration won’t save it. The rest of the effect still happens."
+          "text": "When Lord of Tresserhorn enters the battlefield, if you have zero or one other creature on the battlefield, Lord of Tresserhorn itself will be sacrificed as part of its ability's effect. Regeneration won't save it. The rest of the effect still happens."
         },
         {
           "date": "2004-10-04",
@@ -8755,7 +8756,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -8802,7 +8803,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "It’s the ability, not the counter that makes the creature an artifact. The creature remains an artifact even if the +1/+1 counter is removed."
+          "text": "It's the ability, not the counter that makes the creature an artifact. The creature remains an artifact even if the +1/+1 counter is removed."
         }
       ],
       "text": "{T}, Sacrifice Ashnod's Transmogrant: Put a +1/+1 counter on target nonartifact creature. That creature becomes an artifact in addition to its other types.",
@@ -8873,7 +8874,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Clockwork Beast’s last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
+          "text": "Clockwork Beast's last ability resolves, you can choose to put fewer than X +1/+0 counters on it."
         }
       ],
       "subtypes": [
@@ -9073,7 +9074,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This can’t be used to prevent damage caused by a blocked creature with Trample ability."
+          "text": "This can't be used to prevent damage caused by a blocked creature with Trample ability."
         }
       ],
       "text": "{1}: The next time an unblocked creature of your choice would deal combat damage to you this turn, prevent all but 1 of that damage.",
@@ -9122,7 +9123,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have four or fewer cards in your hand when Ivory Tower’s ability resolves, the ability has no effect."
+          "text": "If you have four or fewer cards in your hand when Ivory Tower's ability resolves, the ability has no effect."
         }
       ],
       "text": "At the beginning of your upkeep, you gain X life, where X is the number of cards in your hand minus 4.",
@@ -9167,11 +9168,11 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player’s previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
+          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player's previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says that a player can’t lose life, that player can’t exchange life totals with a player who has a lower life total; in that case, the exchange won’t happen."
+          "text": "If an effect says that a player can't lose life, that player can't exchange life totals with a player who has a lower life total; in that case, the exchange won't happen."
         }
       ],
       "text": "{T}, Sacrifice Mirror Universe: Exchange life totals with target opponent. Activate this ability only during your upkeep.",
@@ -9229,7 +9230,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -9372,7 +9373,7 @@
       "rulings": [
         {
           "date": "2007-09-16",
-          "text": "Ring of Ma’rûf works a little differently than the Wishes from others sets. Rather than letting you simply put a card into your hand from outside the game, this ability replaces your next draw. If you wouldn’t draw a card during the rest of the turn, the ability won’t have any effect."
+          "text": "Ring of Ma'rûf works a little differently than the Wishes from others sets. Rather than letting you simply put a card into your hand from outside the game, this ability replaces your next draw. If you wouldn't draw a card during the rest of the turn, the ability won't have any effect."
         }
       ],
       "text": "{5}, {T}, Exile Ring of Ma'rûf: The next time you would draw a card this turn, instead choose a card you own from outside the game and put it into your hand.",
@@ -9554,7 +9555,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You may choose not to apply Stone Calendar’s cost reduction effect."
+          "text": "You may choose not to apply Stone Calendar's cost reduction effect."
         }
       ],
       "text": "Spells you cast cost up to {1} less to cast.",
@@ -9602,7 +9603,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -9660,19 +9661,19 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can’t be enchanted by an Aura that was also exiled by Tawnos’s Coffin, that Aura will remain exiled."
+          "text": "If the exiled card is returned to the battlefield and, for some reason, it now can't be enchanted by an Aura that was also exiled by Tawnos's Coffin, that Aura will remain exiled."
         },
         {
           "date": "2007-09-16",
-          "text": "If Tawnos’s Coffin leaves the battlefield before its ability has resolved, it will exile the targeted creature forever, since its delayed triggered ability will never trigger."
+          "text": "If Tawnos's Coffin leaves the battlefield before its ability has resolved, it will exile the targeted creature forever, since its delayed triggered ability will never trigger."
         },
         {
           "date": "2008-04-01",
-          "text": "Because the new wording doesn’t use phasing, the exiled card will suffer from summoning sickness upon its return to the battlefield."
+          "text": "Because the new wording doesn't use phasing, the exiled card will suffer from summoning sickness upon its return to the battlefield."
         },
         {
           "date": "2008-04-01",
-          "text": "The effect doesn’t care what types the card has after it is exiled, only that it have been a creature while on the battlefield."
+          "text": "The effect doesn't care what types the card has after it is exiled, only that it have been a creature while on the battlefield."
         }
       ],
       "text": "You may choose not to untap Tawnos's Coffin during your untap step.\n{3}, {T}: Exile target creature and all Auras attached to it. Note the number and kind of counters that were on that creature. When Tawnos's Coffin leaves the battlefield or becomes untapped, return that exiled card to the battlefield under its owner's control tapped with the noted number and kind of counters on it. If you do, return the other exiled cards to the battlefield under their owner's control attached to that permanent.",
@@ -9863,11 +9864,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All permanents untap during a player’s untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
+          "text": "All permanents untap during a player's untap step at once. If Winter Orb is tapped as your untap step begins, your lands will all untap."
         },
         {
           "date": "2016-06-08",
-          "text": "You can’t tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
+          "text": "You can't tap Winter Orb just because you want to. Another ability, such as that of Glare of Subdual, must instruct or allow you to do so."
         }
       ],
       "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",
@@ -10000,7 +10001,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "text": "{T}: Target creature with flying has base power 0 until end of turn.",
@@ -10105,19 +10106,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Once turned into a creature, Mishra’s Factory’s last ability can target itself. If it’s already blocking, this won’t remove it from combat."
+          "text": "Once turned into a creature, Mishra's Factory's last ability can target itself. If it's already blocking, this won't remove it from combat."
         },
         {
           "date": "2016-06-08",
-          "text": "If you turn Mishra’s Factory into a creature but haven’t controlled it continuously since your most recent turn began, you won’t be able to activate its first or last ability."
+          "text": "If you turn Mishra's Factory into a creature but haven't controlled it continuously since your most recent turn began, you won't be able to activate its first or last ability."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
@@ -10169,19 +10170,19 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If control of Rainbow Vale has somehow changed before the “at end of turn” ability resolves, the player who activated the mana ability (not the current controller of Rainbow Vale) chooses one of his or her opponents to gain control of it."
+          "text": "If control of Rainbow Vale has somehow changed before the \"at end of turn\" ability resolves, the player who activated the mana ability (not the current controller of Rainbow Vale) chooses one of his or her opponents to gain control of it."
         },
         {
           "date": "2007-09-16",
-          "text": "If Rainbow Vale’s ability is activated during an End step, its “at the beginning of the end step” trigger won’t trigger until the End step of the next turn. If its ability is activated again during that turn, its “at the beginning of the end step” ability will trigger twice at the End step of that turn."
+          "text": "If Rainbow Vale's ability is activated during an End step, its \"at the beginning of the end step\" trigger won't trigger until the End step of the next turn. If its ability is activated again during that turn, its \"at the beginning of the end step\" ability will trigger twice at the End step of that turn."
         },
         {
           "date": "2007-09-16",
-          "text": "If more than one player manages to tap it for mana in a given turn, then two control-change abilities will trigger at end of the turn. These abilities resolve using the standard order for such things, so the active player’s triggers are put on the stack first, then the opponents’."
+          "text": "If more than one player manages to tap it for mana in a given turn, then two control-change abilities will trigger at end of the turn. These abilities resolve using the standard order for such things, so the active player's triggers are put on the stack first, then the opponents'."
         },
         {
           "date": "2007-09-16",
-          "text": "The opponent is chosen when the “at end of turn” triggered ability resolves."
+          "text": "The opponent is chosen when the \"at end of turn\" triggered ability resolves."
         }
       ],
       "text": "{T}: Add one mana of any color to your mana pool. An opponent gains control of Rainbow Vale at the beginning of the next end step.",
@@ -10234,7 +10235,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Thawing Glaciers enters the battlefield tapped.\n{1}, {T}: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library. Return Thawing Glaciers to its owner's hand at the beginning of the next cleanup step.",

--- a/json/MIR.json
+++ b/json/MIR.json
@@ -189,7 +189,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If there are any creatures on the battlefield, even if they are just your opponent’s, you must put a +1/+1 on one of them. If there are no creatures on the battlefield, then no counter is removed from this card."
+          "text": "If there are any creatures on the battlefield, even if they are just your opponent's, you must put a +1/+1 on one of them. If there are no creatures on the battlefield, then no counter is removed from this card."
         }
       ],
       "text": "Afiya Grove enters the battlefield with three +1/+1 counters on it.\nAt the beginning of your upkeep, move a +1/+1 counter from Afiya Grove onto target creature.\nWhen Afiya Grove has no +1/+1 counters on it, sacrifice it.",
@@ -402,7 +402,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s after the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's after the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Aleatory only during combat after blockers are declared.\nFlip a coin. If you win the flip, target creature gets +1/+1 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
@@ -491,7 +491,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "text": "{5}, {T}, Exile Amulet of Unmaking: Exile target artifact, creature, or land. Activate this ability only any time you could cast a sorcery.",
@@ -604,7 +604,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "subtypes": [
@@ -925,7 +925,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Bad River enters the battlefield tapped.\n{T}, Sacrifice Bad River: Search your library for an Island or Swamp card and put it onto the battlefield. Then shuffle your library.",
@@ -1081,7 +1081,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Upon resolution, this gives the targeted creature trample and creates a delayed-triggered ability that will trigger when the creature becomes blocked. The creature will get +1/+1 for each creature blocking it as that ability resolves. This means that if Barreling Attack is cast after blockers are declared, the targeted creature will gain trample but won’t be able to get +1/+1 because it’s too late for the ability to trigger (unless there is another combat phase in the turn)."
+          "text": "Upon resolution, this gives the targeted creature trample and creates a delayed-triggered ability that will trigger when the creature becomes blocked. The creature will get +1/+1 for each creature blocking it as that ability resolves. This means that if Barreling Attack is cast after blockers are declared, the targeted creature will gain trample but won't be able to get +1/+1 because it's too late for the ability to trigger (unless there is another combat phase in the turn)."
         }
       ],
       "text": "Target creature gains trample until end of turn. When that creature becomes blocked this turn, it gets +1/+1 until end of turn for each creature blocking it.",
@@ -1238,7 +1238,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -2360,7 +2360,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The effect to turn all your non-land cards (including artifacts) white is the effect of a static ability. Thus, a color change on a permanent prior to Celestial Dawn entering the battlefield will be overridden by Celestial Dawn’s effect."
+          "text": "The effect to turn all your non-land cards (including artifacts) white is the effect of a static ability. Thus, a color change on a permanent prior to Celestial Dawn entering the battlefield will be overridden by Celestial Dawn's effect."
         },
         {
           "date": "2004-10-04",
@@ -2384,11 +2384,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Mana produced by spells you control and nonland permanents you control isn’t affected by Celestial Dawn. Llanowar Elves will produce {G}, for example. However, any colored mana may be spent only on the colorless part of costs."
+          "text": "Mana produced by spells you control and nonland permanents you control isn't affected by Celestial Dawn. Llanowar Elves will produce {G}, for example. However, any colored mana may be spent only on the colorless part of costs."
         },
         {
           "date": "2006-09-25",
-          "text": "Land cards you own that aren’t on the battlefield aren’t changed to Plains."
+          "text": "Land cards you own that aren't on the battlefield aren't changed to Plains."
         },
         {
           "date": "2006-09-25",
@@ -2396,15 +2396,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "“Enters the battlefield” triggered abilities of lands you play won’t trigger since the lands will enter the battlefield as Plains. Effects that modify how those lands enter the battlefield, however, will still work. For example, if you play a Dimir Aqueduct, it will enter the battlefield tapped as a Plains, but you won’t return a land to your hand."
+          "text": "\"Enters the battlefield\" triggered abilities of lands you play won't trigger since the lands will enter the battlefield as Plains. Effects that modify how those lands enter the battlefield, however, will still work. For example, if you play a Dimir Aqueduct, it will enter the battlefield tapped as a Plains, but you won't return a land to your hand."
         },
         {
           "date": "2006-09-25",
-          "text": "If you use a text-changing effect such as Mind Bend on Celestial Dawn to change the word “Plains” to a different land type, your lands are all of that new land type, and they will produce mana of the appropriate color for that type."
+          "text": "If you use a text-changing effect such as Mind Bend on Celestial Dawn to change the word \"Plains\" to a different land type, your lands are all of that new land type, and they will produce mana of the appropriate color for that type."
         },
         {
           "date": "2006-09-25",
-          "text": "If a permanent enters the battlefield while Celestial Dawn is on the battlefield, and then Celestial Dawn leaves the battlefield, the permanent’s color will revert to the colors in its mana cost."
+          "text": "If a permanent enters the battlefield while Celestial Dawn is on the battlefield, and then Celestial Dawn leaves the battlefield, the permanent's color will revert to the colors in its mana cost."
         }
       ],
       "text": "Lands you control are Plains.\nNonland cards you own that aren't on the battlefield, spells you control, and nonland permanents you control are white.\nYou may spend white mana as though it were mana of any color. You may spend other mana only as though it were colorless mana.",
@@ -2556,7 +2556,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -2656,7 +2656,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "text": "{2}, {T}: Until end of turn, target creature you control gains flying and has base toughness 1.",
@@ -3008,7 +3008,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -3228,7 +3228,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -3377,7 +3377,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Activated abilities of creatures can't be activated.",
@@ -3709,7 +3709,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Works on creatures that can’t be blocked and on creatures that have special blocking requirements."
+          "text": "Works on creatures that can't be blocked and on creatures that have special blocking requirements."
         }
       ],
       "text": "Cast Dazzling Beauty only during the declare blockers step.\nTarget unblocked attacking creature becomes blocked. (This spell works on creatures that can't be blocked.)\nDraw a card at the beginning of the next turn's upkeep.",
@@ -3999,7 +3999,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"There are harsher ways to learn the meaning of the word ‘no.'\"\n—Rashida Scalebane",
+      "flavor": "\"There are harsher ways to learn the meaning of the word 'no.'\"\n—Rashida Scalebane",
       "id": "3282d7fe107fc36ee0e7102660edce1b19abbb1b",
       "imageName": "disenchant",
       "layout": "normal",
@@ -4153,7 +4153,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then it does not get exiled."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then it does not get exiled."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
@@ -4223,7 +4223,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you’ll still gain the life."
+          "text": "If Divine Offering resolves, but the artifact regenerates or has indestructible, you'll still gain the life."
         }
       ],
       "text": "Destroy target artifact. You gain life equal to its converted mana cost.",
@@ -4500,7 +4500,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If Dream Fighter is assigned to block a creature with Flanking, the Flanking ability and the Dream Fighter ability both trigger. The active player’s Flanking effect is put on the stack first and resolves after the Dream Fighter’s phasing out effect happen, so the Flanking does nothing."
+          "text": "If Dream Fighter is assigned to block a creature with Flanking, the Flanking ability and the Dream Fighter ability both trigger. The active player's Flanking effect is put on the stack first and resolves after the Dream Fighter's phasing out effect happen, so the Flanking does nothing."
         }
       ],
       "subtypes": [
@@ -5190,7 +5190,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for an artifact or enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -5832,7 +5832,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
@@ -5948,7 +5948,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability can be activated by Firebreathing’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability can be activated by Firebreathing's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -6113,7 +6113,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Any X in the creature’s mana cost is zero."
+          "text": "Any X in the creature's mana cost is zero."
         },
         {
           "date": "2004-10-04",
@@ -6171,7 +6171,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Flood Plain enters the battlefield tapped.\n{T}, Sacrifice Flood Plain: Search your library for a Plains or Island card and put it onto the battlefield. Then shuffle your library.",
@@ -6411,7 +6411,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The “if you can’t” in the first ability refers to putting the card in your hand, as well as being unable to choose a card. Thus, if you can’t choose a card during resolution, you lose the game."
+          "text": "The \"if you can't\" in the first ability refers to putting the card in your hand, as well as being unable to choose a card. Thus, if you can't choose a card during resolution, you lose the game."
         },
         {
           "date": "2004-10-04",
@@ -7488,23 +7488,23 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If a cost includes life gain (like Invigorate’s alternative cost does), that cost can’t be paid."
+          "text": "If a cost includes life gain (like Invigorate's alternative cost does), that cost can't be paid."
         },
         {
           "date": "2008-05-01",
-          "text": "Effects that would replace gaining life with some other effect won’t be able to do anything because it’s impossible for players to gain life."
+          "text": "Effects that would replace gaining life with some other effect won't be able to do anything because it's impossible for players to gain life."
         },
         {
           "date": "2008-05-01",
-          "text": "Effects that replace an event with gaining life (like Words of Worship’s effect does) will end up replacing the event with nothing."
+          "text": "Effects that replace an event with gaining life (like Words of Worship's effect does) will end up replacing the event with nothing."
         },
         {
           "date": "2008-05-01",
-          "text": "If an effect says to set your life total to a certain number, and that number is higher than your current life total, that effect will normally cause you to gain life equal to the difference. With Forsaken Wastes on the battlefield, that part of the effect won’t do anything. (If the number is lower than your current life total, the effect will work as normal.)"
+          "text": "If an effect says to set your life total to a certain number, and that number is higher than your current life total, that effect will normally cause you to gain life equal to the difference. With Forsaken Wastes on the battlefield, that part of the effect won't do anything. (If the number is lower than your current life total, the effect will work as normal.)"
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -7796,7 +7796,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "The tokens have ‘Mountainwalk’ in their text, and will be affected by text-changing effects accordingly."
+          "text": "The tokens have 'Mountainwalk' in their text, and will be affected by text-changing effects accordingly."
         }
       ],
       "text": "Create three 1/1 red Goblin Scout creature tokens with mountainwalk. (They can't be blocked as long as defending player controls a Mountain.)",
@@ -8061,7 +8061,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "subtypes": [
@@ -8229,15 +8229,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You may choose to find any kind of card, including a land. You must exile a card (unless the opponent’s library is empty); you can’t fail to find anything."
+          "text": "You may choose to find any kind of card, including a land. You must exile a card (unless the opponent's library is empty); you can't fail to find anything."
         },
         {
           "date": "2006-09-25",
-          "text": "“Until the beginning of your next upkeep” means the effect wears off as soon as your next upkeep starts. Your last chance to play the card is usually the End step of the player who immediately precedes you."
+          "text": "\"Until the beginning of your next upkeep\" means the effect wears off as soon as your next upkeep starts. Your last chance to play the card is usually the End step of the player who immediately precedes you."
         },
         {
           "date": "2006-09-25",
-          "text": "The exiled card is played using the normal rules for timing and priority for its card type, as well as any other applicable restrictions. You’ll have to pay its mana cost. The only thing that’s different is you’re casting it from the Exile zone."
+          "text": "The exiled card is played using the normal rules for timing and priority for its card type, as well as any other applicable restrictions. You'll have to pay its mana cost. The only thing that's different is you're casting it from the Exile zone."
         }
       ],
       "text": "{2}, {T}, Sacrifice Grinning Totem: Search target opponent's library for a card and exile it. Then that player shuffles his or her library. Until the beginning of your next upkeep, you may play that card. At the beginning of your next upkeep, if you haven't played it, put it into its owner's graveyard.",
@@ -8295,7 +8295,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you pick an Aura that can’t legally enchant this card, then the Aura stays in the graveyard."
+          "text": "If you pick an Aura that can't legally enchant this card, then the Aura stays in the graveyard."
         }
       ],
       "subtypes": [
@@ -8364,11 +8364,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2016-08-23",
-          "text": "Colorless mana added to a player’s mana pool isn’t affected."
+          "text": "Colorless mana added to a player's mana pool isn't affected."
         }
       ],
       "supertypes": [
@@ -9040,7 +9040,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Never taunt an embermage, ‘What are you going to do about it?'\"\n—Akin, seasoned askari",
+      "flavor": "\"Never taunt an embermage, 'What are you going to do about it?'\"\n—Akin, seasoned askari",
       "id": "616cab7fdceefd7ce13db5fcf9c82dc88752c56c",
       "imageName": "incinerate",
       "layout": "normal",
@@ -9095,7 +9095,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Regeneration abilities that would affect that creature can still be activated; they just won’t do anything. The creature can’t be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
+          "text": "Regeneration abilities that would affect that creature can still be activated; they just won't do anything. The creature can't be regenerated for any reason, even if an effect other than Incinerate would deal lethal damage to it or otherwise destroy it."
         }
       ],
       "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
@@ -10610,7 +10610,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If a creature is both black and green, Kaervek’s Hex will deal 1 damage to that creature."
+          "text": "If a creature is both black and green, Kaervek's Hex will deal 1 damage to that creature."
         }
       ],
       "text": "Kaervek's Hex deals 1 damage to each nonblack creature and an additional 1 damage to each green creature.",
@@ -10813,7 +10813,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -11025,7 +11025,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "subtypes": [
@@ -11343,7 +11343,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The Mangara’s Blessing card is only returned if it is still in the graveyard at end of turn and never left the graveyard in the meantime."
+          "text": "The Mangara's Blessing card is only returned if it is still in the graveyard at end of turn and never left the graveyard in the meantime."
         }
       ],
       "text": "You gain 5 life.\nWhen a spell or ability an opponent controls causes you to discard Mangara's Blessing, you gain 2 life, and you return Mangara's Blessing from your graveyard to your hand at the beginning of the next end step.",
@@ -11440,7 +11440,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If there are no cards left, you can still use the ability to turn a draw into a “do nothing”."
+          "text": "If there are no cards left, you can still use the ability to turn a draw into a \"do nothing\"."
         }
       ],
       "text": "When Mangara's Tome enters the battlefield, search your library for five cards, exile them in a face-down pile, and shuffle that pile. Then shuffle your library.\n{2}: The next time you would draw a card this turn, instead put the top card of the exiled pile into its owner's hand.",
@@ -11550,7 +11550,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro’s toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won’t be put into your graveyard when state-based actions are checked."
+          "text": "Creatures are only put into a graveyard for having 0 toughness when state-based actions are checked. If Maro's toughness goes to 0 during the announcement or resolution of a spell or ability and then goes back up above 0 before the end of that announcement or resolution, it won't be put into your graveyard when state-based actions are checked."
         }
       ],
       "subtypes": [
@@ -11725,7 +11725,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell’s destination from its owner’s library to exile."
+          "text": "Memory Lapse has a self-replacement effect that replaces the spell going to the graveyard before any other effect can replace that event. If the spell was cast using flashback, however, flashback will change the spell's destination from its owner's library to exile."
         }
       ],
       "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
@@ -11898,7 +11898,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -11910,11 +11910,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"islandwalk.\" This effect lasts indefinitely.)",
@@ -13468,7 +13468,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"To the tutors, a ‘poem of sand' was of little account, a ‘poem of ivory,' priceless.\"\n—Afari, Tales",
+      "flavor": "\"To the tutors, a 'poem of sand' was of little account, a 'poem of ivory,' priceless.\"\n—Afari, Tales",
       "id": "118712fb4249a1764ec2dc8706a4602d8505fadc",
       "imageName": "mystical tutor",
       "layout": "normal",
@@ -13506,7 +13506,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for an instant or sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -13665,7 +13665,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -13789,11 +13789,11 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If you somehow manage to cast this while other spells are on the stack, those spells won’t be countered."
+          "text": "If you somehow manage to cast this while other spells are on the stack, those spells won't be countered."
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         },
         {
           "date": "2013-04-15",
@@ -13803,7 +13803,7 @@
       "supertypes": [
         "World"
       ],
-      "text": "As Null Chamber enters the battlefield, you and an opponent each choose a card name other than a basic land card name.\nSpells with the chosen names can't be cast.",
+      "text": "As Null Chamber enters the battlefield, you and an opponent each choose a card name other than a basic land card name.\nSpells with the chosen names can't be cast and lands with the chosen names can't be played.",
       "type": "World Enchantment",
       "types": [
         "Enchantment"
@@ -14140,7 +14140,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Phasing in does not trigger “enters the battlefield” abilities, so you don’t have to sacrifice again if it phases in."
+          "text": "Phasing in does not trigger \"enters the battlefield\" abilities, so you don't have to sacrifice again if it phases in."
         },
         {
           "date": "2007-07-15",
@@ -14213,7 +14213,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The life payment is an additional cost, paid at the time you cast Phyrexian Purge. You don’t get any life back if the spell is countered, or if one or more targets have become illegal."
+          "text": "The life payment is an additional cost, paid at the time you cast Phyrexian Purge. You don't get any life back if the spell is countered, or if one or more targets have become illegal."
         }
       ],
       "text": "Destroy any number of target creatures.\nPhyrexian Purge costs 3 life more to cast for each target.",
@@ -15425,7 +15425,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If there are no creatures in the player’s library, then the target creature is still destroyed, you see all the cards in that player’s library, and then they shuffle and continue play."
+          "text": "If there are no creatures in the player's library, then the target creature is still destroyed, you see all the cards in that player's library, and then they shuffle and continue play."
         },
         {
           "date": "2009-10-01",
@@ -15433,15 +15433,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If there are no creature cards in the player’s library, all the cards in that library are revealed, then the library is shuffled. (The targeted creature remains destroyed.)"
+          "text": "If there are no creature cards in the player's library, all the cards in that library are revealed, then the library is shuffled. (The targeted creature remains destroyed.)"
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2013-07-01",
-          "text": "If the targeted creature has indestructible, it’s still a legal target — it just isn’t destroyed. The rest of Polymorph’s effect happens as normal."
+          "text": "If the targeted creature has indestructible, it's still a legal target — it just isn't destroyed. The rest of Polymorph's effect happens as normal."
         }
       ],
       "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card onto the battlefield, then shuffles all other cards revealed this way into his or her library.",
@@ -15525,7 +15525,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -15582,7 +15582,7 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "This is no longer a draw, it’s simply putting the card into your hand."
+          "text": "This is no longer a draw, it's simply putting the card into your hand."
         }
       ],
       "text": "At the beginning of your upkeep, look at the top two cards of your library. You may sacrifice Preferred Selection and pay {2}{G}{G}. If you do, put one of those cards into your hand. If you don't, put one of those cards on the bottom of your library.",
@@ -15783,7 +15783,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says that a player can’t lose life, that player can’t exchange life totals with a player who has a lower life total; in that case, the exchange won’t happen."
+          "text": "If an effect says that a player can't lose life, that player can't exchange life totals with a player who has a lower life total; in that case, the exchange won't happen."
         }
       ],
       "text": "If the difference between your life total and target player's life total is 5 or less, exchange life totals with that player.",
@@ -16211,7 +16211,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -16387,11 +16387,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The creature returns to the opponent when the “until end of turn” effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
+          "text": "The creature returns to the opponent when the \"until end of turn\" effect wears off during the cleanup step. It taps during the Cleanup step (if it is not already tapped), so any abilities triggered off it tapping happen at that time."
         },
         {
           "date": "2008-10-01",
-          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command’s effect ends, or because a spell or ability causes another player to gain control of it."
+          "text": "You tap the creature when you lose control of it for any reason — because Ray of Command's effect ends, or because a spell or ability causes another player to gain control of it."
         }
       ],
       "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature gains haste until end of turn. When you lose control of the creature, tap it.",
@@ -17004,7 +17004,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Rocky Tar Pit enters the battlefield tapped.\n{T}, Sacrifice Rocky Tar Pit: Search your library for a Swamp or Mountain card and put it onto the battlefield. Then shuffle your library.",
@@ -17966,7 +17966,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This only prevents damage the chosen source would deal to you or a creature you control. If the creature would deal damage to another player, a planeswalker, or a creature you don’t control, it does not get prevented."
+          "text": "This only prevents damage the chosen source would deal to you or a creature you control. If the creature would deal damage to another player, a planeswalker, or a creature you don't control, it does not get prevented."
         }
       ],
       "text": "The next time a source of your choice would deal damage to you and/or creatures you control this turn, prevent that damage. If damage from a black source is prevented this way, you gain that much life.",
@@ -18405,7 +18405,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You’ll sacrifice Skulking Ghost even if you counter the spell or ability that targets it. If that spell has no other targets, it’ll be countered when it tries to resolve."
+          "text": "You'll sacrifice Skulking Ghost even if you counter the spell or ability that targets it. If that spell has no other targets, it'll be countered when it tries to resolve."
         }
       ],
       "subtypes": [
@@ -18508,7 +18508,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "subtypes": [
@@ -19273,15 +19273,15 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "As you cast this, you target a creature and an opponent. The opponent does not have to be that creature’s controller."
+          "text": "As you cast this, you target a creature and an opponent. The opponent does not have to be that creature's controller."
         },
         {
           "date": "2008-08-01",
-          "text": "If the opponent becomes an illegal target before the spell resolves (but the creature doesn’t), the spell will still be able to access information about that opponent. It will resolve as normal and deal the appropriate amount of damage to the creature."
+          "text": "If the opponent becomes an illegal target before the spell resolves (but the creature doesn't), the spell will still be able to access information about that opponent. It will resolve as normal and deal the appropriate amount of damage to the creature."
         },
         {
           "date": "2008-08-01",
-          "text": "If the creature becomes an illegal target before the spell resolves (but the opponent doesn’t), the spell will be unable to affect that creature. Although the spell will still resolve, it won’t deal any damage."
+          "text": "If the creature becomes an illegal target before the spell resolves (but the opponent doesn't), the spell will be unable to affect that creature. Although the spell will still resolve, it won't deal any damage."
         }
       ],
       "text": "Superior Numbers deals damage to target creature equal to the number of creatures you control in excess of the number of creatures target opponent controls.",
@@ -20727,7 +20727,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "There is no negative effect if you can’t discard when it phases out. You still get to draw a card when it phases in."
+          "text": "There is no negative effect if you can't discard when it phases out. You still get to draw a card when it phases in."
         }
       ],
       "subtypes": [
@@ -20977,7 +20977,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -21152,7 +21152,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You control the triggered ability, but each player controls the token creature they put onto the battlefield due to the ability’s effect."
+          "text": "You control the triggered ability, but each player controls the token creature they put onto the battlefield due to the ability's effect."
         },
         {
           "date": "2004-10-04",
@@ -21160,11 +21160,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If something changes the names of the tokens, then the “at end of turn” ability will still destroy them."
+          "text": "If something changes the names of the tokens, then the \"at end of turn\" ability will still destroy them."
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -22411,7 +22411,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "subtypes": [
@@ -22805,7 +22805,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "As an additional cost to cast Withering Boon, pay 3 life.\nCounter target creature spell.",
@@ -22859,7 +22859,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a creature card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -23130,11 +23130,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2009-10-01",
-          "text": "If the Dragon is put onto the battlefield and then phases out, the “exile it” ability will still apply. It will trigger at the beginning of the next End step and exile the Dragon if it has phased back in. If the Dragon is still phased out, then it cannot be exiled so ability won’t do anything."
+          "text": "If the Dragon is put onto the battlefield and then phases out, the \"exile it\" ability will still apply. It will trigger at the beginning of the next End step and exile the Dragon if it has phased back in. If the Dragon is still phased out, then it cannot be exiled so ability won't do anything."
         }
       ],
       "subtypes": [
@@ -23195,7 +23195,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [

--- a/json/MM2.json
+++ b/json/MM2.json
@@ -98,7 +98,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Tokens may also be colored permanents. The effect that creates a token states what color it is or whether it’s colorless."
+          "text": "Tokens may also be colored permanents. The effect that creates a token states what color it is or whether it's colorless."
         },
         {
           "date": "2010-06-15",
@@ -110,7 +110,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "All Is Dust doesn’t destroy permanents. Rather, it causes them to be sacrificed. Regeneration, totem armor, and indestructibile can’t save permanents from All Is Dust."
+          "text": "All Is Dust doesn't destroy permanents. Rather, it causes them to be sacrificed. Regeneration, totem armor, and indestructibile can't save permanents from All Is Dust."
         }
       ],
       "subtypes": [
@@ -184,15 +184,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -262,31 +262,31 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "Emrakul can be targeted by spells that try to counter it (such as Lay Bare). Those spells will resolve, but the part of their effect that would counter Emrakul won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Emrakul can be targeted by spells that try to counter it (such as Lay Bare). Those spells will resolve, but the part of their effect that would counter Emrakul won't do anything. Any other effects those spells have will work as normal."
         },
         {
           "date": "2010-06-15",
-          "text": "“Protection from colored spells” means that Emrakul can’t be the target of colored spells (including colored Aura spells) or of abilities whose sources are colored spells (such as the “when you cast” ability of an Ulamog, the Infinite Gyre that’s been turned red by Painter’s Servant). It also means that all damage that would be dealt to Emrakul by colored spells is prevented. Like every protection ability, it works only while Emrakul is on the battlefield."
+          "text": "\"Protection from colored spells\" means that Emrakul can't be the target of colored spells (including colored Aura spells) or of abilities whose sources are colored spells (such as the \"when you cast\" ability of an Ulamog, the Infinite Gyre that's been turned red by Painter's Servant). It also means that all damage that would be dealt to Emrakul by colored spells is prevented. Like every protection ability, it works only while Emrakul is on the battlefield."
         },
         {
           "date": "2010-06-15",
-          "text": "“Colored spells” is not synonymous with “colored instants and sorceries.” For example, if a player cycles Choking Tethers, its triggered ability may target Emrakul because Choking Tethers wasn’t cast as a spell."
+          "text": "\"Colored spells\" is not synonymous with \"colored instants and sorceries.\" For example, if a player cycles Choking Tethers, its triggered ability may target Emrakul because Choking Tethers wasn't cast as a spell."
         },
         {
           "date": "2010-06-15",
-          "text": "Emrakul may be affected by colored spells that don’t target it or deal damage to it, including those that cause it to become blocked. Abilities of colored permanents (such as Journey to Nowhere) may target it. Auras may be moved onto it by abilities or by colored spells that don’t target it (such as Aura Graft)."
+          "text": "Emrakul may be affected by colored spells that don't target it or deal damage to it, including those that cause it to become blocked. Abilities of colored permanents (such as Journey to Nowhere) may target it. Auras may be moved onto it by abilities or by colored spells that don't target it (such as Aura Graft)."
         }
       ],
       "subtypes": [
@@ -358,15 +358,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Karn’s first and third abilities are linked. Similarly, Karn’s second and third abilities are linked. Only cards exiled by either of Karn’s first two abilities will remain in exile when the game restarts."
+          "text": "Karn's first and third abilities are linked. Similarly, Karn's second and third abilities are linked. Only cards exiled by either of Karn's first two abilities will remain in exile when the game restarts."
         },
         {
           "date": "2011-06-01",
-          "text": "A game that restarts immediately ends. The players in that game then immediately begin a new game. No player wins, loses, or draws the original game as a result of Karn’s ability."
+          "text": "A game that restarts immediately ends. The players in that game then immediately begin a new game. No player wins, loses, or draws the original game as a result of Karn's ability."
         },
         {
           "date": "2011-06-01",
-          "text": "In a multiplayer games (a game that started with three or more players in it), any player that left the game before it was restarted with Karn’s ability won’t be involved in the new game."
+          "text": "In a multiplayer games (a game that started with three or more players in it), any player that left the game before it was restarted with Karn's ability won't be involved in the new game."
         },
         {
           "date": "2011-06-01",
@@ -374,23 +374,23 @@
         },
         {
           "date": "2011-06-01",
-          "text": "After the pre-game procedure is complete, but before the new game’s first turn, Karn’s ability finishes resolving and the cards left in exile are put onto the battlefield. If this causes any triggered abilities to trigger, those abilities are put onto the stack at the beginning of the first upkeep step."
+          "text": "After the pre-game procedure is complete, but before the new game's first turn, Karn's ability finishes resolving and the cards left in exile are put onto the battlefield. If this causes any triggered abilities to trigger, those abilities are put onto the stack at the beginning of the first upkeep step."
         },
         {
           "date": "2011-06-01",
-          "text": "Creatures put onto the battlefield due to Karn’s ability will have been under their controller’s control continuously since the beginning of the first turn. They can attack and their activated abilities with {T} in the cost can be activated."
+          "text": "Creatures put onto the battlefield due to Karn's ability will have been under their controller's control continuously since the beginning of the first turn. They can attack and their activated abilities with {T} in the cost can be activated."
         },
         {
           "date": "2011-06-01",
-          "text": "Any permanents put onto the battlefield with Karn’s ability that entered the battlefield tapped will untap during their controller’s first untap step."
+          "text": "Any permanents put onto the battlefield with Karn's ability that entered the battlefield tapped will untap during their controller's first untap step."
         },
         {
           "date": "2011-06-01",
-          "text": "No actions taken in the game that was restarted apply to the new game. For example, if you were dealt damage by Stigma Lasher in the original game, the effect that states you can’t gain life doesn’t carry over to the new game."
+          "text": "No actions taken in the game that was restarted apply to the new game. For example, if you were dealt damage by Stigma Lasher in the original game, the effect that states you can't gain life doesn't carry over to the new game."
         },
         {
           "date": "2011-06-01",
-          "text": "Players won’t have any poison counters or emblems they had in the original game."
+          "text": "Players won't have any poison counters or emblems they had in the original game."
         },
         {
           "date": "2011-06-01",
@@ -402,11 +402,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If a player’s commander was exiled with Karn at the game restarted, that commander won’t be put into the command zone at the beginning of the game. It will be put onto the battlefield when Karn’s ability finishes resolving."
+          "text": "If a player's commander was exiled with Karn at the game restarted, that commander won't be put into the command zone at the beginning of the game. It will be put onto the battlefield when Karn's ability finishes resolving."
         },
         {
           "date": "2011-06-01",
-          "text": "In a multiplayer game using the limited range of influence option, all players are affected and will restart the game, not just those within the range of influence of the ability’s controller."
+          "text": "In a multiplayer game using the limited range of influence option, all players are affected and will restart the game, not just those within the range of influence of the ability's controller."
         }
       ],
       "subtypes": [
@@ -474,15 +474,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -555,19 +555,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -641,23 +641,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "If, during your declare attackers step, Ulamog’s Crusher is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then it doesn’t attack. If there’s a cost associated with having Ulamog’s Crusher attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Ulamog's Crusher is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then it doesn't attack. If there's a cost associated with having Ulamog's Crusher attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If there are multiple combat phases in a turn, Ulamog’s Crusher must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Ulamog's Crusher must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -743,11 +743,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
@@ -842,7 +842,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -920,11 +920,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -936,11 +936,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         },
         {
           "date": "2009-10-01",
-          "text": "Battlegrace Angel could cause a creature to have multiple instances of lifelink. For example, a creature you control that already has lifelink could attack alone while you control Battlegrace Angel, or a creature you control could attack alone while you control more than one Battlegrace Angel. If a creature has multiple instances of lifelink, they are redundant. You’ll still only gain life equal to the damage dealt."
+          "text": "Battlegrace Angel could cause a creature to have multiple instances of lifelink. For example, a creature you control that already has lifelink could attack alone while you control Battlegrace Angel, or a creature you control could attack alone while you control more than one Battlegrace Angel. If a creature has multiple instances of lifelink, they are redundant. You'll still only gain life equal to the damage dealt."
         }
       ],
       "subtypes": [
@@ -1019,7 +1019,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Lands are colorless (even if their frames have some colored elements to them). You can’t target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
+          "text": "Lands are colorless (even if their frames have some colored elements to them). You can't target a Swamp, a Mountain, or any other land with Celestial Purge (unless some other effect has turned that land black or red)."
         }
       ],
       "text": "Exile target black or red permanent.",
@@ -1091,31 +1091,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -1263,11 +1263,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If all other Auras attached to the enchanted creature stop enchanting it, Daybreak Coronet will be attached to an illegal permanent and will be put into its owner’s graveyard."
+          "text": "If all other Auras attached to the enchanted creature stop enchanting it, Daybreak Coronet will be attached to an illegal permanent and will be put into its owner's graveyard."
         },
         {
           "date": "2007-05-01",
-          "text": "Because Retether returns all Auras to the battlefield at the same time, it won’t let you attach Daybreak Coronet to a creature unless that creature is already enchanted."
+          "text": "Because Retether returns all Auras to the battlefield at the same time, it won't let you attach Daybreak Coronet to a creature unless that creature is already enchanted."
         }
       ],
       "subtypes": [
@@ -1341,7 +1341,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If you control three or more artifacts when Dispatch resolves, you’ll tap the creature, then exile it."
+          "text": "If you control three or more artifacts when Dispatch resolves, you'll tap the creature, then exile it."
         }
       ],
       "text": "Tap target creature.\nMetalcraft — If you control three or more artifacts, exile that creature.",
@@ -1414,7 +1414,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If more than one Elesh Norn, Grand Cenobite is under your control, all of their static abilities will briefly apply. Any creatures that have 0 or less toughness and any creatures that now have lethal damage marked on them will be put into graveyards at the same time that the “legend rule” causes all but one of the Elesh Norns to be put into their owners’ graveyards."
+          "text": "If more than one Elesh Norn, Grand Cenobite is under your control, all of their static abilities will briefly apply. Any creatures that have 0 or less toughness and any creatures that now have lethal damage marked on them will be put into graveyards at the same time that the \"legend rule\" causes all but one of the Elesh Norns to be put into their owners' graveyards."
         }
       ],
       "subtypes": [
@@ -1497,7 +1497,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Creatures that come under your control after Fortify resolves won’t get the chosen bonus."
+          "text": "Creatures that come under your control after Fortify resolves won't get the chosen bonus."
         }
       ],
       "text": "Choose one —\n• Creatures you control get +2/+0 until end of turn.\n• Creatures you control get +0/+2 until end of turn.",
@@ -1722,11 +1722,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Iona’s third ability includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It does not include lands or abilities (such as cycling or unearth)."
+          "text": "Iona's third ability includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It does not include lands or abilities (such as cycling or unearth)."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the color is chosen, it’s too late for opponents to respond by casting spells of that color. Iona is not yet in the battlefield at the time the color is chosen, so, for example, there’s no way for an opponent to destroy it by casting Doom Blade if the chosen color is black."
+          "text": "Once the color is chosen, it's too late for opponents to respond by casting spells of that color. Iona is not yet in the battlefield at the time the color is chosen, so, for example, there's no way for an opponent to destroy it by casting Doom Blade if the chosen color is black."
         }
       ],
       "subtypes": [
@@ -1941,7 +1941,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "text": "If Leyline of Sanctity is in your opening hand, you may begin the game with it on the battlefield.\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)",
@@ -2027,7 +2027,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
         }
       ],
       "text": "Target creature gets +2/+2 and gains flying until end of turn.",
@@ -2182,7 +2182,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         },
         {
           "date": "2013-07-01",
@@ -2421,11 +2421,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything, but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled forever."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything, but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled forever."
         },
         {
           "date": "2012-07-01",
-          "text": "Auras attached to the exiled permanent will be put into their owners’ graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         }
       ],
       "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
@@ -2503,11 +2503,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Any Aura attached to the creature is put into its owner’s graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
+          "text": "Any Aura attached to the creature is put into its owner's graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
         },
         {
           "date": "2005-08-01",
-          "text": "If Otherworldly Journey is cast during an end step, the creature won’t return until the beginning of the next end step."
+          "text": "If Otherworldly Journey is cast during an end step, the creature won't return until the beginning of the next end step."
         }
       ],
       "subtypes": [
@@ -2728,7 +2728,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -2885,7 +2885,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If all Equipment attached to Sunspear Shikari somehow becomes unequipped after it deals combat damage in the first combat damage step, it won’t assign combat damage in the second combat damage step."
+          "text": "If all Equipment attached to Sunspear Shikari somehow becomes unequipped after it deals combat damage in the first combat damage step, it won't assign combat damage in the second combat damage step."
         }
       ],
       "subtypes": [
@@ -3321,15 +3321,15 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If you activate Argent Sphinx’s metalcraft ability, Argent Sphinx will return to the battlefield at the beginning of the next end step no matter how many artifacts you control at that time."
+          "text": "If you activate Argent Sphinx's metalcraft ability, Argent Sphinx will return to the battlefield at the beginning of the next end step no matter how many artifacts you control at that time."
         },
         {
           "date": "2011-01-01",
-          "text": "If you activate Argent Sphinx’s metalcraft ability during a turn’s end step, Argent Sphinx will return to the battlefield at the beginning of the following turn’s end step."
+          "text": "If you activate Argent Sphinx's metalcraft ability during a turn's end step, Argent Sphinx will return to the battlefield at the beginning of the following turn's end step."
         },
         {
           "date": "2011-01-01",
-          "text": "If you control an Argent Sphinx owned by another player and activate its ability, Argent Sphinx will return to the battlefield under your control at the beginning of the next end step. You’ll retain control of it indefinitely."
+          "text": "If you control an Argent Sphinx owned by another player and activate its ability, Argent Sphinx will return to the battlefield under your control at the beginning of the next end step. You'll retain control of it indefinitely."
         }
       ],
       "subtypes": [
@@ -3483,7 +3483,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Look at both chosen modes to determine how many targets Cryptic Command has, if any. If it has at least one target, and all its targets are illegal when it tries to resolve, then it will be countered and none of its effects will happen. For example, if you choose the second and fourth modes, and the permanent is an illegal target when Cryptic Command tries to resolve, you won’t draw a card."
+          "text": "Look at both chosen modes to determine how many targets Cryptic Command has, if any. If it has at least one target, and all its targets are illegal when it tries to resolve, then it will be countered and none of its effects will happen. For example, if you choose the second and fourth modes, and the permanent is an illegal target when Cryptic Command tries to resolve, you won't draw a card."
         }
       ],
       "text": "Choose two —\n• Counter target spell.\n• Return target permanent to its owner's hand.\n• Tap all creatures your opponents control.\n• Draw a card.",
@@ -3698,7 +3698,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Guile’s second ability replaces “counter [a certain spell]” with “exile [a certain spell] and you may cast it without paying its mana cost.” You have the option to cast it immediately upon its exile. If you choose not to, it remains exiled and you don’t get another chance to cast it. If the spell or ability that tried to counter the spell has additional effects, it then continues to resolve."
+          "text": "Guile's second ability replaces \"counter [a certain spell]\" with \"exile [a certain spell] and you may cast it without paying its mana cost.\" You have the option to cast it immediately upon its exile. If you choose not to, it remains exiled and you don't get another chance to cast it. If the spell or ability that tried to counter the spell has additional effects, it then continues to resolve."
         },
         {
           "date": "2007-10-01",
@@ -3710,23 +3710,23 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a spell or ability you control attempts to counter a spell that can’t be countered, it doesn’t. Since the spell wouldn’t be countered, Guile’s ability has no effect on it. The spell will continue to resolve normally."
+          "text": "If a spell or ability you control attempts to counter a spell that can't be countered, it doesn't. Since the spell wouldn't be countered, Guile's ability has no effect on it. The spell will continue to resolve normally."
         },
         {
           "date": "2007-10-01",
-          "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+          "text": "The last ability triggers when the Incarnation is put into its owner's graveyard from any zone, not just from on the battlefield."
         },
         {
           "date": "2007-10-01",
-          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+          "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn't *specifically* trigger on leaving the battlefield, so it doesn't behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+          "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner's library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn't trigger and the Incarnation would remain in the graveyard."
         },
         {
           "date": "2007-10-01",
-          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles his or her library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -3951,11 +3951,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -3963,11 +3963,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         },
         {
           "date": "2011-01-01",
-          "text": "Whenever you cast a spell, Inexorable Tide’s ability triggers and goes on the stack on top of it. It will resolve (and you’ll proliferate) before the spell resolves."
+          "text": "Whenever you cast a spell, Inexorable Tide's ability triggers and goes on the stack on top of it. It will resolve (and you'll proliferate) before the spell resolves."
         }
       ],
       "text": "Whenever you cast a spell, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -4188,11 +4188,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Narcolepsy’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability triggers only if the enchanted creature is untapped as any player’s upkeep begins, and (2) the ability does nothing if the enchanted creature is already tapped by the time it resolves."
+          "text": "Narcolepsy's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability triggers only if the enchanted creature is untapped as any player's upkeep begins, and (2) the ability does nothing if the enchanted creature is already tapped by the time it resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "Narcolepsy doesn’t keep the enchanted creature continually tapped. The creature untaps during its controller’s untap step as normal, then is tapped when Narcolepsy’s ability resolves during that upkeep. The creature may be tapped in response (for example, if it has an activated ability with {T} in its cost)."
+          "text": "Narcolepsy doesn't keep the enchanted creature continually tapped. The creature untaps during its controller's untap step as normal, then is tapped when Narcolepsy's ability resolves during that upkeep. The creature may be tapped in response (for example, if it has an activated ability with {T} in its cost)."
         }
       ],
       "subtypes": [
@@ -4417,7 +4417,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The countered spell goes to its owner’s hand from the stack. It never hits the graveyard."
+          "text": "The countered spell goes to its owner's hand from the stack. It never hits the graveyard."
         },
         {
           "date": "2007-02-01",
@@ -4633,11 +4633,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -4645,11 +4645,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         },
         {
           "date": "2011-01-01",
-          "text": "This spell has no targets. You can cast it even if there are no players or permanents with counters on them. If you do, you’ll simply draw a card as it resolves."
+          "text": "This spell has no targets. You can cast it even if there are no players or permanents with counters on them. If you do, you'll simply draw a card as it resolves."
         }
       ],
       "text": "Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)\nDraw a card.",
@@ -4720,7 +4720,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Stoic Rebuttal’s metalcraft ability functions while Stoic Rebuttal is on the stack."
+          "text": "Stoic Rebuttal's metalcraft ability functions while Stoic Rebuttal is on the stack."
         },
         {
           "date": "2011-01-01",
@@ -4795,11 +4795,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an instant or sorcery spell, Surrakar Spellblade’s first ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an instant or sorcery spell, Surrakar Spellblade's first ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         },
         {
           "date": "2010-06-15",
-          "text": "When Surrakar Spellblade’s second ability resolves, you either draw a card for each charge counter on it or you draw no cards at all."
+          "text": "When Surrakar Spellblade's second ability resolves, you either draw a card for each charge counter on it or you draw no cards at all."
         },
         {
           "date": "2010-06-15",
@@ -4955,7 +4955,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "For the second ability, you choose the value of X when you activate it. You don’t look through your library until the ability resolves. (In other words, you can’t look through your library, decide what artifact card you want, and then determine what X is.) You can’t choose an X that’s greater than the number of loyalty counters on Tezzeret."
+          "text": "For the second ability, you choose the value of X when you activate it. You don't look through your library until the ability resolves. (In other words, you can't look through your library, decide what artifact card you want, and then determine what X is.) You can't choose an X that's greater than the number of loyalty counters on Tezzeret."
         },
         {
           "date": "2008-10-01",
@@ -4967,11 +4967,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -5057,11 +5057,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({U/P} can be paid with either {U} or 2 life.)\nDraw two cards, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -5203,11 +5203,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -5215,7 +5215,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -5501,7 +5501,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "You can activate Water Servant’s second ability even if doing so would cause Water Servant’s power to be less than 0."
+          "text": "You can activate Water Servant's second ability even if doing so would cause Water Servant's power to be less than 0."
         }
       ],
       "subtypes": [
@@ -5652,11 +5652,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The effect is mandatory. You’ll lose 1 life even if you have only 1 life left."
+          "text": "The effect is mandatory. You'll lose 1 life even if you have only 1 life left."
         },
         {
           "date": "2008-04-01",
-          "text": "The life loss isn’t a payment. You’ll get a token even if you had 0 life (and another effect is stopping you from losing the game)."
+          "text": "The life loss isn't a payment. You'll get a token even if you had 0 life (and another effect is stopping you from losing the game)."
         }
       ],
       "subtypes": [
@@ -5736,11 +5736,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won’t be on the battlefield to get the bonus."
+          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won't be on the battlefield to get the bonus."
         },
         {
           "date": "2010-06-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -5831,11 +5831,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You must sacrifice exactly one creature to cast this spell; you can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast this spell; you can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "Once you begin to cast Bone Splinters, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast Bone Splinters, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         },
         {
           "date": "2017-03-14",
@@ -6274,11 +6274,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({B/P} can be paid with either {B} or 2 life.)\nTarget creature gets -5/-5 until end of turn.",
@@ -6488,11 +6488,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The second ability is a state trigger. Once it triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "The second ability is a state trigger. Once it triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         },
         {
           "date": "2006-09-25",
-          "text": "When the second ability resolves, Endrek Sahr will be sacrificed regardless of how many Thrulls you control at that time, even if it’s less than seven."
+          "text": "When the second ability resolves, Endrek Sahr will be sacrificed regardless of how many Thrulls you control at that time, even if it's less than seven."
         },
         {
           "date": "2006-09-25",
@@ -6649,7 +6649,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "The state-based action that removes matching +1/+1 and -1/-1 counters won’t check until after you proliferate and Grim Affliction finishes resolving. It’s possible to remove up to two +1/+1 counters from the creature by choosing to put a second -1/-1 counter on the creature when proliferating."
+          "text": "The state-based action that removes matching +1/+1 and -1/-1 counters won't check until after you proliferate and Grim Affliction finishes resolving. It's possible to remove up to two +1/+1 counters from the creature by choosing to put a second -1/-1 counter on the creature when proliferating."
         }
       ],
       "text": "Put a -1/-1 counter on target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -6935,11 +6935,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "It doesn’t matter whose graveyard the creature is put into. It matters only that an opponent controlled it when it left the battlefield."
+          "text": "It doesn't matter whose graveyard the creature is put into. It matters only that an opponent controlled it when it left the battlefield."
         },
         {
           "date": "2008-08-01",
-          "text": "It doesn’t matter how many -1/-1 counters were on the creature when it was put into a graveyard from the battlefield, as long as it had at least one."
+          "text": "It doesn't matter how many -1/-1 counters were on the creature when it was put into a graveyard from the battlefield, as long as it had at least one."
         },
         {
           "date": "2008-08-01",
@@ -7092,10 +7092,10 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The value chosen for X applies to each X in the spell’s effect. You pay {X} only once."
+          "text": "The value chosen for X applies to each X in the spell's effect. You pay {X} only once."
         }
       ],
-      "text": "Choose two —\n• Target player loses X life. \n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
+      "text": "Choose two —\n• Target player loses X life.\n• Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -7171,23 +7171,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -7686,11 +7686,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the creature is an illegal target when Spread the Sickness tries to resolve, the spell is countered. You won’t proliferate."
+          "text": "If the creature is an illegal target when Spread the Sickness tries to resolve, the spell is countered. You won't proliferate."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature regenerates or has indestructible when Spread the Sickness resolves, you’ll still proliferate."
+          "text": "If the creature regenerates or has indestructible when Spread the Sickness resolves, you'll still proliferate."
         }
       ],
       "text": "Destroy target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -7773,15 +7773,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "“Any number of cards” means just that. If you wish, you can choose to leave some or all of the cards with the same name as the targeted card, including that card, in the zone they’re in."
+          "text": "\"Any number of cards\" means just that. If you wish, you can choose to leave some or all of the cards with the same name as the targeted card, including that card, in the zone they're in."
         }
       ],
       "text": "({B/P} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles his or her library.",
@@ -8140,11 +8140,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "Banefire can be targeted by spells that try to counter it (such as Countersquall) regardless of what the value of X is. If X is 5 or more, those spells will still resolve, but the part of their effect that would counter Banefire won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Banefire can be targeted by spells that try to counter it (such as Countersquall) regardless of what the value of X is. If X is 5 or more, those spells will still resolve, but the part of their effect that would counter Banefire won't do anything. Any other effects those spells have will work as normal."
         },
         {
           "date": "2009-02-01",
-          "text": "Banefire’s ability won’t prevent it from being countered by the game rules if its target has become an illegal target."
+          "text": "Banefire's ability won't prevent it from being countered by the game rules if its target has become an illegal target."
         }
       ],
       "text": "Banefire deals X damage to target creature or player.\nIf X is 5 or more, Banefire can't be countered by spells or abilities and the damage can't be prevented.",
@@ -8365,7 +8365,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Once Bloodshot Trainee’s ability is activated, it will resolve as normal even if Bloodshot Trainee’s power is less than 4 by the time the ability resolves."
+          "text": "Once Bloodshot Trainee's ability is activated, it will resolve as normal even if Bloodshot Trainee's power is less than 4 by the time the ability resolves."
         }
       ],
       "subtypes": [
@@ -8574,7 +8574,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Combust can be targeted by spells and abilities that try to counter it (such as Cancel). Those spells and abilities will resolve, but the part of their effect that would counter Combust won’t do anything. Any other effects those spells and abilities have will work as normal."
+          "text": "Combust can be targeted by spells and abilities that try to counter it (such as Cancel). Those spells and abilities will resolve, but the part of their effect that would counter Combust won't do anything. Any other effects those spells and abilities have will work as normal."
         },
         {
           "date": "2010-08-15",
@@ -8582,15 +8582,15 @@
         },
         {
           "date": "2010-08-15",
-          "text": "Spells that create prevention effects affecting the targeted creature can still be cast, and abilities that create prevention effects affecting the targeted creature can still be activated. However, damage prevention shields (including those created before Combust was cast) don’t have any effect on the damage dealt by Combust. If such a prevention effect has an additional effect, the additional effect will still work (if possible)."
+          "text": "Spells that create prevention effects affecting the targeted creature can still be cast, and abilities that create prevention effects affecting the targeted creature can still be activated. However, damage prevention shields (including those created before Combust was cast) don't have any effect on the damage dealt by Combust. If such a prevention effect has an additional effect, the additional effect will still work (if possible)."
         },
         {
           "date": "2010-08-15",
-          "text": "If a static ability would prevent damage from being dealt to the targeted creature, it fails to prevent the damage dealt by Combust. If that ability has an additional effect that doesn’t depend on the amount of damage prevented, that additional effect will still work. It’s applied just once as Combust resolves."
+          "text": "If a static ability would prevent damage from being dealt to the targeted creature, it fails to prevent the damage dealt by Combust. If that ability has an additional effect that doesn't depend on the amount of damage prevented, that additional effect will still work. It's applied just once as Combust resolves."
         },
         {
           "date": "2010-08-15",
-          "text": "Effects that replace or redirect damage without using the word “prevent” aren’t affected by Combust; they’ll work as normal."
+          "text": "Effects that replace or redirect damage without using the word \"prevent\" aren't affected by Combust; they'll work as normal."
         },
         {
           "date": "2010-08-15",
@@ -8668,7 +8668,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The number of targets you choose for Comet Storm is one more than the number of times it’s kicked. First you declare how many times you’re going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you’ll kick the spell and the time you choose the targets."
+          "text": "The number of targets you choose for Comet Storm is one more than the number of times it's kicked. First you declare how many times you're going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you'll kick the spell and the time you choose the targets."
         },
         {
           "date": "2010-03-01",
@@ -8676,7 +8676,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you’re kicking the spell twice. You’ll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
+          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you're kicking the spell twice. You'll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
         },
         {
           "date": "2010-03-01",
@@ -8756,15 +8756,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "When Dragonsoul Knight’s activated ability resolves, Dragonsoul Knight will gain flying and trample in addition to its other abilities. However, becoming a Dragon will make it lose all other creature types. It will no longer be a Human or a Knight."
+          "text": "When Dragonsoul Knight's activated ability resolves, Dragonsoul Knight will gain flying and trample in addition to its other abilities. However, becoming a Dragon will make it lose all other creature types. It will no longer be a Human or a Knight."
         },
         {
           "date": "2009-02-01",
-          "text": "If Dragonsoul Knight gains flying after blockers have been declared, it won’t cause those blocks to change."
+          "text": "If Dragonsoul Knight gains flying after blockers have been declared, it won't cause those blocks to change."
         },
         {
           "date": "2009-02-01",
-          "text": "You can activate Dragonsoul Knight’s ability more than once during a turn. The second time it resolves, it will probably have no visible effect other than giving Dragonsoul Knight another +5/+3."
+          "text": "You can activate Dragonsoul Knight's ability more than once during a turn. The second time it resolves, it will probably have no visible effect other than giving Dragonsoul Knight another +5/+3."
         }
       ],
       "subtypes": [
@@ -8847,7 +8847,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -9157,11 +9157,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({R/P} can be paid with either {R} or 2 life.)\nGut Shot deals 1 damage to target creature or player.",
@@ -9233,7 +9233,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You decide whether to pay {5}{R}{R} as Hellkite Charger’s ability resolves."
+          "text": "You decide whether to pay {5}{R}{R} as Hellkite Charger's ability resolves."
         },
         {
           "date": "2009-10-01",
@@ -9241,7 +9241,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Hellkite Charger’s ability may trigger multiple times in the same turn, since its own ability gives it multiple chances to attack. Each time it resolves, you may create an additional combat phase."
+          "text": "Hellkite Charger's ability may trigger multiple times in the same turn, since its own ability gives it multiple chances to attack. Each time it resolves, you may create an additional combat phase."
         },
         {
           "date": "2009-10-01",
@@ -9391,15 +9391,15 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won’t count toward the total."
+          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won't count toward the total."
         },
         {
           "date": "2007-10-01",
-          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn’t matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don’t count towards the total. Neither does an ability that’s been countered."
+          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn't matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don't count towards the total. Neither does an ability that's been countered."
         },
         {
           "date": "2007-10-01",
-          "text": "You get the bonus only the third time the ability resolves. You won’t get the bonus the fourth, fifth, sixth, or any subsequent times."
+          "text": "You get the bonus only the third time the ability resolves. You won't get the bonus the fourth, fifth, sixth, or any subsequent times."
         }
       ],
       "subtypes": [
@@ -9477,11 +9477,11 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "As the token is created, it checks the printed values of the creature it’s copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "As the token is created, it checks the printed values of the creature it's copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, or so on."
         },
         {
           "date": "2013-06-07",
-          "text": "Haste is part of the token’s copiable values. Copies of that token will also have haste."
+          "text": "Haste is part of the token's copiable values. Copies of that token will also have haste."
         }
       ],
       "subtypes": [
@@ -9638,7 +9638,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You can activate Skarrgan Firebird’s last ability if an opponent was dealt damage by any source, even if you didn’t control that source."
+          "text": "You can activate Skarrgan Firebird's last ability if an opponent was dealt damage by any source, even if you didn't control that source."
         }
       ],
       "subtypes": [
@@ -9788,15 +9788,15 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The mana can be two mana of the same color, or one mana of each of two different colors. The mana can’t be colorless."
+          "text": "The mana can be two mana of the same color, or one mana of each of two different colors. The mana can't be colorless."
         },
         {
           "date": "2007-10-01",
-          "text": "You can use this mana to pay an alternative cost (such as evoke) or additional cost incurred while casting an Elemental spell. It’s not limited to just that spell’s mana cost."
+          "text": "You can use this mana to pay an alternative cost (such as evoke) or additional cost incurred while casting an Elemental spell. It's not limited to just that spell's mana cost."
         },
         {
           "date": "2007-10-01",
-          "text": "The mana can’t be spent to activate activated abilities of Elemental sources that aren’t on the battlefield."
+          "text": "The mana can't be spent to activate activated abilities of Elemental sources that aren't on the battlefield."
         }
       ],
       "subtypes": [
@@ -9875,19 +9875,19 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Soulbright Flamekin’s ability uses the stack and can be responded to. It’s not a mana ability because it has a target."
+          "text": "Soulbright Flamekin's ability uses the stack and can be responded to. It's not a mana ability because it has a target."
         },
         {
           "date": "2007-10-01",
-          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won’t count toward the total."
+          "text": "Counts resolutions, not activations. Any such abilities that are still on the stack won't count toward the total."
         },
         {
           "date": "2007-10-01",
-          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn’t matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don’t count towards the total. Neither does an ability that’s been countered."
+          "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn't matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don't count towards the total. Neither does an ability that's been countered."
         },
         {
           "date": "2007-10-01",
-          "text": "You get the bonus only the third time the ability resolves. You won’t get the bonus the fourth, fifth, sixth, or any subsequent times."
+          "text": "You get the bonus only the third time the ability resolves. You won't get the bonus the fourth, fifth, sixth, or any subsequent times."
         }
       ],
       "subtypes": [
@@ -10044,7 +10044,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -10052,19 +10052,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -10139,15 +10139,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Splinter Twin grants an activated ability to the enchanted creature. That creature’s controller (who is not necessarily the Aura’s controller) can activate it. The creature’s controller is the player who gets the token."
+          "text": "Splinter Twin grants an activated ability to the enchanted creature. That creature's controller (who is not necessarily the Aura's controller) can activate it. The creature's controller is the player who gets the token."
         },
         {
           "date": "2010-06-15",
-          "text": "The token that’s put onto the battlefield copies exactly what’s printed on the enchanted creature (unless that creature is copying something else or it’s a token; see below), plus it has haste. It doesn’t copy whether the enchanted creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or whether it’s been affected by any noncopy effects that changed its power, toughness, types, color, or so on. In particular, it doesn’t copy the ability granted to the enchanted creature by Splinter Twin."
+          "text": "The token that's put onto the battlefield copies exactly what's printed on the enchanted creature (unless that creature is copying something else or it's a token; see below), plus it has haste. It doesn't copy whether the enchanted creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or whether it's been affected by any noncopy effects that changed its power, toughness, types, color, or so on. In particular, it doesn't copy the ability granted to the enchanted creature by Splinter Twin."
         },
         {
           "date": "2010-06-15",
-          "text": "If the enchanted creature is copying something else when the ability resolves (for example, if it’s a Renegade Doppelganger), then the token enters the battlefield as a copy of whatever the enchanted creature is copying, plus it has haste."
+          "text": "If the enchanted creature is copying something else when the ability resolves (for example, if it's a Renegade Doppelganger), then the token enters the battlefield as a copy of whatever the enchanted creature is copying, plus it has haste."
         },
         {
           "date": "2010-06-15",
@@ -10159,15 +10159,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Any enters-the-battlefield abilities of the enchanted creature will trigger when the token is put onto the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the enchanted creature will also work."
+          "text": "Any enters-the-battlefield abilities of the enchanted creature will trigger when the token is put onto the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the enchanted creature will also work."
         },
         {
           "date": "2010-06-15",
-          "text": "The token will not be kicked, even if the creature it’s copying was."
+          "text": "The token will not be kicked, even if the creature it's copying was."
         },
         {
           "date": "2010-06-15",
-          "text": "If you activate the ability and the enchanted creature leaves the battlefield before the ability resolves, you still get a token. The enchanted creature’s last existence on the battlefield is checked to see what it was (specifically, if it was itself or if it was copying something else)."
+          "text": "If you activate the ability and the enchanted creature leaves the battlefield before the ability resolves, you still get a token. The enchanted creature's last existence on the battlefield is checked to see what it was (specifically, if it was itself or if it was copying something else)."
         },
         {
           "date": "2010-06-15",
@@ -10175,11 +10175,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If the ability is activated during a turn’s end step, the token will be exiled at the beginning of the following turn’s end step."
+          "text": "If the ability is activated during a turn's end step, the token will be exiled at the beginning of the following turn's end step."
         },
         {
           "date": "2010-06-15",
-          "text": "If the token isn’t exiled when the delayed triggered ability resolves (due to Stifle, perhaps), it remains on the battlefield indefinitely. It continues to have haste."
+          "text": "If the token isn't exiled when the delayed triggered ability resolves (due to Stifle, perhaps), it remains on the battlefield indefinitely. It continues to have haste."
         },
         {
           "date": "2013-07-01",
@@ -10334,23 +10334,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -10440,7 +10440,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
@@ -10656,7 +10656,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Casting Worldheart Phoenix from your graveyard by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
+          "text": "Casting Worldheart Phoenix from your graveyard by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
         },
         {
           "date": "2009-02-01",
@@ -10664,7 +10664,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "As soon as you start to cast Worldheart Phoenix from your graveyard, the card moves onto the stack. At that point, it’s too late for an opponent to prevent you from casting it by removing it from your graveyard."
+          "text": "As soon as you start to cast Worldheart Phoenix from your graveyard, the card moves onto the stack. At that point, it's too late for an opponent to prevent you from casting it by removing it from your graveyard."
         }
       ],
       "subtypes": [
@@ -10744,11 +10744,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "The “can’t block” effect applies to each of the targeted creatures — and only those creatures — even if Wrap in Flames deals no damage to one or more of them (due to a prevention effect, for example) or Wrap in Flames deals damage to a different creature (due to a redirection effect)."
+          "text": "The \"can't block\" effect applies to each of the targeted creatures — and only those creatures — even if Wrap in Flames deals no damage to one or more of them (due to a prevention effect, for example) or Wrap in Flames deals damage to a different creature (due to a redirection effect)."
         },
         {
           "date": "2010-06-15",
-          "text": "If any of the targeted creatures is an illegal target by the time Wrap in Flames resolves, it won’t be dealt damage and will be able to block. The other targeted creatures will still be affected."
+          "text": "If any of the targeted creatures is an illegal target by the time Wrap in Flames resolves, it won't be dealt damage and will be able to block. The other targeted creatures will still be affected."
         }
       ],
       "text": "Wrap in Flames deals 1 damage to each of up to three target creatures. Those creatures can't block this turn.",
@@ -10889,7 +10889,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "All Suns’ Dawn can have from zero to five targets, one for each color."
+          "text": "All Suns' Dawn can have from zero to five targets, one for each color."
         },
         {
           "date": "2004-12-01",
@@ -10897,7 +10897,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You choose the color each target must be when you choose it as a target, so if the card you targeted as a blue card is red when All Suns’ Dawn resolves, the card is an illegal target, even if the spell doesn’t target another red card."
+          "text": "You choose the color each target must be when you choose it as a target, so if the card you targeted as a blue card is red when All Suns' Dawn resolves, the card is an illegal target, even if the spell doesn't target another red card."
         }
       ],
       "text": "For each color, return up to one target card of that color from your graveyard to your hand. Exile All Suns' Dawn.",
@@ -11172,7 +11172,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If you don’t reveal a creature card, put all the revealed cards on the bottom of your library in any order."
+          "text": "If you don't reveal a creature card, put all the revealed cards on the bottom of your library in any order."
         }
       ],
       "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
@@ -11454,31 +11454,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -11633,11 +11633,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         },
         {
           "date": "2009-02-01",
-          "text": "Matca Rioters’ ability is a “characteristic-defining ability.” It applies at all times in all zones."
+          "text": "Matca Rioters' ability is a \"characteristic-defining ability.\" It applies at all times in all zones."
         }
       ],
       "subtypes": [
@@ -11725,11 +11725,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({G/P} can be paid with either {G} or 2 life.)\nTarget creature gets +2/+2 until end of turn.",
@@ -11948,31 +11948,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreatures you control get +3/+3 until end of turn.",
@@ -12360,7 +12360,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -12431,31 +12431,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -12531,31 +12531,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate three 1/1 green Saproling creature tokens.",
@@ -12700,7 +12700,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Scute Mob’s ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control five or more lands as your upkeep starts, and (2) the ability will do nothing if you control fewer than five lands by the time it resolves."
+          "text": "Scute Mob's ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control five or more lands as your upkeep starts, and (2) the ability will do nothing if you control fewer than five lands by the time it resolves."
         }
       ],
       "subtypes": [
@@ -12846,31 +12846,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target artifact or enchantment.",
@@ -12945,7 +12945,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -13031,7 +13031,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Tarmogoyf’s ability works in all zones, not just while Tarmogoyf is on the battlefield."
+          "text": "Tarmogoyf's ability works in all zones, not just while Tarmogoyf is on the battlefield."
         },
         {
           "date": "2017-03-14",
@@ -13119,7 +13119,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It means X different creatures. You can’t give more than one +1/+1 counter to a creature with this spell."
+          "text": "It means X different creatures. You can't give more than one +1/+1 counter to a creature with this spell."
         }
       ],
       "text": "Put a +1/+1 counter on each of X target creatures.",
@@ -13261,7 +13261,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "This is not the same as hexproof. If, for example, you target one of your opponent’s creatures, your opponents won’t be able to target their own creature with spells or abilities."
+          "text": "This is not the same as hexproof. If, for example, you target one of your opponent's creatures, your opponents won't be able to target their own creature with spells or abilities."
         }
       ],
       "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nTarget creature can't be the target of spells or abilities your opponents control this turn. If Vines of Vastwood was kicked, that creature gets +4/+4 until end of turn.",
@@ -13583,7 +13583,7 @@
         "Black",
         "Green"
       ],
-      "flavor": "\"The Golgari expand, yes, but I refuse to call their tainted creations ‘growth.'\"\n—Veszka, Selesnya evangel",
+      "flavor": "\"The Golgari expand, yes, but I refuse to call their tainted creations 'growth.'\"\n—Veszka, Selesnya evangel",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -13713,7 +13713,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If all chosen targets are illegal as Electrolyze tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt and you won’t draw a card."
+          "text": "If all chosen targets are illegal as Electrolyze tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt and you won't draw a card."
         }
       ],
       "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
@@ -13868,7 +13868,7 @@
         },
         {
           "date": "2006-02-01",
-          "text": "Normally, Ghost Council of Orzhova will return to the battlefield at the end of the same turn it’s exiled. But if it’s exiled during the End step, it’s too late to return it this turn. It has to wait to return to the battlefield until the next End step."
+          "text": "Normally, Ghost Council of Orzhova will return to the battlefield at the end of the same turn it's exiled. But if it's exiled during the End step, it's too late to return it this turn. It has to wait to return to the battlefield until the next End step."
         }
       ],
       "subtypes": [
@@ -14116,11 +14116,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "If a spell or ability causes you to draw multiple cards, Lorescale Coatl’s ability triggers that many times."
+          "text": "If a spell or ability causes you to draw multiple cards, Lorescale Coatl's ability triggers that many times."
         },
         {
           "date": "2009-05-01",
-          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word “draw,” Lorescale Coatl’s ability won’t trigger."
+          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word \"draw,\" Lorescale Coatl's ability won't trigger."
         }
       ],
       "subtypes": [
@@ -14277,7 +14277,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the targeted card is removed from the graveyard before the ability resolves, the ability is countered. You won’t get a Saproling token."
+          "text": "If the targeted card is removed from the graveyard before the ability resolves, the ability is countered. You won't get a Saproling token."
         }
       ],
       "text": "{2}: Exile target creature card from a graveyard. Create a 1/1 green Saproling creature token.",
@@ -14730,7 +14730,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If the targeted creature becomes an illegal target by the time Sigil Blessing resolves, the entire spell will be countered. Your other creatures won’t get +1/+1."
+          "text": "If the targeted creature becomes an illegal target by the time Sigil Blessing resolves, the entire spell will be countered. Your other creatures won't get +1/+1."
         }
       ],
       "text": "Until end of turn, target creature you control gets +3/+3 and other creatures you control get +1/+1.",
@@ -14807,15 +14807,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "You can return a land card to your hand with Vengeful Rebirth. It just won’t deal any damage to the targeted creature or player if you do."
+          "text": "You can return a land card to your hand with Vengeful Rebirth. It just won't deal any damage to the targeted creature or player if you do."
         },
         {
           "date": "2009-05-01",
-          "text": "If the targeted creature or player becomes an illegal target but the targeted card in your graveyard doesn’t, Vengeful Rebirth will still return that card from your graveyard to your hand, but it won’t deal any damage. Vengeful Rebirth will then be exiled."
+          "text": "If the targeted creature or player becomes an illegal target but the targeted card in your graveyard doesn't, Vengeful Rebirth will still return that card from your graveyard to your hand, but it won't deal any damage. Vengeful Rebirth will then be exiled."
         },
         {
           "date": "2009-05-01",
-          "text": "If the targeted card in your graveyard becomes an illegal target but the targeted creature or player doesn’t, Vengeful Rebirth won’t return that card to your hand and it won’t deal any damage (because you didn’t return a nonland card to your hand this way). Vengeful Rebirth will still be exiled, though."
+          "text": "If the targeted card in your graveyard becomes an illegal target but the targeted creature or player doesn't, Vengeful Rebirth won't return that card to your hand and it won't deal any damage (because you didn't return a nonland card to your hand this way). Vengeful Rebirth will still be exiled, though."
         },
         {
           "date": "2009-05-01",
@@ -15337,7 +15337,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a static ability. Attacking creatures you control will get +2/+0 from the moment they’re declared as attackers (or enter the battlefield attacking) until the moment the combat phase ends, they’re removed from combat, or Nobilis of War leaves the battlefield, whichever comes first."
+          "text": "This is a static ability. Attacking creatures you control will get +2/+0 from the moment they're declared as attackers (or enter the battlefield attacking) until the moment the combat phase ends, they're removed from combat, or Nobilis of War leaves the battlefield, whichever comes first."
         }
       ],
       "subtypes": [
@@ -15423,23 +15423,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -15594,7 +15594,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you cast a spell that’s both of the listed colors, both abilities will trigger. You’ll remove a total of two -1/-1 counters from the Hatchling."
+          "text": "If you cast a spell that's both of the listed colors, both abilities will trigger. You'll remove a total of two -1/-1 counters from the Hatchling."
         },
         {
           "date": "2008-08-01",
@@ -15680,19 +15680,19 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If a spell is causing damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Burn Trail says “Burn Trail deals 3 damage to target creature or player.”"
+          "text": "If a spell is causing damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Burn Trail says \"Burn Trail deals 3 damage to target creature or player.\""
         },
         {
           "date": "2008-05-01",
-          "text": "If an ability is causing damage to be dealt, that ability will always identify the source of the damage. The ability itself is never the source. However, the source of the ability is often the source of the damage. For example, Knollspine Invocation’s ability says “Knollspine Invocation deals X damage to target creature or player.”"
+          "text": "If an ability is causing damage to be dealt, that ability will always identify the source of the damage. The ability itself is never the source. However, the source of the ability is often the source of the damage. For example, Knollspine Invocation's ability says \"Knollspine Invocation deals X damage to target creature or player.\""
         },
         {
           "date": "2008-05-01",
-          "text": "If the source of the damage is a permanent, Swans of Bryn Argoll checks who that permanent’s controller is at the time that damage is prevented. If the permanent has left the battlefield by then, its last known information is used. If the source of the damage is a spell, its controller is obvious. If the source of the damage is a card from some other zone (such as a cycled Gempalm Incinerator), Swans of Bryn Argoll checks its owner rather than its controller."
+          "text": "If the source of the damage is a permanent, Swans of Bryn Argoll checks who that permanent's controller is at the time that damage is prevented. If the permanent has left the battlefield by then, its last known information is used. If the source of the damage is a spell, its controller is obvious. If the source of the damage is a card from some other zone (such as a cycled Gempalm Incinerator), Swans of Bryn Argoll checks its owner rather than its controller."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with wither would deal damage to Swans of Bryn Argoll, that damage is treated just like any other damage. It’s prevented, and the creature’s controller draws cards. Swans of Bryn Argoll doesn’t get any -1/-1 counters."
+          "text": "If a creature with wither would deal damage to Swans of Bryn Argoll, that damage is treated just like any other damage. It's prevented, and the creature's controller draws cards. Swans of Bryn Argoll doesn't get any -1/-1 counters."
         }
       ],
       "subtypes": [
@@ -15984,7 +15984,7 @@
         },
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -16057,7 +16057,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If you activate Chimeric Mass’s last ability while it has no charge counters on it, it will become a 0/0 creature and be put into its owner’s graveyard as a state-based action."
+          "text": "If you activate Chimeric Mass's last ability while it has no charge counters on it, it will become a 0/0 creature and be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2011-01-01",
@@ -16065,7 +16065,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "For example, say you activate the last ability of a Chimeric Mass with three charge counters on it. After it resolves, you cast Giant Growth targeting it. It’s now 6/6. Then Diminish (“Target creature becomes 1/1 until end of turn”) is cast targeting it. Once Diminish resolves, Chimeric Mass would be 4/4. Activating Chimeric Mass’s last ability a second time would make it 6/6 again until end of turn."
+          "text": "For example, say you activate the last ability of a Chimeric Mass with three charge counters on it. After it resolves, you cast Giant Growth targeting it. It's now 6/6. Then Diminish (\"Target creature becomes 1/1 until end of turn\") is cast targeting it. Once Diminish resolves, Chimeric Mass would be 4/4. Activating Chimeric Mass's last ability a second time would make it 6/6 again until end of turn."
         }
       ],
       "text": "Chimeric Mass enters the battlefield with X charge counters on it.\n{1}: Until end of turn, Chimeric Mass becomes a Construct artifact creature with \"This creature's power and toughness are each equal to the number of charge counters on it.\"",
@@ -16258,7 +16258,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Culling Dais’s last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
+          "text": "As Culling Dais's last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
         }
       ],
       "text": "{T}, Sacrifice a creature: Put a charge counter on Culling Dais.\n{1}, Sacrifice Culling Dais: Draw a card for each charge counter on Culling Dais.",
@@ -16323,11 +16323,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Darksteel Axe itself has indestructible, not the creature it’s equipping."
+          "text": "Darksteel Axe itself has indestructible, not the creature it's equipping."
         },
         {
           "date": "2013-07-01",
-          "text": "Although Darksteel Axe has indestructible, it can still be put into the graveyard for other reasons. The most likely reason is if it’s sacrificed."
+          "text": "Although Darksteel Axe has indestructible, it can still be put into the graveyard for other reasons. The most likely reason is if it's sacrificed."
         }
       ],
       "subtypes": [
@@ -16396,7 +16396,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "“Protection from all colors” means protection from white, from blue, from black, from red, and from green. (In other words, it doesn’t just mean “protection from objects that have all five colors.”)"
+          "text": "\"Protection from all colors\" means protection from white, from blue, from black, from red, and from green. (In other words, it doesn't just mean \"protection from objects that have all five colors.\")"
         }
       ],
       "subtypes": [
@@ -16871,23 +16871,23 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The creature type “Bird” was inadvertently omitted from each of Glint Hawk Idol’s abilities. It has received errata to correct this omission; when either of its abilities resolves, it will become a Bird artifact creature."
+          "text": "The creature type \"Bird\" was inadvertently omitted from each of Glint Hawk Idol's abilities. It has received errata to correct this omission; when either of its abilities resolves, it will become a Bird artifact creature."
         },
         {
           "date": "2011-01-01",
-          "text": "If Glint Hawk Idol becomes a creature before you begin a turn with it under your control, it will be affected by “summoning sickness.”"
+          "text": "If Glint Hawk Idol becomes a creature before you begin a turn with it under your control, it will be affected by \"summoning sickness.\""
         },
         {
           "date": "2011-01-01",
-          "text": "If Glint Hawk Idol and another artifact enter the battlefield under your control at the same time, Glint Hawk Idol’s first ability will trigger. You may have it become a creature, but since it will be affected by “summoning sickness,” it won’t be able to attack that turn."
+          "text": "If Glint Hawk Idol and another artifact enter the battlefield under your control at the same time, Glint Hawk Idol's first ability will trigger. You may have it become a creature, but since it will be affected by \"summoning sickness,\" it won't be able to attack that turn."
         },
         {
           "date": "2011-01-01",
-          "text": "If either of Glint Hawk Idol’s two abilities resolve while it’s a creature, that ability will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "If either of Glint Hawk Idol's two abilities resolve while it's a creature, that ability will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         },
         {
           "date": "2011-01-01",
-          "text": "For example, say one of Glint Hawk Idol’s abilities has resolved and it’s a 2/2 creature. You cast Giant Growth targeting it. It’s now 5/5. Then Diminish (“Target creature becomes 1/1 until end of turn”) is cast targeting it. Once Diminish resolves, Glint Hawk Idol would be 4/4. Activating Glint Hawk Idol’s last ability at this point would make it 5/5 again until end of turn."
+          "text": "For example, say one of Glint Hawk Idol's abilities has resolved and it's a 2/2 creature. You cast Giant Growth targeting it. It's now 5/5. Then Diminish (\"Target creature becomes 1/1 until end of turn\") is cast targeting it. Once Diminish resolves, Glint Hawk Idol would be 4/4. Activating Glint Hawk Idol's last ability at this point would make it 5/5 again until end of turn."
         }
       ],
       "text": "Whenever another artifact enters the battlefield under your control, you may have Glint Hawk Idol become a 2/2 Bird artifact creature with flying until end of turn.\n{W}: Glint Hawk Idol becomes a 2/2 Bird artifact creature with flying until end of turn.",
@@ -17086,15 +17086,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The ability affects each spell that’s not an artifact spell, including your own."
+          "text": "The ability affects each spell that's not an artifact spell, including your own."
         },
         {
           "date": "2010-03-01",
-          "text": "The ability affects the total cost of each nonartifact spell, but it doesn’t change that spell’s mana cost or converted mana cost. The extra mana also doesn’t change how many times you kicked the spell or what the value of X is (if applicable)."
+          "text": "The ability affects the total cost of each nonartifact spell, but it doesn't change that spell's mana cost or converted mana cost. The extra mana also doesn't change how many times you kicked the spell or what the value of X is (if applicable)."
         },
         {
           "date": "2010-03-01",
-          "text": "When determining a spell’s total cost, effects that increase the cost are applied before effects that reduce the cost."
+          "text": "When determining a spell's total cost, effects that increase the cost are applied before effects that reduce the cost."
         }
       ],
       "subtypes": [
@@ -17493,35 +17493,35 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The second ability triggers whenever a player casts an instant or sorcery spell that targets only one Golem and no other object or player. That Golem can be Precursor Golem itself, one of the Golem tokens it created, or any other Golem. It doesn’t matter who controls the Golem."
+          "text": "The second ability triggers whenever a player casts an instant or sorcery spell that targets only one Golem and no other object or player. That Golem can be Precursor Golem itself, one of the Golem tokens it created, or any other Golem. It doesn't matter who controls the Golem."
         },
         {
           "date": "2011-01-01",
-          "text": "If an instant or sorcery spell has multiple targets, but it’s targeting the same Golem with all of them (such as Agony Warp targeting the same Golem twice), Precursor Golem’s last ability will trigger."
+          "text": "If an instant or sorcery spell has multiple targets, but it's targeting the same Golem with all of them (such as Agony Warp targeting the same Golem twice), Precursor Golem's last ability will trigger."
         },
         {
           "date": "2011-01-01",
-          "text": "Any Golem that couldn’t be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Precursor Golem’s second ability."
+          "text": "Any Golem that couldn't be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Precursor Golem's second ability."
         },
         {
           "date": "2011-01-01",
-          "text": "The controller of the spell that caused Precursor Golem’s second ability to trigger also controls all the copies. That player chooses the order the copies are put onto the stack. The original spell will be on the stack beneath those copies and will resolve last."
+          "text": "The controller of the spell that caused Precursor Golem's second ability to trigger also controls all the copies. That player chooses the order the copies are put onto the stack. The original spell will be on the stack beneath those copies and will resolve last."
         },
         {
           "date": "2011-01-01",
-          "text": "The copies that Precursor Golem’s second ability creates are created on the stack, so they’re not “cast.” Abilities that trigger when a player casts a spell (like Precursor Golem’s second ability itself) won’t trigger."
+          "text": "The copies that Precursor Golem's second ability creates are created on the stack, so they're not \"cast.\" Abilities that trigger when a player casts a spell (like Precursor Golem's second ability itself) won't trigger."
         },
         {
           "date": "2011-01-01",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copies will have the same mode. Their controller can’t choose a different one."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copies will have the same mode. Their controller can't choose a different one."
         },
         {
           "date": "2011-01-01",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Fireball does), the copies have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Fireball does), the copies have the same value of X."
         },
         {
           "date": "2011-01-01",
-          "text": "The controller of a copy can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
+          "text": "The controller of a copy can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
         }
       ],
       "subtypes": [
@@ -17661,11 +17661,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If Rusted Relic stops being a creature during combat (because you lose control of one or more artifacts, perhaps), it is removed from combat and will not deal or be dealt combat damage. Creatures it was blocking remain blocked. It won’t re-enter that combat, even if you wind up controlling three or more artifacts again during that combat phase."
+          "text": "If Rusted Relic stops being a creature during combat (because you lose control of one or more artifacts, perhaps), it is removed from combat and will not deal or be dealt combat damage. Creatures it was blocking remain blocked. It won't re-enter that combat, even if you wind up controlling three or more artifacts again during that combat phase."
         },
         {
           "date": "2011-01-01",
-          "text": "Whether Rusted Relic has “summoning sickness” is based on how long you have continuously controlled it, not on how long it has continuously been a creature."
+          "text": "Whether Rusted Relic has \"summoning sickness\" is based on how long you have continuously controlled it, not on how long it has continuously been a creature."
         }
       ],
       "text": "Metalcraft — Rusted Relic is a 5/5 Golem artifact creature as long as you control three or more artifacts.",
@@ -17861,7 +17861,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You can activate Spellskite’s ability even if Spellskite wouldn’t be a legal target for the spell or ability. However, the target of that spell or ability will remain unchanged."
+          "text": "You can activate Spellskite's ability even if Spellskite wouldn't be a legal target for the spell or ability. However, the target of that spell or ability will remain unchanged."
         },
         {
           "date": "2011-06-01",
@@ -17869,23 +17869,23 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If the spell or ability has multiple instances of the word “target,” you choose which target you’re changing to Spellskite when Spellskite’s ability resolves."
+          "text": "If the spell or ability has multiple instances of the word \"target,\" you choose which target you're changing to Spellskite when Spellskite's ability resolves."
         },
         {
           "date": "2011-06-01",
-          "text": "By activating Spellskite’s ability multiple times, you can change each target of a spell or ability with multiple instances of the word “target” to Spellskite, one at a time."
+          "text": "By activating Spellskite's ability multiple times, you can change each target of a spell or ability with multiple instances of the word \"target\" to Spellskite, one at a time."
         },
         {
           "date": "2011-06-01",
-          "text": "The target of the spell or ability won’t change unless Spellskite fulfills all the targeting criteria, even if multiple instances of the word “target” are used. For example, you can’t change both targets of Arc Trail to Spellskite."
+          "text": "The target of the spell or ability won't change unless Spellskite fulfills all the targeting criteria, even if multiple instances of the word \"target\" are used. For example, you can't change both targets of Arc Trail to Spellskite."
         },
         {
           "date": "2011-06-01",
-          "text": "If a spell or ability has multiple targets but doesn’t use the word “target” multiple times, such as Fulgent Distraction, you can only successfully change one of the targets to Spellskite."
+          "text": "If a spell or ability has multiple targets but doesn't use the word \"target\" multiple times, such as Fulgent Distraction, you can only successfully change one of the targets to Spellskite."
         },
         {
           "date": "2011-06-01",
-          "text": "If a spell or ability has a variable number of targets, you can’t change the number of targets."
+          "text": "If a spell or ability has a variable number of targets, you can't change the number of targets."
         },
         {
           "date": "2011-06-01",
@@ -18021,15 +18021,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You can’t pay the cost of the second ability unless Sunforger is attached to a creature."
+          "text": "You can't pay the cost of the second ability unless Sunforger is attached to a creature."
         },
         {
           "date": "2005-10-01",
-          "text": "Any card you find must be legally castable (for example, you have to be able to choose a legal target for it). If you can’t find a castable card (or choose not to), nothing happens and you shuffle your library."
+          "text": "Any card you find must be legally castable (for example, you have to be able to choose a legal target for it). If you can't find a castable card (or choose not to), nothing happens and you shuffle your library."
         },
         {
           "date": "2005-10-01",
-          "text": "The card is cast from your library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can’t be paid."
+          "text": "The card is cast from your library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can't be paid."
         }
       ],
       "subtypes": [
@@ -18288,19 +18288,19 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Blinkmoth Nexus gains the creature type “Blinkmoth” when it becomes a creature. This means that it ends up with three types (land, artifact, and creature), plus one creature subtype (Blinkmoth)."
+          "text": "Blinkmoth Nexus gains the creature type \"Blinkmoth\" when it becomes a creature. This means that it ends up with three types (land, artifact, and creature), plus one creature subtype (Blinkmoth)."
         },
         {
           "date": "2004-12-01",
-          "text": "The “target Blinkmoth gets +1/+1” ability can target any creature with the creature type Blinkmoth."
+          "text": "The \"target Blinkmoth gets +1/+1\" ability can target any creature with the creature type Blinkmoth."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.",
@@ -18439,7 +18439,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Although Darksteel Citadel is an artifact, it can’t be cast as a spell. Playing it follows the normal rules for playing a land."
+          "text": "Although Darksteel Citadel is an artifact, it can't be cast as a spell. Playing it follows the normal rules for playing a land."
         }
       ],
       "text": "Indestructible\n{T}: Add {C} to your mana pool.",
@@ -18574,7 +18574,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The mana generated by the last ability can’t be spent to activate abilities of Eldrazi sources that aren’t on the battlefield."
+          "text": "The mana generated by the last ability can't be spent to activate abilities of Eldrazi sources that aren't on the battlefield."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}: Add {C}{C} to your mana pool. Spend this mana only to cast colorless Eldrazi spells or activate abilities of colorless Eldrazi.",
@@ -18736,11 +18736,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Eye of Ugin doesn’t have a mana ability."
+          "text": "Eye of Ugin doesn't have a mana ability."
         },
         {
           "date": "2010-03-01",
-          "text": "Eye of Ugin’s second ability lets you find any colorless creature card in your deck, such as an artifact creature card that has no colored mana symbols in its mana cost, or a creature card that’s become colorless due to Mycosynth Lattice."
+          "text": "Eye of Ugin's second ability lets you find any colorless creature card in your deck, such as an artifact creature card that has no colored mana symbols in its mana cost, or a creature card that's become colorless due to Mycosynth Lattice."
         },
         {
           "date": "2013-04-15",

--- a/json/MM3.json
+++ b/json/MM3.json
@@ -294,7 +294,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Entreat the Angels’s converted mana cost is based on its mana cost of {X}{X}{W}{W}{W}, even if you’re casting it for its miracle cost. For example, if you cast Entreat the Angels for its miracle cost and choose 4 for X, its converted mana cost is 11."
+          "text": "Entreat the Angels's converted mana cost is based on its mana cost of {X}{X}{W}{W}{W}, even if you're casting it for its miracle cost. For example, if you cast Entreat the Angels for its miracle cost and choose 4 for X, its converted mana cost is 11."
         }
       ],
       "text": "Create X 4/4 white Angel creature tokens with flying.\nMiracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
@@ -364,11 +364,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -376,11 +376,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -464,7 +464,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won’t trigger that turn."
+          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won't trigger that turn."
         }
       ],
       "subtypes": [
@@ -605,11 +605,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Graceful Reprieve’s effect works only once. If the targeted creature leaves the battlefield and is then returned to the battlefield, it’s considered to be a new creature. If that new creature is put into a graveyard, it won’t come back a second time."
+          "text": "Graceful Reprieve's effect works only once. If the targeted creature leaves the battlefield and is then returned to the battlefield, it's considered to be a new creature. If that new creature is put into a graveyard, it won't come back a second time."
         },
         {
           "date": "2017-03-14",
-          "text": "Graceful Reprieve can target a token creature, but since tokens cease to exist after they leave the battlefield, it won’t be returned to the battlefield."
+          "text": "Graceful Reprieve can target a token creature, but since tokens cease to exist after they leave the battlefield, it won't be returned to the battlefield."
         }
       ],
       "text": "When target creature dies this turn, return that card to the battlefield under its owner's control.",
@@ -750,7 +750,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Kor Hookmaster’s ability can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Kor Hookmaster's ability can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -829,7 +829,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Kor Skyfisher’s triggered ability doesn’t target a permanent. You choose which one to return to its owner’s hand as the ability resolves. No one can respond to the choice."
+          "text": "Kor Skyfisher's triggered ability doesn't target a permanent. You choose which one to return to its owner's hand as the ability resolves. No one can respond to the choice."
         },
         {
           "date": "2017-03-14",
@@ -977,7 +977,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2017-03-14",
@@ -985,7 +985,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Linvala’s last ability affects only creatures on the battlefield. Activated abilities that work in other zones (such as bloodrush or unearth) can still be activated. Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected."
+          "text": "Linvala's last ability affects only creatures on the battlefield. Activated abilities that work in other zones (such as bloodrush or unearth) can still be activated. Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected."
         }
       ],
       "subtypes": [
@@ -1134,7 +1134,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If a creature has been dealt damage, that damage remains marked on it until the cleanup step. If Master Splicer leaves the battlefield and a Golem creature you control has been dealt damage, that creature will be destroyed if the damage is now lethal. Similarly, if that causes a Golem to have 0 toughness, it’s put into its owner’s graveyard."
+          "text": "If a creature has been dealt damage, that damage remains marked on it until the cleanup step. If Master Splicer leaves the battlefield and a Golem creature you control has been dealt damage, that creature will be destroyed if the damage is now lethal. Similarly, if that causes a Golem to have 0 toughness, it's put into its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -1214,11 +1214,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Any “as this enters the battlefield” choices for the affected creature are made by its owner, not its old controller."
+          "text": "Any \"as this enters the battlefield\" choices for the affected creature are made by its owner, not its old controller."
         },
         {
           "date": "2007-02-01",
-          "text": "If Momentary Blink is cast on a token creature, the token will not return to the battlefield, because of the rule that says a token that leaves the battlefield can’t come back."
+          "text": "If Momentary Blink is cast on a token creature, the token will not return to the battlefield, because of the rule that says a token that leaves the battlefield can't come back."
         }
       ],
       "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -1295,11 +1295,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature’s controller won’t search for a basic land card."
+          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature's controller won't search for a basic land card."
         },
         {
           "date": "2017-03-14",
-          "text": "The controller of the exiled creature isn’t required to search his or her library for a basic land. If that player doesn’t, the player won’t shuffle his or her library."
+          "text": "The controller of the exiled creature isn't required to search his or her library for a basic land. If that player doesn't, the player won't shuffle his or her library."
         }
       ],
       "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
@@ -1369,11 +1369,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -1594,11 +1594,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -1606,11 +1606,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -1687,11 +1687,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The token doesn’t have haste (unless the card it’s copying has haste) and usually won’t be able to attack."
+          "text": "The token doesn't have haste (unless the card it's copying has haste) and usually won't be able to attack."
         },
         {
           "date": "2017-03-14",
-          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn’t copy any information about the object the card was before it was put into your graveyard."
+          "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
         },
         {
           "date": "2017-03-14",
@@ -1699,7 +1699,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The delayed triggered ability that exiles the token isn’t a characteristic of the token. If an effect such as populate copies the token, the new copy won’t be exiled."
+          "text": "The delayed triggered ability that exiles the token isn't a characteristic of the token. If an effect such as populate copies the token, the new copy won't be exiled."
         },
         {
           "date": "2017-03-14",
@@ -1707,7 +1707,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If the card copied by the token had any “when [this permanent] enters the battlefield” abilities, then the token also has those abilities and will trigger them when it’s created. Similarly, any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities that the token has copied will also work."
+          "text": "If the card copied by the token had any \"when [this permanent] enters the battlefield\" abilities, then the token also has those abilities and will trigger them when it's created. Similarly, any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities that the token has copied will also work."
         }
       ],
       "text": "At the beginning of each upkeep, you may exile target creature card from your graveyard. If you do, create a token that's a copy of that card, except it's a Spirit in addition to its other types. Exile it at the beginning of the next end step.",
@@ -1861,7 +1861,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other’s ability to trigger."
+          "text": "Two Soul Wardens entering the battlefield at the same time will each cause the other's ability to trigger."
         },
         {
           "date": "2005-08-01",
@@ -1940,7 +1940,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keyword abilities, such as equip, are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keyword abilities, such as equip, are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2017-03-14",
@@ -1948,7 +1948,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Stony Silence’s ability affects only artifacts on the battlefield. Activated abilities that work in other zones (such as cycling) can still be activated. Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected."
+          "text": "Stony Silence's ability affects only artifacts on the battlefield. Activated abilities that work in other zones (such as cycling) can still be activated. Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected."
         }
       ],
       "text": "Activated abilities of artifacts can't be activated.",
@@ -2018,7 +2018,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Each player chooses the order that creatures he or she owns are put onto the bottom of his or her library. This order isn’t revealed to other players."
+          "text": "Each player chooses the order that creatures he or she owns are put onto the bottom of his or her library. This order isn't revealed to other players."
         }
       ],
       "text": "Put all creatures on the bottom of their owners' libraries.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
@@ -2158,11 +2158,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -2170,11 +2170,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -2319,11 +2319,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "You don’t reveal the other two cards, nor do you reveal their order on the bottom of the library."
+          "text": "You don't reveal the other two cards, nor do you reveal their order on the bottom of the library."
         },
         {
           "date": "2012-07-01",
-          "text": "If there are fewer than three cards in your library when Augur of Bolas’s ability resolves, you’ll look at the remaining cards. This won’t cause you to lose the game as you haven’t drawn from an empty library."
+          "text": "If there are fewer than three cards in your library when Augur of Bolas's ability resolves, you'll look at the remaining cards. This won't cause you to lose the game as you haven't drawn from an empty library."
         }
       ],
       "subtypes": [
@@ -2465,7 +2465,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "The token copies exactly what was printed on the original creature and nothing else (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2017-03-14",
@@ -2473,7 +2473,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If the copied creature is a token, the token that’s created copies the original characteristics of that token as stated by the effect that created the token."
+          "text": "If the copied creature is a token, the token that's created copies the original characteristics of that token as stated by the effect that created the token."
         },
         {
           "date": "2017-03-14",
@@ -2481,7 +2481,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         }
       ],
       "text": "Create a token that's a copy of target creature you control.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -2629,7 +2629,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Crippling Chill can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Crippling Chill can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         }
       ],
       "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
@@ -2700,23 +2700,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -2724,7 +2724,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -2794,11 +2794,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If you activate the ability granted by Deadeye Navigator, the creature will be exiled, the pair will immediately be broken, and then the card will be returned to the battlefield. Deadeye Navigator’s soulbond ability triggers when that card enters the battlefield and the pair can then be reunited."
+          "text": "If you activate the ability granted by Deadeye Navigator, the creature will be exiled, the pair will immediately be broken, and then the card will be returned to the battlefield. Deadeye Navigator's soulbond ability triggers when that card enters the battlefield and the pair can then be reunited."
         },
         {
           "date": "2017-03-14",
-          "text": "Once Deadeye Navigator or the creature it’s paired with is exiled, the other creature will no longer have the activated ability. However, you can activate the ability of one creature in response to activating the ability of the other creature."
+          "text": "Once Deadeye Navigator or the creature it's paired with is exiled, the other creature will no longer have the activated ability. However, you can activate the ability of one creature in response to activating the ability of the other creature."
         }
       ],
       "subtypes": [
@@ -2872,7 +2872,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Familiar’s Ruse can’t be cast without a target spell. It can’t target itself."
+          "text": "Familiar's Ruse can't be cast without a target spell. It can't target itself."
         }
       ],
       "text": "As an additional cost to cast Familiar's Ruse, return a creature you control to its owner's hand.\nCounter target spell.",
@@ -2944,7 +2944,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "If you have fewer than four cards in your library, you’ll look at all the cards there and put one into your hand and the rest into your graveyard."
+          "text": "If you have fewer than four cards in your library, you'll look at all the cards there and put one into your hand and the rest into your graveyard."
         }
       ],
       "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -3085,7 +3085,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You can choose to find fewer than four cards if you want. If you find one or two cards, your opponent must choose for them to be put into your graveyard, even if he or she doesn’t want to."
+          "text": "You can choose to find fewer than four cards if you want. If you find one or two cards, your opponent must choose for them to be put into your graveyard, even if he or she doesn't want to."
         }
       ],
       "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
@@ -3288,7 +3288,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Mist Raven’s ability is mandatory. If Mist Raven is the only creature on the battlefield when its ability triggers, you must choose it as the target."
+          "text": "Mist Raven's ability is mandatory. If Mist Raven is the only creature on the battlefield when its ability triggers, you must choose it as the target."
         }
       ],
       "subtypes": [
@@ -3490,7 +3490,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Phantasmal Image copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it gains the Illusion creature type and the triggered ability. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Phantasmal Image copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it gains the Illusion creature type and the triggered ability. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2017-03-14",
@@ -3510,11 +3510,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Phantasmal Image enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Phantasmal Image enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2017-03-14",
-          "text": "If Phantasmal Image somehow enters the battlefield at the same time as another creature, Phantasmal Image can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Phantasmal Image somehow enters the battlefield at the same time as another creature, Phantasmal Image can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         }
       ],
       "subtypes": [
@@ -3592,19 +3592,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Rewind targets only a spell. It doesn’t target any lands. The lands are chosen as Rewind resolves."
+          "text": "Rewind targets only a spell. It doesn't target any lands. The lands are chosen as Rewind resolves."
         },
         {
           "date": "2017-03-14",
-          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can’t choose one land and have it untap four times, for example."
+          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can't choose one land and have it untap four times, for example."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won’t untap any lands."
+          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won't untap any lands."
         },
         {
           "date": "2017-03-14",
-          "text": "If Rewind resolves but the target spell can’t be countered, you’ll still untap lands."
+          "text": "If Rewind resolves but the target spell can't be countered, you'll still untap lands."
         }
       ],
       "text": "Counter target spell. Untap up to four lands.",
@@ -3677,7 +3677,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If there’s only one card in your library as Sea Gate Oracle’s ability resolves, you’ll put it into your hand."
+          "text": "If there's only one card in your library as Sea Gate Oracle's ability resolves, you'll put it into your hand."
         }
       ],
       "subtypes": [
@@ -3813,14 +3813,11 @@
       "power": "2",
       "printings": [
         "ISD",
+        "pWCQ",
         "MM3"
       ],
       "rarity": "Mythic Rare",
       "rulings": [
-        {
-          "date": "2013-07-01",
-          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
-        },
         {
           "date": "2017-03-14",
           "text": "If you cast an instant or sorcery with {X} in its mana cost this way, you still choose the value of X as part of casting the spell and pay that cost."
@@ -3832,6 +3829,10 @@
         {
           "date": "2017-03-14",
           "text": "You may pay any optional additional costs the spell has, such as conspire costs. You must pay any mandatory additional costs the spell has, such as that of Bone Splinters."
+        },
+        {
+          "date": "2017-04-18",
+          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
         }
       ],
       "subtypes": [
@@ -4041,7 +4042,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Tandem Lookout or the creature it’s paired with is dealt lethal damage at the same time that either deals damage to an opponent, its ability triggers. You’ll draw a card even though that creature no longer has the ability."
+          "text": "If Tandem Lookout or the creature it's paired with is dealt lethal damage at the same time that either deals damage to an opponent, its ability triggers. You'll draw a card even though that creature no longer has the ability."
         }
       ],
       "subtypes": [
@@ -4182,15 +4183,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Venser’s triggered ability targets a spell cast with flashback, that spell will be exiled instead of returning to its owner’s hand."
+          "text": "If Venser's triggered ability targets a spell cast with flashback, that spell will be exiled instead of returning to its owner's hand."
         },
         {
           "date": "2017-03-14",
-          "text": "If a spell is returned to its owner’s hand, it’s removed from the stack and thus will not resolve. The spell isn’t countered; it just no longer exists. This works against a spell that can’t be countered."
+          "text": "If a spell is returned to its owner's hand, it's removed from the stack and thus will not resolve. The spell isn't countered; it just no longer exists. This works against a spell that can't be countered."
         },
         {
           "date": "2017-03-14",
-          "text": "If a copy of a spell is returned to its owner’s hand, it’s moved there, then it will cease to exist as a state-based action. It can’t be recast."
+          "text": "If a copy of a spell is returned to its owner's hand, it's moved there, then it will cease to exist as a state-based action. It can't be recast."
         }
       ],
       "subtypes": [
@@ -4270,11 +4271,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Frost’s ability tracks the creature, not the creature’s controller. That is, if the creature changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "Wall of Frost's ability tracks the creature, not the creature's controller. That is, if the creature changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-07-18",
-          "text": "If the creature isn’t tapped during its controller’s next untap step (perhaps because it was untapped by a spell), Wall of Frost’s ability has no effect at that time. It won’t try to keep the creature tapped on subsequent turns."
+          "text": "If the creature isn't tapped during its controller's next untap step (perhaps because it was untapped by a spell), Wall of Frost's ability has no effect at that time. It won't try to keep the creature tapped on subsequent turns."
         }
       ],
       "subtypes": [
@@ -4581,11 +4582,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You must sacrifice exactly one creature to cast this spell; you can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast this spell; you can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "Once you begin to cast Bone Splinters, no player may take actions until you’re done. Notably, opponents can’t try to remove the creature you wish to sacrifice."
+          "text": "Once you begin to cast Bone Splinters, no player may take actions until you're done. Notably, opponents can't try to remove the creature you wish to sacrifice."
         },
         {
           "date": "2017-03-14",
@@ -4661,23 +4662,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -4748,7 +4749,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Cower in Fear affects only creatures your opponents control at the time it resolves. It won’t affect creatures that come under their control later in the turn."
+          "text": "Cower in Fear affects only creatures your opponents control at the time it resolves. It won't affect creatures that come under their control later in the turn."
         }
       ],
       "text": "Creatures your opponents control get -1/-1 until end of turn.",
@@ -4813,7 +4814,8 @@
         "pJGP",
         "pMPR",
         "PLC",
-        "MM3"
+        "MM3",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -4890,23 +4892,23 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Death’s Shadow’s ability applies only while Death’s Shadow is on the battlefield. In all other zones, its power and toughness are 13."
+          "text": "Death's Shadow's ability applies only while Death's Shadow is on the battlefield. In all other zones, its power and toughness are 13."
         },
         {
           "date": "2017-03-14",
-          "text": "The value of X changes as you gain and lose life. It’s not locked in as Death’s Shadow enters the battlefield."
+          "text": "The value of X changes as you gain and lose life. It's not locked in as Death's Shadow enters the battlefield."
         },
         {
           "date": "2017-03-14",
-          "text": "If your life total is 13 or greater and nothing else is boosting the toughness of Death’s Shadow, it’s put into its owner’s graveyard as a state-based action."
+          "text": "If your life total is 13 or greater and nothing else is boosting the toughness of Death's Shadow, it's put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2017-03-14",
-          "text": "If your life total is less than 0 and an effect (such as the one from an opponent’s Abyssal Persecutor) is keeping you from losing the game, Death’s Shadow’s ability will actually increase its power and toughness. For example, if your life total is -2, Death’s Shadow gets +2/+2."
+          "text": "If your life total is less than 0 and an effect (such as the one from an opponent's Abyssal Persecutor) is keeping you from losing the game, Death's Shadow's ability will actually increase its power and toughness. For example, if your life total is -2, Death's Shadow gets +2/+2."
         },
         {
           "date": "2017-03-14",
-          "text": "In a Two-Headed Giant game, your life total is your team’s life total."
+          "text": "In a Two-Headed Giant game, your life total is your team's life total."
         }
       ],
       "subtypes": [
@@ -5051,7 +5053,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Players won’t know which player or planeswalker Desecration Demon will attack, if any, when deciding whether to sacrifice a creature."
+          "text": "Players won't know which player or planeswalker Desecration Demon will attack, if any, when deciding whether to sacrifice a creature."
         },
         {
           "date": "2017-03-14",
@@ -5133,23 +5135,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -5295,11 +5297,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon’s triggered ability will trigger."
+          "text": "If Extractor Demon and another creature leave the battlefield at the same time, Extractor Demon's triggered ability will trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "You can target any player with Extractor Demon’s triggered ability. The target doesn’t have to be the controller of the creature that left the battlefield."
+          "text": "You can target any player with Extractor Demon's triggered ability. The target doesn't have to be the controller of the creature that left the battlefield."
         }
       ],
       "subtypes": [
@@ -5375,7 +5377,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Falkenrath Noble and another creature die at the same time, Falkenrath Noble’s triggered ability will trigger for each of them."
+          "text": "If Falkenrath Noble and another creature die at the same time, Falkenrath Noble's triggered ability will trigger for each of them."
         }
       ],
       "subtypes": [
@@ -5516,7 +5518,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "You can’t activate Griselbrand’s ability if you have 6 or less life."
+          "text": "You can't activate Griselbrand's ability if you have 6 or less life."
         }
       ],
       "subtypes": [
@@ -5593,11 +5595,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Use the creature’s power the last time it was on the battlefield to determine how many cards its controller puts into his or her graveyard."
+          "text": "Use the creature's power the last time it was on the battlefield to determine how many cards its controller puts into his or her graveyard."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature is an illegal target when Grisly Spectacle tries to resolve, it will be countered and none of its effects will happen. The creature’s controller won’t put any cards into his or her graveyard."
+          "text": "If the creature is an illegal target when Grisly Spectacle tries to resolve, it will be countered and none of its effects will happen. The creature's controller won't put any cards into his or her graveyard."
         }
       ],
       "text": "Destroy target nonartifact creature. Its controller puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
@@ -5802,21 +5804,22 @@
       "originalType": "Planeswalker — Liliana",
       "printings": [
         "ISD",
+        "pWCQ",
         "MM3"
       ],
       "rarity": "Mythic Rare",
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "When Liliana’s first ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order chooses a card to discard, then those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
+          "text": "When Liliana's first ability resolves, first the player whose turn it is chooses a card to discard, then each other player in turn order chooses a card to discard, then those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
         },
         {
           "date": "2017-03-14",
-          "text": "The player targeted by Liliana’s second ability chooses which creature to sacrifice when the ability resolves. This ability doesn’t target any creature."
+          "text": "The player targeted by Liliana's second ability chooses which creature to sacrifice when the ability resolves. This ability doesn't target any creature."
         },
         {
           "date": "2017-03-14",
-          "text": "When Liliana’s third ability resolves, you put each permanent the player controls into one of the two piles. For example, you could put a creature into one pile and an Aura enchanting that creature into the other pile."
+          "text": "When Liliana's third ability resolves, you put each permanent the player controls into one of the two piles. For example, you could put a creature into one pile and an Aura enchanting that creature into the other pile."
         },
         {
           "date": "2017-03-14",
@@ -5960,11 +5963,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Mortician Beetle’s ability triggers whenever any player, including you, sacrifices a creature because some other spell, ability, or cost instructed the player to do so. Mortician Beetle itself doesn’t allow you to sacrifice any creatures."
+          "text": "Mortician Beetle's ability triggers whenever any player, including you, sacrifices a creature because some other spell, ability, or cost instructed the player to do so. Mortician Beetle itself doesn't allow you to sacrifice any creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "If a creature is sacrificed as a cost to cast a spell or activate an ability, Mortician Beetle’s ability resolves before that spell or ability."
+          "text": "If a creature is sacrificed as a cost to cast a spell or activate an ability, Mortician Beetle's ability resolves before that spell or ability."
         }
       ],
       "subtypes": [
@@ -6109,7 +6112,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Defender only matters when Ogre Jailbreaker could be declared as an attacking creature. If Ogre Jailbreaker is already attacking, losing control of your only Gate won’t cause Ogre Jailbreaker to leave combat."
+          "text": "Defender only matters when Ogre Jailbreaker could be declared as an attacking creature. If Ogre Jailbreaker is already attacking, losing control of your only Gate won't cause Ogre Jailbreaker to leave combat."
         }
       ],
       "subtypes": [
@@ -6132,7 +6135,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"The undead are not ‘awakened.' They are evicted when there is no room left in the pit for more bodies.\"",
+      "flavor": "\"The undead are not 'awakened.' They are evicted when there is no room left in the pit for more bodies.\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -6391,7 +6394,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Only creatures on the battlefield will be exiled. In other zones, they’re “creature cards,” not “creatures.”"
+          "text": "Only creatures on the battlefield will be exiled. In other zones, they're \"creature cards,\" not \"creatures.\""
         },
         {
           "date": "2017-03-14",
@@ -6399,11 +6402,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named “Beast.”"
+          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named \"Beast.\""
         },
         {
           "date": "2017-03-14",
-          "text": "A double-faced creature only has the name of the face that’s up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn’t be exiled."
+          "text": "A double-faced creature only has the name of the face that's up. For example, if Village Ironsmith is targeted by Sever the Bloodline, Ironfang wouldn't be exiled."
         }
       ],
       "text": "Exile target creature and all other creatures with the same name as that creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -6535,11 +6538,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You can sacrifice Vampire Aristocrat to activate its own ability, but it won’t be around to get the bonus."
+          "text": "You can sacrifice Vampire Aristocrat to activate its own ability, but it won't be around to get the bonus."
         },
         {
           "date": "2009-10-01",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature has been dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature has been dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -6764,11 +6767,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Battle-Rattle Shaman’s ability triggers when the beginning of combat step starts during each of your turns. It resolves before you declare attackers."
+          "text": "Battle-Rattle Shaman's ability triggers when the beginning of combat step starts during each of your turns. It resolves before you declare attackers."
         },
         {
           "date": "2017-03-14",
-          "text": "If a spell or ability causes your turn to have multiple combat phases, Battle Rattle Shaman’s ability triggers during each of them."
+          "text": "If a spell or ability causes your turn to have multiple combat phases, Battle Rattle Shaman's ability triggers during each of them."
         }
       ],
       "subtypes": [
@@ -6837,25 +6840,26 @@
         "8ED",
         "9ED",
         "MMA",
-        "MM3"
+        "MM3",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability “{T}: Add {R} to your mana pool.”"
+          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability \"{T}: Add {R} to your mana pool.\""
         },
         {
           "date": "2017-03-14",
-          "text": "Blood Moon’s effect doesn’t affect names or supertypes. It won’t turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won’t be named “Mountain.”"
+          "text": "Blood Moon's effect doesn't affect names or supertypes. It won't turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won't be named \"Mountain.\""
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply “as” a land enters the battlefield, such as the first ability of Cavern of Souls."
+          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply \"as\" a land enters the battlefield, such as the first ability of Cavern of Souls."
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that triggers “when” it enters the battlefield, it will lose that ability before it triggers."
+          "text": "If a nonbasic land has an ability that triggers \"when\" it enters the battlefield, it will lose that ability before it triggers."
         }
       ],
       "text": "Nonbasic lands are Mountains.",
@@ -6932,7 +6936,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Bonfire of the Damned’s converted mana cost is based on its mana cost of {X}{X}{R}, even if you’re casting it for its miracle cost. For example, if you cast Bonfire of the Damned for its miracle cost and choose 4 for X, its converted mana cost is 9."
+          "text": "Bonfire of the Damned's converted mana cost is based on its mana cost of {X}{X}{R}, even if you're casting it for its miracle cost. For example, if you cast Bonfire of the Damned for its miracle cost and choose 4 for X, its converted mana cost is 9."
         },
         {
           "date": "2017-03-14",
@@ -6940,7 +6944,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Preventing some or all of the damage dealt to the player won’t affect the amount of damage dealt to each creature that player controls. The same is true for any effect that increases or decreases the amount of damage dealt to the player."
+          "text": "Preventing some or all of the damage dealt to the player won't affect the amount of damage dealt to each creature that player controls. The same is true for any effect that increases or decreases the amount of damage dealt to the player."
         }
       ],
       "text": "Bonfire of the Damned deals X damage to target player and each creature he or she controls.\nMiracle {X}{R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
@@ -7010,7 +7014,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target creature is an illegal target by the time Chandra’s Outrage resolves, the entire spell is countered. No player is dealt damage."
+          "text": "If the target creature is an illegal target by the time Chandra's Outrage resolves, the entire spell is countered. No player is dealt damage."
         }
       ],
       "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
@@ -7153,23 +7157,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -7177,11 +7181,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         },
         {
           "date": "2017-03-14",
-          "text": "An overloaded Dynacharge affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn won’t get +2/+0."
+          "text": "An overloaded Dynacharge affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn won't get +2/+0."
         }
       ],
       "text": "Target creature you control gets +2/+0 until end of turn.\nOverload {2}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -7251,7 +7255,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Goblin Assault’s second ability affects all Goblin creatures controlled by all players. It’s not limited to the tokens created with the first ability."
+          "text": "Goblin Assault's second ability affects all Goblin creatures controlled by all players. It's not limited to the tokens created with the first ability."
         }
       ],
       "text": "At the beginning of your upkeep, create a 1/1 red Goblin creature token with haste.\nGoblin creatures attack each turn if able.",
@@ -7463,7 +7467,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The damage dealt by Hellrider’s triggered ability isn’t combat damage and may be redirected to a planeswalker controlled by the defending player."
+          "text": "The damage dealt by Hellrider's triggered ability isn't combat damage and may be redirected to a planeswalker controlled by the defending player."
         },
         {
           "date": "2017-03-14",
@@ -7629,11 +7633,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Magma Jet deals 2 damage to target creature or player. Scry 2.",
@@ -7703,23 +7707,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -7727,7 +7731,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -7810,7 +7814,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Although Mogg Flunkies can’t attack alone, other attacking creature(s) don’t have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
+          "text": "Although Mogg Flunkies can't attack alone, other attacking creature(s) don't have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
         },
         {
           "date": "2017-03-14",
@@ -7818,7 +7822,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player’s blocking creatures."
+          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player's blocking creatures."
         }
       ],
       "subtypes": [
@@ -8030,12 +8034,8 @@
       "rarity": "Mythic Rare",
       "rulings": [
         {
-          "date": "2013-07-01",
-          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
-        },
-        {
           "date": "2017-03-14",
-          "text": "Only instant and sorcery cards in your graveyard when Past in Flames resolves will gain flashback. Instant and sorcery cards that are put into your graveyard later in the turn, including the resolving Past in Flames, won’t gain flashback."
+          "text": "Only instant and sorcery cards in your graveyard when Past in Flames resolves will gain flashback. Instant and sorcery cards that are put into your graveyard later in the turn, including the resolving Past in Flames, won't gain flashback."
         },
         {
           "date": "2017-03-14",
@@ -8048,6 +8048,10 @@
         {
           "date": "2017-03-14",
           "text": "You may pay any optional additional costs the spell has, such as conspire costs. You must pay any mandatory additional costs the spell has, such as that of Bone Splinters."
+        },
+        {
+          "date": "2017-04-18",
+          "text": "For split cards, the flashback cost you pay is determined by the half you cast"
         }
       ],
       "text": "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -8117,19 +8121,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Pyrewild Shaman’s last ability triggers only once for each time combat damage is dealt, no matter how many creatures are dealing damage at that time."
+          "text": "Pyrewild Shaman's last ability triggers only once for each time combat damage is dealt, no matter how many creatures are dealing damage at that time."
         },
         {
           "date": "2017-03-14",
-          "text": "Pyrewild Shaman’s ability can trigger during each combat damage step. For example, if a creature with first strike deals combat damage, you can return Pyrewild Shaman to your hand and discard it using its bloodrush ability to pump up an attacking creature without first strike. Then, when that creature deals combat damage, you can return Pyrewild Shaman to your hand again."
+          "text": "Pyrewild Shaman's ability can trigger during each combat damage step. For example, if a creature with first strike deals combat damage, you can return Pyrewild Shaman to your hand and discard it using its bloodrush ability to pump up an attacking creature without first strike. Then, when that creature deals combat damage, you can return Pyrewild Shaman to your hand again."
         },
         {
           "date": "2017-03-14",
-          "text": "Pyrewild Shaman’s last ability triggers only if it’s in your graveyard when the creatures deal combat damage to a player. It returns to your hand only if it’s still in your graveyard when the ability resolves. Notably, if Pyrewild Shaman is dealt lethal damage at the same time that a creature you control deals combat damage to a player, Pyrewild Shaman’s ability won’t trigger."
+          "text": "Pyrewild Shaman's last ability triggers only if it's in your graveyard when the creatures deal combat damage to a player. It returns to your hand only if it's still in your graveyard when the ability resolves. Notably, if Pyrewild Shaman is dealt lethal damage at the same time that a creature you control deals combat damage to a player, Pyrewild Shaman's ability won't trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "If creatures you control deal combat damage to more than one player at the same time (perhaps because it’s a multiplayer game), Pyrewild Shaman’s ability will trigger once for each of those players. However, only the first such ability that you pay for will return Pyrewild Shaman to your hand. Even if it’s put back into your graveyard before the other abilities resolve, it’s considered a different Pyrewild Shaman than the one whose ability triggered."
+          "text": "If creatures you control deal combat damage to more than one player at the same time (perhaps because it's a multiplayer game), Pyrewild Shaman's ability will trigger once for each of those players. However, only the first such ability that you pay for will return Pyrewild Shaman to your hand. Even if it's put back into your graveyard before the other abilities resolve, it's considered a different Pyrewild Shaman than the one whose ability triggered."
         }
       ],
       "subtypes": [
@@ -8278,47 +8282,47 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If either of Pyromancer Ascension’s abilities triggers, it will go on the stack on top of the spell that caused it to trigger. The ability will resolve first. If it’s Pyromancer Ascension’s second ability that triggered, the copy it creates will also resolve before the original spell. The copy is created even if the original spell has been countered."
+          "text": "If either of Pyromancer Ascension's abilities triggers, it will go on the stack on top of the spell that caused it to trigger. The ability will resolve first. If it's Pyromancer Ascension's second ability that triggered, the copy it creates will also resolve before the original spell. The copy is created even if the original spell has been countered."
         },
         {
           "date": "2017-03-14",
-          "text": "If Pyromancer Ascension’s first ability triggers, you’ll put a quest counter on it even if the card in your graveyard leaves your graveyard by the time the ability resolves or if the spell you cast is countered."
+          "text": "If Pyromancer Ascension's first ability triggers, you'll put a quest counter on it even if the card in your graveyard leaves your graveyard by the time the ability resolves or if the spell you cast is countered."
         },
         {
           "date": "2017-03-14",
-          "text": "If you cast an instant or sorcery spell from your graveyard (due to an ability such as flashback, for example), Pyromancer Ascension’s first ability won’t trigger unless another card with the same name is in your graveyard."
+          "text": "If you cast an instant or sorcery spell from your graveyard (due to an ability such as flashback, for example), Pyromancer Ascension's first ability won't trigger unless another card with the same name is in your graveyard."
         },
         {
           "date": "2017-03-14",
-          "text": "The second ability triggers only if Pyromancer Ascension already has two quest counters on it at the time you cast an instant or sorcery spell. This means a spell can’t cause the second counter to be put on Pyromancer Ascension and then become copied. It also means a player can’t remove Pyromancer Ascension in response to you casting an instant or sorcery spell in order to prevent the ability from triggering."
+          "text": "The second ability triggers only if Pyromancer Ascension already has two quest counters on it at the time you cast an instant or sorcery spell. This means a spell can't cause the second counter to be put on Pyromancer Ascension and then become copied. It also means a player can't remove Pyromancer Ascension in response to you casting an instant or sorcery spell in order to prevent the ability from triggering."
         },
         {
           "date": "2017-03-14",
-          "text": "Pyromancer Ascension’s second ability can copy any instant or sorcery spell, not just one with targets."
+          "text": "Pyromancer Ascension's second ability can copy any instant or sorcery spell, not just one with targets."
         },
         {
           "date": "2017-03-14",
-          "text": "The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger."
+          "text": "The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. A different mode cannot be chosen."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. A different mode cannot be chosen."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Bonfire of the Damned does), the copy will have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Bonfire of the Damned does), the copy will have the same value of X."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell has damage divided as it was cast (like Fiery Justice does), the division can’t be changed (although the targets receiving that damage still can)."
+          "text": "If the spell has damage divided as it was cast (like Fiery Justice does), the division can't be changed (although the targets receiving that damage still can)."
         },
         {
           "date": "2017-03-14",
-          "text": "You can’t choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
+          "text": "You can't choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell that has the same name as a card in your graveyard, you may put a quest counter on Pyromancer Ascension.\nWhenever you cast an instant or sorcery spell while Pyromancer Ascension has two or more quest counters on it, you may copy that spell. You may choose new targets for the copy.",
@@ -8529,27 +8533,27 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         },
         {
           "date": "2017-03-14",
-          "text": "Scourge Devil’s triggered ability affects only creatures you control at the time it resolves, including Scourge Devil itself. Creatures you begin to control later in the turn won’t get +1/+0."
+          "text": "Scourge Devil's triggered ability affects only creatures you control at the time it resolves, including Scourge Devil itself. Creatures you begin to control later in the turn won't get +1/+0."
         }
       ],
       "subtypes": [
@@ -8762,7 +8766,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may target a creature you already control. You may target a creature that’s already untapped."
+          "text": "You may target a creature you already control. You may target a creature that's already untapped."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gets +2/+0 and gains haste.",
@@ -8833,23 +8837,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -8924,7 +8928,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "The enters-the-battlefield ability can target any permanent, including one that’s untapped or one that you already control."
+          "text": "The enters-the-battlefield ability can target any permanent, including one that's untapped or one that you already control."
         }
       ],
       "subtypes": [
@@ -8995,11 +8999,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You can tap any untapped Spider you control, including one you haven’t controlled continuously since the beginning of your most recent turn, to pay the cost of Arachnus Spinner’s activated ability. You can even tap Arachnus Spinner itself to pay this cost."
+          "text": "You can tap any untapped Spider you control, including one you haven't controlled continuously since the beginning of your most recent turn, to pay the cost of Arachnus Spinner's activated ability. You can even tap Arachnus Spinner itself to pay this cost."
         },
         {
           "date": "2017-03-14",
-          "text": "If you choose to search your library this way, you don’t have to find a card named Arachnus Web, even if one is there. You’ll still shuffle your library after searching it."
+          "text": "If you choose to search your library this way, you don't have to find a card named Arachnus Web, even if one is there. You'll still shuffle your library after searching it."
         },
         {
           "date": "2017-03-14",
@@ -9072,27 +9076,27 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2017-03-14",
-          "text": "Arachnus Web’s triggered ability checks at the beginning of each end step, not just yours."
+          "text": "Arachnus Web's triggered ability checks at the beginning of each end step, not just yours."
         },
         {
           "date": "2017-03-14",
-          "text": "If the enchanted creature’s power isn’t 4 or greater when the end step begins, the last ability won’t trigger at all."
+          "text": "If the enchanted creature's power isn't 4 or greater when the end step begins, the last ability won't trigger at all."
         },
         {
           "date": "2017-03-14",
-          "text": "If Arachnus Web’s last ability triggers, but the enchanted creature’s power is reduced to 3 or less before the ability resolves, the ability will have no effect. Arachnus Web won’t be destroyed."
+          "text": "If Arachnus Web's last ability triggers, but the enchanted creature's power is reduced to 3 or less before the ability resolves, the ability will have no effect. Arachnus Web won't be destroyed."
         },
         {
           "date": "2017-03-14",
-          "text": "If Arachnus Web enters the battlefield attached to an attacking or blocking creature (due to Arachnus Spinner’s ability, for example), that creature will continue to attack or block."
+          "text": "If Arachnus Web enters the battlefield attached to an attacking or blocking creature (due to Arachnus Spinner's ability, for example), that creature will continue to attack or block."
         },
         {
           "date": "2017-03-14",
-          "text": "Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected."
+          "text": "Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected."
         }
       ],
       "subtypes": [
@@ -9236,11 +9240,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -9387,11 +9391,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The value of X is determined only as Craterhoof Behemoth’s triggered ability resolves, potentially including Craterhoof Behemoth itself. It won’t change later in the turn if the number of creatures you control changes."
+          "text": "The value of X is determined only as Craterhoof Behemoth's triggered ability resolves, potentially including Craterhoof Behemoth itself. It won't change later in the turn if the number of creatures you control changes."
         },
         {
           "date": "2017-03-14",
-          "text": "Craterhoof Behemoth’s triggered ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Craterhoof Behemoth's triggered ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -9535,11 +9539,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -9547,11 +9551,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -9559,15 +9563,15 @@
         },
         {
           "date": "2017-03-14",
-          "text": "You can cast Druid’s Deliverance even if you don’t control any creature tokens."
+          "text": "You can cast Druid's Deliverance even if you don't control any creature tokens."
         },
         {
           "date": "2017-03-14",
-          "text": "Combat damage dealt to creatures or planeswalkers you control won’t be prevented."
+          "text": "Combat damage dealt to creatures or planeswalkers you control won't be prevented."
         },
         {
           "date": "2017-03-14",
-          "text": "In a Two-Headed Giant game, combat damage dealt to your teammate won’t be prevented."
+          "text": "In a Two-Headed Giant game, combat damage dealt to your teammate won't be prevented."
         }
       ],
       "text": "Prevent all combat damage that would be dealt to you this turn. Populate. (Create a token that's a copy of a creature token you control.)",
@@ -9639,15 +9643,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Explore’s effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don’t get to play a land as Explore resolves; Explore fully resolves first and draws a card, perhaps a land you’ll play later."
+          "text": "Explore's effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don't get to play a land as Explore resolves; Explore fully resolves first and draws a card, perhaps a land you'll play later."
         },
         {
           "date": "2017-03-14",
-          "text": "The effects of multiple Explores in the same turn are cumulative. They’re also cumulative with other effects that let you play additional lands, such as the one from Urban Evolution."
+          "text": "The effects of multiple Explores in the same turn are cumulative. They're also cumulative with other effects that let you play additional lands, such as the one from Urban Evolution."
         },
         {
           "date": "2017-03-14",
-          "text": "If you somehow manage to cast Explore when it’s not your turn, you’ll draw a card when it resolves, but you won’t be able to play a land that turn."
+          "text": "If you somehow manage to cast Explore when it's not your turn, you'll draw a card when it resolves, but you won't be able to play a land that turn."
         }
       ],
       "text": "You may play an additional land this turn.\nDraw a card.",
@@ -9717,15 +9721,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You create the Saproling tokens, even if Fists of Ironwood enters the battlefield attached to another player’s creature."
+          "text": "You create the Saproling tokens, even if Fists of Ironwood enters the battlefield attached to another player's creature."
         },
         {
           "date": "2017-03-14",
-          "text": "The Saproling tokens aren’t created until after Fists of Ironwood is on the battlefield, so you can’t cast Fists of Ironwood on one of those tokens."
+          "text": "The Saproling tokens aren't created until after Fists of Ironwood is on the battlefield, so you can't cast Fists of Ironwood on one of those tokens."
         },
         {
           "date": "2017-03-14",
-          "text": "If the target creature is an illegal target when Fists of Ironwood tries to resolve, Fists of Ironwood will be countered and won’t enter the battlefield. You won’t create Saproling tokens."
+          "text": "If the target creature is an illegal target when Fists of Ironwood tries to resolve, Fists of Ironwood will be countered and won't enter the battlefield. You won't create Saproling tokens."
         }
       ],
       "subtypes": [
@@ -10018,7 +10022,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If a Might of Old Krosa on the stack is copied, the copy will give only +2/+2, even if it’s your main phase. This is because you didn’t cast the copy."
+          "text": "If a Might of Old Krosa on the stack is copied, the copy will give only +2/+2, even if it's your main phase. This is because you didn't cast the copy."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
@@ -10162,11 +10166,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Primal Command’s modes are performed in the order listed. If you put a noncreature permanent on top of its owner’s library and have that player shuffle his or her graveyard into his or her library, that card is shuffled away."
+          "text": "Primal Command's modes are performed in the order listed. If you put a noncreature permanent on top of its owner's library and have that player shuffle his or her graveyard into his or her library, that card is shuffled away."
         },
         {
           "date": "2017-03-14",
-          "text": "Primal Command won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect if you target yourself with its third mode."
+          "text": "Primal Command won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect if you target yourself with its third mode."
         }
       ],
       "text": "Choose two —\n• Target player gains 7 life.\n• Put target noncreature permanent on top of its owner's library.\n• Target player shuffles his or her graveyard into his or her library.\n• Search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
@@ -10302,7 +10306,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. No +1/+1 counter will be put on Scavenging Ooze and you won’t gain life. Notably, this means that if you activate Scavenging Ooze’s ability multiple times targeting the same creature card, only the first instance of the ability to resolve will have any effect."
+          "text": "If the target card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. No +1/+1 counter will be put on Scavenging Ooze and you won't gain life. Notably, this means that if you activate Scavenging Ooze's ability multiple times targeting the same creature card, only the first instance of the ability to resolve will have any effect."
         }
       ],
       "subtypes": [
@@ -10384,7 +10388,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "You can activate Seal of Primordium’s ability targeting Seal of Primordium itself if you want it to leave the battlefield. This is because targets are chosen before costs are paid. The ability will be countered as it tries to resolve."
+          "text": "You can activate Seal of Primordium's ability targeting Seal of Primordium itself if you want it to leave the battlefield. This is because targets are chosen before costs are paid. The ability will be countered as it tries to resolve."
         }
       ],
       "text": "Sacrifice Seal of Primordium: Destroy target artifact or enchantment.",
@@ -10588,7 +10592,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The value of X is determined only as Strength in Numbers resolves. It won’t change later in the turn if the number of attacking creatures changes."
+          "text": "The value of X is determined only as Strength in Numbers resolves. It won't change later in the turn if the number of attacking creatures changes."
         }
       ],
       "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of attacking creatures.",
@@ -10657,11 +10661,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -10669,7 +10673,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If there are seven or fewer cards in your library, you’ll look at all of them."
+          "text": "If there are seven or fewer cards in your library, you'll look at all of them."
         }
       ],
       "subtypes": [
@@ -10815,7 +10819,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Tarmogoyf’s ability works in all zones, not just while Tarmogoyf is on the battlefield."
+          "text": "Tarmogoyf's ability works in all zones, not just while Tarmogoyf is on the battlefield."
         },
         {
           "date": "2017-03-14",
@@ -10905,19 +10909,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You choose whether to kick a spell as you cast it, and you pay that much along with the spell’s mana cost at the same time. Kicking a spell is always optional."
+          "text": "You choose whether to kick a spell as you cast it, and you pay that much along with the spell's mana cost at the same time. Kicking a spell is always optional."
         },
         {
           "date": "2017-03-14",
-          "text": "You can pay any particular kicker cost only once. You can’t pay it multiple times to get multiples of either triggered ability."
+          "text": "You can pay any particular kicker cost only once. You can't pay it multiple times to get multiples of either triggered ability."
         },
         {
           "date": "2017-03-14",
-          "text": "If Thornscape Battlemage is put onto the battlefield as the result of a spell or ability, there’s no opportunity to kick it."
+          "text": "If Thornscape Battlemage is put onto the battlefield as the result of a spell or ability, there's no opportunity to kick it."
         },
         {
           "date": "2017-03-14",
-          "text": "Kicker costs don’t change a spell’s mana cost or converted mana cost."
+          "text": "Kicker costs don't change a spell's mana cost or converted mana cost."
         }
       ],
       "subtypes": [
@@ -10990,7 +10994,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Thragtusk’s second ability will trigger no matter what zone Thragtusk goes to."
+          "text": "Thragtusk's second ability will trigger no matter what zone Thragtusk goes to."
         }
       ],
       "subtypes": [
@@ -11065,11 +11069,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The second target of Ulvenwald Tracker’s ability can be another creature you control, but it can’t be the same creature as the first target."
+          "text": "The second target of Ulvenwald Tracker's ability can be another creature you control, but it can't be the same creature as the first target."
         },
         {
           "date": "2017-03-14",
-          "text": "If either target of Ulvenwald Tracker’s ability is an illegal target when the ability tries to resolve, neither creature will deal or be dealt damage."
+          "text": "If either target of Ulvenwald Tracker's ability is an illegal target when the ability tries to resolve, neither creature will deal or be dealt damage."
         }
       ],
       "subtypes": [
@@ -11216,7 +11220,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The converted mana cost of a creature token is 0, unless that token is a copy of another creature, in which case it copies that creature’s mana cost."
+          "text": "The converted mana cost of a creature token is 0, unless that token is a copy of another creature, in which case it copies that creature's mana cost."
         },
         {
           "date": "2017-03-14",
@@ -11359,19 +11363,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If you don’t reveal any creature cards, or if you choose not to put a revealed creature card onto the battlefield, all the revealed cards go on the bottom of your library."
+          "text": "If you don't reveal any creature cards, or if you choose not to put a revealed creature card onto the battlefield, all the revealed cards go on the bottom of your library."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature that you put onto the battlefield leaves the battlefield before your next end step, it won’t be returned to your hand at the beginning of your next end step."
+          "text": "If the creature that you put onto the battlefield leaves the battlefield before your next end step, it won't be returned to your hand at the beginning of your next end step."
         },
         {
           "date": "2017-03-14",
-          "text": "If you put a creature onto the battlefield this way during your end step, it won’t be returned to your hand until your next end step."
+          "text": "If you put a creature onto the battlefield this way during your end step, it won't be returned to your hand until your next end step."
         },
         {
           "date": "2017-03-14",
-          "text": "The triggered ability that the creature gains won’t be copied if an effect creates a token that’s a copy of that creature or causes another object to become a copy of that creature."
+          "text": "The triggered ability that the creature gains won't be copied if an effect creates a token that's a copy of that creature or causes another object to become a copy of that creature."
         }
       ],
       "text": "Reveal the top four cards of your library. You may put a creature card from among them onto the battlefield. It gains \"At the beginning of your end step, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
@@ -11869,11 +11873,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Carnage Gladiator’s ability triggers whenever any creature blocks, regardless of who controls that creature or which creature it blocked."
+          "text": "Carnage Gladiator's ability triggers whenever any creature blocks, regardless of who controls that creature or which creature it blocked."
         },
         {
           "date": "2017-03-14",
-          "text": "If a creature can block multiple creatures and does so, Carnage Gladiator’s ability triggers only once."
+          "text": "If a creature can block multiple creatures and does so, Carnage Gladiator's ability triggers only once."
         }
       ],
       "subtypes": [
@@ -12106,7 +12110,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Cruel Ultimatum’s only target is an opponent. You don’t choose which creature card in your graveyard you’ll return to your hand until Cruel Ultimatum resolves."
+          "text": "Cruel Ultimatum's only target is an opponent. You don't choose which creature card in your graveyard you'll return to your hand until Cruel Ultimatum resolves."
         },
         {
           "date": "2017-03-14",
@@ -12114,7 +12118,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If, as Cruel Ultimatum begins to resolve, your opponent’s life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent’s life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You’ll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
+          "text": "If, as Cruel Ultimatum begins to resolve, your opponent's life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent's life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You'll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
         }
       ],
       "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
@@ -12259,15 +12263,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target permanent is an illegal target when Dinrova Horror’s ability tries to resolve, the ability will be countered and none of its effects will happen. No player will discard a card."
+          "text": "If the target permanent is an illegal target when Dinrova Horror's ability tries to resolve, the ability will be countered and none of its effects will happen. No player will discard a card."
         },
         {
           "date": "2017-03-14",
-          "text": "If a player has no cards in his or her hand and Dinrova Horror returns a card to that player’s hand, the player must discard that card. He or she won’t have the opportunity to cast that card (or do anything else with it) before discarding it."
+          "text": "If a player has no cards in his or her hand and Dinrova Horror returns a card to that player's hand, the player must discard that card. He or she won't have the opportunity to cast that card (or do anything else with it) before discarding it."
         },
         {
           "date": "2017-03-14",
-          "text": "A token permanent returned to a player’s hand isn’t a card and can’t be discarded. It will cease to exist when state-based actions are performed after the ability finishes resolving."
+          "text": "A token permanent returned to a player's hand isn't a card and can't be discarded. It will cease to exist when state-based actions are performed after the ability finishes resolving."
         }
       ],
       "subtypes": [
@@ -12343,15 +12347,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "When resolving Domri’s first ability, if the card you look at isn’t a creature card, or if it’s a creature card you don’t want to put into your hand, you simply put it back on top of your library. You don’t reveal it or say why you’re putting it back."
+          "text": "When resolving Domri's first ability, if the card you look at isn't a creature card, or if it's a creature card you don't want to put into your hand, you simply put it back on top of your library. You don't reveal it or say why you're putting it back."
         },
         {
           "date": "2017-03-14",
-          "text": "The second target of Domri’s second ability can be another creature you control, but it can’t be the same creature as the first target."
+          "text": "The second target of Domri's second ability can be another creature you control, but it can't be the same creature as the first target."
         },
         {
           "date": "2017-03-14",
-          "text": "If either target of Domri’s second ability is an illegal target when the ability tries to resolve, neither creature will deal or be dealt damage."
+          "text": "If either target of Domri's second ability is an illegal target when the ability tries to resolve, neither creature will deal or be dealt damage."
         },
         {
           "date": "2017-03-14",
@@ -12431,7 +12435,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Evil Twin copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it gains the activated ability. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Evil Twin copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it gains the activated ability. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2017-03-14",
@@ -12451,15 +12455,15 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named “Beast.”"
+          "text": "Unless a token is a copy of another creature or was explicitly given a name by the effect that created it, its name is the creature types it was given when it was created. For example, the Beast tokens created by Thragtusk and by Baloth Cage Trap are both named \"Beast.\""
         },
         {
           "date": "2017-03-14",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Evil Twin enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Evil Twin enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2017-03-14",
-          "text": "If Evil Twin somehow enters the battlefield at the same time as another creature, Evil Twin can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Evil Twin somehow enters the battlefield at the same time as another creature, Evil Twin can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2017-03-14",
@@ -12540,7 +12544,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Falkenrath Aristocrat’s activated ability checks whether the sacrificed creature as it last existed on the battlefield was a Human. It doesn’t matter what its creature types are in the graveyard."
+          "text": "Falkenrath Aristocrat's activated ability checks whether the sacrificed creature as it last existed on the battlefield was a Human. It doesn't matter what its creature types are in the graveyard."
         },
         {
           "date": "2017-03-14",
@@ -12640,7 +12644,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The target opponent for the life-gaining effect may also be a target for the damage-dealing effect. If this happens and the damage brings that player’s life total to 0 or less, the life-gaining effect will raise his or her life total above 0 again before the player would lose the game."
+          "text": "The target opponent for the life-gaining effect may also be a target for the damage-dealing effect. If this happens and the damage brings that player's life total to 0 or less, the life-gaining effect will raise his or her life total above 0 again before the player would lose the game."
         }
       ],
       "text": "Fiery Justice deals 5 damage divided as you choose among any number of target creatures and/or players. Target opponent gains 5 life.",
@@ -12792,11 +12796,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Goblin Electromancer can’t reduce colored mana costs or {C} in the cost of instant or sorcery spells."
+          "text": "Goblin Electromancer can't reduce colored mana costs or {C} in the cost of instant or sorcery spells."
         },
         {
           "date": "2017-03-14",
-          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben’s ability), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben's ability), apply those increases before applying cost reductions."
         },
         {
           "date": "2017-03-14",
@@ -13218,7 +13222,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "When Kathari Bomber’s triggered ability resolves, you create two Goblin tokens regardless of how much combat damage Kathari Bomber dealt to the player. You create the tokens even if you can’t sacrifice Kathari Bomber."
+          "text": "When Kathari Bomber's triggered ability resolves, you create two Goblin tokens regardless of how much combat damage Kathari Bomber dealt to the player. You create the tokens even if you can't sacrifice Kathari Bomber."
         }
       ],
       "subtypes": [
@@ -13367,11 +13371,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the target spell is an illegal target when Mystic Genesis tries to resolve, Mystic Genesis will be countered and none of its effects will happen. You won’t get an Ooze token."
+          "text": "If the target spell is an illegal target when Mystic Genesis tries to resolve, Mystic Genesis will be countered and none of its effects will happen. You won't get an Ooze token."
         },
         {
           "date": "2017-03-14",
-          "text": "You may target a spell that can’t be countered. When Mystic Genesis resolves, the target spell will be unaffected, but you’ll still get an Ooze token."
+          "text": "You may target a spell that can't be countered. When Mystic Genesis resolves, the target spell will be unaffected, but you'll still get an Ooze token."
         }
       ],
       "text": "Counter target spell. Create an X/X green Ooze creature token, where X is that spell's converted mana cost.",
@@ -13518,11 +13522,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Once Obzedat’s ability has returned it to the battlefield, it has haste for as long as it remains on the battlefield. If an opponent gains control of it (perhaps with Olivia Voldaren or Soul Ransom), it can attack that turn."
+          "text": "Once Obzedat's ability has returned it to the battlefield, it has haste for as long as it remains on the battlefield. If an opponent gains control of it (perhaps with Olivia Voldaren or Soul Ransom), it can attack that turn."
         },
         {
           "date": "2017-03-14",
-          "text": "If you gain control of Obzedat “until end of turn,” you’ll control it during your end step and you choose whether to exile it. If you do, it returns to the battlefield under its owner’s control at the beginning of your next upkeep, not its owner’s next upkeep."
+          "text": "If you gain control of Obzedat \"until end of turn,\" you'll control it during your end step and you choose whether to exile it. If you do, it returns to the battlefield under its owner's control at the beginning of your next upkeep, not its owner's next upkeep."
         }
       ],
       "subtypes": [
@@ -13606,7 +13610,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If you activate Olivia Voldaren’s last ability, and before that ability resolves you lose control of Olivia Voldaren, the ability will resolve with no effect. You won’t gain control of the targeted Vampire."
+          "text": "If you activate Olivia Voldaren's last ability, and before that ability resolves you lose control of Olivia Voldaren, the ability will resolve with no effect. You won't gain control of the targeted Vampire."
         }
       ],
       "subtypes": [
@@ -13685,7 +13689,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you target yourself, you’ll put the top two cards of your library into your graveyard before drawing cards."
+          "text": "If you target yourself, you'll put the top two cards of your library into your graveyard before drawing cards."
         }
       ],
       "text": "Target player puts the top two cards of his or her library into his or her graveyard. Draw two cards.",
@@ -13767,7 +13771,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an artifact, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an artifact, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target artifact or creature. It can't be regenerated.",
@@ -13916,23 +13920,23 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If you activate a card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2008-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Remove Soul) will not."
         },
         {
           "date": "2008-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The unearth effect will no longer apply to it."
         }
       ],
       "subtypes": [
@@ -14083,7 +14087,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "No player can do anything between you choosing a card and that card being exiled. Notably, your opponent can’t cast the card once Sin Collector’s ability has started to resolve."
+          "text": "No player can do anything between you choosing a card and that card being exiled. Notably, your opponent can't cast the card once Sin Collector's ability has started to resolve."
         }
       ],
       "subtypes": [
@@ -14239,11 +14243,11 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "You may choose just the first mode (targeting a creature spell), just the second mode (targeting a creature card in your graveyard), or both modes (targeting a creature spell and a creature card in your graveyard). You can’t choose a mode unless there’s a legal target for it."
+          "text": "You may choose just the first mode (targeting a creature spell), just the second mode (targeting a creature card in your graveyard), or both modes (targeting a creature spell and a creature card in your graveyard). You can't choose a mode unless there's a legal target for it."
         },
         {
           "date": "2009-05-01",
-          "text": "If you choose both modes, you choose their targets at the same time. You can’t counter your own creature spell and then return that card from your graveyard to your hand."
+          "text": "If you choose both modes, you choose their targets at the same time. You can't counter your own creature spell and then return that card from your graveyard to your hand."
         }
       ],
       "text": "Choose one or both —\n• Counter target creature spell.\n• Return target creature card from your graveyard to your hand.",
@@ -14315,11 +14319,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "In most cases, you’ll enchant a creature controlled by an opponent, which will cause you to gain control of that creature. Any of your opponents can activate the last ability of Soul Ransom by discarding two cards. When that ability resolves, you’ll sacrifice Soul Ransom and draw two cards."
+          "text": "In most cases, you'll enchant a creature controlled by an opponent, which will cause you to gain control of that creature. Any of your opponents can activate the last ability of Soul Ransom by discarding two cards. When that ability resolves, you'll sacrifice Soul Ransom and draw two cards."
         },
         {
           "date": "2017-03-14",
-          "text": "You’ll draw two cards even if you can’t sacrifice Soul Ransom, perhaps because it left the battlefield in response to Soul Ransom’s ability."
+          "text": "You'll draw two cards even if you can't sacrifice Soul Ransom, perhaps because it left the battlefield in response to Soul Ransom's ability."
         }
       ],
       "subtypes": [
@@ -14394,7 +14398,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "If the value chosen for X is larger than the number of cards left in your library, you’ll lose the game the next time state-based actions are performed."
+          "text": "If the value chosen for X is larger than the number of cards left in your library, you'll lose the game the next time state-based actions are performed."
         }
       ],
       "text": "You gain X life and draw X cards.",
@@ -14620,7 +14624,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Noncreature permanents will untap as normal during their controllers’ untap steps."
+          "text": "Noncreature permanents will untap as normal during their controllers' untap steps."
         }
       ],
       "subtypes": [
@@ -14696,7 +14700,7 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "Only creatures you control when Sunhome Guildmage’s first ability resolves will get +1/+0. Creatures that come under your control later in the turn will not."
+          "text": "Only creatures you control when Sunhome Guildmage's first ability resolves will get +1/+0. Creatures that come under your control later in the turn will not."
         }
       ],
       "subtypes": [
@@ -14844,23 +14848,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -14868,11 +14872,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         },
         {
           "date": "2017-03-14",
-          "text": "The set of creatures that gets +1/+0 from an overloaded Teleportal is determined as the spell resolves. Creatures you begin to control later in the turn won’t get +1/+0. However, because the second part of Teleportal’s effect doesn’t change the characteristics of any permanents, the set of creatures that can’t be blocked is constantly updated. Any creature you control at the moment blockers are chosen can’t be blocked."
+          "text": "The set of creatures that gets +1/+0 from an overloaded Teleportal is determined as the spell resolves. Creatures you begin to control later in the turn won't get +1/+0. However, because the second part of Teleportal's effect doesn't change the characteristics of any permanents, the set of creatures that can't be blocked is constantly updated. Any creature you control at the moment blockers are chosen can't be blocked."
         }
       ],
       "text": "Target creature you control gets +1/+0 until end of turn and can't be blocked this turn.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -15245,15 +15249,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Urban Evolution’s effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don’t get to play a land as Urban Evolution resolves; Urban Evolution fully resolves first and draws three cards, perhaps including a land you’ll play later."
+          "text": "Urban Evolution's effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don't get to play a land as Urban Evolution resolves; Urban Evolution fully resolves first and draws three cards, perhaps including a land you'll play later."
         },
         {
           "date": "2017-03-14",
-          "text": "The effects of multiple Urban Evolutions in the same turn are cumulative. They’re also cumulative with other effects that let you play additional lands, such as the one from Explore."
+          "text": "The effects of multiple Urban Evolutions in the same turn are cumulative. They're also cumulative with other effects that let you play additional lands, such as the one from Explore."
         },
         {
           "date": "2017-03-14",
-          "text": "If you somehow manage to cast Urban Evolution when it’s not your turn, you’ll draw three cards when it resolves, but you won’t be able to play a land that turn."
+          "text": "If you somehow manage to cast Urban Evolution when it's not your turn, you'll draw three cards when it resolves, but you won't be able to play a land that turn."
         }
       ],
       "text": "Draw three cards. You may play an additional land this turn.",
@@ -15326,15 +15330,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Vanish into Memory cares about the creature’s power just before it left the battlefield and its toughness just after it returns to the battlefield. For example, if you target a 2/2 creature with two +1/+1 counters on it, you’ll draw four cards, then when it returns to the battlefield without any counters on it, you’ll discard two cards."
+          "text": "Vanish into Memory cares about the creature's power just before it left the battlefield and its toughness just after it returns to the battlefield. For example, if you target a 2/2 creature with two +1/+1 counters on it, you'll draw four cards, then when it returns to the battlefield without any counters on it, you'll discard two cards."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature exiled with Vanish into Memory never returns to the battlefield (because it was a token creature, for example), you don’t discard any cards."
+          "text": "If the creature exiled with Vanish into Memory never returns to the battlefield (because it was a token creature, for example), you don't discard any cards."
         },
         {
           "date": "2017-03-14",
-          "text": "If the creature exiled with Vanish into Memory isn’t a creature card (for example, a crewed Vehicle), that card will still be returned to the battlefield, but not as a creature. Since the card returned to the battlefield has no toughness, you discard no cards."
+          "text": "If the creature exiled with Vanish into Memory isn't a creature card (for example, a crewed Vehicle), that card will still be returned to the battlefield, but not as a creature. Since the card returned to the battlefield has no toughness, you discard no cards."
         }
       ],
       "text": "Exile target creature. You draw cards equal to that creature's power. At the beginning of your next upkeep, return that card to the battlefield under its owner's control. If you do, discard cards equal to that creature's toughness.",
@@ -15406,11 +15410,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Voice of Resurgence’s ability triggers because an opponent cast a spell during your turn, the token will be created before that spell resolves."
+          "text": "If Voice of Resurgence's ability triggers because an opponent cast a spell during your turn, the token will be created before that spell resolves."
         },
         {
           "date": "2017-03-14",
-          "text": "The power and toughness of the token change as the number of creatures you control changes. The token’s ability counts itself, so it’ll be at least 1/1."
+          "text": "The power and toughness of the token change as the number of creatures you control changes. The token's ability counts itself, so it'll be at least 1/1."
         },
         {
           "date": "2017-03-14",
@@ -15563,11 +15567,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -15575,11 +15579,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -15587,11 +15591,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The ability that defines Wayfaring Temple’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Wayfaring Temple's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2017-03-14",
-          "text": "As long as Wayfaring Temple is on the battlefield, its first ability will count itself, so it’ll be at least 1/1."
+          "text": "As long as Wayfaring Temple is on the battlefield, its first ability will count itself, so it'll be at least 1/1."
         }
       ],
       "subtypes": [
@@ -15743,7 +15747,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "An Aura put onto the battlefield without being cast doesn’t target anything, so it could be attached to a permanent with shroud or hexproof. However, the Aura’s enchant ability restricts what it can be attached to."
+          "text": "An Aura put onto the battlefield without being cast doesn't target anything, so it could be attached to a permanent with shroud or hexproof. However, the Aura's enchant ability restricts what it can be attached to."
         }
       ],
       "subtypes": [
@@ -15889,11 +15893,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Boros Reckoner’s first ability will trigger even if it is dealt lethal damage. For example, if it blocks a 7/7 creature, its ability will trigger and Boros Reckoner will deal 7 damage to the target creature or player."
+          "text": "Boros Reckoner's first ability will trigger even if it is dealt lethal damage. For example, if it blocks a 7/7 creature, its ability will trigger and Boros Reckoner will deal 7 damage to the target creature or player."
         },
         {
           "date": "2017-03-14",
-          "text": "Damage dealt by Boros Reckoner due to its first ability isn’t combat damage, even if it was combat damage that caused that ability to trigger."
+          "text": "Damage dealt by Boros Reckoner due to its first ability isn't combat damage, even if it was combat damage that caused that ability to trigger."
         },
         {
           "date": "2017-03-14",
@@ -15976,7 +15980,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Burning-Tree Emissary’s ability isn’t a mana ability. It uses the stack and can be responded to."
+          "text": "Burning-Tree Emissary's ability isn't a mana ability. It uses the stack and can be responded to."
         }
       ],
       "subtypes": [
@@ -16052,7 +16056,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The delayed triggered ability that exiles the token isn’t a characteristic of the token. If an effect such as populate copies the token, the new token won’t be exiled."
+          "text": "The delayed triggered ability that exiles the token isn't a characteristic of the token. If an effect such as populate copies the token, the new token won't be exiled."
         }
       ],
       "text": "Create a 4/4 red and green Giant Warrior creature token with haste. Exile it at the beginning of the next end step.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)",
@@ -16268,11 +16272,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -16280,11 +16284,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -16292,7 +16296,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "You must target an artifact or enchantment to cast Sundering Growth. If that artifact or enchantment is an illegal target when Sundering Growth tries to resolve, it will be countered and none of its effects will happen. You won’t populate."
+          "text": "You must target an artifact or enchantment to cast Sundering Growth. If that artifact or enchantment is an illegal target when Sundering Growth tries to resolve, it will be countered and none of its effects will happen. You won't populate."
         }
       ],
       "text": "Destroy target artifact or enchantment, then populate. (Create a token that's a copy of a creature token you control.)",
@@ -16442,7 +16446,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -16518,27 +16522,27 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If a spell gains a second instance of conspire from Wort’s ability, you may choose to pay for one, both, or none of those abilities. Each conspire ability triggers only if you tap two creatures specifically for that ability."
+          "text": "If a spell gains a second instance of conspire from Wort's ability, you may choose to pay for one, both, or none of those abilities. Each conspire ability triggers only if you tap two creatures specifically for that ability."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. A different mode can’t be chosen."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. A different mode can't be chosen."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Bonfire of the Damned does), the copy will have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Bonfire of the Damned does), the copy will have the same value of X."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell has damage divided as it was cast (like Fiery Justice does), the division can’t be changed (although the targets receiving that damage still can)."
+          "text": "If the spell has damage divided as it was cast (like Fiery Justice does), the division can't be changed (although the targets receiving that damage still can)."
         },
         {
           "date": "2017-03-14",
-          "text": "Some spells instruct you to sacrifice a creature as an additional cost to cast that spell. If you sacrifice Wort to pay that cost, that spell won’t have conspire at the moment it becomes cast, so conspire won’t trigger, even if you tapped two creatures."
+          "text": "Some spells instruct you to sacrifice a creature as an additional cost to cast that spell. If you sacrifice Wort to pay that cost, that spell won't have conspire at the moment it becomes cast, so conspire won't trigger, even if you tapped two creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "If you’re casting a spell for its flashback cost, you can’t pay another alternative cost (such as an overload cost or a Trap’s alternative cost) instead. You may pay additional costs, such as conspire."
+          "text": "If you're casting a spell for its flashback cost, you can't pay another alternative cost (such as an overload cost or a Trap's alternative cost) instead. You may pay additional costs, such as conspire."
         }
       ],
       "subtypes": [
@@ -16800,7 +16804,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keyword abilities, such as equip, are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keyword abilities, such as equip, are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2017-03-14",
@@ -16808,7 +16812,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Damping Matrix’s ability affects only artifacts and creatures on the battlefield. Activated abilities that work in other zones (such as bloodrush or unearth) can still be activated. Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected."
+          "text": "Damping Matrix's ability affects only artifacts and creatures on the battlefield. Activated abilities that work in other zones (such as bloodrush or unearth) can still be activated. Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected."
         }
       ],
       "text": "Activated abilities of artifacts and creatures can't be activated unless they're mana abilities.",
@@ -17007,19 +17011,19 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The second ability doesn’t stop players from playing land cards from graveyards or libraries since lands aren’t cast."
+          "text": "The second ability doesn't stop players from playing land cards from graveyards or libraries since lands aren't cast."
         },
         {
           "date": "2017-04-18",
-          "text": "A noncreature card can enter the battlefield from a graveyard or library if another card’s effect (such as that of March of the Machines) will make it a creature after it has entered the battlefield."
+          "text": "A noncreature card can enter the battlefield from a graveyard or library if another card's effect (such as that of March of the Machines) will make it a creature after it has entered the battlefield."
         },
         {
           "date": "2017-04-18",
-          "text": "If an object has a static ability that could cause it to become a creature or stop being a creature, that ability is considered when applying Grafdigger’s Cage. For example, Rusted Relic can enter the battlefield from a graveyard or library only if you control fewer than three artifacts before it enters. Thassa, God of the Sea can enter only if your devotion to blue is less than five before it enters."
+          "text": "If an object has a static ability that could cause it to become a creature or stop being a creature, that ability is considered when applying Grafdigger's Cage. For example, Rusted Relic can enter the battlefield from a graveyard or library only if you control fewer than three artifacts before it enters. Thassa, God of the Sea can enter only if your devotion to blue is less than five before it enters."
         },
         {
           "date": "2017-04-18",
-          "text": "Applying a replacement effect may cause Grafdigger’s Cage to stop an object from entering the battlefield. For example, Sculpting Steel can enter the battlefield from a graveyard or library only if it’s not entering as a copy of an artifact creature. However, a replacement effect can’t be applied to cause Grafdigger’s Cage to not apply. Phyrexian Metamorph can’t enter the battlefield even if you wish to copy a noncreature artifact."
+          "text": "Applying a replacement effect may cause Grafdigger's Cage to stop an object from entering the battlefield. For example, Sculpting Steel can enter the battlefield from a graveyard or library only if it's not entering as a copy of an artifact creature. However, a replacement effect can't be applied to cause Grafdigger's Cage to not apply. Phyrexian Metamorph can't enter the battlefield even if you wish to copy a noncreature artifact."
         }
       ],
       "text": "Creature cards can't enter the battlefield from graveyards or libraries.\nPlayers can't cast spells from graveyards or libraries.",
@@ -17746,11 +17750,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You must choose an existing creature type, such as Zombie or Warrior. Card types such as artifact can’t be chosen."
+          "text": "You must choose an existing creature type, such as Zombie or Warrior. Card types such as artifact can't be chosen."
         },
         {
           "date": "2017-03-14",
-          "text": "The spell can’t be countered if the mana produced by Cavern of Souls is spent to cover any cost of the spell, even an additional cost such as a kicker cost. This is true even if you use the mana to pay an additional cost while casting a spell “without paying its mana cost.”"
+          "text": "The spell can't be countered if the mana produced by Cavern of Souls is spent to cover any cost of the spell, even an additional cost such as a kicker cost. This is true even if you use the mana to pay an additional cost while casting a spell \"without paying its mana cost.\""
         }
       ],
       "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",

--- a/json/MMA.json
+++ b/json/MMA.json
@@ -85,7 +85,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Adarkar Valkyrie’s ability can target a token creature, but since token creatures cease to exist when they leave the battlefield, it won’t be returned to the battlefield."
+          "text": "Adarkar Valkyrie's ability can target a token creature, but since token creatures cease to exist when they leave the battlefield, it won't be returned to the battlefield."
         }
       ],
       "subtypes": [
@@ -269,11 +269,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The last sentence applies only if your life total is being reduced by damage. Other effects or costs (such as “lose 1 life” or “pay 1 life”) can reduce your life total below 1 as normal."
+          "text": "The last sentence applies only if your life total is being reduced by damage. Other effects or costs (such as \"lose 1 life\" or \"pay 1 life\") can reduce your life total below 1 as normal."
         },
         {
           "date": "2006-09-25",
-          "text": "You can’t pay more life than you have."
+          "text": "You can't pay more life than you have."
         },
         {
           "date": "2006-09-25",
@@ -281,11 +281,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "After the effect wears off during the cleanup step, you’ll lose the game if your total is 0 or less (or you have ten or more poison counters)."
+          "text": "After the effect wears off during the cleanup step, you'll lose the game if your total is 0 or less (or you have ten or more poison counters)."
         },
         {
           "date": "2006-09-25",
-          "text": "Angel’s Grace doesn’t prevent damage. It only changes the result of damage dealt to you. For example, a creature with lifelink that deals damage to you will still cause its controller to gain life, even if that damage would reduce your life total to less than 1."
+          "text": "Angel's Grace doesn't prevent damage. It only changes the result of damage dealt to you. For example, a creature with lifelink that deals damage to you will still cause its controller to gain life, even if that damage would reduce your life total to less than 1."
         },
         {
           "date": "2013-06-07",
@@ -293,23 +293,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
@@ -491,7 +491,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The second mode affects all creatures during the player’s next untap step, including creatures controlled by other players (who may have untapped because of Seedborn Muse, for example) and creatures that weren’t on the battlefield when Blinding Beam resolved."
+          "text": "The second mode affects all creatures during the player's next untap step, including creatures controlled by other players (who may have untapped because of Seedborn Muse, for example) and creatures that weren't on the battlefield when Blinding Beam resolved."
         }
       ],
       "text": "Choose one —\n• Tap two target creatures.\n• Creatures don't untap during target player's next untap step.\nEntwine {1} (Choose both if you pay the entwine cost.)",
@@ -550,11 +550,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you put Bound in Silence onto the battlefield without casting it, perhaps using the “recruiting” ability of a card like Amrou Scout, it will enter attached to a creature. You choose that creature as you’re putting it onto the battlefield. If there’s no creature on the battlefield it can be attached to, it stays in whatever zone it was in."
+          "text": "If you put Bound in Silence onto the battlefield without casting it, perhaps using the \"recruiting\" ability of a card like Amrou Scout, it will enter attached to a creature. You choose that creature as you're putting it onto the battlefield. If there's no creature on the battlefield it can be attached to, it stays in whatever zone it was in."
         },
         {
           "date": "2007-05-01",
-          "text": "Bound in Silence isn’t a creature and isn’t affected by any effect that affects creatures or Rebel creatures."
+          "text": "Bound in Silence isn't a creature and isn't affected by any effect that affects creatures or Rebel creatures."
         }
       ],
       "subtypes": [
@@ -618,7 +618,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -626,11 +626,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Create two 1/1 white Kithkin Soldier creature tokens.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -869,11 +869,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren’t permanents and don’t exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
+          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren't permanents and don't exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s a creature whose toughness is 0 or less, or if it’s an Aura that’s either unattached or attached to something illegal."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a permanent with indestructible to be put into the graveyard. However, a permanent with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's a creature whose toughness is 0 or less, or if it's an Aura that's either unattached or attached to something illegal."
         }
       ],
       "subtypes": [
@@ -948,7 +948,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This effect takes into account spells that were cast earlier in the turn that Ethersworn Canonist entered the battlefield, including any spells still on the stack. However, any spells on the stack as Ethersworn Canonist enters the battlefield have already been cast by that point, so they’re not affected by it."
+          "text": "This effect takes into account spells that were cast earlier in the turn that Ethersworn Canonist entered the battlefield, including any spells still on the stack. However, any spells on the stack as Ethersworn Canonist enters the battlefield have already been cast by that point, so they're not affected by it."
         }
       ],
       "subtypes": [
@@ -1013,7 +1013,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Feudkiller’s Verdict doesn’t target an opponent. If you have more life than any opponent when that part of the effect happens, you’ll put the token onto the battlefield."
+          "text": "Feudkiller's Verdict doesn't target an opponent. If you have more life than any opponent when that part of the effect happens, you'll put the token onto the battlefield."
         }
       ],
       "subtypes": [
@@ -1086,7 +1086,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won’t trigger that turn."
+          "text": "If the permanent that returns to the battlefield has any abilities that trigger at the beginning of the end step, those abilities won't trigger that turn."
         }
       ],
       "subtypes": [
@@ -1149,7 +1149,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -1279,39 +1279,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1441,7 +1441,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If, after dealing first-strike combat damage, Kithkin Greatheart loses first strike (perhaps because the Giant you controlled was destroyed by first-strike combat damage), it won’t deal regular combat damage."
+          "text": "If, after dealing first-strike combat damage, Kithkin Greatheart loses first strike (perhaps because the Giant you controlled was destroyed by first-strike combat damage), it won't deal regular combat damage."
         }
       ],
       "subtypes": [
@@ -1505,7 +1505,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -1513,19 +1513,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -1595,11 +1595,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Any Aura attached to the creature is put into its owner’s graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
+          "text": "Any Aura attached to the creature is put into its owner's graveyard as a state-based action. Equipment attached to the creature become unattached but remain on the battlefield."
         },
         {
           "date": "2005-08-01",
-          "text": "If Otherworldly Journey is cast during an end step, the creature won’t return until the beginning of the next end step."
+          "text": "If Otherworldly Journey is cast during an end step, the creature won't return until the beginning of the next end step."
         }
       ],
       "subtypes": [
@@ -1661,7 +1661,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Pallid Mycoderm gives a creature that’s both a Saproling and a Fungus (such as Mistform Ultimus) +1/+1, not +2/+2."
+          "text": "Pallid Mycoderm gives a creature that's both a Saproling and a Fungus (such as Mistform Ultimus) +1/+1, not +2/+2."
         }
       ],
       "subtypes": [
@@ -1731,11 +1731,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature’s controller won’t search for a basic land card."
+          "text": "If the targeted creature becomes an illegal target by the time Path to Exile would resolve, the entire spell is countered. The creature's controller won't search for a basic land card."
         },
         {
           "date": "2017-03-14",
-          "text": "The controller of the exiled creature isn’t required to search his or her library for a basic land. If that player doesn’t, the player won’t shuffle his or her library."
+          "text": "The controller of the exiled creature isn't required to search his or her library for a basic land. If that player doesn't, the player won't shuffle his or her library."
         }
       ],
       "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
@@ -1795,7 +1795,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -1803,23 +1803,23 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         },
         {
           "date": "2008-04-01",
-          "text": "Reveillark’s ability may target zero, one, or two creature cards in your graveyard. Each target must have power 2 or less."
+          "text": "Reveillark's ability may target zero, one, or two creature cards in your graveyard. Each target must have power 2 or less."
         }
       ],
       "subtypes": [
@@ -2010,7 +2010,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Because the cost of Sandsower’s ability doesn’t include the {T} symbol, you can tap any three untapped creatures you control (including Sandsower itself), even if those creatures haven’t been under your control continuously since the beginning of your most recent turn."
+          "text": "Because the cost of Sandsower's ability doesn't include the {T} symbol, you can tap any three untapped creatures you control (including Sandsower itself), even if those creatures haven't been under your control continuously since the beginning of your most recent turn."
         }
       ],
       "subtypes": [
@@ -2076,7 +2076,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Notably, the ability granted by the second mode isn’t lifelink. It’s a triggered ability that triggers whenever the creature with that ability deals damage. If that creature also has lifelink, you’ll gain life as a result of that damage and also when the triggered ability resolves. Multiple instances of this ability trigger separately."
+          "text": "Notably, the ability granted by the second mode isn't lifelink. It's a triggered ability that triggers whenever the creature with that ability deals damage. If that creature also has lifelink, you'll gain life as a result of that damage and also when the triggered ability resolves. Multiple instances of this ability trigger separately."
         }
       ],
       "text": "Choose one —\n• Creatures you control get +2/+2 until end of turn.\n• Until end of turn, creatures you control gain \"Whenever this creature deals damage, you gain that much life.\"\nEntwine {1}{W} (Choose both if you pay the entwine cost.)",
@@ -2136,7 +2136,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "This ability doesn’t target a creature. You may attach the Equipment to a creature that has shroud, for example. However, the creature must be able to be legally equipped by the Equipment. You can’t attach the Equipment to a creature that has protection from artifacts, for example."
+          "text": "This ability doesn't target a creature. You may attach the Equipment to a creature that has shroud, for example. However, the creature must be able to be legally equipped by the Equipment. You can't attach the Equipment to a creature that has protection from artifacts, for example."
         },
         {
           "date": "2008-04-01",
@@ -2572,7 +2572,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Look at both chosen modes to determine how many targets Cryptic Command has, if any. If it has at least one target, and all its targets are illegal when it tries to resolve, then it will be countered and none of its effects will happen. For example, if you choose the second and fourth modes, and the permanent is an illegal target when Cryptic Command tries to resolve, you won’t draw a card."
+          "text": "Look at both chosen modes to determine how many targets Cryptic Command has, if any. If it has at least one target, and all its targets are illegal when it tries to resolve, then it will be countered and none of its effects will happen. For example, if you choose the second and fourth modes, and the permanent is an illegal target when Cryptic Command tries to resolve, you won't draw a card."
         }
       ],
       "text": "Choose two —\n• Counter target spell.\n• Return target permanent to its owner's hand.\n• Tap all creatures your opponents control.\n• Draw a card.",
@@ -2634,15 +2634,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -2762,39 +2762,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -2860,7 +2860,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The target creature is chosen as the spell is cast. You don’t reveal cards until the spell resolves."
+          "text": "The target creature is chosen as the spell is cast. You don't reveal cards until the spell resolves."
         }
       ],
       "text": "Choose target creature. Reveal cards from the top of your library until you reveal a nonland card. That creature gets +X/-X until end of turn, where X is that card's converted mana cost. Put all cards revealed this way on the bottom of your library in any order.",
@@ -2921,7 +2921,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "When Esperzoa’s ability resolves, if you control no other artifacts, you’ll have to return Esperzoa itself."
+          "text": "When Esperzoa's ability resolves, if you control no other artifacts, you'll have to return Esperzoa itself."
         }
       ],
       "subtypes": [
@@ -2991,11 +2991,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This effect doesn’t change the mana cost or converted mana cost of an artifact spell. Rather, it reduces the total cost of the spell, which is the amount you actually pay while casting it. The total cost takes into account additional or alternative costs."
+          "text": "This effect doesn't change the mana cost or converted mana cost of an artifact spell. Rather, it reduces the total cost of the spell, which is the amount you actually pay while casting it. The total cost takes into account additional or alternative costs."
         },
         {
           "date": "2008-10-01",
-          "text": "This effect can reduce only the generic portion of the artifact spell’s total cost."
+          "text": "This effect can reduce only the generic portion of the artifact spell's total cost."
         }
       ],
       "subtypes": [
@@ -3122,7 +3122,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You can choose to find fewer than four cards if you want. If you find one or two cards, your opponent must choose for them to be put into your graveyard, even if he or she doesn’t want to."
+          "text": "You can choose to find fewer than four cards if you want. If you find one or two cards, your opponent must choose for them to be put into your graveyard, even if he or she doesn't want to."
         }
       ],
       "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
@@ -3189,23 +3189,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -3448,7 +3448,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Using delve doesn’t reduce the value of X. It just reduces the amount of mana Logic Knot’s controller has to pay."
+          "text": "Using delve doesn't reduce the value of X. It just reduces the amount of mana Logic Knot's controller has to pay."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nCounter target spell unless its controller pays {X}.",
@@ -3570,7 +3570,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Since the activated ability doesn’t have a tap symbol in its cost, you can tap a creature (including Mothdust Changeling itself) that hasn’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the activated ability doesn't have a tap symbol in its cost, you can tap a creature (including Mothdust Changeling itself) that hasn't been under your control since your most recent turn began to pay the cost."
         }
       ],
       "subtypes": [
@@ -3698,11 +3698,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Narcomoeba is revealed or looked at while moving from your library to your graveyard (such as with Mind Funeral), its ability will trigger when it’s put into your graveyard. It was still in your library while it was revealed or being looked at."
+          "text": "If Narcomoeba is revealed or looked at while moving from your library to your graveyard (such as with Mind Funeral), its ability will trigger when it's put into your graveyard. It was still in your library while it was revealed or being looked at."
         },
         {
           "date": "2007-05-01",
-          "text": "If Narcomoeba is removed from your graveyard before its ability resolves, it won’t be put onto the battlefield."
+          "text": "If Narcomoeba is removed from your graveyard before its ability resolves, it won't be put onto the battlefield."
         }
       ],
       "subtypes": [
@@ -3766,7 +3766,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Counter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
@@ -3825,7 +3825,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If you don’t reveal an instant or sorcery card, put all the revealed cards on the bottom of your library in any order."
+          "text": "If you don't reveal an instant or sorcery card, put all the revealed cards on the bottom of your library in any order."
         }
       ],
       "subtypes": [
@@ -4121,39 +4121,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -4332,7 +4332,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "The value of X needs to be determined both when the ability triggers (so you can choose a target) and again when the ability resolves (to check if that target is still legal). If the number of Faeries you control has decreased enough in that time to make the target illegal, Spellstutter Sprite’s ability will be countered (and the targeted spell will resolve as normal)."
+          "text": "The value of X needs to be determined both when the ability triggers (so you can choose a target) and again when the ability resolves (to check if that target is still legal). If the number of Faeries you control has decreased enough in that time to make the target illegal, Spellstutter Sprite's ability will be countered (and the targeted spell will resolve as normal)."
         }
       ],
       "subtypes": [
@@ -4399,23 +4399,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -4540,7 +4540,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -4612,7 +4612,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If Vedalken Dismisser is the only creature on the battlefield when its ability triggers, you’ll have to choose it as the target."
+          "text": "If Vedalken Dismisser is the only creature on the battlefield when its ability triggers, you'll have to choose it as the target."
         }
       ],
       "subtypes": [
@@ -4740,7 +4740,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -4811,11 +4811,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The last ability will trigger only if Auntie’s Snitch is in your graveyard at the moment a Goblin or Rogue deals combat damage to a player. The ability will check again when it tries to resolve. If Auntie’s Snitch hasn’t left the graveyard by this time, you may return it to your hand."
+          "text": "The last ability will trigger only if Auntie's Snitch is in your graveyard at the moment a Goblin or Rogue deals combat damage to a player. The ability will check again when it tries to resolve. If Auntie's Snitch hasn't left the graveyard by this time, you may return it to your hand."
         },
         {
           "date": "2008-04-01",
-          "text": "If a Goblin or Rogue you control deals combat damage to a player while Auntie’s Snitch is in your graveyard, you can return Auntie’s Snitch to your hand, then you can cast it for its prowl cost that turn."
+          "text": "If a Goblin or Rogue you control deals combat damage to a player while Auntie's Snitch is in your graveyard, you can return Auntie's Snitch to your hand, then you can cast it for its prowl cost that turn."
         }
       ],
       "subtypes": [
@@ -4938,7 +4938,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "While Bridge from Below is on the battlefield, it has no effect. It does something only if it’s in a graveyard."
+          "text": "While Bridge from Below is on the battlefield, it has no effect. It does something only if it's in a graveyard."
         },
         {
           "date": "2007-05-01",
@@ -5062,7 +5062,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If you control a permanent that’s a creature and a land, and you choose to sacrifice it as you sacrifice creatures, it won’t be on the battlefield when you sacrifice lands. You can’t sacrifice it again."
+          "text": "If you control a permanent that's a creature and a land, and you choose to sacrifice it as you sacrifice creatures, it won't be on the battlefield when you sacrifice lands. You can't sacrifice it again."
         }
       ],
       "text": "Each player loses X life, discards X cards, sacrifices X creatures, then sacrifices X lands.",
@@ -5181,7 +5181,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell’s cost."
+          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell's cost."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDestroy target nongreen creature. It can't be regenerated.",
@@ -5240,7 +5240,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you have no cards in hand, you can’t pay the echo cost and Deepcavern Imp will be sacrificed."
+          "text": "If you have no cards in hand, you can't pay the echo cost and Deepcavern Imp will be sacrificed."
         }
       ],
       "subtypes": [
@@ -5312,7 +5312,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Target creature gets -1/-1 until end of turn for each basic land type among lands you control.",
@@ -5558,23 +5558,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
@@ -5695,7 +5695,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Faerie Macabre’s second ability can be activated only while it’s in your hand. You can do this any time you could cast an instant."
+          "text": "Faerie Macabre's second ability can be activated only while it's in your hand. You can do this any time you could cast an instant."
         },
         {
           "date": "2008-05-01",
@@ -5825,7 +5825,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Horobi’s Whisper can target a creature even if you don’t control a Swamp, but the spell does nothing."
+          "text": "Horobi's Whisper can target a creature even if you don't control a Swamp, but the spell does nothing."
         },
         {
           "date": "2013-06-07",
@@ -5833,15 +5833,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -6032,7 +6032,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -6159,39 +6159,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -6199,7 +6199,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If the creature’s power is less than 0, use its actual value to determine the total life loss. However, if this total is 0 or less, no life is lost. For example, if Phthisis destroys a -2/3 creature, its controller would lose 1 life. If it destroys a -4/3 creature, its controller would lose no life."
+          "text": "If the creature's power is less than 0, use its actual value to determine the total life loss. However, if this total is 0 or less, no life is lost. For example, if Phthisis destroys a -2/3 creature, its controller would lose 1 life. If it destroys a -4/3 creature, its controller would lose no life."
         }
       ],
       "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5—{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
@@ -6324,7 +6324,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -6332,11 +6332,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Target player discards a card.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -6397,7 +6397,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You may pay the cost of Skeletal Vampire’s activated abilities by sacrificing any Bat, not just a Bat token it created."
+          "text": "You may pay the cost of Skeletal Vampire's activated abilities by sacrificing any Bat, not just a Bat token it created."
         }
       ],
       "subtypes": [
@@ -6455,13 +6455,14 @@
       "originalType": "Instant",
       "printings": [
         "FUT",
-        "MMA"
+        "MMA",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Destroy target nonblack creature.\nAt the beginning of your next upkeep, pay {2}{B}. If you don't, you lose the game.",
@@ -6527,15 +6528,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         },
         {
           "date": "2013-06-07",
-          "text": "Notably, Stinkweed Imp’s ability isn’t deathtouch. It’s a triggered ability that triggers only on combat damage."
+          "text": "Notably, Stinkweed Imp's ability isn't deathtouch. It's a triggered ability that triggers only on combat damage."
         }
       ],
       "subtypes": [
@@ -6663,7 +6664,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -6671,11 +6672,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         }
       ],
       "text": "Target player loses 2 life and you gain 2 life.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
@@ -6802,7 +6803,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell’s cost."
+          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell's cost."
         }
       ],
       "subtypes": [
@@ -6870,7 +6871,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If the card is an illegla target as the ability resolves, the ability will be countered and none of its effects will happen. Warren Pilferers won’t gain haste."
+          "text": "If the card is an illegla target as the ability resolves, the ability will be countered and none of its effects will happen. Warren Pilferers won't gain haste."
         }
       ],
       "subtypes": [
@@ -6992,7 +6993,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Blind-Spot Giant checks if you control another Giant only as you declare it as an attacking or blocking creature. Once you do, if you lose control of your other Giants, Blind-Spot Giant won’t stop attacking or blocking."
+          "text": "Blind-Spot Giant checks if you control another Giant only as you declare it as an attacking or blocking creature. Once you do, if you lose control of your other Giants, Blind-Spot Giant won't stop attacking or blocking."
         }
       ],
       "subtypes": [
@@ -7050,25 +7051,26 @@
         "8ED",
         "9ED",
         "MMA",
-        "MM3"
+        "MM3",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability “{T}: Add {R} to your mana pool.”"
+          "text": "Nonbasic lands will lose any other land types and abilities they had. They will gain the land type Mountain and gain the ability \"{T}: Add {R} to your mana pool.\""
         },
         {
           "date": "2017-03-14",
-          "text": "Blood Moon’s effect doesn’t affect names or supertypes. It won’t turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won’t be named “Mountain.”"
+          "text": "Blood Moon's effect doesn't affect names or supertypes. It won't turn any land into a basic land or remove the legendary supertype from a legendary land, and the lands won't be named \"Mountain.\""
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply “as” a land enters the battlefield, such as the first ability of Cavern of Souls."
+          "text": "If a nonbasic land has an ability that causes it to enter the battlefield tapped, that ability will still function. For example, if Blood Crypt is entering the battlefield, its controller may pay 2 life to have it enter untapped. Regardless of this choice, it will be only a Mountain and not a Swamp. The same is also true of any other abilities that modify how a land enters the battlefield or apply \"as\" a land enters the battlefield, such as the first ability of Cavern of Souls."
         },
         {
           "date": "2017-03-14",
-          "text": "If a nonbasic land has an ability that triggers “when” it enters the battlefield, it will lose that ability before it triggers."
+          "text": "If a nonbasic land has an ability that triggers \"when\" it enters the battlefield, it will lose that ability before it triggers."
         }
       ],
       "text": "Nonbasic lands are Mountains.",
@@ -7255,7 +7257,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Crush Underfoot doesn’t target the Giant creature you control. You choose that Giant as Crush Underfoot resolves. If you don’t control a Giant creature at that time, the spell will finish resolving with no effect."
+          "text": "Crush Underfoot doesn't target the Giant creature you control. You choose that Giant as Crush Underfoot resolves. If you don't control a Giant creature at that time, the spell will finish resolving with no effect."
         }
       ],
       "subtypes": [
@@ -7322,19 +7324,19 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         },
         {
           "date": "2013-06-07",
-          "text": "Desperate Ritual isn’t a mana ability. When cast, it (or the spell it’s spliced onto) goes on the stack like any spell and can be responded to."
+          "text": "Desperate Ritual isn't a mana ability. When cast, it (or the spell it's spliced onto) goes on the stack like any spell and can be responded to."
         }
       ],
       "subtypes": [
@@ -7401,15 +7403,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -7473,15 +7475,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -7551,7 +7553,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -7678,15 +7680,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -7749,15 +7751,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -7824,39 +7826,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -7924,11 +7926,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Although Grinning Ignus’s ability has a timing restriction, it’s still a mana ability. It doesn’t use the stack and it can’t be responded to."
+          "text": "Although Grinning Ignus's ability has a timing restriction, it's still a mana ability. It doesn't use the stack and it can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -8051,11 +8053,11 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "As the token is created, it checks the printed values of the creature it’s copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "As the token is created, it checks the printed values of the creature it's copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, or so on."
         },
         {
           "date": "2013-06-07",
-          "text": "Haste is part of the token’s copiable values. Copies of that token will also have haste."
+          "text": "Haste is part of the token's copiable values. Copies of that token will also have haste."
         }
       ],
       "subtypes": [
@@ -8239,7 +8241,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Molten Disaster was kicked, Molten Disaster has split second as long as it’s on the stack."
+          "text": "If Molten Disaster was kicked, Molten Disaster has split second as long as it's on the stack."
         },
         {
           "date": "2013-06-07",
@@ -8247,23 +8249,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nIf Molten Disaster was kicked, it has split second. (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nMolten Disaster deals X damage to each creature without flying and each player.",
@@ -8322,39 +8324,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -8420,11 +8422,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Pyromancer’s Swath doesn’t change the source or recipient of the damage."
+          "text": "Pyromancer's Swath doesn't change the source or recipient of the damage."
         },
         {
           "date": "2007-05-01",
-          "text": "If all damage from a source is prevented (because of Pay No Heed, for example) or if a source would deal 0 damage, the effect of Pyromancer’s Swath will not apply as that source is no longer dealing damage."
+          "text": "If all damage from a source is prevented (because of Pay No Heed, for example) or if a source would deal 0 damage, the effect of Pyromancer's Swath will not apply as that source is no longer dealing damage."
         },
         {
           "date": "2007-05-01",
@@ -8488,39 +8490,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -8584,11 +8586,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The counter is removed as a cost, so it can’t be responded to."
+          "text": "The counter is removed as a cost, so it can't be responded to."
         },
         {
           "date": "2007-05-01",
-          "text": "If an suspended card’s last time counter is removed this way, the suspend triggered ability is put on the stack on top of the Rift Elemental ability. The same is true for the vanishing ability of a permanent that loses its last time counter."
+          "text": "If an suspended card's last time counter is removed this way, the suspend triggered ability is put on the stack on top of the Rift Elemental ability. The same is true for the vanishing ability of a permanent that loses its last time counter."
         }
       ],
       "subtypes": [
@@ -8716,7 +8718,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You must sacrifice exactly one artifact to cast this spell; you can’t cast it without sacrificing an artifact, and you can’t sacrifice additional artifacts."
+          "text": "You must sacrifice exactly one artifact to cast this spell; you can't cast it without sacrificing an artifact, and you can't sacrifice additional artifacts."
         },
         {
           "date": "2014-07-18",
@@ -8781,7 +8783,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Squee’s ability triggers only if it’s in your graveyard as your upkeep begins."
+          "text": "Squee's ability triggers only if it's in your graveyard as your upkeep begins."
         }
       ],
       "subtypes": [
@@ -8971,23 +8973,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nSudden Shock deals 2 damage to target creature or player.",
@@ -9236,15 +9238,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -9321,7 +9323,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
@@ -9502,7 +9504,7 @@
         },
         {
           "date": "2005-10-01",
-          "text": "Doubling Season affects cards that “enter the battlefield with” a certain number of counters. Triskelion, for example, would enter the battlefield with six +1/+1 counters on it rather than three."
+          "text": "Doubling Season affects cards that \"enter the battlefield with\" a certain number of counters. Triskelion, for example, would enter the battlefield with six +1/+1 counters on it rather than three."
         },
         {
           "date": "2005-10-01",
@@ -9510,7 +9512,7 @@
         },
         {
           "date": "2005-10-01",
-          "text": "Planeswalkers will enter the battlefield with double the normal amount of loyalty counters. However, if you activate an ability whose cost has you put loyalty counters on a planeswalker, the number you put on isn’t doubled. This is because those counters are put on as a cost, not as an effect."
+          "text": "Planeswalkers will enter the battlefield with double the normal amount of loyalty counters. However, if you activate an ability whose cost has you put loyalty counters on a planeswalker, the number you put on isn't doubled. This is because those counters are put on as a cost, not as an effect."
         }
       ],
       "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
@@ -9569,39 +9571,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -9786,39 +9788,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -9891,11 +9893,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -10019,15 +10021,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Mana from any source other than a land with the supertype “basic” can’t be spent to cast Imperiosaur."
+          "text": "Mana from any source other than a land with the supertype \"basic\" can't be spent to cast Imperiosaur."
         },
         {
           "date": "2007-05-01",
-          "text": "Many mana-producing effects (such as Heartbeat of Spring or Utopia Sprawl, for example) add mana to a player’s mana pool whenever a land becomes tapped. This mana is produced by the enchantment, not the land, so it can’t be used to pay for Imperiosaur."
+          "text": "Many mana-producing effects (such as Heartbeat of Spring or Utopia Sprawl, for example) add mana to a player's mana pool whenever a land becomes tapped. This mana is produced by the enchantment, not the land, so it can't be used to pay for Imperiosaur."
         },
         {
           "date": "2007-05-01",
-          "text": "A small number of effects (Pulse of Llanowar and Hall of Gemstone, for example) state that a land “produces” certain mana instead of what it would normally produce. If the land is basic, then mana produced this way can be spent to cast Imperiosaur."
+          "text": "A small number of effects (Pulse of Llanowar and Hall of Gemstone, for example) state that a land \"produces\" certain mana instead of what it would normally produce. If the land is basic, then mana produced this way can be spent to cast Imperiosaur."
         },
         {
           "date": "2007-05-01",
@@ -10035,7 +10037,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Imperiosaur’s restriction applies to the total cost to cast it. If there are any additional costs (such as from Feroz’s Ban, for example), those costs would have to be paid with mana produced by basic lands as well."
+          "text": "Imperiosaur's restriction applies to the total cost to cast it. If there are any additional costs (such as from Feroz's Ban, for example), those costs would have to be paid with mana produced by basic lands as well."
         }
       ],
       "subtypes": [
@@ -10171,7 +10173,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You announce the target creatures and how you’re distributing the +1/+1 counters as you put the triggered ability on the stack. If one of the target creatures becomes illegal, you can’t change how the counters will be distributed."
+          "text": "You announce the target creatures and how you're distributing the +1/+1 counters as you put the triggered ability on the stack. If one of the target creatures becomes illegal, you can't change how the counters will be distributed."
         }
       ],
       "subtypes": [
@@ -10311,23 +10313,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
@@ -10390,11 +10392,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "text": "Return up to three target land cards from your graveyard to your hand.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
@@ -10528,11 +10530,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -10595,39 +10597,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -10825,7 +10827,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "It doesn’t matter why the card was exiled or who owns it."
+          "text": "It doesn't matter why the card was exiled or who owns it."
         },
         {
           "date": "2007-05-01",
@@ -10833,7 +10835,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If Riftsweeper affects a card that’s haunting a creature, the haunt effect ends."
+          "text": "If Riftsweeper affects a card that's haunting a creature, the haunt effect ends."
         }
       ],
       "subtypes": [
@@ -10898,11 +10900,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-06-07",
-          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won’t be affected."
+          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won't be affected."
         }
       ],
       "text": "Choose one —\n• Untap all lands you control.\n• Until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
@@ -10961,39 +10963,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -11056,7 +11058,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Sporesower Thallid’s triggered ability will put a spore counter on each Fungus creature you control, even if that Fungus doesn’t have any abilities that makes use of them."
+          "text": "Sporesower Thallid's triggered ability will put a spore counter on each Fungus creature you control, even if that Fungus doesn't have any abilities that makes use of them."
         }
       ],
       "subtypes": [
@@ -11185,7 +11187,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Search your library for a green creature card, reveal it, and put it into your hand. Then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
@@ -11248,7 +11250,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -11322,7 +11324,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Tarmogoyf’s ability works in all zones, not just while Tarmogoyf is on the battlefield."
+          "text": "Tarmogoyf's ability works in all zones, not just while Tarmogoyf is on the battlefield."
         },
         {
           "date": "2017-03-14",
@@ -11618,7 +11620,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The creatures get trample once; they don’t get trample for each basic land type."
+          "text": "The creatures get trample once; they don't get trample for each basic land type."
         },
         {
           "date": "2006-09-25",
@@ -11638,7 +11640,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
@@ -11703,7 +11705,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Verdeloth won’t give himself +1/+1 unless he somehow becomes a Saproling."
+          "text": "Verdeloth won't give himself +1/+1 unless he somehow becomes a Saproling."
         }
       ],
       "subtypes": [
@@ -11771,7 +11773,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -11779,19 +11781,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -11862,23 +11864,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -11948,7 +11950,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If all chosen targets are illegal as Electrolyze tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt and you won’t draw a card."
+          "text": "If all chosen targets are illegal as Electrolyze tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt and you won't draw a card."
         }
       ],
       "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
@@ -12086,31 +12088,31 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -12185,15 +12187,15 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The activated ability’s cost checks the land’s subtype, not its name. You can sacrifice a nonbasic land this way as long as it has the subtype Forest or Plains."
+          "text": "The activated ability's cost checks the land's subtype, not its name. You can sacrifice a nonbasic land this way as long as it has the subtype Forest or Plains."
         },
         {
           "date": "2009-02-01",
-          "text": "Sacrificing a Forest or Plains is part of the cost of Knight of the Reliquary’s activated ability. Assuming that sacrificing the land puts it into your graveyard, Knight of the Reliquary’s first ability will immediately give it an additional +1/+1 when that cost is paid because there’ll be a new land card in your graveyard. Paying a cost can’t be responded to (with Shock, for example)."
+          "text": "Sacrificing a Forest or Plains is part of the cost of Knight of the Reliquary's activated ability. Assuming that sacrificing the land puts it into your graveyard, Knight of the Reliquary's first ability will immediately give it an additional +1/+1 when that cost is paid because there'll be a new land card in your graveyard. Paying a cost can't be responded to (with Shock, for example)."
         },
         {
           "date": "2009-02-01",
-          "text": "Knight of the Reliquary’s activated ability lets you find any land card, not just a basic land card."
+          "text": "Knight of the Reliquary's activated ability lets you find any land card, not just a basic land card."
         }
       ],
       "subtypes": [
@@ -12263,7 +12265,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
@@ -12330,15 +12332,15 @@
         },
         {
           "date": "2009-05-01",
-          "text": "The name of a creature token is the same as its creature types unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 1/1 Soldier creature token is named “Soldier.”"
+          "text": "The name of a creature token is the same as its creature types unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 1/1 Soldier creature token is named \"Soldier.\""
         },
         {
           "date": "2009-05-01",
-          "text": "A face-down creature has no name, so it doesn’t have the same name as anything else."
+          "text": "A face-down creature has no name, so it doesn't have the same name as anything else."
         },
         {
           "date": "2013-07-01",
-          "text": "If Maelstrom Pulse resolves but the targeted permanent isn’t destroyed (perhaps because it regenerates or has indestructible), all other permanents with the same name as it will still be destroyed (unless they also have indestructible."
+          "text": "If Maelstrom Pulse resolves but the targeted permanent isn't destroyed (perhaps because it regenerates or has indestructible), all other permanents with the same name as it will still be destroyed (unless they also have indestructible."
         }
       ],
       "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
@@ -12399,7 +12401,7 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "The four land cards, as well as all the other cards revealed during this process, are put into the graveyard. If there aren’t four land cards left in the targeted opponent’s library, that player’s entire library is put into the graveyard."
+          "text": "The four land cards, as well as all the other cards revealed during this process, are put into the graveyard. If there aren't four land cards left in the targeted opponent's library, that player's entire library is put into the graveyard."
         }
       ],
       "text": "Target opponent reveals cards from the top of his or her library until four land cards are revealed. That player puts all cards revealed this way into his or her graveyard.",
@@ -12468,11 +12470,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "“Protection from everything” means the following: Progenitus can’t be blocked, Progenitus can’t be enchanted or equipped, Progenitus can’t be the target of spells or abilities, and all damage that would be dealt to Progenitus is prevented."
+          "text": "\"Protection from everything\" means the following: Progenitus can't be blocked, Progenitus can't be enchanted or equipped, Progenitus can't be the target of spells or abilities, and all damage that would be dealt to Progenitus is prevented."
         },
         {
           "date": "2009-02-01",
-          "text": "Progenitus can still be affected by effects that don’t target it or deal damage to it (such as Day of Judgment)."
+          "text": "Progenitus can still be affected by effects that don't target it or deal damage to it (such as Day of Judgment)."
         }
       ],
       "subtypes": [
@@ -12545,11 +12547,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Sarkhan Vol’s first ability affects only creatures you control when that ability resolves."
+          "text": "Sarkhan Vol's first ability affects only creatures you control when that ability resolves."
         },
         {
           "date": "2008-10-01",
-          "text": "You may target any creature with the second ability, not just a creature an opponent controls. If you target a creature you already control, you’ll gain control of it (which will usually have no visible effect), it’ll untap, and it’ll gain haste until end of turn."
+          "text": "You may target any creature with the second ability, not just a creature an opponent controls. If you target a creature you already control, you'll gain control of it (which will usually have no visible effect), it'll untap, and it'll gain haste until end of turn."
         }
       ],
       "subtypes": [
@@ -12808,7 +12810,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "This ability triggers when you cast Demigod of Revenge as a spell. It won’t trigger if Demigod of Revenge is put directly onto the battlefield."
+          "text": "This ability triggers when you cast Demigod of Revenge as a spell. It won't trigger if Demigod of Revenge is put directly onto the battlefield."
         },
         {
           "date": "2008-05-01",
@@ -12816,7 +12818,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If Demigod of Revenge is countered *before* its triggered ability resolves, the ability will still resolve. It will return that Demigod of Revenge from your graveyard to the battlefield, as well as any others. If you’re casting a spell to counter Demigod of Revenge, it’s important to clarify you’re casting it *after* the triggered ability resolves if you don’t want that Demigod of Revenge to be put onto the battlefield."
+          "text": "If Demigod of Revenge is countered *before* its triggered ability resolves, the ability will still resolve. It will return that Demigod of Revenge from your graveyard to the battlefield, as well as any others. If you're casting a spell to counter Demigod of Revenge, it's important to clarify you're casting it *after* the triggered ability resolves if you don't want that Demigod of Revenge to be put onto the battlefield."
         }
       ],
       "subtypes": [
@@ -12951,19 +12953,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Figure of Destiny’s abilities overwrite its power, toughness, and creature types. Typically, those abilities are activated in the order they appear on the card. However, if Figure of Destiny is an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike, and you activate its first ability, it will become a 2/2 Kithkin Spirit that still has flying and first strike."
+          "text": "Figure of Destiny's abilities overwrite its power, toughness, and creature types. Typically, those abilities are activated in the order they appear on the card. However, if Figure of Destiny is an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike, and you activate its first ability, it will become a 2/2 Kithkin Spirit that still has flying and first strike."
         },
         {
           "date": "2008-08-01",
-          "text": "You can activate Figure of Destiny’s second and third abilities regardless of what creature types it is. Each of those abilities checks Figure of Destiny’s creature types when that ability resolves. If Figure of Destiny isn’t the appropriate creature type at that time, the ability does nothing."
+          "text": "You can activate Figure of Destiny's second and third abilities regardless of what creature types it is. Each of those abilities checks Figure of Destiny's creature types when that ability resolves. If Figure of Destiny isn't the appropriate creature type at that time, the ability does nothing."
         },
         {
           "date": "2008-08-01",
-          "text": "Figure of Destiny’s second ability checks whether it’s a Spirit, and its third ability checks whether it’s a Warrior. It doesn’t matter how it became the appropriate creature type."
+          "text": "Figure of Destiny's second ability checks whether it's a Spirit, and its third ability checks whether it's a Warrior. It doesn't matter how it became the appropriate creature type."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -13038,23 +13040,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -13175,7 +13177,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Murderous Redcap’s power is checked at the time the ability resolves. If it’s left the battlefield by then, its last known information is used."
+          "text": "Murderous Redcap's power is checked at the time the ability resolves. If it's left the battlefield by then, its last known information is used."
         },
         {
           "date": "2013-06-07",
@@ -13187,23 +13189,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -13270,7 +13272,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You target the opponent when you activate Oona’s ability. You don’t choose the color until the ability resolves."
+          "text": "You target the opponent when you activate Oona's ability. You don't choose the color until the ability resolves."
         },
         {
           "date": "2008-05-01",
@@ -13404,7 +13406,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You’re casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
+          "text": "Casting a card by using its retrace ability works just like casting any other spell, with two exceptions: You're casting it from your graveyard rather than your hand, and you must discard a land card in addition to any other costs."
         },
         {
           "date": "2008-08-01",
@@ -13412,11 +13414,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "When a retrace card you cast from your graveyard resolves or is countered, it’s put back into your graveyard. You may use the retrace ability to cast it again."
+          "text": "When a retrace card you cast from your graveyard resolves or is countered, it's put back into your graveyard. You may use the retrace ability to cast it again."
         },
         {
           "date": "2008-08-01",
-          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it’s still in the graveyard."
+          "text": "If the active player casts a spell that has retrace, that player may cast that card again after it resolves, before another player can remove the card from the graveyard. The active player has priority after the spell resolves, so he or she can immediately cast a new spell. Since casting a card with retrace from the graveyard moves that card onto the stack, no one else would have the chance to affect it while it's still in the graveyard."
         },
         {
           "date": "2008-08-01",
@@ -13692,11 +13694,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "For the leaves-the-battlefield ability, the number of counters on Arcbound Wanderer at the time it left the battlefield is what’s relevant; the number of colors of mana used to pay its cost doesn’t matter anymore."
+          "text": "For the leaves-the-battlefield ability, the number of counters on Arcbound Wanderer at the time it left the battlefield is what's relevant; the number of colors of mana used to pay its cost doesn't matter anymore."
         },
         {
           "date": "2004-12-01",
-          "text": "When the Wanderer leaves the battlefield, you may put the counters onto a single target artifact creature. You can’t split them among two or more artifact creatures."
+          "text": "When the Wanderer leaves the battlefield, you may put the counters onto a single target artifact creature. You can't split them among two or more artifact creatures."
         },
         {
           "date": "2006-09-25",
@@ -13873,7 +13875,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The number of counters on Chalice of the Void matters only at the time the spell is cast. Changing the number of charge counters on Chalice of the Void after a spell has been cast won’t change whether the ability counters the spell. If the Chalice had the correct number of counters when the spell was cast, its ability will trigger. If the Chalice had too many or too few counters when the spell was cast, the Chalice’s ability won’t trigger."
+          "text": "The number of counters on Chalice of the Void matters only at the time the spell is cast. Changing the number of charge counters on Chalice of the Void after a spell has been cast won't change whether the ability counters the spell. If the Chalice had the correct number of counters when the spell was cast, its ability will trigger. If the Chalice had too many or too few counters when the spell was cast, the Chalice's ability won't trigger."
         },
         {
           "date": "2004-12-01",
@@ -13881,7 +13883,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Chalice of the Void has to be on the battlefield at the end of casting a spell for the ability to trigger. If you sacrifice Chalice of the Void as a cost to cast a spell, its ability can’t trigger."
+          "text": "Chalice of the Void has to be on the battlefield at the end of casting a spell for the ability to trigger. If you sacrifice Chalice of the Void as a cost to cast a spell, its ability can't trigger."
         }
       ],
       "text": "Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
@@ -13934,7 +13936,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If Engineered Explosives had no charge counters on it when you sacrificed it, it won’t destroy an animated land, because that permanent is a land in addition to being a creature."
+          "text": "If Engineered Explosives had no charge counters on it when you sacrificed it, it won't destroy an animated land, because that permanent is a land in addition to being a creature."
         }
       ],
       "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
@@ -13992,39 +13994,39 @@
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -14193,44 +14195,40 @@
       "rarity": "Rare",
       "rulings": [
         {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "date": "2013-06-07",
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
-        },
-        {
-          "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -14238,7 +14236,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 3—{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color to your mana pool.",
@@ -14505,11 +14503,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If you activate Relic of Progenitus’s first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
+          "text": "If you activate Relic of Progenitus's first ability, the targeted player chooses which card to exile. The choice is made as the ability resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "You can activate Relic of Progenitus’s second ability even if no players have any cards in their graveyards. You’ll still draw a card."
+          "text": "You can activate Relic of Progenitus's second ability even if no players have any cards in their graveyards. You'll still draw a card."
         }
       ],
       "text": "{T}: Target player exiles a card from his or her graveyard.\n{1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.",
@@ -14667,7 +14665,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The triggered ability has one target: the creature or player to be dealt 2 damage. If that creature or player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "The triggered ability has one target: the creature or player to be dealt 2 damage. If that creature or player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "subtypes": [
@@ -14724,7 +14722,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You may put the triggered ability with no targets. However, If you choose a target creature in your graveyard, and that card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "You may put the triggered ability with no targets. However, If you choose a target creature in your graveyard, and that card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "subtypes": [
@@ -14780,15 +14778,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The creature’s power and the number of Islands you control matter only when the ability is activated and when it resolves. After that, only the fact that Vedalken Shackles remains tapped matters. If the creature stops being a creature, you’ll keep control of it."
+          "text": "The creature's power and the number of Islands you control matter only when the ability is activated and when it resolves. After that, only the fact that Vedalken Shackles remains tapped matters. If the creature stops being a creature, you'll keep control of it."
         },
         {
           "date": "2004-12-01",
-          "text": "If Vedalken Shackles becomes untapped before its ability resolves, you won’t gain control of the creature."
+          "text": "If Vedalken Shackles becomes untapped before its ability resolves, you won't gain control of the creature."
         },
         {
           "date": "2004-12-01",
-          "text": "If Vedalken Shackles leaves the battlefield, it’s no longer tapped, so the control-changing effect ends."
+          "text": "If Vedalken Shackles leaves the battlefield, it's no longer tapped, so the control-changing effect ends."
         }
       ],
       "text": "You may choose not to untap Vedalken Shackles during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control for as long as Vedalken Shackles remains tapped.",
@@ -14890,19 +14888,19 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Blinkmoth Nexus gains the creature type “Blinkmoth” when it becomes a creature. This means that it ends up with three types (land, artifact, and creature), plus one creature subtype (Blinkmoth)."
+          "text": "Blinkmoth Nexus gains the creature type \"Blinkmoth\" when it becomes a creature. This means that it ends up with three types (land, artifact, and creature), plus one creature subtype (Blinkmoth)."
         },
         {
           "date": "2004-12-01",
-          "text": "The “target Blinkmoth gets +1/+1” ability can target any creature with the creature type Blinkmoth."
+          "text": "The \"target Blinkmoth gets +1/+1\" ability can target any creature with the creature type Blinkmoth."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.",
@@ -14961,7 +14959,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass’s triggered ability is put on the stack on top of it. City of Brass’s ability will resolve first."
+          "text": "If you tap City of Brass while you are casting a spell or activating an ability, its ability will trigger and wait. When you finish casting that spell or activating that ability, City of Brass's triggered ability is put on the stack on top of it. City of Brass's ability will resolve first."
         },
         {
           "date": "2004-10-04",
@@ -15023,11 +15021,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "text": "Dakmor Salvage enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",

--- a/json/MMQ.json
+++ b/json/MMQ.json
@@ -257,7 +257,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -752,7 +752,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It really does mean “all creatures”, including your opponent’s."
+          "text": "It really does mean \"all creatures\", including your opponent's."
         },
         {
           "date": "2004-10-04",
@@ -1572,7 +1572,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the creature is an illegal target when Last Breath tries to resolve, it will be countered and none of its effects will happen. Its controller won’t gain 4 life."
+          "text": "If the creature is an illegal target when Last Breath tries to resolve, it will be countered and none of its effects will happen. Its controller won't gain 4 life."
         }
       ],
       "text": "Exile target creature with power 2 or less. Its controller gains 4 life.",
@@ -1997,7 +1997,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -2057,7 +2057,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -2117,7 +2117,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -2224,7 +2224,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -2284,7 +2284,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -3081,11 +3081,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This ability will trigger any creature’s “whenever this becomes blocked” ability."
+          "text": "This ability will trigger any creature's \"whenever this becomes blocked\" ability."
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, the ability can be activated during any of them as long as it’s after the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, the ability can be activated during any of them as long as it's after the beginning of that phase's Declare Blockers Step."
         }
       ],
       "subtypes": [
@@ -3490,11 +3490,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You put the creature onto the battlefield, so you control it and any “enters the battlefield” abilities it has."
+          "text": "You put the creature onto the battlefield, so you control it and any \"enters the battlefield\" abilities it has."
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles his or her library.",
@@ -4797,7 +4797,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Target noncreature artifact becomes an artifact creature with power and toughness each equal to its converted mana cost until end of turn. (It retains its abilities.)",
@@ -4863,7 +4863,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -4933,7 +4933,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures are only prevented from untapping during the targeted player’s next untap step. They can still can untap during other player’s untap steps."
+          "text": "The creatures are only prevented from untapping during the targeted player's next untap step. They can still can untap during other player's untap steps."
         },
         {
           "date": "2008-08-01",
@@ -6259,7 +6259,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can choose X=0. This doesn’t have an effect most of the time, but it does mean that creatures can’t attack unless the controller chooses to pay the cost (a cost of zero is not automatically paid, so the controller can choose to not pay)."
+          "text": "You can choose X=0. This doesn't have an effect most of the time, but it does mean that creatures can't attack unless the controller chooses to pay the cost (a cost of zero is not automatically paid, so the controller can choose to not pay)."
         },
         {
           "date": "2004-10-04",
@@ -6660,7 +6660,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -6719,7 +6719,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -6779,7 +6779,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -6838,7 +6838,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -6897,7 +6897,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -6956,7 +6956,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -7015,7 +7015,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a Mercenary card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -7085,11 +7085,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "“Legend” is no longer a creature type, and may not be chosen."
+          "text": "\"Legend\" is no longer a creature type, and may not be chosen."
         },
         {
           "date": "2005-08-01",
-          "text": "If you choose Wall, then your creatures can still attack because creature types don’t confer abilities such as defender (any more than, say, choosing creature type Bird would confer flying)."
+          "text": "If you choose Wall, then your creatures can still attack because creature types don't confer abilities such as defender (any more than, say, choosing creature type Bird would confer flying)."
         },
         {
           "date": "2013-09-20",
@@ -9434,15 +9434,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Vendetta resolves, the spell is countered. You won’t lose life."
+          "text": "If the targeted creature is an illegal target by the time Vendetta resolves, the spell is countered. You won't lose life."
         },
         {
           "date": "2010-06-15",
-          "text": "The destroyed creature’s last existence on the battlefield is checked to determine its toughness."
+          "text": "The destroyed creature's last existence on the battlefield is checked to determine its toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature isn’t destroyed due to totem armor’s effect, Vendetta continues to resolve. You lose life equal to the creature’s current toughness (after the Aura with totem armor has been destroyed)."
+          "text": "If the targeted creature isn't destroyed due to totem armor's effect, Vendetta continues to resolve. You lose life equal to the creature's current toughness (after the Aura with totem armor has been destroyed)."
         }
       ],
       "text": "Destroy target nonblack creature. It can't be regenerated. You lose life equal to that creature's toughness.",
@@ -9677,7 +9677,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Battle Squadron’s last ability applies in all zones. While it’s on the battlefield, it counts itself, so it’ll be at least 1/1."
+          "text": "Battle Squadron's last ability applies in all zones. While it's on the battlefield, it counts itself, so it'll be at least 1/1."
         }
       ],
       "subtypes": [
@@ -11792,7 +11792,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Squee’s ability triggers only if it’s in your graveyard as your upkeep begins."
+          "text": "Squee's ability triggers only if it's in your graveyard as your upkeep begins."
         }
       ],
       "subtypes": [
@@ -12061,7 +12061,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t pick a card that can’t legally be returned to the battlefield. If there are no cards that can be legally returned, then you can’t pick one."
+          "text": "You can't pick a card that can't legally be returned to the battlefield. If there are no cards that can be legally returned, then you can't pick one."
         },
         {
           "date": "2005-08-01",
@@ -12344,7 +12344,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If there is at least one creature on the battlefield when you are announcing this, you can’t choose zero targets. You must choose between 1 and X targets."
+          "text": "If there is at least one creature on the battlefield when you are announcing this, you can't choose zero targets. You must choose between 1 and X targets."
         }
       ],
       "text": "Volcanic Wind deals X damage divided as you choose among any number of target creatures, where X is the number of creatures on the battlefield as you cast Volcanic Wind.",
@@ -12399,7 +12399,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can choose X=0. This doesn’t have an effect most of the time, but it does mean that creatures can’t block unless the controller chooses to pay the cost (a cost of zero is not automatically paid). You can use this to make your creatures unable to block an attacker."
+          "text": "You can choose X=0. This doesn't have an effect most of the time, but it does mean that creatures can't block unless the controller chooses to pay the cost (a cost of zero is not automatically paid). You can use this to make your creatures unable to block an attacker."
         },
         {
           "date": "2004-10-04",
@@ -12715,7 +12715,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a permanent card with the same name as target nontoken creature and put that card onto the battlefield. Then shuffle your library.",
@@ -13463,7 +13463,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Erithizon’s controller controls the triggered ability, but their opponent chooses the target."
+          "text": "Erithizon's controller controls the triggered ability, but their opponent chooses the target."
         }
       ],
       "subtypes": [
@@ -14033,7 +14033,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If an effect says that an opponent can’t gain life, you can’t have that player gain life to pay Invigorate’s alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost’s action is replaced with nothing."
+          "text": "If an effect says that an opponent can't gain life, you can't have that player gain life to pay Invigorate's alternative cost. If an effect instead replaces life gain, such as that of Sulfuric Vortex, you may choose to pay the cost even though the cost's action is replaced with nothing."
         }
       ],
       "text": "If you control a Forest, rather than pay Invigorate's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
@@ -14086,11 +14086,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can pay the “reveal your hand” cost even if your hand is already revealed due to another effect."
+          "text": "You can pay the \"reveal your hand\" cost even if your hand is already revealed due to another effect."
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "If you have no land cards in hand, you may reveal your hand rather than pay Land Grant's mana cost.\nSearch your library for a Forest card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -14396,7 +14396,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All lands become 2/2 creatures until end of turn. They're still lands.",
@@ -14882,7 +14882,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -14940,7 +14940,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -16013,7 +16013,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you pay the {3}, you do not choose a new pair of targets when it repeats. This means that if you lose the flip, you have the choice of having your creature destroyed or paying {3} to try again to win the flip. If you lose again, you get the same choice, and so on. You can keep trying to destroy your opponent’s creature as long as you have mana to pay."
+          "text": "If you pay the {3}, you do not choose a new pair of targets when it repeats. This means that if you lose the flip, you have the choice of having your creature destroyed or paying {3} to try again to win the flip. If you lose again, you get the same choice, and so on. You can keep trying to destroy your opponent's creature as long as you have mana to pay."
         },
         {
           "date": "2004-10-04",
@@ -16064,7 +16064,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have no cards in your library, then damage done to you will have no effect since it will get changed into a removal that can’t happen."
+          "text": "If you have no cards in your library, then damage done to you will have no effect since it will get changed into a removal that can't happen."
         },
         {
           "date": "2004-10-04",
@@ -16614,7 +16614,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "{4}, {T}: Put a charge counter on Magistrate's Scepter.\n{T}, Remove three charge counters from Magistrate's Scepter: Take an extra turn after this one.",
@@ -16662,7 +16662,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It only checks if you played a land. Putting a land onto the battlefield by using an effect of another card does not count as “playing a land”."
+          "text": "It only checks if you played a land. Putting a land onto the battlefield by using an effect of another card does not count as \"playing a land\"."
         }
       ],
       "text": "At the beginning of your end step, if you didn't play a land this turn, you may draw a card.",
@@ -17068,7 +17068,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [

--- a/json/MOR.json
+++ b/json/MOR.json
@@ -134,7 +134,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A spell you cast that’s both creature types costs {1} less to cast, not {2} less."
+          "text": "A spell you cast that's both creature types costs {1} less to cast, not {2} less."
         },
         {
           "date": "2008-04-01",
@@ -261,7 +261,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The player who would be dealt damage chooses the order in which to apply prevention and replacement effects that would affect that damage. This includes effects that involve choices, like the prevention effect from Battletide Alchemist’s ability and the redirection effect that’s part of the planeswalker rules. Those choices (such as whether you’ll actually use Battletide Alchemist’s ability to prevent that damage) are made as the relevant effects are applied."
+          "text": "The player who would be dealt damage chooses the order in which to apply prevention and replacement effects that would affect that damage. This includes effects that involve choices, like the prevention effect from Battletide Alchemist's ability and the redirection effect that's part of the planeswalker rules. Those choices (such as whether you'll actually use Battletide Alchemist's ability to prevent that damage) are made as the relevant effects are applied."
         }
       ],
       "subtypes": [
@@ -584,7 +584,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The second ability is cumulative. That is, each creature you control with any +1/+1 counters on it can block an additional creature for each Cenn’s Tactician you control. Cenn’s Tactician doesn’t care whether the creature has any +1/+1 counters on it beyond the first."
+          "text": "The second ability is cumulative. That is, each creature you control with any +1/+1 counters on it can block an additional creature for each Cenn's Tactician you control. Cenn's Tactician doesn't care whether the creature has any +1/+1 counters on it beyond the first."
         }
       ],
       "subtypes": [
@@ -801,7 +801,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "You choose a target for this spell as you cast it, but you don’t choose a creature type until the spell resolves."
+          "text": "You choose a target for this spell as you cast it, but you don't choose a creature type until the spell resolves."
         },
         {
           "date": "2008-04-01",
@@ -1020,7 +1020,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Feudkiller’s Verdict doesn’t target an opponent. If you have more life than any opponent when that part of the effect happens, you’ll put the token onto the battlefield."
+          "text": "Feudkiller's Verdict doesn't target an opponent. If you have more life than any opponent when that part of the effect happens, you'll put the token onto the battlefield."
         }
       ],
       "subtypes": [
@@ -1229,11 +1229,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Graceful Reprieve’s effect works only once. If the targeted creature leaves the battlefield and is then returned to the battlefield, it’s considered to be a new creature. If that new creature is put into a graveyard, it won’t come back a second time."
+          "text": "Graceful Reprieve's effect works only once. If the targeted creature leaves the battlefield and is then returned to the battlefield, it's considered to be a new creature. If that new creature is put into a graveyard, it won't come back a second time."
         },
         {
           "date": "2017-03-14",
-          "text": "Graceful Reprieve can target a token creature, but since tokens cease to exist after they leave the battlefield, it won’t be returned to the battlefield."
+          "text": "Graceful Reprieve can target a token creature, but since tokens cease to exist after they leave the battlefield, it won't be returned to the battlefield."
         }
       ],
       "text": "When target creature dies this turn, return that card to the battlefield under its owner's control.",
@@ -1756,15 +1756,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -1772,11 +1772,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -1887,7 +1887,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -1895,19 +1895,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -2229,11 +2229,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You choose what the Soldier you put onto the battlefield is attacking. It doesn’t have to attack the same player or planeswalker as Preeminent Captain."
+          "text": "You choose what the Soldier you put onto the battlefield is attacking. It doesn't have to attack the same player or planeswalker as Preeminent Captain."
         },
         {
           "date": "2014-07-18",
-          "text": "Any abilities of the Soldier creature card that trigger “Whenever [this creature] attacks” won’t trigger because the creature was never declared as an attacking creature."
+          "text": "Any abilities of the Soldier creature card that trigger \"Whenever [this creature] attacks\" won't trigger because the creature was never declared as an attacking creature."
         }
       ],
       "subtypes": [
@@ -2342,11 +2342,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don’t win the clash, the spell is put into the graveyard from the stack as normal."
+          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don't win the clash, the spell is put into the graveyard from the stack as normal."
         },
         {
           "date": "2008-04-01",
-          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won’t be returned to your hand."
+          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won't be returned to your hand."
         }
       ],
       "text": "Target creature you control gains protection from the color of your choice until end of turn. Clash with an opponent. If you win, return Redeem the Lost to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -2453,7 +2453,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -2461,23 +2461,23 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         },
         {
           "date": "2008-04-01",
-          "text": "Reveillark’s ability may target zero, one, or two creature cards in your graveyard. Each target must have power 2 or less."
+          "text": "Reveillark's ability may target zero, one, or two creature cards in your graveyard. Each target must have power 2 or less."
         }
       ],
       "subtypes": [
@@ -2691,7 +2691,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "This ability doesn’t target a creature. You may attach the Equipment to a creature that has shroud, for example. However, the creature must be able to be legally equipped by the Equipment. You can’t attach the Equipment to a creature that has protection from artifacts, for example."
+          "text": "This ability doesn't target a creature. You may attach the Equipment to a creature that has shroud, for example. However, the creature must be able to be legally equipped by the Equipment. You can't attach the Equipment to a creature that has protection from artifacts, for example."
         },
         {
           "date": "2008-04-01",
@@ -3011,15 +3011,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -3027,11 +3027,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -3141,7 +3141,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Since the activated ability doesn’t have a tap symbol in its cost, you can tap creatures that haven’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the activated ability doesn't have a tap symbol in its cost, you can tap creatures that haven't been under your control since your most recent turn began to pay the cost."
         },
         {
           "date": "2008-04-01",
@@ -4014,15 +4014,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -4030,11 +4030,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -4247,11 +4247,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "You cast the instant or sorcery card as part of the resolution of this spell. It’s cast from your opponent’s library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can’t be paid."
+          "text": "You cast the instant or sorcery card as part of the resolution of this spell. It's cast from your opponent's library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can't be paid."
         },
         {
           "date": "2008-04-01",
-          "text": "If you can’t find an instant or sorcery card that can be legally cast, or choose not to find one, skip that part of the effect. Then the opponent shuffles his or her library."
+          "text": "If you can't find an instant or sorcery card that can be legally cast, or choose not to find one, skip that part of the effect. Then the opponent shuffles his or her library."
         }
       ],
       "subtypes": [
@@ -4673,7 +4673,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Since the activated ability doesn’t have a tap symbol in its cost, you can tap a creature (including Mothdust Changeling itself) that hasn’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the activated ability doesn't have a tap symbol in its cost, you can tap a creature (including Mothdust Changeling itself) that hasn't been under your control since your most recent turn began to pay the cost."
         }
       ],
       "subtypes": [
@@ -4811,7 +4811,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -4916,7 +4916,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -4924,19 +4924,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -5152,11 +5152,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don’t win the clash, the spell is put into the graveyard from the stack as normal."
+          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don't win the clash, the spell is put into the graveyard from the stack as normal."
         },
         {
           "date": "2008-04-01",
-          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won’t be returned to your hand."
+          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won't be returned to your hand."
         }
       ],
       "text": "Draw a card. Clash with an opponent. If you win, return Research the Deep to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -5266,11 +5266,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The creature gets the counter if it would enter the battlefield under your control. It doesn’t matter who owns the creature or what zone it enters the battlefield from (such as your opponent’s graveyard, for example)."
+          "text": "The creature gets the counter if it would enter the battlefield under your control. It doesn't matter who owns the creature or what zone it enters the battlefield from (such as your opponent's graveyard, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "The creature gets the counter if its copiable characteristics as it would exist on the battlefield include the specified creature type. For example, say you control Conspiracy, and the chosen creature type is Wizard. If you put a creature onto the battlefield that isn’t normally a Wizard, it won’t get a counter from Sage of Fables."
+          "text": "The creature gets the counter if its copiable characteristics as it would exist on the battlefield include the specified creature type. For example, say you control Conspiracy, and the chosen creature type is Wizard. If you put a creature onto the battlefield that isn't normally a Wizard, it won't get a counter from Sage of Fables."
         },
         {
           "date": "2008-04-01",
@@ -5278,7 +5278,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If Sage of Fables enters the battlefield at the same time as another Wizard (due to Living End, for example), that creature doesn’t get a +1/+1 counter."
+          "text": "If Sage of Fables enters the battlefield at the same time as another Wizard (due to Living End, for example), that creature doesn't get a +1/+1 counter."
         }
       ],
       "subtypes": [
@@ -5498,15 +5498,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Since the activated ability doesn’t have a tap symbol in its cost, you can tap creatures (including Sigil Tracer itself) that haven’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the activated ability doesn't have a tap symbol in its cost, you can tap creatures (including Sigil Tracer itself) that haven't been under your control since your most recent turn began to pay the cost."
         },
         {
           "date": "2008-04-01",
-          "text": "If the spell is modal (that is, it says “choose one —” or “choose two —”), the choice of mode(s) can’t be changed."
+          "text": "If the spell is modal (that is, it says \"choose one —\" or \"choose two —\"), the choice of mode(s) can't be changed."
         },
         {
           "date": "2008-04-01",
-          "text": "Sigil Tracer’s ability can copy an instant or sorcery spell that isn’t targeted."
+          "text": "Sigil Tracer's ability can copy an instant or sorcery spell that isn't targeted."
         },
         {
           "date": "2008-04-01",
@@ -5620,7 +5620,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -5628,23 +5628,23 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         },
         {
           "date": "2008-04-01",
-          "text": "You choose an opponent when the ability resolves. Once you determine how many more cards than you that player has, that number is locked in as the amount you’ll draw."
+          "text": "You choose an opponent when the ability resolves. Once you determine how many more cards than you that player has, that number is locked in as the amount you'll draw."
         }
       ],
       "subtypes": [
@@ -5754,7 +5754,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A spell you cast that’s both creature types costs {1} less to cast, not {2} less."
+          "text": "A spell you cast that's both creature types costs {1} less to cast, not {2} less."
         },
         {
           "date": "2008-04-01",
@@ -6286,15 +6286,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -6302,11 +6302,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -6417,11 +6417,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The last ability will trigger only if Auntie’s Snitch is in your graveyard at the moment a Goblin or Rogue deals combat damage to a player. The ability will check again when it tries to resolve. If Auntie’s Snitch hasn’t left the graveyard by this time, you may return it to your hand."
+          "text": "The last ability will trigger only if Auntie's Snitch is in your graveyard at the moment a Goblin or Rogue deals combat damage to a player. The ability will check again when it tries to resolve. If Auntie's Snitch hasn't left the graveyard by this time, you may return it to your hand."
         },
         {
           "date": "2008-04-01",
-          "text": "If a Goblin or Rogue you control deals combat damage to a player while Auntie’s Snitch is in your graveyard, you can return Auntie’s Snitch to your hand, then you can cast it for its prowl cost that turn."
+          "text": "If a Goblin or Rogue you control deals combat damage to a player while Auntie's Snitch is in your graveyard, you can return Auntie's Snitch to your hand, then you can cast it for its prowl cost that turn."
         }
       ],
       "subtypes": [
@@ -6533,11 +6533,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The effect is mandatory. You’ll lose 1 life even if you have only 1 life left."
+          "text": "The effect is mandatory. You'll lose 1 life even if you have only 1 life left."
         },
         {
           "date": "2008-04-01",
-          "text": "The life loss isn’t a payment. You’ll get a token even if you had 0 life (and another effect is stopping you from losing the game)."
+          "text": "The life loss isn't a payment. You'll get a token even if you had 0 life (and another effect is stopping you from losing the game)."
         }
       ],
       "subtypes": [
@@ -6870,11 +6870,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A Swamp affected by this ability is still a land, still a Swamp, and may still be tapped for black mana. If it had any other card types or subtypes, it retains those as well. This ability doesn’t affect the permanent’s colors, if any."
+          "text": "A Swamp affected by this ability is still a land, still a Swamp, and may still be tapped for black mana. If it had any other card types or subtypes, it retains those as well. This ability doesn't affect the permanent's colors, if any."
         },
         {
           "date": "2008-04-01",
-          "text": "A Swamp affected by this ability is subject to the “summoning sickness” rule: If its controller hasn’t continuously controlled it since the beginning of his or her most recent turn, it can’t attack or be tapped for mana (or use any other {T} abilities)."
+          "text": "A Swamp affected by this ability is subject to the \"summoning sickness\" rule: If its controller hasn't continuously controlled it since the beginning of his or her most recent turn, it can't attack or be tapped for mana (or use any other {T} abilities)."
         }
       ],
       "subtypes": [
@@ -7090,7 +7090,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The effect is mandatory. If you control the only creature that’s been dealt damage this turn, you must target that creature."
+          "text": "The effect is mandatory. If you control the only creature that's been dealt damage this turn, you must target that creature."
         },
         {
           "date": "2008-04-01",
@@ -7205,7 +7205,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A spell you cast that’s both creature types costs {1} less to cast, not {2} less."
+          "text": "A spell you cast that's both creature types costs {1} less to cast, not {2} less."
         },
         {
           "date": "2008-04-01",
@@ -7320,7 +7320,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Maralen prevents players from drawing cards for any reason, including as a cost, as an effect, and as a result of the “draw a card” turn-based action during the draw step."
+          "text": "Maralen prevents players from drawing cards for any reason, including as a cost, as an effect, and as a result of the \"draw a card\" turn-based action during the draw step."
         },
         {
           "date": "2008-04-01",
@@ -7328,19 +7328,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "While Maralen is on the battlefield, replacement effects that instruct a player to do something instead of drawing a card won’t work."
+          "text": "While Maralen is on the battlefield, replacement effects that instruct a player to do something instead of drawing a card won't work."
         },
         {
           "date": "2008-04-01",
-          "text": "While Maralen is on the battlefield, a player can’t choose to draw cards (or choose to have another player draw cards) as a spell or ability resolves. For example, if you cast the Development side of Research // Development (“Put a 3/1 red Elemental creature token onto the battlefield unless any opponent lets you draw a card. Repeat this process two more times.”), you’ll put three Elemental tokens onto the battlefield because your opponents can’t “let you draw a card.”"
+          "text": "While Maralen is on the battlefield, a player can't choose to draw cards (or choose to have another player draw cards) as a spell or ability resolves. For example, if you cast the Development side of Research // Development (\"Put a 3/1 red Elemental creature token onto the battlefield unless any opponent lets you draw a card. Repeat this process two more times.\"), you'll put three Elemental tokens onto the battlefield because your opponents can't \"let you draw a card.\""
         },
         {
           "date": "2008-04-01",
-          "text": "The effect of the triggered ability is mandatory. The life loss isn’t a payment; you’ll lose 3 life even if you have 3 or less life left. Unless your library is empty, you must put a card from your library into your hand."
+          "text": "The effect of the triggered ability is mandatory. The life loss isn't a payment; you'll lose 3 life even if you have 3 or less life left. Unless your library is empty, you must put a card from your library into your hand."
         },
         {
           "date": "2008-04-01",
-          "text": "In a Two-Headed Giant game, Maralen’s triggered ability will trigger twice per draw step (once for each player on the active team). Maralen’s controller chooses the order to put the abilities on the stack."
+          "text": "In a Two-Headed Giant game, Maralen's triggered ability will trigger twice per draw step (once for each player on the active team). Maralen's controller chooses the order to put the abilities on the stack."
         }
       ],
       "subtypes": [
@@ -7760,15 +7760,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -7776,11 +7776,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -7889,7 +7889,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If the player has fewer than three cards in his or her hand, the player reveals all of them, you choose all of them, and they’re all discarded."
+          "text": "If the player has fewer than three cards in his or her hand, the player reveals all of them, you choose all of them, and they're all discarded."
         }
       ],
       "subtypes": [
@@ -7998,7 +7998,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -8006,19 +8006,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -8132,19 +8132,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The creature gets the counter if it would enter the battlefield under your control. It doesn’t matter who owns the creature or what zone it enters the battlefield from (such as your opponent’s graveyard, for example)."
+          "text": "The creature gets the counter if it would enter the battlefield under your control. It doesn't matter who owns the creature or what zone it enters the battlefield from (such as your opponent's graveyard, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "The creature gets the counter if its copiable characteristics as it would exist on the battlefield include the specified creature type. For example, say you control Conspiracy, and the chosen creature type is Rogue. If you put a creature onto the battlefield that isn’t normally a Rogue, it won’t get a counter from Oona’s Blackguard."
+          "text": "The creature gets the counter if its copiable characteristics as it would exist on the battlefield include the specified creature type. For example, say you control Conspiracy, and the chosen creature type is Rogue. If you put a creature onto the battlefield that isn't normally a Rogue, it won't get a counter from Oona's Blackguard."
         },
         {
           "date": "2008-04-01",
-          "text": "The effects from more than one of these cards are cumulative. That is, if you have two Oona’s Blackguard on the battlefield, Rogue creatures you control enter the battlefield with two additional +1/+1 counters on them."
+          "text": "The effects from more than one of these cards are cumulative. That is, if you have two Oona's Blackguard on the battlefield, Rogue creatures you control enter the battlefield with two additional +1/+1 counters on them."
         },
         {
           "date": "2008-04-01",
-          "text": "If Oona’s Blackguard enters the battlefield at the same time as another Rogue (due to Living End, for example), that creature doesn’t get a +1/+1 counter."
+          "text": "If Oona's Blackguard enters the battlefield at the same time as another Rogue (due to Living End, for example), that creature doesn't get a +1/+1 counter."
         }
       ],
       "subtypes": [
@@ -8258,7 +8258,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "You choose a target for this spell as you cast it, but you don’t choose a creature type until the spell resolves."
+          "text": "You choose a target for this spell as you cast it, but you don't choose a creature type until the spell resolves."
         }
       ],
       "text": "Choose a creature type. Target creature gets -1/-1 until end of turn for each permanent of the chosen type you control.",
@@ -8467,7 +8467,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The opponent you clash with doesn’t have to be the player targeted by Pulling Teeth."
+          "text": "The opponent you clash with doesn't have to be the player targeted by Pulling Teeth."
         }
       ],
       "text": "Clash with an opponent. If you win, target player discards two cards. Otherwise, that player discards a card. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -8571,11 +8571,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don’t win the clash, the spell is put into the graveyard from the stack as normal."
+          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don't win the clash, the spell is put into the graveyard from the stack as normal."
         },
         {
           "date": "2008-04-01",
-          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won’t be returned to your hand."
+          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won't be returned to your hand."
         }
       ],
       "text": "Return target creature card from a graveyard to its owner's hand. Clash with an opponent. If you win, return Revive the Fallen to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -8785,15 +8785,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -8801,11 +8801,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -8916,7 +8916,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "This ability checks whether you control any Goblins twice each turn: once when the ability would trigger, and once when it resolves. If you control any Goblins at either time, you won’t sacrifice Stenchskipper. (If you control any Goblins at the time the ability would trigger, it doesn’t trigger at all.)"
+          "text": "This ability checks whether you control any Goblins twice each turn: once when the ability would trigger, and once when it resolves. If you control any Goblins at either time, you won't sacrifice Stenchskipper. (If you control any Goblins at the time the ability would trigger, it doesn't trigger at all.)"
         }
       ],
       "subtypes": [
@@ -9029,7 +9029,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -9353,7 +9353,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The ability is mandatory. If you’re the only player who controls any other creatures, you must target one of your own creatures with the ability."
+          "text": "The ability is mandatory. If you're the only player who controls any other creatures, you must target one of your own creatures with the ability."
         }
       ],
       "subtypes": [
@@ -9569,7 +9569,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A player who doesn’t want to shuffle his or her library may choose not to search for a creature card."
+          "text": "A player who doesn't want to shuffle his or her library may choose not to search for a creature card."
         }
       ],
       "subtypes": [
@@ -9912,7 +9912,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A spell you cast that’s both creature types costs {1} less to cast, not {2} less."
+          "text": "A spell you cast that's both creature types costs {1} less to cast, not {2} less."
         },
         {
           "date": "2008-04-01",
@@ -10317,6 +10317,10 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
@@ -10363,7 +10367,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn’t prevent that creature from dealing combat damage."
+          "text": "Giving a creature first strike after creatures with first strike deal combat damage doesn't prevent that creature from dealing combat damage."
         }
       ],
       "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
@@ -10573,11 +10577,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Lunk Errant “attacks alone” if it’s the only creature declared as an attacker as the declare attackers step begins. The ability won’t trigger if Lunk Errant and some other creatures are declared as attackers, then those other creatures leave the battlefield or are otherwise removed from combat. The ability also won’t trigger if Lunk Errant is put onto the battlefield attacking, even if no other creatures are attacking at that time."
+          "text": "Lunk Errant \"attacks alone\" if it's the only creature declared as an attacker as the declare attackers step begins. The ability won't trigger if Lunk Errant and some other creatures are declared as attackers, then those other creatures leave the battlefield or are otherwise removed from combat. The ability also won't trigger if Lunk Errant is put onto the battlefield attacking, even if no other creatures are attacking at that time."
         },
         {
           "date": "2008-04-01",
-          "text": "In a Two-Headed Giant game, Lunk Errant must be the only creature declared as an attacker by the entire attacking team for it to be considered “attacking alone.”"
+          "text": "In a Two-Headed Giant game, Lunk Errant must be the only creature declared as an attacker by the entire attacking team for it to be considered \"attacking alone.\""
         }
       ],
       "subtypes": [
@@ -10687,15 +10691,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -10703,11 +10707,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -10817,15 +10821,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -10833,11 +10837,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -11050,11 +11054,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don’t win the clash, the spell is put into the graveyard from the stack as normal."
+          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don't win the clash, the spell is put into the graveyard from the stack as normal."
         },
         {
           "date": "2008-04-01",
-          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won’t be returned to your hand."
+          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won't be returned to your hand."
         }
       ],
       "text": "Release the Ants deals 1 damage to target creature or player. Clash with an opponent. If you win, return Release the Ants to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -11165,11 +11169,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If either one of the creatures leaves the battlefield before Rivals’ Duel resolves, no damage is dealt to or by the remaining creature. If both creatures leave the battlefield before Rivals’ Duel resolves, the spell is countered for having no legal targets."
+          "text": "If either one of the creatures leaves the battlefield before Rivals' Duel resolves, no damage is dealt to or by the remaining creature. If both creatures leave the battlefield before Rivals' Duel resolves, the spell is countered for having no legal targets."
         },
         {
           "date": "2008-04-01",
-          "text": "If, by the time Rivals’ Duel resolves, an effect has caused the two target creatures to share a creature type, Rivals’ Duel is countered for having no legal targets."
+          "text": "If, by the time Rivals' Duel resolves, an effect has caused the two target creatures to share a creature type, Rivals' Duel is countered for having no legal targets."
         }
       ],
       "text": "Choose two target creatures that share no creature types. Those creatures fight each other. (Each deals damage equal to its power to the other.)",
@@ -11278,7 +11282,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "You choose a target for this spell as you cast it, but you don’t choose a creature type until the spell resolves."
+          "text": "You choose a target for this spell as you cast it, but you don't choose a creature type until the spell resolves."
         },
         {
           "date": "2008-04-01",
@@ -11493,15 +11497,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -11509,11 +11513,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -11726,7 +11730,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "In a Two-Headed Giant game, only creatures you control trigger the ability and get the bonus, but your teammate’s attacking creatures are included in the calculation of those bonuses."
+          "text": "In a Two-Headed Giant game, only creatures you control trigger the ability and get the bonus, but your teammate's attacking creatures are included in the calculation of those bonuses."
         }
       ],
       "text": "Whenever a creature you control attacks, it gets +1/+0 until end of turn for each other attacking creature that shares a creature type with it.",
@@ -11836,7 +11840,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -11844,19 +11848,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -12068,7 +12072,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If a card named Stomping Slabs wasn’t revealed this way, Stomping Slabs deals no damage to its target."
+          "text": "If a card named Stomping Slabs wasn't revealed this way, Stomping Slabs deals no damage to its target."
         }
       ],
       "text": "Reveal the top seven cards of your library, then put those cards on the bottom of your library in any order. If a card named Stomping Slabs was revealed this way, Stomping Slabs deals 7 damage to target creature or player.",
@@ -12178,7 +12182,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If the target leaves the battlefield or otherwise becomes an illegal target before the ability resolves, the ability is countered and Sunflare Shaman won’t deal any damage to itself."
+          "text": "If the target leaves the battlefield or otherwise becomes an illegal target before the ability resolves, the ability is countered and Sunflare Shaman won't deal any damage to itself."
         }
       ],
       "subtypes": [
@@ -12395,11 +12399,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don’t win the clash, the spell is put into the graveyard from the stack as normal."
+          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don't win the clash, the spell is put into the graveyard from the stack as normal."
         },
         {
           "date": "2008-04-01",
-          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won’t be returned to your hand."
+          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won't be returned to your hand."
         }
       ],
       "text": "Titan's Revenge deals X damage to target creature or player. Clash with an opponent. If you win, return Titan's Revenge to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
@@ -12821,7 +12825,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A spell you cast that’s both creature types costs {1} less to cast, not {2} less."
+          "text": "A spell you cast that's both creature types costs {1} less to cast, not {2} less."
         },
         {
           "date": "2008-04-01",
@@ -12941,11 +12945,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The creature gets the counter if it would enter the battlefield under your control. It doesn’t matter who owns the creature or what zone it enters the battlefield from (such as your opponent’s graveyard, for example)."
+          "text": "The creature gets the counter if it would enter the battlefield under your control. It doesn't matter who owns the creature or what zone it enters the battlefield from (such as your opponent's graveyard, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "The creature gets the counter if its copiable characteristics as it would exist on the battlefield include the specified creature type. For example, say you control Conspiracy, and the chosen creature type is Warrior. If you put a creature onto the battlefield that isn’t normally a Warrior, it won’t get a counter from Bramblewood Paragon."
+          "text": "The creature gets the counter if its copiable characteristics as it would exist on the battlefield include the specified creature type. For example, say you control Conspiracy, and the chosen creature type is Warrior. If you put a creature onto the battlefield that isn't normally a Warrior, it won't get a counter from Bramblewood Paragon."
         },
         {
           "date": "2008-04-01",
@@ -12953,7 +12957,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If Bramblewood Paragon enters the battlefield at the same time as another Warrior (due to Living End, for example), that creature doesn’t get a +1/+1 counter."
+          "text": "If Bramblewood Paragon enters the battlefield at the same time as another Warrior (due to Living End, for example), that creature doesn't get a +1/+1 counter."
         }
       ],
       "subtypes": [
@@ -13168,7 +13172,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The creature’s power is checked as this ability resolves. If the creature has left the battlefield, use its last known information."
+          "text": "The creature's power is checked as this ability resolves. If the creature has left the battlefield, use its last known information."
         },
         {
           "date": "2008-04-01",
@@ -13176,7 +13180,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If the creature has 1 power, this ability lets you look at the top card of your library, then you’ll have to leave it there."
+          "text": "If the creature has 1 power, this ability lets you look at the top card of your library, then you'll have to leave it there."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, you may look at the top X cards of your library, where X is that creature's power. If you do, put one of those cards on top of your library and the rest on the bottom of your library in any order.",
@@ -13701,7 +13705,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Although the targeted player doesn’t need to find a basic land card if he or she doesn’t want to, that player must shuffle his or her library."
+          "text": "Although the targeted player doesn't need to find a basic land card if he or she doesn't want to, that player must shuffle his or her library."
         }
       ],
       "subtypes": [
@@ -13915,11 +13919,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Since the activated ability doesn’t have a tap symbol in its cost, you can tap creatures (including Gilt-Leaf Archdruid itself) that haven’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the activated ability doesn't have a tap symbol in its cost, you can tap creatures (including Gilt-Leaf Archdruid itself) that haven't been under your control since your most recent turn began to pay the cost."
         },
         {
           "date": "2008-04-01",
-          "text": "The second ability’s effect has no duration. You retain control of those lands until the game ends or until some other effect causes them to change control."
+          "text": "The second ability's effect has no duration. You retain control of those lands until the game ends or until some other effect causes them to change control."
         }
       ],
       "subtypes": [
@@ -14030,7 +14034,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The second ability triggers only when an Archer permanent you control deals damage to a creature. It won’t trigger when an Archer spell you control deals damage."
+          "text": "The second ability triggers only when an Archer permanent you control deals damage to a creature. It won't trigger when an Archer spell you control deals damage."
         },
         {
           "date": "2008-04-01",
@@ -14146,7 +14150,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Since Heritage Druid’s activated ability doesn’t have a tap symbol in its cost, you can tap creatures that haven’t been under your control since your most recent turn began (including Heritage Druid itself) to pay the cost."
+          "text": "Since Heritage Druid's activated ability doesn't have a tap symbol in its cost, you can tap creatures that haven't been under your control since your most recent turn began (including Heritage Druid itself) to pay the cost."
         }
       ],
       "subtypes": [
@@ -14361,15 +14365,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -14377,15 +14381,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         },
         {
           "date": "2008-04-01",
-          "text": "You play the revealed card as part of the resolution of this ability. It’s played from your library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the card as normal when playing it. Any X in the mana cost will be 0. Alternative costs can’t be paid."
+          "text": "You play the revealed card as part of the resolution of this ability. It's played from your library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the card as normal when playing it. Any X in the mana cost will be 0. Alternative costs can't be paid."
         }
       ],
       "subtypes": [
@@ -14705,7 +14709,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The creature’s toughness is checked as this ability resolves. If the creature has left the battlefield, use its last known information."
+          "text": "The creature's toughness is checked as this ability resolves. If the creature has left the battlefield, use its last known information."
         }
       ],
       "subtypes": [
@@ -14928,11 +14932,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don’t win the clash, the spell is put into the graveyard from the stack as normal."
+          "text": "If you win the clash, the spell moves from the stack to your hand as part of its resolution. It never hits the graveyard. If you don't win the clash, the spell is put into the graveyard from the stack as normal."
         },
         {
           "date": "2008-04-01",
-          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won’t be returned to your hand."
+          "text": "If the spell is countered for any reason (for example, if all its targets become illegal), none of its effects happen. There is no clash, and the spell card won't be returned to your hand."
         },
         {
           "date": "2008-04-01",
@@ -15044,7 +15048,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Reins of the Vinesteed’s last ability triggers if it and the creature it’s enchanting are both put into the graveyard at the same time, or if the creature it’s enchanting is put into the graveyard but Reins of the Vinesteed isn’t. (In the second case, Reins of the Vinesteed is then put into the graveyard as a state-based action.)"
+          "text": "Reins of the Vinesteed's last ability triggers if it and the creature it's enchanting are both put into the graveyard at the same time, or if the creature it's enchanting is put into the graveyard but Reins of the Vinesteed isn't. (In the second case, Reins of the Vinesteed is then put into the graveyard as a state-based action.)"
         },
         {
           "date": "2008-04-01",
@@ -15052,11 +15056,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "This triggered ability doesn’t target a creature. You may return Reins of the Vinesteed to the battlefield attached to a creature that has shroud, for example. However, the creature must be able to be legally enchanted by Reins of the Vinesteed. You can’t return Reins of the Vinesteed to the battlefield attached to a creature that has protection from green, for example."
+          "text": "This triggered ability doesn't target a creature. You may return Reins of the Vinesteed to the battlefield attached to a creature that has shroud, for example. However, the creature must be able to be legally enchanted by Reins of the Vinesteed. You can't return Reins of the Vinesteed to the battlefield attached to a creature that has protection from green, for example."
         },
         {
           "date": "2008-04-01",
-          "text": "You can choose to return Reins of the Vinesteed to the battlefield attached to a creature another player controls. You still control Reins of the Vinesteed. When that creature is put into a graveyard, the ability of Reins of the Vinesteed will trigger again and you’ll be able choose another creature for the Aura to enchant."
+          "text": "You can choose to return Reins of the Vinesteed to the battlefield attached to a creature another player controls. You still control Reins of the Vinesteed. When that creature is put into a graveyard, the ability of Reins of the Vinesteed will trigger again and you'll be able choose another creature for the Aura to enchant."
         }
       ],
       "subtypes": [
@@ -15279,7 +15283,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "You sacrifice the lands as part of the resolution of Scapeshift. It isn’t an additional cost."
+          "text": "You sacrifice the lands as part of the resolution of Scapeshift. It isn't an additional cost."
         }
       ],
       "text": "Sacrifice any number of lands. Search your library for up to that many land cards, put them onto the battlefield tapped, then shuffle your library.",
@@ -15491,7 +15495,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Evoke doesn’t change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+          "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
         },
         {
           "date": "2008-04-01",
@@ -15499,19 +15503,19 @@
         },
         {
           "date": "2008-04-01",
-          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn’t change. You just pay the evoke cost instead."
+          "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
         },
         {
           "date": "2008-04-01",
-          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That’s because they affect the total cost of the spell, not its mana cost."
+          "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "Whether evoke’s sacrifice ability triggers when the creature enters the battlefield depends on whether the spell’s controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+          "text": "Whether evoke's sacrifice ability triggers when the creature enters the battlefield depends on whether the spell's controller chose to pay the evoke cost, not whether he or she actually paid it (if it was reduced or otherwise altered by another ability, for example)."
         },
         {
           "date": "2008-04-01",
-          "text": "If you’re casting a spell “without paying its mana cost,” you can’t use its evoke ability."
+          "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
         }
       ],
       "subtypes": [
@@ -15620,15 +15624,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -15636,11 +15640,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -15751,15 +15755,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn’t have any special rules associated with it."
+          "text": "Kinship is an ability word that indicates a group of similar triggered abilities that appear on _Morningtide_ creatures. It doesn't have any special rules associated with it."
         },
         {
           "date": "2008-04-01",
-          "text": "The first two sentences of every kinship ability are the same (except for the creature’s name). Only the last sentence varies from one kinship ability to the next."
+          "text": "The first two sentences of every kinship ability are the same (except for the creature's name). Only the last sentence varies from one kinship ability to the next."
         },
         {
           "date": "2008-04-01",
-          "text": "You don’t have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
+          "text": "You don't have to reveal the top card of your library, even if it shares a creature type with the creature that has the kinship ability."
         },
         {
           "date": "2008-04-01",
@@ -15767,11 +15771,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You’ll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
+          "text": "If you have multiple creatures with kinship abilities, each triggers and resolves separately. You'll look at the same card for each one, unless you have some method of shuffling your library or moving that card to a different zone."
         },
         {
           "date": "2008-04-01",
-          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability’s effect."
+          "text": "If the top card of your library is already revealed (due to Magus of the Future, for example), you still have the option to reveal it or not as part of a kinship ability's effect."
         }
       ],
       "subtypes": [
@@ -15878,11 +15882,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Each of these Equipment has a triggered ability that says “Whenever a [creature type] creature enters the battlefield, you may attach [this Equipment] to it.” This triggers whenever any creature of the specified creature type enters the battlefield, no matter who controls it. You may attach your Equipment to another player’s creature this way, even though you can’t do so with the equip ability."
+          "text": "Each of these Equipment has a triggered ability that says \"Whenever a [creature type] creature enters the battlefield, you may attach [this Equipment] to it.\" This triggers whenever any creature of the specified creature type enters the battlefield, no matter who controls it. You may attach your Equipment to another player's creature this way, even though you can't do so with the equip ability."
         },
         {
           "date": "2008-04-01",
-          "text": "If you attach an Equipment you control to another player’s creature, you retain control of the Equipment, but you don’t control the creature. Only you can activate the Equipment’s equip ability, and if the Equipment’s ability triggers again, you choose whether to move the Equipment. Only the creature’s controller can activate any activated abilities the Equipment grants to the creature, and “you” in any abilities granted to the creature refers to that player."
+          "text": "If you attach an Equipment you control to another player's creature, you retain control of the Equipment, but you don't control the creature. Only you can activate the Equipment's equip ability, and if the Equipment's ability triggers again, you choose whether to move the Equipment. Only the creature's controller can activate any activated abilities the Equipment grants to the creature, and \"you\" in any abilities granted to the creature refers to that player."
         }
       ],
       "subtypes": [
@@ -15989,11 +15993,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Each of these Equipment has a triggered ability that says “Whenever a [creature type] creature enters the battlefield, you may attach [this Equipment] to it.” This triggers whenever any creature of the specified creature type enters the battlefield, no matter who controls it. You may attach your Equipment to another player’s creature this way, even though you can’t do so with the equip ability."
+          "text": "Each of these Equipment has a triggered ability that says \"Whenever a [creature type] creature enters the battlefield, you may attach [this Equipment] to it.\" This triggers whenever any creature of the specified creature type enters the battlefield, no matter who controls it. You may attach your Equipment to another player's creature this way, even though you can't do so with the equip ability."
         },
         {
           "date": "2008-04-01",
-          "text": "If you attach an Equipment you control to another player’s creature, you retain control of the Equipment, but you don’t control the creature. Only you can activate the Equipment’s equip ability, and if the Equipment’s ability triggers again, you choose whether to move the Equipment. Only the creature’s controller can activate any activated abilities the Equipment grants to the creature, and “you” in any abilities granted to the creature refers to that player."
+          "text": "If you attach an Equipment you control to another player's creature, you retain control of the Equipment, but you don't control the creature. Only you can activate the Equipment's equip ability, and if the Equipment's ability triggers again, you choose whether to move the Equipment. Only the creature's controller can activate any activated abilities the Equipment grants to the creature, and \"you\" in any abilities granted to the creature refers to that player."
         }
       ],
       "subtypes": [
@@ -16205,11 +16209,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Each of these Equipment has a triggered ability that says “Whenever a [creature type] creature enters the battlefield, you may attach [this Equipment] to it.” This triggers whenever any creature of the specified creature type enters the battlefield, no matter who controls it. You may attach your Equipment to another player’s creature this way, even though you can’t do so with the equip ability."
+          "text": "Each of these Equipment has a triggered ability that says \"Whenever a [creature type] creature enters the battlefield, you may attach [this Equipment] to it.\" This triggers whenever any creature of the specified creature type enters the battlefield, no matter who controls it. You may attach your Equipment to another player's creature this way, even though you can't do so with the equip ability."
         },
         {
           "date": "2008-04-01",
-          "text": "If you attach an Equipment you control to another player’s creature, you retain control of the Equipment, but you don’t control the creature. Only you can activate the Equipment’s equip ability, and if the Equipment’s ability triggers again, you choose whether to move the Equipment. Only the creature’s controller can activate any activated abilities the Equipment grants to the creature, and “you” in any abilities granted to the creature refers to that player."
+          "text": "If you attach an Equipment you control to another player's creature, you retain control of the Equipment, but you don't control the creature. Only you can activate the Equipment's equip ability, and if the Equipment's ability triggers again, you choose whether to move the Equipment. Only the creature's controller can activate any activated abilities the Equipment grants to the creature, and \"you\" in any abilities granted to the creature refers to that player."
         }
       ],
       "subtypes": [
@@ -16316,11 +16320,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Each of these Equipment has a triggered ability that says “Whenever a [creature type] creature enters the battlefield, you may attach [this Equipment] to it.” This triggers whenever any creature of the specified creature type enters the battlefield, no matter who controls it. You may attach your Equipment to another player’s creature this way, even though you can’t do so with the equip ability."
+          "text": "Each of these Equipment has a triggered ability that says \"Whenever a [creature type] creature enters the battlefield, you may attach [this Equipment] to it.\" This triggers whenever any creature of the specified creature type enters the battlefield, no matter who controls it. You may attach your Equipment to another player's creature this way, even though you can't do so with the equip ability."
         },
         {
           "date": "2008-04-01",
-          "text": "If you attach an Equipment you control to another player’s creature, you retain control of the Equipment, but you don’t control the creature. Only you can activate the Equipment’s equip ability, and if the Equipment’s ability triggers again, you choose whether to move the Equipment. Only the creature’s controller can activate any activated abilities the Equipment grants to the creature, and “you” in any abilities granted to the creature refers to that player."
+          "text": "If you attach an Equipment you control to another player's creature, you retain control of the Equipment, but you don't control the creature. Only you can activate the Equipment's equip ability, and if the Equipment's ability triggers again, you choose whether to move the Equipment. Only the creature's controller can activate any activated abilities the Equipment grants to the creature, and \"you\" in any abilities granted to the creature refers to that player."
         }
       ],
       "subtypes": [
@@ -16525,7 +16529,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Murmuring Bosk is a Forest, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do. For example, you can’t find Murmuring Bosk with Fertilid’s ability (“searches his or her library for a basic land card”), but you can find Murmuring Bosk with Everbark Shaman’s ability (“search your library for two Forest cards”)."
+          "text": "Murmuring Bosk is a Forest, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do. For example, you can't find Murmuring Bosk with Fertilid's ability (\"searches his or her library for a basic land card\"), but you can find Murmuring Bosk with Everbark Shaman's ability (\"search your library for two Forest cards\")."
         }
       ],
       "subtypes": [
@@ -16627,11 +16631,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Although Mutavault has all creature types while it’s animated, it does not have the changeling keyword ability."
+          "text": "Although Mutavault has all creature types while it's animated, it does not have the changeling keyword ability."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2013-07-01",
@@ -16731,11 +16735,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "You can use the mana produced by Primal Beyond’s last ability to pay an alternative cost (such as evoke) or additional cost incurred while casting an Elemental spell. It’s not limited to just that spell’s mana cost."
+          "text": "You can use the mana produced by Primal Beyond's last ability to pay an alternative cost (such as evoke) or additional cost incurred while casting an Elemental spell. It's not limited to just that spell's mana cost."
         },
         {
           "date": "2008-04-01",
-          "text": "The mana can’t be spent to activate activated abilities of Elemental sources that aren’t on the battlefield (such as the reinforce ability of an Elemental card in your hand)."
+          "text": "The mana can't be spent to activate activated abilities of Elemental sources that aren't on the battlefield (such as the reinforce ability of an Elemental card in your hand)."
         }
       ],
       "text": "As Primal Beyond enters the battlefield, you may reveal an Elemental card from your hand. If you don't, Primal Beyond enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast an Elemental spell or activate an ability of an Elemental.",

--- a/json/MPS.json
+++ b/json/MPS.json
@@ -4,6 +4,8 @@
     "Kaladesh Inventions"
   ],
   "code": "MPS",
+  "magicCardsInfoCode": "mpskld",
+  "gathererCode": "MPS_KLD",
   "releaseDate": "2016-09-30",
   "border": "black",
   "type": "masterpiece",
@@ -47,6 +49,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "1",
       "multiverseid": 420588,
       "name": "Cataclysmic Gearhulk",
       "number": "1",
@@ -69,15 +72,15 @@
         },
         {
           "date": "2016-09-20",
-          "text": "Cataclysmic Gearhulk will be sacrificed to its own ability if you don’t choose it as your artifact or your creature."
+          "text": "Cataclysmic Gearhulk will be sacrificed to its own ability if you don't choose it as your artifact or your creature."
         },
         {
           "date": "2016-09-20",
-          "text": "Lands can’t be chosen and won’t be sacrificed, even if they have other types (such as an artifact land)."
+          "text": "Lands can't be chosen and won't be sacrificed, even if they have other types (such as an artifact land)."
         },
         {
           "date": "2016-09-20",
-          "text": "If you don’t control any permanents of one of the types, you’ll still choose the permanents of the types you do control."
+          "text": "If you don't control any permanents of one of the types, you'll still choose the permanents of the types you do control."
         }
       ],
       "subtypes": [
@@ -130,6 +133,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "2",
       "multiverseid": 420589,
       "name": "Torrential Gearhulk",
       "number": "2",
@@ -144,11 +148,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If you cast the card, you do so as part of the resolution of Torrential Gearhulk’s triggered ability. You can’t wait to cast it later in the turn. Timing restrictions (such as “Cast [this card] only during combat”) still apply."
+          "text": "If you cast the card, you do so as part of the resolution of Torrential Gearhulk's triggered ability. You can't wait to cast it later in the turn. Timing restrictions (such as \"Cast [this card] only during combat\") still apply."
         },
         {
           "date": "2016-09-20",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Incendiary Sabotage, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as emerge costs. You can, however, pay additional costs. If the card has any mandatory additional costs, such as that of Incendiary Sabotage, you must pay those to cast the card."
         },
         {
           "date": "2016-09-20",
@@ -205,6 +209,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "3",
       "multiverseid": 420590,
       "name": "Noxious Gearhulk",
       "number": "3",
@@ -223,7 +228,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If the target creature has indestructible, it isn’t destroyed this way and you won’t gain life. If it is destroyed but put into a zone other than a graveyard, you’ll gain life."
+          "text": "If the target creature has indestructible, it isn't destroyed this way and you won't gain life. If it is destroyed but put into a zone other than a graveyard, you'll gain life."
         }
       ],
       "subtypes": [
@@ -276,6 +281,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "4",
       "multiverseid": 420591,
       "name": "Combustible Gearhulk",
       "number": "4",
@@ -294,11 +300,11 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If you have fewer than three cards in your library, the opponent may choose to have you draw three cards. If so, you’ll lose the game as state-based actions are performed."
+          "text": "If you have fewer than three cards in your library, the opponent may choose to have you draw three cards. If so, you'll lose the game as state-based actions are performed."
         },
         {
           "date": "2016-09-20",
-          "text": "While Combustible Gearhulk’s triggered ability is resolving, no player may take any actions other than those specified by the Gearhulk. Once the opponent makes a choice, players can’t cast spells or activate abilities until after the cards are drawn or put into the graveyard and damage has been dealt (if applicable)."
+          "text": "While Combustible Gearhulk's triggered ability is resolving, no player may take any actions other than those specified by the Gearhulk. Once the opponent makes a choice, players can't cast spells or activate abilities until after the cards are drawn or put into the graveyard and damage has been dealt (if applicable)."
         }
       ],
       "subtypes": [
@@ -351,6 +357,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "5",
       "multiverseid": 420592,
       "name": "Verdurous Gearhulk",
       "number": "5",
@@ -365,11 +372,11 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "You choose how the counters will be distributed as you put Verdurous Gearhulk’s triggered ability onto the stack. Each target creature must be assigned at least one counter."
+          "text": "You choose how the counters will be distributed as you put Verdurous Gearhulk's triggered ability onto the stack. Each target creature must be assigned at least one counter."
         },
         {
           "date": "2016-09-20",
-          "text": "If one of the target creatures becomes an illegal target in response to Verdurous Gearhulk’s triggered ability, the +1/+1 counters that would have been put on that creature are lost. They can’t be put on another legal target."
+          "text": "If one of the target creatures becomes an illegal target in response to Verdurous Gearhulk's triggered ability, the +1/+1 counters that would have been put on that creature are lost. They can't be put on another legal target."
         },
         {
           "date": "2016-09-20",
@@ -456,6 +463,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "7",
       "multiverseid": 420594,
       "name": "Champion's Helm",
       "number": "7",
@@ -469,7 +477,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "It’s possible for a Champion’s Helm you control to be attached to a creature an opponent controls (if an opponent gains control of your equipped creature, for example). In this case, the creature couldn’t be the target of spells or abilities you control, as you are an opponent of the controller of the creature with hexproof."
+          "text": "It's possible for a Champion's Helm you control to be attached to a creature an opponent controls (if an opponent gains control of your equipped creature, for example). In this case, the creature couldn't be the target of spells or abilities you control, as you are an opponent of the controller of the creature with hexproof."
         }
       ],
       "subtypes": [
@@ -511,6 +519,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "8",
       "multiverseid": 420595,
       "name": "Chromatic Lantern",
       "number": "8",
@@ -525,7 +534,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Lands you control won’t lose any other abilities they had. They also won’t gain or lose any land types."
+          "text": "Lands you control won't lose any other abilities they had. They also won't gain or lose any land types."
         }
       ],
       "text": "Lands you control have \"{T}: Add one mana of any color to your mana pool.\"\n{T}: Add one mana of any color to your mana pool.",
@@ -563,6 +572,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "9",
       "multiverseid": 420596,
       "name": "Chrome Mox",
       "number": "9",
@@ -578,11 +588,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If no card is imprinted on Chrome Mox, it can’t add mana to your mana pool. It can never add colorless mana to your mana pool, even if the imprinted card has a colorless mana symbol in its mana cost."
+          "text": "If no card is imprinted on Chrome Mox, it can't add mana to your mana pool. It can never add colorless mana to your mana pool, even if the imprinted card has a colorless mana symbol in its mana cost."
         },
         {
           "date": "2016-06-08",
-          "text": "If you imprinted a multicolored card, you choose one of that card’s colors each time Chrome Mox’s ability resolves."
+          "text": "If you imprinted a multicolored card, you choose one of that card's colors each time Chrome Mox's ability resolves."
         }
       ],
       "text": "Imprint — When Chrome Mox enters the battlefield, you may exile a nonartifact, nonland card from your hand.\n{T}: Add one mana of any of the exiled card's colors to your mana pool.",
@@ -621,6 +631,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "10",
       "multiverseid": 420597,
       "name": "Cloudstone Curio",
       "number": "10",
@@ -667,6 +678,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "11",
       "multiverseid": 420598,
       "name": "Crucible of Worlds",
       "number": "11",
@@ -686,11 +698,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Crucible of Worlds doesn’t change the times when you can play those land cards. You can still play only one land per turn, and only during your main phase when you have priority and the stack is empty."
+          "text": "Crucible of Worlds doesn't change the times when you can play those land cards. You can still play only one land per turn, and only during your main phase when you have priority and the stack is empty."
         },
         {
           "date": "2004-12-01",
-          "text": "Crucible of Worlds doesn’t allow you to activate activated abilities (such as cycling) of land cards in your graveyard."
+          "text": "Crucible of Worlds doesn't allow you to activate activated abilities (such as cycling) of land cards in your graveyard."
         }
       ],
       "text": "You may play land cards from your graveyard.",
@@ -728,6 +740,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "12",
       "multiverseid": 420599,
       "name": "Gauntlet of Power",
       "number": "12",
@@ -769,6 +782,7 @@
         }
       ],
       "manaCost": "{X}{X}",
+      "mciNumber": "13",
       "multiverseid": 420600,
       "name": "Hangarback Walker",
       "number": "13",
@@ -783,11 +797,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The value of each X in Hangarback Walker’s mana cost must be equal. For example, if X is 2, you’ll pay {4} to cast Hangarback Walker and it will enter the battlefield with two +1/+1 counters on it."
+          "text": "The value of each X in Hangarback Walker's mana cost must be equal. For example, if X is 2, you'll pay {4} to cast Hangarback Walker and it will enter the battlefield with two +1/+1 counters on it."
         },
         {
           "date": "2015-06-22",
-          "text": "If enough -1/-1 counters are put on Hangarback Walker at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got any -1/-1 counters will be used to determine how many Thopter tokens you get. For example, if there are three +1/+1 counters on Hangarback Walker and it gets four -1/-1 counters, you’ll get three Thopter tokens. That’s because Hangarback Walker’s triggered ability checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If enough -1/-1 counters are put on Hangarback Walker at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got any -1/-1 counters will be used to determine how many Thopter tokens you get. For example, if there are three +1/+1 counters on Hangarback Walker and it gets four -1/-1 counters, you'll get three Thopter tokens. That's because Hangarback Walker's triggered ability checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -831,6 +845,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "14",
       "multiverseid": 420601,
       "name": "Lightning Greaves",
       "number": "14",
@@ -851,7 +866,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You are not allowed to “unequip” equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won’t be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
+          "text": "You are not allowed to \"unequip\" equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won't be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
         }
       ],
       "subtypes": [
@@ -889,6 +904,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "15",
       "multiverseid": 420602,
       "name": "Lotus Petal",
       "number": "15",
@@ -929,6 +945,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "16",
       "multiverseid": 420603,
       "name": "Mana Crypt",
       "number": "16",
@@ -976,6 +993,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "17",
       "multiverseid": 420604,
       "name": "Mana Vault",
       "number": "17",
@@ -1031,6 +1049,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "18",
       "multiverseid": 420605,
       "name": "Mind's Eye",
       "number": "18",
@@ -1078,6 +1097,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "19",
       "multiverseid": 420606,
       "name": "Mox Opal",
       "number": "19",
@@ -1128,6 +1148,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "20",
       "multiverseid": 420607,
       "name": "Painter's Servant",
       "number": "20",
@@ -1146,23 +1167,23 @@
         },
         {
           "date": "2008-05-01",
-          "text": "This ability doesn’t overwrite any previous colors. Rather, it adds another color."
+          "text": "This ability doesn't overwrite any previous colors. Rather, it adds another color."
         },
         {
           "date": "2008-05-01",
-          "text": "The effects of multiple Painter’s Servants are cumulative."
+          "text": "The effects of multiple Painter's Servants are cumulative."
         },
         {
           "date": "2008-05-01",
-          "text": "While Painter’s Servant is on the battlefield, an effect that changes an object’s colors will overwrite Painter’s Servant’s effect. For example, casting Cerulean Wisps on a creature will turn it blue, regardless of the color chosen for Painter’s Servant."
+          "text": "While Painter's Servant is on the battlefield, an effect that changes an object's colors will overwrite Painter's Servant's effect. For example, casting Cerulean Wisps on a creature will turn it blue, regardless of the color chosen for Painter's Servant."
         },
         {
           "date": "2008-05-01",
-          "text": "Each card becomes a new object as it changes zones, so this effect will apply to it from scratch in the new zone. Zone-change replacement abilities that care about the new color (like “[color] permanents enter the battlefield tapped”) won’t work because those effects are applied as the card is entering its new zone. Zone-change triggered abilities that care about the new color (like “when a [color] permanent enters the battlefield” or “when you cast a [color] spell”) will work because those effects apply after the card is already in its new zone."
+          "text": "Each card becomes a new object as it changes zones, so this effect will apply to it from scratch in the new zone. Zone-change replacement abilities that care about the new color (like \"[color] permanents enter the battlefield tapped\") won't work because those effects are applied as the card is entering its new zone. Zone-change triggered abilities that care about the new color (like \"when a [color] permanent enters the battlefield\" or \"when you cast a [color] spell\") will work because those effects apply after the card is already in its new zone."
         },
         {
           "date": "2008-05-01",
-          "text": "If something affected by Painter’s Servant is normally colorless, it will simply be the new color. It won’t be both the new color and colorless."
+          "text": "If something affected by Painter's Servant is normally colorless, it will simply be the new color. It won't be both the new color and colorless."
         }
       ],
       "subtypes": [
@@ -1206,6 +1227,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "21",
       "multiverseid": 420608,
       "name": "Rings of Brighthearth",
       "number": "21",
@@ -1219,7 +1241,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         }
       ],
       "text": "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy.",
@@ -1253,6 +1275,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "22",
       "multiverseid": 420609,
       "name": "Scroll Rack",
       "number": "22",
@@ -1306,6 +1329,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "23",
       "multiverseid": 420610,
       "name": "Sculpting Steel",
       "number": "23",
@@ -1320,11 +1344,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Any enters-the-battlefield abilities of the copied artifact will trigger when Sculpting Steel enters the battlefield. Any “as enters the battlefield” or “enters the battlefield with” abilities of the chosen artifact will also work. For example, if Sculpting Steel copies an artifact creature with sunburst, the copy will get +1/+1 counters based on the number of different colors of mana used to pay Sculpting Steel’s total cost. If Sculpting Steel copies a noncreature artifact with sunburst, the copy will get charge counters based on the number of different colors of mana used to pay Sculpting Steel’s total cost."
+          "text": "Any enters-the-battlefield abilities of the copied artifact will trigger when Sculpting Steel enters the battlefield. Any \"as enters the battlefield\" or \"enters the battlefield with\" abilities of the chosen artifact will also work. For example, if Sculpting Steel copies an artifact creature with sunburst, the copy will get +1/+1 counters based on the number of different colors of mana used to pay Sculpting Steel's total cost. If Sculpting Steel copies a noncreature artifact with sunburst, the copy will get charge counters based on the number of different colors of mana used to pay Sculpting Steel's total cost."
         },
         {
           "date": "2007-07-15",
-          "text": "Sculpting Steel doesn’t copy whether the original artifact is tapped or untapped. It also doesn’t copy any counters on that artifact, any Auras or Equipment attached to that artifact, or any effects that are currently affecting that artifact — you get exactly what’s printed on the chosen card and nothing more. So if you copy an animated Chimeric Staff, for example, you get a normal, nonanimated Chimeric Staff."
+          "text": "Sculpting Steel doesn't copy whether the original artifact is tapped or untapped. It also doesn't copy any counters on that artifact, any Auras or Equipment attached to that artifact, or any effects that are currently affecting that artifact — you get exactly what's printed on the chosen card and nothing more. So if you copy an animated Chimeric Staff, for example, you get a normal, nonanimated Chimeric Staff."
         },
         {
           "date": "2007-07-15",
@@ -1336,7 +1360,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "You can choose not to copy anything. In that case, Sculpting Steel stays on the battlefield as an artifact that doesn’t do much of anything."
+          "text": "You can choose not to copy anything. In that case, Sculpting Steel stays on the battlefield as an artifact that doesn't do much of anything."
         }
       ],
       "text": "You may have Sculpting Steel enter the battlefield as a copy of any artifact on the battlefield.",
@@ -1367,6 +1391,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "24",
       "multiverseid": 420611,
       "name": "Sol Ring",
       "number": "24",
@@ -1427,6 +1452,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "25",
       "multiverseid": 420612,
       "name": "Solemn Simulacrum",
       "number": "25",
@@ -1480,6 +1506,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "26",
       "multiverseid": 420613,
       "name": "Static Orb",
       "number": "26",
@@ -1529,6 +1556,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "27",
       "multiverseid": 420614,
       "name": "Steel Overseer",
       "number": "27",
@@ -1544,7 +1572,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Steel Overseer is affected by its own ability (assuming that, by the time the ability resolves, you still control Steel Overseer and its types haven’t changed). You’ll put a +1/+1 counter on it, as well as on each other artifact creature you control."
+          "text": "Steel Overseer is affected by its own ability (assuming that, by the time the ability resolves, you still control Steel Overseer and its types haven't changed). You'll put a +1/+1 counter on it, as well as on each other artifact creature you control."
         }
       ],
       "subtypes": [
@@ -1587,6 +1615,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "28",
       "multiverseid": 420615,
       "name": "Sword of Feast and Famine",
       "number": "28",
@@ -1602,7 +1631,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You’ll untap all lands you control even if the player doesn’t discard a card."
+          "text": "You'll untap all lands you control even if the player doesn't discard a card."
         }
       ],
       "subtypes": [
@@ -1643,6 +1672,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "29",
       "multiverseid": 420616,
       "name": "Sword of Fire and Ice",
       "number": "29",
@@ -1658,7 +1688,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The triggered ability has one target: the creature or player to be dealt 2 damage. If that creature or player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "The triggered ability has one target: the creature or player to be dealt 2 damage. If that creature or player is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "subtypes": [
@@ -1699,6 +1729,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "30",
       "multiverseid": 420617,
       "name": "Sword of Light and Shadow",
       "number": "30",
@@ -1714,7 +1745,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You may put the triggered ability with no targets. However, If you choose a target creature in your graveyard, and that card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "You may put the triggered ability with no targets. However, If you choose a target creature in your graveyard, and that card is an illegal target when the ability tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "subtypes": [
@@ -1756,6 +1787,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "31",
       "multiverseid": 425802,
       "name": "Arcbound Ravager",
       "number": "31",
@@ -1806,6 +1838,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "32",
       "multiverseid": 425803,
       "name": "Black Vise",
       "number": "32",
@@ -1831,7 +1864,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "text": "As Black Vise enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, Black Vise deals X damage to that player, where X is the number of cards in his or her hand minus 4.",
@@ -1869,6 +1902,7 @@
         }
       ],
       "manaCost": "{X}{X}",
+      "mciNumber": "33",
       "multiverseid": 425804,
       "name": "Chalice of the Void",
       "number": "33",
@@ -1887,7 +1921,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The number of counters on Chalice of the Void matters only at the time the spell is cast. Changing the number of charge counters on Chalice of the Void after a spell has been cast won’t change whether the ability counters the spell. If the Chalice had the correct number of counters when the spell was cast, its ability will trigger. If the Chalice had too many or too few counters when the spell was cast, the Chalice’s ability won’t trigger."
+          "text": "The number of counters on Chalice of the Void matters only at the time the spell is cast. Changing the number of charge counters on Chalice of the Void after a spell has been cast won't change whether the ability counters the spell. If the Chalice had the correct number of counters when the spell was cast, its ability will trigger. If the Chalice had too many or too few counters when the spell was cast, the Chalice's ability won't trigger."
         },
         {
           "date": "2004-12-01",
@@ -1895,7 +1929,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Chalice of the Void has to be on the battlefield at the end of casting a spell for the ability to trigger. If you sacrifice Chalice of the Void as a cost to cast a spell, its ability can’t trigger."
+          "text": "Chalice of the Void has to be on the battlefield at the end of casting a spell for the ability to trigger. If you sacrifice Chalice of the Void as a cost to cast a spell, its ability can't trigger."
         }
       ],
       "text": "Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
@@ -1934,6 +1968,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "34",
       "multiverseid": 425805,
       "name": "Defense Grid",
       "number": "34",
@@ -1953,7 +1988,7 @@
         },
         {
           "date": "2006-05-01",
-          "text": "In Two-Headed Giant, spells don’t cost extra on your own turn."
+          "text": "In Two-Headed Giant, spells don't cost extra on your own turn."
         }
       ],
       "text": "Each spell costs {3} more to cast except during its controller's turn.",
@@ -1991,6 +2026,7 @@
         }
       ],
       "manaCost": "{6}",
+      "mciNumber": "35",
       "multiverseid": 425806,
       "name": "Duplicant",
       "number": "35",
@@ -2012,11 +2048,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Duplicant’s base power and toughness change to the imprinted card’s power and toughness. Counters and other effects that modify Duplicant’s power and toughness still apply."
+          "text": "Duplicant's base power and toughness change to the imprinted card's power and toughness. Counters and other effects that modify Duplicant's power and toughness still apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Abilities that define a creature’s power and toughness apply while that card is in exile, but abilities that add or subtract from it don’t. For example, the ability of Battle Squadron applies to determine Duplicant’s power and toughness, but the ability of Werebear doesn’t. Duplicant’s power and toughness are constantly updated if the exiled card’s power and/or toughness change."
+          "text": "Abilities that define a creature's power and toughness apply while that card is in exile, but abilities that add or subtract from it don't. For example, the ability of Battle Squadron applies to determine Duplicant's power and toughness, but the ability of Werebear doesn't. Duplicant's power and toughness are constantly updated if the exiled card's power and/or toughness change."
         },
         {
           "date": "2016-06-08",
@@ -2024,7 +2060,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If a melded permanent is exiled by Duplicant’s triggered ability, that ability’s controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
+          "text": "If a melded permanent is exiled by Duplicant's triggered ability, that ability's controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
         }
       ],
       "subtypes": [
@@ -2067,6 +2103,7 @@
         }
       ],
       "manaCost": "{X}",
+      "mciNumber": "36",
       "multiverseid": 425807,
       "name": "Engineered Explosives",
       "number": "36",
@@ -2081,7 +2118,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If Engineered Explosives had no charge counters on it when you sacrificed it, it won’t destroy an animated land, because that permanent is a land in addition to being a creature."
+          "text": "If Engineered Explosives had no charge counters on it when you sacrificed it, it won't destroy an animated land, because that permanent is a land in addition to being a creature."
         }
       ],
       "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
@@ -2120,6 +2157,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "37",
       "multiverseid": 425808,
       "name": "Ensnaring Bridge",
       "number": "37",
@@ -2177,6 +2215,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "38",
       "multiverseid": 425809,
       "name": "Extraplanar Lens",
       "number": "38",
@@ -2219,6 +2258,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "39",
       "multiverseid": 425810,
       "name": "Grindstone",
       "number": "39",
@@ -2268,6 +2308,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "40",
       "multiverseid": 425811,
       "name": "Meekstone",
       "number": "40",
@@ -2322,6 +2363,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "41",
       "multiverseid": 425812,
       "name": "Oblivion Stone",
       "number": "41",
@@ -2377,6 +2419,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "42",
       "multiverseid": 425813,
       "name": "Ornithopter",
       "number": "42",
@@ -2444,6 +2487,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "43",
       "multiverseid": 425814,
       "name": "Paradox Engine",
       "number": "43",
@@ -2457,7 +2501,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Paradox Engine’s triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+          "text": "Paradox Engine's triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
         }
       ],
       "supertypes": [
@@ -2502,6 +2546,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "44",
       "multiverseid": 425815,
       "name": "Pithing Needle",
       "number": "44",
@@ -2518,15 +2563,15 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Pithing Needle affects cards regardless of what zone they’re in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can’t cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
+          "text": "Pithing Needle affects cards regardless of what zone they're in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can't cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
         },
         {
           "date": "2005-06-01",
-          "text": "You can name any card, even if that card doesn’t normally have an activated ability. You can’t name a token unless that token has the same name as a card."
+          "text": "You can name any card, even if that card doesn't normally have an activated ability. You can't name a token unless that token has the same name as a card."
         },
         {
           "date": "2005-06-01",
-          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can’t be activated."
+          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -2534,7 +2579,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” Triggered abilities and static abilities of the named card work normally."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" Triggered abilities and static abilities of the named card work normally."
         }
       ],
       "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
@@ -2577,6 +2622,7 @@
         }
       ],
       "manaCost": "{6}",
+      "mciNumber": "45",
       "multiverseid": 425816,
       "name": "Planar Bridge",
       "number": "45",
@@ -2632,6 +2678,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "46",
       "multiverseid": 425817,
       "name": "Platinum Angel",
       "number": "46",
@@ -2651,23 +2698,23 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They’ll still work."
+          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They'll still work."
         },
         {
           "date": "2004-12-01",
-          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can’t prevent you from losing the game)."
+          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can't prevent you from losing the game)."
         },
         {
           "date": "2009-10-01",
-          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn’t matter whether you have 0 or less life, you’re forced to draw a card while your library is empty, you have ten or more poison counters, you’re dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
+          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn't matter whether you have 0 or less life, you're forced to draw a card while your library is empty, you have ten or more poison counters, you're dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
         },
         {
           "date": "2009-10-01",
-          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you’re penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
+          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you're penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
         },
         {
           "date": "2009-10-01",
-          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can’t lose the game and the opposing team can’t win the game."
+          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can't lose the game and the opposing team can't win the game."
         }
       ],
       "subtypes": [
@@ -2684,7 +2731,7 @@
     {
       "artist": "Richard Wright",
       "cmc": 2,
-      "flavor": "\"At the outset, we weren't aware of Chief Baral's motives for the project. It's now apparent that he intends to use the device to hamper the ‘mages' among the ranks of the renegades.\"\n—Consulate engineer's log",
+      "flavor": "\"At the outset, we weren't aware of Chief Baral's motives for the project. It's now apparent that he intends to use the device to hamper the 'mages' among the ranks of the renegades.\"\n—Consulate engineer's log",
       "id": "ff31af9b51661edb5cc9ea6fc3521b779998f83f",
       "imageName": "sphere of resistance",
       "layout": "normal",
@@ -2707,6 +2754,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "47",
       "multiverseid": 425818,
       "name": "Sphere of Resistance",
       "number": "47",
@@ -2759,6 +2807,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "48",
       "multiverseid": 425819,
       "name": "Staff of Domination",
       "number": "48",
@@ -2805,6 +2854,7 @@
         }
       ],
       "manaCost": "{8}",
+      "mciNumber": "49",
       "multiverseid": 425820,
       "name": "Sundering Titan",
       "number": "49",
@@ -2821,11 +2871,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Sundering Titan’s two abilities aren’t targeted. When one of the abilities resolves, the Titan’s controller must choose one land for each basic land type (Plains, Island, Swamp, Mountain, and Forest)."
+          "text": "Sundering Titan's two abilities aren't targeted. When one of the abilities resolves, the Titan's controller must choose one land for each basic land type (Plains, Island, Swamp, Mountain, and Forest)."
         },
         {
           "date": "2004-12-01",
-          "text": "If one of the basic land types isn’t present, it isn’t chosen. If the only land of a certain type is one you control, you must choose it."
+          "text": "If one of the basic land types isn't present, it isn't chosen. If the only land of a certain type is one you control, you must choose it."
         },
         {
           "date": "2004-12-01",
@@ -2876,6 +2926,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "50",
       "multiverseid": 425821,
       "name": "Sword of Body and Mind",
       "number": "50",
@@ -2890,7 +2941,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If there are fewer than ten cards in that player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than ten cards in that player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "subtypes": [
@@ -2931,6 +2982,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "51",
       "multiverseid": 425822,
       "name": "Sword of War and Peace",
       "number": "51",
@@ -2944,7 +2996,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You count the cards in the each player’s hand when the triggered ability resolves."
+          "text": "You count the cards in the each player's hand when the triggered ability resolves."
         }
       ],
       "subtypes": [
@@ -2986,6 +3038,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "52",
       "multiverseid": 425823,
       "name": "Trinisphere",
       "number": "52",
@@ -3000,15 +3053,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Trinisphere’s ability affects the total cost of the spell. It is applied *after* any other cost increasers or cost reducers are applied: First apply any cost increases. Next apply any cost reducers. Finally look at the amount of mana you have to pay. If it’s less than three mana, you’ll pay three mana."
+          "text": "Trinisphere's ability affects the total cost of the spell. It is applied *after* any other cost increasers or cost reducers are applied: First apply any cost increases. Next apply any cost reducers. Finally look at the amount of mana you have to pay. If it's less than three mana, you'll pay three mana."
         },
         {
           "date": "2004-12-01",
-          "text": "Even with a cost reducer on the battlefield, spells can’t cost less than three mana to cast."
+          "text": "Even with a cost reducer on the battlefield, spells can't cost less than three mana to cast."
         },
         {
           "date": "2004-12-01",
-          "text": "If a spell costs at least three mana due to additional costs, such as kicker costs, that’s fine."
+          "text": "If a spell costs at least three mana due to additional costs, such as kicker costs, that's fine."
         },
         {
           "date": "2004-12-01",
@@ -3016,7 +3069,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Casting a creature with morph face down already costs three mana, even though the converted mana cost of the face-down spell is zero, so Trinisphere normally doesn’t modify the total cost of a face-down creature spell. However, if Dream Chisel is reducing that cost while Trinisphere is on the battlefield, you’ll still have to pay three mana for the spell."
+          "text": "Casting a creature with morph face down already costs three mana, even though the converted mana cost of the face-down spell is zero, so Trinisphere normally doesn't modify the total cost of a face-down creature spell. However, if Dream Chisel is reducing that cost while Trinisphere is on the battlefield, you'll still have to pay three mana for the spell."
         }
       ],
       "text": "As long as Trinisphere is untapped, each spell that would cost less than three mana to cast costs three mana to cast. (Additional mana in the cost may be paid with any color of mana or colorless mana. For example, a spell that would cost {1}{B} to cast costs {2}{B} to cast instead.)",
@@ -3054,6 +3107,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "53",
       "multiverseid": 425824,
       "name": "Vedalken Shackles",
       "number": "53",
@@ -3068,15 +3122,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The creature’s power and the number of Islands you control matter only when the ability is activated and when it resolves. After that, only the fact that Vedalken Shackles remains tapped matters. If the creature stops being a creature, you’ll keep control of it."
+          "text": "The creature's power and the number of Islands you control matter only when the ability is activated and when it resolves. After that, only the fact that Vedalken Shackles remains tapped matters. If the creature stops being a creature, you'll keep control of it."
         },
         {
           "date": "2004-12-01",
-          "text": "If Vedalken Shackles becomes untapped before its ability resolves, you won’t gain control of the creature."
+          "text": "If Vedalken Shackles becomes untapped before its ability resolves, you won't gain control of the creature."
         },
         {
           "date": "2004-12-01",
-          "text": "If Vedalken Shackles leaves the battlefield, it’s no longer tapped, so the control-changing effect ends."
+          "text": "If Vedalken Shackles leaves the battlefield, it's no longer tapped, so the control-changing effect ends."
         }
       ],
       "text": "You may choose not to untap Vedalken Shackles during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control for as long as Vedalken Shackles remains tapped.",
@@ -3114,6 +3168,7 @@
         }
       ],
       "manaCost": "{6}",
+      "mciNumber": "54",
       "multiverseid": 425825,
       "name": "Wurmcoil Engine",
       "number": "54",

--- a/json/MPS_AKH.json
+++ b/json/MPS_AKH.json
@@ -3123,7 +3123,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3240,7 +3260,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],
@@ -3319,7 +3359,27 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
           "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
           "legality": "Legal"
         }
       ],

--- a/json/MRD.json
+++ b/json/MRD.json
@@ -216,7 +216,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -664,7 +664,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The second mode affects all creatures during the player’s next untap step, including creatures controlled by other players (who may have untapped because of Seedborn Muse, for example) and creatures that weren’t on the battlefield when Blinding Beam resolved."
+          "text": "The second mode affects all creatures during the player's next untap step, including creatures controlled by other players (who may have untapped because of Seedborn Muse, for example) and creatures that weren't on the battlefield when Blinding Beam resolved."
         }
       ],
       "text": "Choose one —\n• Tap two target creatures.\n• Creatures don't untap during target player's next untap step.\nEntwine {1} (Choose both if you pay the entwine cost.)",
@@ -2874,7 +2874,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The Equipment remains on the battlefield under its controller’s control, but is no longer attached to that creature."
+          "text": "The Equipment remains on the battlefield under its controller's control, but is no longer attached to that creature."
         }
       ],
       "text": "Unattach all Equipment from target creature.",
@@ -2964,7 +2964,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The enchanted permanent must be both an artifact and a creature. Domineer can be cast only on an artifact creature. Domineer “falls off” and is put into the graveyard if the artifact creature it’s enchanting stops being an artifact or stops being a creature."
+          "text": "The enchanted permanent must be both an artifact and a creature. Domineer can be cast only on an artifact creature. Domineer \"falls off\" and is put into the graveyard if the artifact creature it's enchanting stops being an artifact or stops being a creature."
         }
       ],
       "subtypes": [
@@ -3781,7 +3781,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If an Equipment becomes a creature, it can no longer equip a creature. If it’s currently attached to a creature, it becomes unattached (but remains on the battlefield). You can activate the Equipment’s equip ability, but it won’t do anything."
+          "text": "If an Equipment becomes a creature, it can no longer equip a creature. If it's currently attached to a creature, it becomes unattached (but remains on the battlefield). You can activate the Equipment's equip ability, but it won't do anything."
         },
         {
           "date": "2004-12-01",
@@ -3789,11 +3789,11 @@
         },
         {
           "date": "2007-07-15",
-          "text": "If a noncreature artifact becomes an artifact creature this way and then another effect animates it, the new effect overrides March of the Machines’s effect. For example, Chimeric Staff is a 4/4 creature while March of the Machines is on the battlefield. If you activate Chimeric Staff’s ability and choose X = 5, Chimeric Staff will be a 5/5 artifact creature for the rest of the turn."
+          "text": "If a noncreature artifact becomes an artifact creature this way and then another effect animates it, the new effect overrides March of the Machines's effect. For example, Chimeric Staff is a 4/4 creature while March of the Machines is on the battlefield. If you activate Chimeric Staff's ability and choose X = 5, Chimeric Staff will be a 5/5 artifact creature for the rest of the turn."
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         }
       ],
       "text": "Each noncreature artifact is an artifact creature with power and toughness each equal to its converted mana cost. (Equipment that's a creature can't equip a creature.)",
@@ -3989,7 +3989,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"The Knowledge Pool has all the answers—especially ‘No.'\"",
+      "flavor": "\"The Knowledge Pool has all the answers—especially 'No.'\"",
       "foreignNames": [
         {
           "language": "French",
@@ -4234,7 +4234,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you use this card to gain Wall of Deceit’s ability to turn itself face down, you will not be able to turn this card face up because it will not have the Morph ability."
+          "text": "If you use this card to gain Wall of Deceit's ability to turn itself face down, you will not be able to turn this card face up because it will not have the Morph ability."
         },
         {
           "date": "2004-10-04",
@@ -4246,23 +4246,23 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Quicksilver Elemental gains only activated abilities. It doesn’t gain keyword abilities (unless those keyword abilities are activated), triggered abilities, or static abilities."
+          "text": "Quicksilver Elemental gains only activated abilities. It doesn't gain keyword abilities (unless those keyword abilities are activated), triggered abilities, or static abilities."
         },
         {
           "date": "2004-12-01",
-          "text": "Quicksilver Elemental can gain the activated abilities of any creature on the battlefield that you can target with its ability, even if you don’t control that creature."
+          "text": "Quicksilver Elemental can gain the activated abilities of any creature on the battlefield that you can target with its ability, even if you don't control that creature."
         },
         {
           "date": "2004-12-01",
-          "text": "The granted abilities effectively use “this permanent,” rather than “[that card’s name],” so you treat the abilities as if they were printed on Quicksilver Elemental. For example, you treat an ability that says “Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn” as “Sacrifice a creature: Quicksilver Elemental gets +2/+2 until end of turn.”"
+          "text": "The granted abilities effectively use \"this permanent,\" rather than \"[that card's name],\" so you treat the abilities as if they were printed on Quicksilver Elemental. For example, you treat an ability that says \"Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn\" as \"Sacrifice a creature: Quicksilver Elemental gets +2/+2 until end of turn.\""
         },
         {
           "date": "2004-12-01",
-          "text": "Quicksilver Elemental has a rather tricky interaction with Leonin Bola. You can actually unattach your opponent’s Bola as part of the cost of activating the Elemental-copied ability."
+          "text": "Quicksilver Elemental has a rather tricky interaction with Leonin Bola. You can actually unattach your opponent's Bola as part of the cost of activating the Elemental-copied ability."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -4444,11 +4444,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You need to pay the costs of any cards you play from the Exile zone. This could be a problem if you don’t have the right colors of mana available."
+          "text": "You need to pay the costs of any cards you play from the Exile zone. This could be a problem if you don't have the right colors of mana available."
         },
         {
           "date": "2004-12-01",
-          "text": "Replacing your draws isn’t optional. You can’t draw cards from your own library, even if all your opponents’ libraries are empty."
+          "text": "Replacing your draws isn't optional. You can't draw cards from your own library, even if all your opponents' libraries are empty."
         },
         {
           "date": "2004-12-01",
@@ -4456,7 +4456,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The cards are exiled, not put onto the players’ hands. Players can look at and play the exiled cards, but can’t do anything else with them (the exiled cards can’t be discarded or cycled, for example)."
+          "text": "The cards are exiled, not put onto the players' hands. Players can look at and play the exiled cards, but can't do anything else with them (the exiled cards can't be discarded or cycled, for example)."
         },
         {
           "date": "2008-08-01",
@@ -4729,7 +4729,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Choose one —\n• Each player shuffles his or her hand and graveyard into his or her library.\n• Each player draws seven cards.\nEntwine {2} (Choose both if you pay the entwine cost.)",
@@ -5197,7 +5197,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "Barter in Blood doesn’t target any creatures and may be cast even if a player controls fewer than two creatures."
+          "text": "Barter in Blood doesn't target any creatures and may be cast even if a player controls fewer than two creatures."
         }
       ],
       "text": "Each player sacrifices two creatures.",
@@ -5471,7 +5471,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature or player is an illegal target by the time Consume Spirit would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
@@ -6707,11 +6707,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The power and toughness of the Demon token are set when Promise of Power resolves. They’re unaffected if the number of cards in your hand changes later."
+          "text": "The power and toughness of the Demon token are set when Promise of Power resolves. They're unaffected if the number of cards in your hand changes later."
         },
         {
           "date": "2004-12-01",
-          "text": "If you pay the entwine cost, you draw five cards, then lose five life, then put the Demon token onto the battlefield. The five cards you draw count toward the Demon’s power and toughness."
+          "text": "If you pay the entwine cost, you draw five cards, then lose five life, then put the Demon token onto the battlefield. The five cards you draw count toward the Demon's power and toughness."
         }
       ],
       "text": "Choose one —\n• You draw five cards and you lose 5 life.\n• Create an X/X black Demon creature token with flying, where X is the number of cards in your hand.\nEntwine {4} (Choose both if you pay the entwine cost.)",
@@ -6805,7 +6805,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -7882,7 +7882,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The exchange isn’t optional. If there is a legal choice, you must make one."
+          "text": "The exchange isn't optional. If there is a legal choice, you must make one."
         },
         {
           "date": "2004-12-01",
@@ -7894,7 +7894,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The permanents are exchanged only if they’re both on the battlefield when the ability resolves."
+          "text": "The permanents are exchanged only if they're both on the battlefield when the ability resolves."
         },
         {
           "date": "2004-12-01",
@@ -8167,11 +8167,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You must choose a target creature when you cast Fiery Gambit. If that target isn’t legal on resolution, Fiery Gambit has no effect and you don’t even flip a coin."
+          "text": "You must choose a target creature when you cast Fiery Gambit. If that target isn't legal on resolution, Fiery Gambit has no effect and you don't even flip a coin."
         },
         {
           "date": "2004-12-01",
-          "text": "You can flip any number of coins (you can even flip more than three), but Fiery Gambit has no effect if you lose any of the flips. You can’t continue flipping if you lose a flip."
+          "text": "You can flip any number of coins (you can even flip more than three), but Fiery Gambit has no effect if you lose any of the flips. You can't continue flipping if you lose a flip."
         },
         {
           "date": "2004-12-01",
@@ -8617,11 +8617,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If you choose the “sacrifice a creature” mode, you choose the target of the damage on announcement, but don’t choose what to sacrifice until resolution. You must sacrifice a creature when Grab the Reins resolves, even if you don’t want to. If you don’t control any creatures at that time, Grab the Reins deals no damage."
+          "text": "If you choose the \"sacrifice a creature\" mode, you choose the target of the damage on announcement, but don't choose what to sacrifice until resolution. You must sacrifice a creature when Grab the Reins resolves, even if you don't want to. If you don't control any creatures at that time, Grab the Reins deals no damage."
         },
         {
           "date": "2004-12-01",
-          "text": "If you cast this with Entwine, you don’t get priority in the middle of resolution. You can’t steal something, do anything (like attack with it), and then sacrifice it."
+          "text": "If you cast this with Entwine, you don't get priority in the middle of resolution. You can't steal something, do anything (like attack with it), and then sacrifice it."
         }
       ],
       "text": "Choose one —\n• Until end of turn, you gain control of target creature and it gains haste.\n• Sacrifice a creature. Grab the Reins deals damage equal to that creature's power to target creature or player.\nEntwine {2}{R} (Choose both if you pay the entwine cost.)",
@@ -9625,7 +9625,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You must sacrifice exactly one artifact to cast this spell; you can’t cast it without sacrificing an artifact, and you can’t sacrifice additional artifacts."
+          "text": "You must sacrifice exactly one artifact to cast this spell; you can't cast it without sacrificing an artifact, and you can't sacrifice additional artifacts."
         },
         {
           "date": "2014-07-18",
@@ -9991,11 +9991,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Other players’ Equipment is moved onto the Battlemaster as well as your own. This doesn’t change who controls the Equipment or who can activate its equip ability to move it onto another creature."
+          "text": "Other players' Equipment is moved onto the Battlemaster as well as your own. This doesn't change who controls the Equipment or who can activate its equip ability to move it onto another creature."
         },
         {
           "date": "2004-12-01",
-          "text": "If an Equipment can’t equip Vulshok Battlemaster, it isn’t attached to the Battlemaster, and it doesn’t become unattached (if it’s attached to a creature)."
+          "text": "If an Equipment can't equip Vulshok Battlemaster, it isn't attached to the Battlemaster, and it doesn't become unattached (if it's attached to a creature)."
         }
       ],
       "subtypes": [
@@ -10444,7 +10444,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -10906,11 +10906,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The artifact’s converted mana cost must be exactly equal to the amount of mana in your mana pool when the ability resolves. If there’s less mana or more mana, the artifact won’t be destroyed."
+          "text": "The artifact's converted mana cost must be exactly equal to the amount of mana in your mana pool when the ability resolves. If there's less mana or more mana, the artifact won't be destroyed."
         },
         {
           "date": "2004-12-01",
-          "text": "The mana has to be in your mana pool before the ability resolves. The ability doesn’t allow you to activate mana abilities while it’s resolving."
+          "text": "The mana has to be in your mana pool before the ability resolves. The ability doesn't allow you to activate mana abilities while it's resolving."
         }
       ],
       "subtypes": [
@@ -11179,7 +11179,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "If you cast an entwined Journey of Discovery using Vedalken Orrery during an opponent’s turn, you can’t play two lands during that turn."
+          "text": "If you cast an entwined Journey of Discovery using Vedalken Orrery during an opponent's turn, you can't play two lands during that turn."
         }
       ],
       "text": "Choose one —\n• Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle your library.\n• You may play up to two additional lands this turn.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
@@ -13035,7 +13035,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The counters stay on Banshee’s Blade even if it becomes unattached, or moves from one creature to another."
+          "text": "The counters stay on Banshee's Blade even if it becomes unattached, or moves from one creature to another."
         }
       ],
       "subtypes": [
@@ -13127,7 +13127,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The “precombat main phase” is the first main phase of the turn. All other main phases are “postcombat main phases.”"
+          "text": "The \"precombat main phase\" is the first main phase of the turn. All other main phases are \"postcombat main phases.\""
         }
       ],
       "text": "At the beginning of each player's precombat main phase, if Blinkmoth Urn is untapped, that player adds {C} to his or her mana pool for each artifact he or she controls.",
@@ -13493,7 +13493,7 @@
         },
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -13587,7 +13587,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The number of counters on Chalice of the Void matters only at the time the spell is cast. Changing the number of charge counters on Chalice of the Void after a spell has been cast won’t change whether the ability counters the spell. If the Chalice had the correct number of counters when the spell was cast, its ability will trigger. If the Chalice had too many or too few counters when the spell was cast, the Chalice’s ability won’t trigger."
+          "text": "The number of counters on Chalice of the Void matters only at the time the spell is cast. Changing the number of charge counters on Chalice of the Void after a spell has been cast won't change whether the ability counters the spell. If the Chalice had the correct number of counters when the spell was cast, its ability will trigger. If the Chalice had too many or too few counters when the spell was cast, the Chalice's ability won't trigger."
         },
         {
           "date": "2004-12-01",
@@ -13595,7 +13595,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Chalice of the Void has to be on the battlefield at the end of casting a spell for the ability to trigger. If you sacrifice Chalice of the Void as a cost to cast a spell, its ability can’t trigger."
+          "text": "Chalice of the Void has to be on the battlefield at the end of casting a spell for the ability to trigger. If you sacrifice Chalice of the Void as a cost to cast a spell, its ability can't trigger."
         }
       ],
       "text": "Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
@@ -13684,7 +13684,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "This is a mana ability, which means it can be activated as part of the process of casting a spell or activating another ability. If that happens you get the mana right away, but you don’t get to look at the drawn card until you have finished casting that spell or activating that ability."
+          "text": "This is a mana ability, which means it can be activated as part of the process of casting a spell or activating another ability. If that happens you get the mana right away, but you don't get to look at the drawn card until you have finished casting that spell or activating that ability."
         }
       ],
       "text": "{1}, {T}, Sacrifice Chromatic Sphere: Add one mana of any color to your mana pool. Draw a card.",
@@ -13770,11 +13770,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If no card is imprinted on Chrome Mox, it can’t add mana to your mana pool. It can never add colorless mana to your mana pool, even if the imprinted card has a colorless mana symbol in its mana cost."
+          "text": "If no card is imprinted on Chrome Mox, it can't add mana to your mana pool. It can never add colorless mana to your mana pool, even if the imprinted card has a colorless mana symbol in its mana cost."
         },
         {
           "date": "2016-06-08",
-          "text": "If you imprinted a multicolored card, you choose one of that card’s colors each time Chrome Mox’s ability resolves."
+          "text": "If you imprinted a multicolored card, you choose one of that card's colors each time Chrome Mox's ability resolves."
         }
       ],
       "text": "Imprint — When Chrome Mox enters the battlefield, you may exile a nonartifact, nonland card from your hand.\n{T}: Add one mana of any of the exiled card's colors to your mana pool.",
@@ -14458,15 +14458,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You choose the target. If there’s more than one nonland permanent tied for lowest converted mana cost, you choose which one to target."
+          "text": "You choose the target. If there's more than one nonland permanent tied for lowest converted mana cost, you choose which one to target."
         },
         {
           "date": "2004-12-01",
-          "text": "If the targeted permanent doesn’t have the lowest converted mana cost when the ability resolves, the ability is countered and the permanent isn’t destroyed."
+          "text": "If the targeted permanent doesn't have the lowest converted mana cost when the ability resolves, the ability is countered and the permanent isn't destroyed."
         },
         {
           "date": "2004-12-01",
-          "text": "Most tokens have a converted mana cost of 0. A token that’s a copy of another permanent or card has a converted mana cost equal to that permanent or card’s converted mana cost."
+          "text": "Most tokens have a converted mana cost of 0. A token that's a copy of another permanent or card has a converted mana cost equal to that permanent or card's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -14555,7 +14555,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keyword abilities, such as equip, are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keyword abilities, such as equip, are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2017-03-14",
@@ -14563,7 +14563,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Damping Matrix’s ability affects only artifacts and creatures on the battlefield. Activated abilities that work in other zones (such as bloodrush or unearth) can still be activated. Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected."
+          "text": "Damping Matrix's ability affects only artifacts and creatures on the battlefield. Activated abilities that work in other zones (such as bloodrush or unearth) can still be activated. Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected."
         }
       ],
       "text": "Activated abilities of artifacts and creatures can't be activated unless they're mana abilities.",
@@ -14909,11 +14909,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Duplicant’s base power and toughness change to the imprinted card’s power and toughness. Counters and other effects that modify Duplicant’s power and toughness still apply."
+          "text": "Duplicant's base power and toughness change to the imprinted card's power and toughness. Counters and other effects that modify Duplicant's power and toughness still apply."
         },
         {
           "date": "2016-06-08",
-          "text": "Abilities that define a creature’s power and toughness apply while that card is in exile, but abilities that add or subtract from it don’t. For example, the ability of Battle Squadron applies to determine Duplicant’s power and toughness, but the ability of Werebear doesn’t. Duplicant’s power and toughness are constantly updated if the exiled card’s power and/or toughness change."
+          "text": "Abilities that define a creature's power and toughness apply while that card is in exile, but abilities that add or subtract from it don't. For example, the ability of Battle Squadron applies to determine Duplicant's power and toughness, but the ability of Werebear doesn't. Duplicant's power and toughness are constantly updated if the exiled card's power and/or toughness change."
         },
         {
           "date": "2016-06-08",
@@ -14921,7 +14921,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "If a melded permanent is exiled by Duplicant’s triggered ability, that ability’s controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
+          "text": "If a melded permanent is exiled by Duplicant's triggered ability, that ability's controller chooses the relative timestamp of the two meld cards. Duplicant looks at the information of the one with the later timestamp."
         }
       ],
       "subtypes": [
@@ -15011,7 +15011,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Setting up the regeneration shield doesn’t remove Duskworker from combat. However, Duskworker is removed from combat if it would be destroyed and then regenerates."
+          "text": "Setting up the regeneration shield doesn't remove Duskworker from combat. However, Duskworker is removed from combat if it would be destroyed and then regenerates."
         }
       ],
       "subtypes": [
@@ -15360,7 +15360,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Each instance of each creature’s combat damage is counted separately. If three creatures with double strike attack you and all of them are unblocked, you may draw up to six cards."
+          "text": "Each instance of each creature's combat damage is counted separately. If three creatures with double strike attack you and all of them are unblocked, you may draw up to six cards."
         }
       ],
       "text": "Whenever a source an opponent controls deals damage to you, if Farsight Mask is untapped, you may draw a card.",
@@ -15847,7 +15847,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You must choose a target for Goblin Charbelcher’s ability as you activate it, before you reveal any cards."
+          "text": "You must choose a target for Goblin Charbelcher's ability as you activate it, before you reveal any cards."
         },
         {
           "date": "2016-06-08",
@@ -16453,7 +16453,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -16732,19 +16732,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player’s pool."
+          "text": "Tapping a card with an effect like this will never pay the cost of an ability. For example, tapping a land with this card will not put mana into a player's pool."
         },
         {
           "date": "2004-10-04",
-          "text": "Icy Manipulator can’t be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
+          "text": "Icy Manipulator can't be used to stop someone from using an ability of the permanent you plan to tap. It can be used to make a player use the ability now or to not use it."
         },
         {
           "date": "2004-10-04",
-          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger “if the card becomes tapped” effects."
+          "text": "The ability can target a tapped card, but tapping a tapped card does nothing useful. And it will not trigger \"if the card becomes tapped\" effects."
         },
         {
           "date": "2004-10-04",
-          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can’t wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can’t start declaring attackers without letting you use the Icy Manipulator."
+          "text": "If you want to stop someone from attacking with a creature by using this card, you must do so before attackers are declared. You can't wait until after attackers are declared and then try to use it to make a creature stop attacking. Note that your opponent can't start declaring attackers without letting you use the Icy Manipulator."
         },
         {
           "date": "2004-10-04",
@@ -16928,7 +16928,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the imprinted card leaves the exile zone while the activated ability is on the stack, the copy can’t be made."
+          "text": "If the imprinted card leaves the exile zone while the activated ability is on the stack, the copy can't be made."
         },
         {
           "date": "2016-06-08",
@@ -16940,7 +16940,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Because you’re already casting the spell using an alternative cost (by casting it without paying its mana cost), you can’t pay any other alternative costs for the card. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
+          "text": "Because you're already casting the spell using an alternative cost (by casting it without paying its mana cost), you can't pay any other alternative costs for the card. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2016-06-08",
@@ -16948,7 +16948,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you don’t want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
+          "text": "If you don't want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
         },
         {
           "date": "2017-04-18",
@@ -17035,11 +17035,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "“You” is always Jinxed Choker’s current controller."
+          "text": "\"You\" is always Jinxed Choker's current controller."
         },
         {
           "date": "2004-12-01",
-          "text": "If you activate Jinxed Choker’s activated ability, you choose to either add or remove a counter when the ability resolves."
+          "text": "If you activate Jinxed Choker's activated ability, you choose to either add or remove a counter when the ability resolves."
         }
       ],
       "text": "At the beginning of your end step, target opponent gains control of Jinxed Choker and puts a charge counter on it.\nAt the beginning of your upkeep, Jinxed Choker deals damage to you equal to the number of charge counters on it.\n{3}: Put a charge counter on Jinxed Choker or remove one from it.",
@@ -17123,11 +17123,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you and your opponent both flip at the same time, you can see your opponent’s result before choosing which result to keep."
+          "text": "If you and your opponent both flip at the same time, you can see your opponent's result before choosing which result to keep."
         },
         {
           "date": "2013-04-15",
-          "text": "If an effect tells you to flip more than one coin at once, this replace each individual coin flip. For example, if an effect tells you to flip two coins, you’ll first flip two coins and ignore one, then flip two more coins and ignore one of those. You don’t flip four coins and ignore two."
+          "text": "If an effect tells you to flip more than one coin at once, this replace each individual coin flip. For example, if an effect tells you to flip two coins, you'll first flip two coins and ignore one, then flip two more coins and ignore one of those. You don't flip four coins and ignore two."
         }
       ],
       "supertypes": [
@@ -17635,7 +17635,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "After the opponent has guessed, you may reveal your hand. If your opponent was wrong, you draw a card. If your opponent was right, you don’t draw a card."
+          "text": "After the opponent has guessed, you may reveal your hand. If your opponent was wrong, you draw a card. If your opponent was right, you don't draw a card."
         },
         {
           "date": "2004-12-01",
@@ -17643,7 +17643,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t draw a card if you don’t reveal your hand."
+          "text": "You can't draw a card if you don't reveal your hand."
         }
       ],
       "text": "{2}, {T}: Choose a card name. Target opponent guesses whether a card with that name is in your hand. You may reveal your hand. If you do and your opponent guessed wrong, draw a card.",
@@ -17730,7 +17730,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{G}, Sacrifice Lifespark Spellbomb: Until end of turn, target land becomes a 3/3 creature that's still a land.\n{1}, Sacrifice Lifespark Spellbomb: Draw a card.",
@@ -17898,7 +17898,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You are not allowed to “unequip” equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won’t be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
+          "text": "You are not allowed to \"unequip\" equipment from a creature. If Lightning Greaves is attached to the only creature you control, you won't be able to attach other equipment to it (or target it with anything else) until you have another creature onto which you can move Lightning Greaves."
         }
       ],
       "subtypes": [
@@ -18328,7 +18328,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "It triggers for each permanent that untaps, so if ten permanents you control untap, Mesmeric Orb’s effect puts the top ten cards of your library into your graveyard."
+          "text": "It triggers for each permanent that untaps, so if ten permanents you control untap, Mesmeric Orb's effect puts the top ten cards of your library into your graveyard."
         },
         {
           "date": "2004-12-01",
@@ -18336,7 +18336,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If permanents become untapped during the untap step, Mesmeric Orb’s ability will trigger that many times. However, since no player gets priority during the untap step, those abilities wait to be put on the stack until the upkeep starts. At that time, all the “beginning of upkeep” triggers will also trigger. Those abililties and Mesmeric Orb’s triggers can be put on the stack in any order."
+          "text": "If permanents become untapped during the untap step, Mesmeric Orb's ability will trigger that many times. However, since no player gets priority during the untap step, those abilities wait to be put on the stack until the upkeep starts. At that time, all the \"beginning of upkeep\" triggers will also trigger. Those abililties and Mesmeric Orb's triggers can be put on the stack in any order."
         }
       ],
       "text": "Whenever a permanent becomes untapped, that permanent's controller puts the top card of his or her library into his or her graveyard.",
@@ -18512,31 +18512,31 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You could gain control of yourself using Mindslaver, but gaining control of yourself doesn’t really do anything."
+          "text": "You could gain control of yourself using Mindslaver, but gaining control of yourself doesn't really do anything."
         },
         {
           "date": "2004-12-01",
-          "text": "You don’t control any of the other player’s permanents, spells, or abilities."
+          "text": "You don't control any of the other player's permanents, spells, or abilities."
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t make the other player concede. A player can choose to concede at any time."
+          "text": "You can't make the other player concede. A player can choose to concede at any time."
         },
         {
           "date": "2004-12-01",
-          "text": "You get to make every decision the other player would have made during that turn. You can’t make any illegal decisions or illegal choices — you can’t do anything that player couldn’t do. You can spend mana in the player’s mana pool only on that player’s spells and abilities. The mana in your mana pool can be spent only on your spells and abilities."
+          "text": "You get to make every decision the other player would have made during that turn. You can't make any illegal decisions or illegal choices — you can't do anything that player couldn't do. You can spend mana in the player's mana pool only on that player's spells and abilities. The mana in your mana pool can be spent only on your spells and abilities."
         },
         {
           "date": "2004-12-01",
-          "text": "You choose which spells the other player casts, and make all decisions as those spells are cast and when they resolve. For example, you choose the target for that player’s Shock, and what card that player gets with Diabolic Tutor."
+          "text": "You choose which spells the other player casts, and make all decisions as those spells are cast and when they resolve. For example, you choose the target for that player's Shock, and what card that player gets with Diabolic Tutor."
         },
         {
           "date": "2004-12-01",
-          "text": "You choose which activated abilities the other player activates, and make all decisions as those abilities are activated and when they resolve. For example, you can have your opponent sacrifice his or her creatures to his or her Nantuko Husk or have your opponent’s Timberwatch Elf give your blocking creature +X/+X."
+          "text": "You choose which activated abilities the other player activates, and make all decisions as those abilities are activated and when they resolve. For example, you can have your opponent sacrifice his or her creatures to his or her Nantuko Husk or have your opponent's Timberwatch Elf give your blocking creature +X/+X."
         },
         {
           "date": "2004-12-01",
-          "text": "You make all decisions for the other player’s triggered abilities, including what they target and any decisions made when they resolve."
+          "text": "You make all decisions for the other player's triggered abilities, including what they target and any decisions made when they resolve."
         },
         {
           "date": "2004-12-01",
@@ -18548,19 +18548,19 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t make any decisions that aren’t called for or allowed by the game rules, or by any cards, permanents, spells, abilities, and so on."
+          "text": "You can't make any decisions that aren't called for or allowed by the game rules, or by any cards, permanents, spells, abilities, and so on."
         },
         {
           "date": "2004-12-01",
-          "text": "If you make another player cast Shahrazad, you don’t control that player in the subgame, but you continue to control them once the subgame is completed."
+          "text": "If you make another player cast Shahrazad, you don't control that player in the subgame, but you continue to control them once the subgame is completed."
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "supertypes": [
@@ -18646,7 +18646,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Mindstorm Crown’s ability doesn’t have an “intervening ‘if’ clause.” It always goes onto the stack at the start of your upkeep."
+          "text": "Mindstorm Crown's ability doesn't have an \"intervening 'if' clause.\" It always goes onto the stack at the start of your upkeep."
         },
         {
           "date": "2004-12-01",
@@ -20244,11 +20244,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can remove any +1/+1 counter on Pentavus to activate its first activated ability, not just ones created by Pentavus's other abilities."
         },
         {
           "date": "2011-09-22",
-          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus’s second activated ability, not just ones created by Pentavus’s other abilities."
+          "text": "You can sacrifice any Pentavite creature you control (such as an Adaptive Automaton with Pentavite as its chosen type) to activate Pentavus's second activated ability, not just ones created by Pentavus's other abilities."
         }
       ],
       "subtypes": [
@@ -20431,23 +20431,23 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They’ll still work."
+          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They'll still work."
         },
         {
           "date": "2004-12-01",
-          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can’t prevent you from losing the game)."
+          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can't prevent you from losing the game)."
         },
         {
           "date": "2009-10-01",
-          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn’t matter whether you have 0 or less life, you’re forced to draw a card while your library is empty, you have ten or more poison counters, you’re dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
+          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn't matter whether you have 0 or less life, you're forced to draw a card while your library is empty, you have ten or more poison counters, you're dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
         },
         {
           "date": "2009-10-01",
-          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you’re penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
+          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you're penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
         },
         {
           "date": "2009-10-01",
-          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can’t lose the game and the opposing team can’t win the game."
+          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can't lose the game and the opposing team can't win the game."
         }
       ],
       "subtypes": [
@@ -20694,7 +20694,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "This ability will trigger even if the player’s library is empty at the time he or she is supposed to shuffle it."
+          "text": "This ability will trigger even if the player's library is empty at the time he or she is supposed to shuffle it."
         }
       ],
       "text": "Whenever a spell or ability causes a player to shuffle his or her library, Psychogenic Probe deals 2 damage to him or her.",
@@ -20947,7 +20947,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Sacrificing an artifact isn’t optional. If you control an artifact other than Rust Elemental, you must sacrifice it. Otherwise, you must tap Rust Elemental and lose 4 life."
+          "text": "Sacrificing an artifact isn't optional. If you control an artifact other than Rust Elemental, you must sacrifice it. Otherwise, you must tap Rust Elemental and lose 4 life."
         }
       ],
       "subtypes": [
@@ -21276,11 +21276,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Any enters-the-battlefield abilities of the copied artifact will trigger when Sculpting Steel enters the battlefield. Any “as enters the battlefield” or “enters the battlefield with” abilities of the chosen artifact will also work. For example, if Sculpting Steel copies an artifact creature with sunburst, the copy will get +1/+1 counters based on the number of different colors of mana used to pay Sculpting Steel’s total cost. If Sculpting Steel copies a noncreature artifact with sunburst, the copy will get charge counters based on the number of different colors of mana used to pay Sculpting Steel’s total cost."
+          "text": "Any enters-the-battlefield abilities of the copied artifact will trigger when Sculpting Steel enters the battlefield. Any \"as enters the battlefield\" or \"enters the battlefield with\" abilities of the chosen artifact will also work. For example, if Sculpting Steel copies an artifact creature with sunburst, the copy will get +1/+1 counters based on the number of different colors of mana used to pay Sculpting Steel's total cost. If Sculpting Steel copies a noncreature artifact with sunburst, the copy will get charge counters based on the number of different colors of mana used to pay Sculpting Steel's total cost."
         },
         {
           "date": "2007-07-15",
-          "text": "Sculpting Steel doesn’t copy whether the original artifact is tapped or untapped. It also doesn’t copy any counters on that artifact, any Auras or Equipment attached to that artifact, or any effects that are currently affecting that artifact — you get exactly what’s printed on the chosen card and nothing more. So if you copy an animated Chimeric Staff, for example, you get a normal, nonanimated Chimeric Staff."
+          "text": "Sculpting Steel doesn't copy whether the original artifact is tapped or untapped. It also doesn't copy any counters on that artifact, any Auras or Equipment attached to that artifact, or any effects that are currently affecting that artifact — you get exactly what's printed on the chosen card and nothing more. So if you copy an animated Chimeric Staff, for example, you get a normal, nonanimated Chimeric Staff."
         },
         {
           "date": "2007-07-15",
@@ -21292,7 +21292,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "You can choose not to copy anything. In that case, Sculpting Steel stays on the battlefield as an artifact that doesn’t do much of anything."
+          "text": "You can choose not to copy anything. In that case, Sculpting Steel stays on the battlefield as an artifact that doesn't do much of anything."
         }
       ],
       "text": "You may have Sculpting Steel enter the battlefield as a copy of any artifact on the battlefield.",
@@ -21375,15 +21375,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The Scythe’s ability triggers even if something other than the damage dealt by the equipped creature causes the creature to be put into a graveyard that turn."
+          "text": "The Scythe's ability triggers even if something other than the damage dealt by the equipped creature causes the creature to be put into a graveyard that turn."
         },
         {
           "date": "2004-12-01",
-          "text": "Scythe of the Wretched needs to equip your creature when the other creature goes to the graveyard for the ability to trigger, but it doesn’t matter whether the Scythe equipped your creature when the damage was actually dealt."
+          "text": "Scythe of the Wretched needs to equip your creature when the other creature goes to the graveyard for the ability to trigger, but it doesn't matter whether the Scythe equipped your creature when the damage was actually dealt."
         },
         {
           "date": "2004-12-01",
-          "text": "If the card isn’t a creature when it comes back onto the battlefield, then Scythe of the Wretched won’t move onto it."
+          "text": "If the card isn't a creature when it comes back onto the battlefield, then Scythe of the Wretched won't move onto it."
         }
       ],
       "subtypes": [
@@ -21993,7 +21993,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "The token is an exact copy in every way, except that it’s a token, not a card."
+          "text": "The token is an exact copy in every way, except that it's a token, not a card."
         },
         {
           "date": "2004-12-01",
@@ -22088,7 +22088,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If there’s only one imprinted sorcery card, nothing happens."
+          "text": "If there's only one imprinted sorcery card, nothing happens."
         },
         {
           "date": "2004-12-01",
@@ -22096,27 +22096,27 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Spellweaver Helix’s second ability creates a copy of the imprinted card in the Exile zone (that’s where the imprinted sorcery card is), then allows you to cast it without paying its mana cost."
+          "text": "Spellweaver Helix's second ability creates a copy of the imprinted card in the Exile zone (that's where the imprinted sorcery card is), then allows you to cast it without paying its mana cost."
         },
         {
           "date": "2004-12-01",
-          "text": "You cast the copy while this ability is resolving, and still on the stack. Normally, you’re not allowed to cast spells or activate abilities at this time. Spellweaver Helix’s ability breaks this rule. (The card that triggered this ability is also still on the stack.)"
+          "text": "You cast the copy while this ability is resolving, and still on the stack. Normally, you're not allowed to cast spells or activate abilities at this time. Spellweaver Helix's ability breaks this rule. (The card that triggered this ability is also still on the stack.)"
         },
         {
           "date": "2004-12-01",
-          "text": "You don’t pay the spell’s mana cost. If a spell has X in its mana cost, X is 0. You do pay any additional costs for that spell. You can’t use any alternative costs."
+          "text": "You don't pay the spell's mana cost. If a spell has X in its mana cost, X is 0. You do pay any additional costs for that spell. You can't use any alternative costs."
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t cast the copy if an effect prevents you from casting sorceries or from casting that particular sorcery."
+          "text": "You can't cast the copy if an effect prevents you from casting sorceries or from casting that particular sorcery."
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t cast the copy unless all of its targets can be chosen."
+          "text": "You can't cast the copy unless all of its targets can be chosen."
         },
         {
           "date": "2004-12-01",
-          "text": "If you don’t want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
+          "text": "If you don't want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
         },
         {
           "date": "2005-03-01",
@@ -22124,7 +22124,7 @@
         },
         {
           "date": "2017-04-18",
-          "text": "A split card has the same name as a spell if either of its names is that spell’s name."
+          "text": "A split card has the same name as a spell if either of its names is that spell's name."
         }
       ],
       "text": "Imprint — When Spellweaver Helix enters the battlefield, you may exile two target sorcery cards from a single graveyard.\nWhenever a player casts a card, if it has the same name as one of the cards exiled with Spellweaver Helix, you may copy the other. If you do, you may cast the copy without paying its mana cost.",
@@ -23116,7 +23116,7 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "The player gets the mana whether they want it or not. If it isn’t spent, it will disappear at the end of the current step (or phase)."
+          "text": "The player gets the mana whether they want it or not. If it isn't spent, it will disappear at the end of the current step (or phase)."
         }
       ],
       "text": "Whenever a player casts a creature spell, that player adds {G} to his or her mana pool.",
@@ -23200,15 +23200,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Tel-Jilad Stylus’s ability may target a permanent you own but do not control."
+          "text": "Tel-Jilad Stylus's ability may target a permanent you own but do not control."
         },
         {
           "date": "2004-12-01",
-          "text": "Tel-Jilad Stylus’s ability can put tokens on the bottom of your library (where they then cease to exist)."
+          "text": "Tel-Jilad Stylus's ability can put tokens on the bottom of your library (where they then cease to exist)."
         },
         {
           "date": "2004-12-01",
-          "text": "You own all cards that started the game in your deck, and all cards that you “Wished” into the game (with one of the Judgment Wish cards or Ring of Maruf)."
+          "text": "You own all cards that started the game in your deck, and all cards that you \"Wished\" into the game (with one of the Judgment Wish cards or Ring of Maruf)."
         },
         {
           "date": "2009-10-01",
@@ -23382,11 +23382,11 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Each time there’s a tie for the highest cost, only the players involved in the tie continue."
+          "text": "Each time there's a tie for the highest cost, only the players involved in the tie continue."
         },
         {
           "date": "2004-12-01",
-          "text": "If a player fails to exile a card, he or she can’t take the extra turn."
+          "text": "If a player fails to exile a card, he or she can't take the extra turn."
         },
         {
           "date": "2004-12-01",
@@ -23394,7 +23394,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Remember which player would have taken the next turn if Timesifter’s ability hadn’t triggered the first time. After Timesifter leaves the battlefield and all extra turns have been taken, that player takes the next turn."
+          "text": "Remember which player would have taken the next turn if Timesifter's ability hadn't triggered the first time. After Timesifter leaves the battlefield and all extra turns have been taken, that player takes the next turn."
         },
         {
           "date": "2004-12-01",
@@ -23971,11 +23971,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it’ll be destroyed before you get a chance to activate its ability."
+          "text": "If you activate the ability of an attacking or blocking Triskelion during the declare blockers step, it will deal less combat damage as a result. If you wait until the combat damage step, but Triskelion is dealt lethal damage, it'll be destroyed before you get a chance to activate its ability."
         },
         {
           "date": "2010-08-15",
-          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won’t be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
+          "text": "If Triskelion has damage marked on it, activating its ability may cause that damage to become lethal. For example, say a Triskelion with two +1/+1 counters on it has been dealt 2 damage earlier in the turn. If you activate its ability by removing a +1/+1 counter from it, it now has 2 toughness and is destroyed as a state-based action. You won't be able to remove the other +1/+1 counter from it to activate its ability again. The first activation of the ability will still resolve."
         }
       ],
       "subtypes": [
@@ -25208,11 +25208,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{6}: Stalking Stones becomes a 3/3 Elemental artifact creature that's still a land. (This effect lasts indefinitely.)",

--- a/json/NMS.json
+++ b/json/NMS.json
@@ -2224,7 +2224,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -3622,7 +3622,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -3682,7 +3682,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -3741,7 +3741,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -4198,7 +4198,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose zero targets. You must choose between 1 and 2 targets."
+          "text": "You can't choose zero targets. You must choose between 1 and 2 targets."
         }
       ],
       "subtypes": [
@@ -4414,7 +4414,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "Flowstone Crusher’s ability can be activated multiple times, but Flowstone Crusher is put into the graveyard after an effect resolves that makes its toughness 0."
+          "text": "Flowstone Crusher's ability can be activated multiple times, but Flowstone Crusher is put into the graveyard after an effect resolves that makes its toughness 0."
         }
       ],
       "subtypes": [
@@ -4798,11 +4798,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If placed on a Laccolith creature, both this card’s ability and the Laccolith’s ability will trigger and have their effect."
+          "text": "If placed on a Laccolith creature, both this card's ability and the Laccolith's ability will trigger and have their effect."
         },
         {
           "date": "2004-10-04",
-          "text": "If this is on an opponent’s creature, the controller of this card (not the creature’s controller) decides whether to use this card’s ability or not, and decides what the target will be."
+          "text": "If this is on an opponent's creature, the controller of this card (not the creature's controller) decides whether to use this card's ability or not, and decides what the target will be."
         },
         {
           "date": "2004-10-04",
@@ -5289,7 +5289,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -5507,11 +5507,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Creature cards which are revealed but are not the lowest cost, or any non-creature cards revealed remain in their owners’ hands and stop being revealed."
+          "text": "Creature cards which are revealed but are not the lowest cost, or any non-creature cards revealed remain in their owners' hands and stop being revealed."
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t have to choose a creature card, but choosing a non creature does nothing except maybe bluff your opponent."
+          "text": "You don't have to choose a creature card, but choosing a non creature does nothing except maybe bluff your opponent."
         }
       ],
       "text": "Each player chooses a card in his or her hand. Then each player reveals his or her chosen card. The owner of each creature card revealed this way with the lowest converted mana cost puts it onto the battlefield.",
@@ -5565,7 +5565,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Until end of turn, target land becomes a 3/3 creature that's still a land.",
@@ -6140,11 +6140,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -6152,7 +6152,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -6737,7 +6737,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block a creature enchanted with this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block a creature enchanted with this."
         }
       ],
       "subtypes": [
@@ -7208,7 +7208,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Note that you can’t choose to leave this card tapped during your untap step (unless some other effect says so)."
+          "text": "Note that you can't choose to leave this card tapped during your untap step (unless some other effect says so)."
         },
         {
           "date": "2004-10-04",

--- a/json/NPH.json
+++ b/json/NPH.json
@@ -132,15 +132,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Karn’s first and third abilities are linked. Similarly, Karn’s second and third abilities are linked. Only cards exiled by either of Karn’s first two abilities will remain in exile when the game restarts."
+          "text": "Karn's first and third abilities are linked. Similarly, Karn's second and third abilities are linked. Only cards exiled by either of Karn's first two abilities will remain in exile when the game restarts."
         },
         {
           "date": "2011-06-01",
-          "text": "A game that restarts immediately ends. The players in that game then immediately begin a new game. No player wins, loses, or draws the original game as a result of Karn’s ability."
+          "text": "A game that restarts immediately ends. The players in that game then immediately begin a new game. No player wins, loses, or draws the original game as a result of Karn's ability."
         },
         {
           "date": "2011-06-01",
-          "text": "In a multiplayer games (a game that started with three or more players in it), any player that left the game before it was restarted with Karn’s ability won’t be involved in the new game."
+          "text": "In a multiplayer games (a game that started with three or more players in it), any player that left the game before it was restarted with Karn's ability won't be involved in the new game."
         },
         {
           "date": "2011-06-01",
@@ -148,23 +148,23 @@
         },
         {
           "date": "2011-06-01",
-          "text": "After the pre-game procedure is complete, but before the new game’s first turn, Karn’s ability finishes resolving and the cards left in exile are put onto the battlefield. If this causes any triggered abilities to trigger, those abilities are put onto the stack at the beginning of the first upkeep step."
+          "text": "After the pre-game procedure is complete, but before the new game's first turn, Karn's ability finishes resolving and the cards left in exile are put onto the battlefield. If this causes any triggered abilities to trigger, those abilities are put onto the stack at the beginning of the first upkeep step."
         },
         {
           "date": "2011-06-01",
-          "text": "Creatures put onto the battlefield due to Karn’s ability will have been under their controller’s control continuously since the beginning of the first turn. They can attack and their activated abilities with {T} in the cost can be activated."
+          "text": "Creatures put onto the battlefield due to Karn's ability will have been under their controller's control continuously since the beginning of the first turn. They can attack and their activated abilities with {T} in the cost can be activated."
         },
         {
           "date": "2011-06-01",
-          "text": "Any permanents put onto the battlefield with Karn’s ability that entered the battlefield tapped will untap during their controller’s first untap step."
+          "text": "Any permanents put onto the battlefield with Karn's ability that entered the battlefield tapped will untap during their controller's first untap step."
         },
         {
           "date": "2011-06-01",
-          "text": "No actions taken in the game that was restarted apply to the new game. For example, if you were dealt damage by Stigma Lasher in the original game, the effect that states you can’t gain life doesn’t carry over to the new game."
+          "text": "No actions taken in the game that was restarted apply to the new game. For example, if you were dealt damage by Stigma Lasher in the original game, the effect that states you can't gain life doesn't carry over to the new game."
         },
         {
           "date": "2011-06-01",
-          "text": "Players won’t have any poison counters or emblems they had in the original game."
+          "text": "Players won't have any poison counters or emblems they had in the original game."
         },
         {
           "date": "2011-06-01",
@@ -176,11 +176,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If a player’s commander was exiled with Karn at the game restarted, that commander won’t be put into the command zone at the beginning of the game. It will be put onto the battlefield when Karn’s ability finishes resolving."
+          "text": "If a player's commander was exiled with Karn at the game restarted, that commander won't be put into the command zone at the beginning of the game. It will be put onto the battlefield when Karn's ability finishes resolving."
         },
         {
           "date": "2011-06-01",
-          "text": "In a multiplayer game using the limited range of influence option, all players are affected and will restart the game, not just those within the range of influence of the ability’s controller."
+          "text": "In a multiplayer game using the limited range of influence option, all players are affected and will restart the game, not just those within the range of influence of the ability's controller."
         }
       ],
       "subtypes": [
@@ -300,11 +300,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
@@ -648,15 +648,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "Cathedral Membrane’s ability will trigger no matter why it’s put into a graveyard during the combat phase, not just because of combat damage."
+          "text": "Cathedral Membrane's ability will trigger no matter why it's put into a graveyard during the combat phase, not just because of combat damage."
         }
       ],
       "subtypes": [
@@ -775,7 +775,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "subtypes": [
@@ -886,7 +886,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If you control three or more artifacts when Dispatch resolves, you’ll tap the creature, then exile it."
+          "text": "If you control three or more artifacts when Dispatch resolves, you'll tap the creature, then exile it."
         }
       ],
       "text": "Tap target creature.\nMetalcraft — If you control three or more artifacts, exile that creature.",
@@ -992,7 +992,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Due Respect won’t tap any permanents that have entered the battlefield before it resolved."
+          "text": "Due Respect won't tap any permanents that have entered the battlefield before it resolved."
         }
       ],
       "text": "Permanents enter the battlefield tapped this turn.\nDraw a card.",
@@ -1101,7 +1101,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If more than one Elesh Norn, Grand Cenobite is under your control, all of their static abilities will briefly apply. Any creatures that have 0 or less toughness and any creatures that now have lethal damage marked on them will be put into graveyards at the same time that the “legend rule” causes all but one of the Elesh Norns to be put into their owners’ graveyards."
+          "text": "If more than one Elesh Norn, Grand Cenobite is under your control, all of their static abilities will briefly apply. Any creatures that have 0 or less toughness and any creatures that now have lethal damage marked on them will be put into graveyards at the same time that the \"legend rule\" causes all but one of the Elesh Norns to be put into their owners' graveyards."
         }
       ],
       "subtypes": [
@@ -1218,7 +1218,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "In a Commander game, a player may replace Exclusion Ritual exiling his or her commander with putting that commander into the command zone. If this happens, Exclusion Ritual’s last ability will have no effect."
+          "text": "In a Commander game, a player may replace Exclusion Ritual exiling his or her commander with putting that commander into the command zone. If this happens, Exclusion Ritual's last ability will have no effect."
         }
       ],
       "text": "Imprint — When Exclusion Ritual enters the battlefield, exile target nonland permanent.\nPlayers can't cast spells with the same name as the exiled card.",
@@ -1324,7 +1324,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Forced Worship’s activated ability may only be activated if Forced Worship is on the battlefield. If it’s no longer on the battlefield when the ability resolves, the ability has no effect."
+          "text": "Forced Worship's activated ability may only be activated if Forced Worship is on the battlefield. If it's no longer on the battlefield when the ability resolves, the ability has no effect."
         }
       ],
       "subtypes": [
@@ -1760,11 +1760,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({W/P} can be paid with either {W} or 2 life.)\nMarrow Shards deals 1 damage to each attacking creature.",
@@ -1872,7 +1872,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If a creature has been dealt damage, that damage remains marked on it until the cleanup step. If Master Splicer leaves the battlefield and a Golem creature you control has been dealt damage, that creature will be destroyed if the damage is now lethal. Similarly, if that causes a Golem to have 0 toughness, it’s put into its owner’s graveyard."
+          "text": "If a creature has been dealt damage, that damage remains marked on it until the cleanup step. If Master Splicer leaves the battlefield and a Golem creature you control has been dealt damage, that creature will be destroyed if the damage is now lethal. Similarly, if that causes a Golem to have 0 toughness, it's put into its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -1994,11 +1994,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
@@ -2010,15 +2010,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Multiple Norn’s Annexes controlled by the same player will each impose a cost to attack. Players choose how they pay each cost individually. For example, if a creature you control is attacking a player who controls two Norn’s Annexes, you may pay {W} for one cost and 2 life for the other."
+          "text": "Multiple Norn's Annexes controlled by the same player will each impose a cost to attack. Players choose how they pay each cost individually. For example, if a creature you control is attacking a player who controls two Norn's Annexes, you may pay {W} for one cost and 2 life for the other."
         },
         {
           "date": "2011-06-01",
-          "text": "If you control Norn’s Annex, your opponents can choose not to attack with a creature with an ability that says it must attack."
+          "text": "If you control Norn's Annex, your opponents can choose not to attack with a creature with an ability that says it must attack."
         },
         {
           "date": "2011-06-01",
-          "text": "In a Two-Headed Giant game, if one player controls Norn’s Annex, creatures can’t attack that player’s team or a planeswalker that player controls unless their controller pays {W}{P} for each of those creatures he or she controls. Creatures can attack planeswalkers controlled by that player’s teammate without having to pay this cost."
+          "text": "In a Two-Headed Giant game, if one player controls Norn's Annex, creatures can't attack that player's team or a planeswalker that player controls unless their controller pays {W}{P} for each of those creatures he or she controls. Creatures can attack planeswalkers controlled by that player's teammate without having to pay this cost."
         }
       ],
       "text": "({W/P} can be paid with either {W} or 2 life.)\nCreatures can't attack you or a planeswalker you control unless their controller pays {W/P} for each of those creatures.",
@@ -2123,15 +2123,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Phyrexian Unlife won’t affect damage that reduces your life total from a positive number to 0 or less. For example, if you’re at 3 life and are dealt 5 damage, you’ll end up at -2 life. The next time you’re dealt damage, it will be dealt as though its source had infect."
+          "text": "Phyrexian Unlife won't affect damage that reduces your life total from a positive number to 0 or less. For example, if you're at 3 life and are dealt 5 damage, you'll end up at -2 life. The next time you're dealt damage, it will be dealt as though its source had infect."
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 0 or less life and Phyrexian Unlife leaves the battlefield, you’ll lose the game (unless some other effect is keeping you from losing)."
+          "text": "If you're at 0 or less life and Phyrexian Unlife leaves the battlefield, you'll lose the game (unless some other effect is keeping you from losing)."
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 0 or less life, you can’t pay any amount of life except 0."
+          "text": "If you're at 0 or less life, you can't pay any amount of life except 0."
         },
         {
           "date": "2011-06-01",
@@ -2254,11 +2254,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "subtypes": [
@@ -2369,11 +2369,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You may still activate the Equipment’s other equip ability if you wish."
+          "text": "You may still activate the Equipment's other equip ability if you wish."
         },
         {
           "date": "2011-06-01",
-          "text": "Once the equip {0} ability is activated, destroying Puresteel Paladin or causing its controller to control fewer than three artifacts won’t stop it from resolving."
+          "text": "Once the equip {0} ability is activated, destroying Puresteel Paladin or causing its controller to control fewer than three artifacts won't stop it from resolving."
         }
       ],
       "subtypes": [
@@ -2484,7 +2484,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You choose which mode you’re using — or whether to use both modes — as you’re casting the spell. Once this choice is made, it can’t be changed later while the spell is on the stack."
+          "text": "You choose which mode you're using — or whether to use both modes — as you're casting the spell. Once this choice is made, it can't be changed later while the spell is on the stack."
         },
         {
           "date": "2011-06-01",
@@ -3122,11 +3122,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You can target an artifact with Argent Mutation. When it resolves, you’ll simply draw a card."
+          "text": "You can target an artifact with Argent Mutation. When it resolves, you'll simply draw a card."
         },
         {
           "date": "2011-06-01",
-          "text": "If the permanent is an illegal target when Argent Mutation tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the permanent is an illegal target when Argent Mutation tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "text": "Target permanent becomes an artifact in addition to its other types until end of turn.\nDraw a card.",
@@ -3231,7 +3231,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Only creatures you control on the battlefield when Arm with Aether resolves gain the ability. Creatures you gain control of later in the turn won’t be affected."
+          "text": "Only creatures you control on the battlefield when Arm with Aether resolves gain the ability. Creatures you gain control of later in the turn won't be affected."
         },
         {
           "date": "2011-06-01",
@@ -3569,11 +3569,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "The instant or sorcery card you target with the enters-the-battlefield triggered ability is cast as part of the resolution of that ability. Timing restrictions based on the card’s type are ignored. Other restrictions, such as “Cast [this card] only during combat,” are not."
+          "text": "The instant or sorcery card you target with the enters-the-battlefield triggered ability is cast as part of the resolution of that ability. Timing restrictions based on the card's type are ignored. Other restrictions, such as \"Cast [this card] only during combat,\" are not."
         },
         {
           "date": "2011-06-01",
-          "text": "If you are unable to cast the card, perhaps because there are no legal targets available, the card remains in its owner’s graveyard."
+          "text": "If you are unable to cast the card, perhaps because there are no legal targets available, the card remains in its owner's graveyard."
         },
         {
           "date": "2011-06-01",
@@ -3585,7 +3585,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "subtypes": [
@@ -4024,15 +4024,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "The targeted player may have no cards in his or her hand. You’ll still draw a card."
+          "text": "The targeted player may have no cards in his or her hand. You'll still draw a card."
         }
       ],
       "text": "({U/P} can be paid with either {U} or 2 life.)\nLook at target player's hand.\nDraw a card.",
@@ -4244,15 +4244,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Jin-Gitaxias doesn’t affect the maximum hand size of its controller."
+          "text": "Jin-Gitaxias doesn't affect the maximum hand size of its controller."
         },
         {
           "date": "2011-06-01",
-          "text": "If a player has more cards in his or her hand than his or her maximum hand size during the cleanup step (after the end step) of that player’s turn, that player discards until he or she has that many cards. A player’s maximum hand size isn’t checked at any time other than his or her own cleanup step."
+          "text": "If a player has more cards in his or her hand than his or her maximum hand size during the cleanup step (after the end step) of that player's turn, that player discards until he or she has that many cards. A player's maximum hand size isn't checked at any time other than his or her own cleanup step."
         },
         {
           "date": "2011-06-01",
-          "text": "Unless another spell or ability is affecting your opponent’s maximum hand size, Jin-Gitaxias’s ability will result in your opponent having a maximum hand size of zero. He or she will discard each card from his or her hand during the cleanup step at the end of his or her turn."
+          "text": "Unless another spell or ability is affecting your opponent's maximum hand size, Jin-Gitaxias's ability will result in your opponent having a maximum hand size of zero. He or she will discard each card from his or her hand during the cleanup step at the end of his or her turn."
         }
       ],
       "subtypes": [
@@ -4377,11 +4377,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
@@ -4389,7 +4389,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Each Phyrexian mana symbol in a spell’s mana cost contributes 1 to that spell’s converted mana cost. For example, Mental Misstep’s converted mana cost is 1, regardless of how its cost was paid."
+          "text": "Each Phyrexian mana symbol in a spell's mana cost contributes 1 to that spell's converted mana cost. For example, Mental Misstep's converted mana cost is 1, regardless of how its cost was paid."
         }
       ],
       "text": "({U/P} can be paid with either {U} or 2 life.)\nCounter target spell with converted mana cost 1.",
@@ -4495,7 +4495,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You must be able to target an opponent to cast Mindculling. If that opponent is an illegal target when Mindculling tries to resolve, it’ll be countered and will have no effect. You won’t draw two cards."
+          "text": "You must be able to target an opponent to cast Mindculling. If that opponent is an illegal target when Mindculling tries to resolve, it'll be countered and will have no effect. You won't draw two cards."
         },
         {
           "date": "2011-06-01",
@@ -4715,15 +4715,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Phyrexian Ingester will get bonuses based on the card’s power and toughness in exile. Counters, Auras, and Equipment it had on it before it was exiled won’t add to those numbers."
+          "text": "Phyrexian Ingester will get bonuses based on the card's power and toughness in exile. Counters, Auras, and Equipment it had on it before it was exiled won't add to those numbers."
         },
         {
           "date": "2016-06-08",
-          "text": "Abilities that define a creature’s power and toughness apply while that card is in exile, but abilities that add or subtract from it don’t. For example, the ability of Battle Squadron applies to determine Phyrexian Ingester’s power and toughness, but the ability of Werebear doesn’t. Phyrexian Ingester’s power and toughness are constantly updated if the exiled card’s power and/or toughness change."
+          "text": "Abilities that define a creature's power and toughness apply while that card is in exile, but abilities that add or subtract from it don't. For example, the ability of Battle Squadron applies to determine Phyrexian Ingester's power and toughness, but the ability of Werebear doesn't. Phyrexian Ingester's power and toughness are constantly updated if the exiled card's power and/or toughness change."
         },
         {
           "date": "2016-06-08",
-          "text": "If the card in exile isn’t a creature card (perhaps because it was a land that was temporarily a creature while on the battlefield), Phyrexian Ingester doesn’t get a bonus."
+          "text": "If the card in exile isn't a creature card (perhaps because it was a land that was temporarily a creature while on the battlefield), Phyrexian Ingester doesn't get a bonus."
         }
       ],
       "subtypes": [
@@ -4846,15 +4846,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "Except for also being an artifact, Phyrexian Metamorph copies exactly what was printed on the original permanent and nothing more (unless that creature is itself copying something or is a token; see below). It doesn’t copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras attached to it, or any noncopy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Except for also being an artifact, Phyrexian Metamorph copies exactly what was printed on the original permanent and nothing more (unless that creature is itself copying something or is a token; see below). It doesn't copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras attached to it, or any noncopy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2011-06-01",
@@ -4866,23 +4866,23 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If the chosen creature is copying something else (for example, if the chosen creature is a Clone), then your Phyrexian Metamorph enters the battlefield as whatever the chosen creature copied, except it’s also an artifact."
+          "text": "If the chosen creature is copying something else (for example, if the chosen creature is a Clone), then your Phyrexian Metamorph enters the battlefield as whatever the chosen creature copied, except it's also an artifact."
         },
         {
           "date": "2011-06-01",
-          "text": "If the chosen permanent is a token, Phyrexian Metamorph copies the original characteristics of that token as stated by the effect that put the token onto the battlefield, except it’s also an artifact. Phyrexian Metamorph is not a token."
+          "text": "If the chosen permanent is a token, Phyrexian Metamorph copies the original characteristics of that token as stated by the effect that put the token onto the battlefield, except it's also an artifact. Phyrexian Metamorph is not a token."
         },
         {
           "date": "2011-06-01",
-          "text": "Any enters-the-battlefield abilities of the copied permanent will trigger when Phyrexian Metamorph enters the battlefield. Any “as [this] enters the battlefield” or “[this] enters the battlefield with” abilities of the chosen permanent will also work."
+          "text": "Any enters-the-battlefield abilities of the copied permanent will trigger when Phyrexian Metamorph enters the battlefield. Any \"as [this] enters the battlefield\" or \"[this] enters the battlefield with\" abilities of the chosen permanent will also work."
         },
         {
           "date": "2011-06-01",
-          "text": "If Phyrexian Metamorph somehow enters the battlefield at the same time as another permanent (due to Mass Polymorph or Liliana Vess’s third ability, for example), Phyrexian Metamorph can’t become a copy of that permanent. You may only choose a permanent that’s already on the battlefield."
+          "text": "If Phyrexian Metamorph somehow enters the battlefield at the same time as another permanent (due to Mass Polymorph or Liliana Vess's third ability, for example), Phyrexian Metamorph can't become a copy of that permanent. You may only choose a permanent that's already on the battlefield."
         },
         {
           "date": "2011-06-01",
-          "text": "You can choose not to copy anything. In that case, Phyrexian Metamorph simply enters the battlefield as a 0/0 artifact creature and is put into its owner’s graveyard as a state-based action (unless something else is raising its toughness)."
+          "text": "You can choose not to copy anything. In that case, Phyrexian Metamorph simply enters the battlefield as a 0/0 artifact creature and is put into its owner's graveyard as a state-based action (unless something else is raising its toughness)."
         }
       ],
       "subtypes": [
@@ -5096,11 +5096,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If your opponent’s library has one card in it and he or she is instructed to shuffle that library, Psychic Surgery will trigger. You may’ exile the one card in that library."
+          "text": "If your opponent's library has one card in it and he or she is instructed to shuffle that library, Psychic Surgery will trigger. You may' exile the one card in that library."
         },
         {
           "date": "2011-06-01",
-          "text": "In most cases, Green Sun’s Zenith instructs you to shuffle your library twice. Although shuffling that library only once is an acceptable shortcut, Psychic Surgery’s ability will still trigger twice."
+          "text": "In most cases, Green Sun's Zenith instructs you to shuffle your library twice. Although shuffling that library only once is an acceptable shortcut, Psychic Surgery's ability will still trigger twice."
         }
       ],
       "text": "Whenever an opponent shuffles his or her library, you may look at the top two cards of that library. You may exile one of those cards. Then put the rest on top of that library in any order.",
@@ -5219,11 +5219,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "subtypes": [
@@ -5453,11 +5453,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({U/P} can be paid with either {U} or 2 life.)\nDraw two cards, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -5788,7 +5788,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"I despise Vorinclex and his slobberings about ‘evolution.' Only I know true progress.\"\n—Jin-Gitaxias, Core Augur",
+      "flavor": "\"I despise Vorinclex and his slobberings about 'evolution.' Only I know true progress.\"\n—Jin-Gitaxias, Core Augur",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -5875,10 +5875,6 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The choice of creature type is made when the enters-the-battlefield ability resolves."
-        },
-        {
-          "date": "2011-06-01",
           "text": "You must choose an existing _Magic_ creature type."
         },
         {
@@ -5887,7 +5883,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Replacement effects that modify creatures of a certain type as they enter the battlefield will apply (or not apply) before you apply Xenograft’s effect. For example, if Warrior is the chosen creature type and you control Bramblewood Paragon, a Runeclaw Bear would not enter the battlefield with an additional +1/+1 counter."
+          "text": "Replacement effects that modify creatures of a certain type as they enter the battlefield will apply (or not apply) before you apply Xenograft's effect. For example, if Warrior is the chosen creature type and you control Bramblewood Paragon, a Runeclaw Bear would not enter the battlefield with an additional +1/+1 counter."
         }
       ],
       "text": "As Xenograft enters the battlefield, choose a creature type.\nEach creature you control is the chosen type in addition to its other types.",
@@ -5993,7 +5989,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You’ll choose the target creature when the ability goes on the stack. You’ll choose whether or not to sacrifice Blind Zealot when the ability resolves."
+          "text": "You'll choose the target creature when the ability goes on the stack. You'll choose whether or not to sacrifice Blind Zealot when the ability resolves."
         }
       ],
       "subtypes": [
@@ -6204,7 +6200,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "subtypes": [
@@ -6315,11 +6311,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Unlike most abilities that force a player to discard cards, this ability may be activated whenever you could cast an instant, including during your opponent’s draw step after he or she has drawn a card."
+          "text": "Unlike most abilities that force a player to discard cards, this ability may be activated whenever you could cast an instant, including during your opponent's draw step after he or she has drawn a card."
         },
         {
           "date": "2011-06-01",
-          "text": "You can’t force an opponent to discard a card he or she casts by activating Dementia Bat’s ability in response. The spell is on the stack by then."
+          "text": "You can't force an opponent to discard a card he or she casts by activating Dementia Bat's ability in response. The spell is on the stack by then."
         }
       ],
       "subtypes": [
@@ -6550,11 +6546,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({B/P} can be paid with either {B} or 2 life.)\nTarget creature gets -5/-5 until end of turn.",
@@ -6667,11 +6663,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn’t start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
+          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn't start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -6894,7 +6890,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability “{T}: Add {B} to your mana pool.” Evil Presence doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability \"{T}: Add {B} to your mana pool.\" Evil Presence doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         }
       ],
       "subtypes": [
@@ -7003,7 +6999,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "As long as the player is a legal target when Geth’s Verdict resolves, that player loses 1 life even if he or she didn’t sacrifice a creature (most likely because he or she didn’t control any)."
+          "text": "As long as the player is a legal target when Geth's Verdict resolves, that player loses 1 life even if he or she didn't sacrifice a creature (most likely because he or she didn't control any)."
         }
       ],
       "text": "Target player sacrifices a creature and loses 1 life.",
@@ -7108,7 +7104,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You choose a target creature for Glistening Oil as you cast it, just as you would with any Aura. If that creature is an illegal target when Glistening Oil tries to resolve, Glistening Oil will be countered and be put into its owner’s graveyard. It won’t enter the battlefield and its last ability won’t trigger."
+          "text": "You choose a target creature for Glistening Oil as you cast it, just as you would with any Aura. If that creature is an illegal target when Glistening Oil tries to resolve, Glistening Oil will be countered and be put into its owner's graveyard. It won't enter the battlefield and its last ability won't trigger."
         },
         {
           "date": "2011-06-01",
@@ -7230,7 +7226,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "The state-based action that removes matching +1/+1 and -1/-1 counters won’t check until after you proliferate and Grim Affliction finishes resolving. It’s possible to remove up to two +1/+1 counters from the creature by choosing to put a second -1/-1 counter on the creature when proliferating."
+          "text": "The state-based action that removes matching +1/+1 and -1/-1 counters won't check until after you proliferate and Grim Affliction finishes resolving. It's possible to remove up to two +1/+1 counters from the creature by choosing to put a second -1/-1 counter on the creature when proliferating."
         }
       ],
       "text": "Put a -1/-1 counter on target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -7550,7 +7546,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The loss of life is equal to Mortis Dogs’s power as it last existed on the battlefield."
+          "text": "The loss of life is equal to Mortis Dogs's power as it last existed on the battlefield."
         }
       ],
       "subtypes": [
@@ -7769,7 +7765,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Only permanents still on the battlefield when Phyrexian Obliterator’s triggered ability resolves can be sacrificed."
+          "text": "Only permanents still on the battlefield when Phyrexian Obliterator's triggered ability resolves can be sacrificed."
         }
       ],
       "subtypes": [
@@ -7892,15 +7888,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "Pith Driller’s ability is mandatory. If it’s the only creature on the battlefield when it enters the battlefield, Pith Driller’s ability will target itself."
+          "text": "Pith Driller's ability is mandatory. If it's the only creature on the battlefield when it enters the battlefield, Pith Driller's ability will target itself."
         }
       ],
       "subtypes": [
@@ -8022,11 +8018,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
@@ -8034,7 +8030,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If the creature is no longer on the battlefield at the beginning of the next end step, it won’t be exiled."
+          "text": "If the creature is no longer on the battlefield at the beginning of the next end step, it won't be exiled."
         }
       ],
       "text": "({B/P} can be paid with either {B} or 2 life.)\nReturn target creature card with converted mana cost X from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step.",
@@ -8140,11 +8136,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Other players, including the card’s owner, can’t look at the card while it remains exiled."
+          "text": "Other players, including the card's owner, can't look at the card while it remains exiled."
         },
         {
           "date": "2011-06-01",
-          "text": "Playing a card exiled with Praetor’s Grasp follows all the normal rules for playing that card. You must pay its costs, and you must follow all timing restrictions, for example."
+          "text": "Playing a card exiled with Praetor's Grasp follows all the normal rules for playing that card. You must pay its costs, and you must follow all timing restrictions, for example."
         }
       ],
       "text": "Search target opponent's library for a card and exile it face down. Then that player shuffles his or her library. You may look at and play that card for as long as it remains exiled.",
@@ -8250,7 +8246,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The source’s controller will get one poison counter for each time that source deals damage to Reaper of Sheoldred, not one poison counter for each 1 damage dealt."
+          "text": "The source's controller will get one poison counter for each time that source deals damage to Reaper of Sheoldred, not one poison counter for each 1 damage dealt."
         }
       ],
       "subtypes": [
@@ -8365,7 +8361,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "In a Two-Headed Giant game, the last ability will trigger twice at the beginning of the opposing team’s upkeep, once for each player on that team. Each player sacrifices only a creature he or she controls."
+          "text": "In a Two-Headed Giant game, the last ability will trigger twice at the beginning of the opposing team's upkeep, once for each player on that team. Each player sacrifices only a creature he or she controls."
         }
       ],
       "subtypes": [
@@ -8491,15 +8487,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "“Any number of cards” means just that. If you wish, you can choose to leave some or all of the cards with the same name as the targeted card, including that card, in the zone they’re in."
+          "text": "\"Any number of cards\" means just that. If you wish, you can choose to leave some or all of the cards with the same name as the targeted card, including that card, in the zone they're in."
         }
       ],
       "text": "({B/P} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles his or her library.",
@@ -8724,11 +8720,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "subtypes": [
@@ -8961,19 +8957,19 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "Act of Aggression can target any creature an opponent controls, even one that’s untapped."
+          "text": "Act of Aggression can target any creature an opponent controls, even one that's untapped."
         },
         {
           "date": "2011-06-01",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "text": "({R/P} can be paid with either {R} or 2 life.)\nGain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn.",
@@ -9079,7 +9075,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The artifact or creature is sacrificed as costs are paid. Players can’t respond to the paying of costs by trying to destroy that artifact or creature."
+          "text": "The artifact or creature is sacrificed as costs are paid. Players can't respond to the paying of costs by trying to destroy that artifact or creature."
         }
       ],
       "text": "As an additional cost to cast Artillerize, sacrifice an artifact or creature.\nArtillerize deals 5 damage to target creature or player.",
@@ -9188,15 +9184,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "An Equipment that’s also a creature can’t be equipped to anything."
+          "text": "An Equipment that's also a creature can't be equipped to anything."
         },
         {
           "date": "2011-06-01",
-          "text": "If an artifact affected by Bludgeon Brawl later becomes a creature, Bludgeon Brawl’s effect no longer applies to it. That artifact will stop being an Equipment and become unattached from any creature it was attached to; it will remain on the battlefield. The same thing if Bludgeon Brawl leaves the battlefield."
+          "text": "If an artifact affected by Bludgeon Brawl later becomes a creature, Bludgeon Brawl's effect no longer applies to it. That artifact will stop being an Equipment and become unattached from any creature it was attached to; it will remain on the battlefield. The same thing if Bludgeon Brawl leaves the battlefield."
         },
         {
           "date": "2011-06-01",
-          "text": "While Bludgeon Brawl is on the battlefield, an Aura enchantment that somehow becomes an artifact in addition to its other types will also become an Equipment. Any of its abilities that refer to either “enchanted creature” or “equipped creature” refer to the creature it’s currently attached to. It can be attached to other creatures using its equip ability. If you try to attach the Aura Equipment to a creature it can’t legally be attached to, it remains where it is. If the creature it’s attached to becomes an illegal permanent for it to enchant, the Aura Equipment will be put into its owner’s graveyard as a state-based action."
+          "text": "While Bludgeon Brawl is on the battlefield, an Aura enchantment that somehow becomes an artifact in addition to its other types will also become an Equipment. Any of its abilities that refer to either \"enchanted creature\" or \"equipped creature\" refer to the creature it's currently attached to. It can be attached to other creatures using its equip ability. If you try to attach the Aura Equipment to a creature it can't legally be attached to, it remains where it is. If the creature it's attached to becomes an illegal permanent for it to enchant, the Aura Equipment will be put into its owner's graveyard as a state-based action."
         }
       ],
       "text": "Each noncreature, non-Equipment artifact is an Equipment with equip {X} and \"Equipped creature gets +X/+0,\" where X is that artifact's converted mana cost.",
@@ -9306,7 +9302,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "subtypes": [
@@ -9416,7 +9412,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If Fallen Ferromancer’s ability deals 1 damage to a creature, that damage will cause a -1/-1 counter to be placed on the creature. If it deals 1 damage to a player, that player gets a poison counter."
+          "text": "If Fallen Ferromancer's ability deals 1 damage to a creature, that damage will cause a -1/-1 counter to be placed on the creature. If it deals 1 damage to a player, that player gets a poison counter."
         }
       ],
       "subtypes": [
@@ -9848,11 +9844,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({R/P} can be paid with either {R} or 2 life.)\nGut Shot deals 1 damage to target creature or player.",
@@ -10075,11 +10071,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "subtypes": [
@@ -10296,7 +10292,7 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -10415,15 +10411,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "Rage Extractor’s ability checks for any spell you cast with any Phyrexian mana symbol in its mana cost, regardless of that symbol’s color or how the cost was paid."
+          "text": "Rage Extractor's ability checks for any spell you cast with any Phyrexian mana symbol in its mana cost, regardless of that symbol's color or how the cost was paid."
         },
         {
           "date": "2011-06-01",
@@ -10650,11 +10646,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({R/P} can be paid with either {R} or 2 life.)\nNonartifact creatures can't block this turn.",
@@ -10867,7 +10863,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Slag Fiend’s power- and toughness-setting ability works in all zones, not just on the battlefield."
+          "text": "Slag Fiend's power- and toughness-setting ability works in all zones, not just on the battlefield."
         }
       ],
       "subtypes": [
@@ -10990,11 +10986,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "subtypes": [
@@ -11211,7 +11207,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Urabrask the Hidden gives itself haste while it’s on the battlefield."
+          "text": "Urabrask the Hidden gives itself haste while it's on the battlefield."
         }
       ],
       "subtypes": [
@@ -11424,7 +11420,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the creature or player is an illegal target when Volt Charge tries to resolve, it will be countered and none of its effects will happen. You won’t proliferate."
+          "text": "If the creature or player is an illegal target when Volt Charge tries to resolve, it will be countered and none of its effects will happen. You won't proliferate."
         }
       ],
       "text": "Volt Charge deals 3 damage to target creature or player. Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -11743,7 +11739,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent’s controller won’t get a Beast token."
+          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent's controller won't get a Beast token."
         },
         {
           "date": "2013-07-01",
@@ -11864,15 +11860,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         },
         {
           "date": "2011-06-01",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is copying something else; see below). If its mana cost includes {X}, X is considered to be 0. If it has no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is copying something else; see below). If its mana cost includes {X}, X is considered to be 0. If it has no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
         },
         {
           "date": "2011-06-01",
@@ -11880,7 +11876,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If a creature is copying something else, its converted mana cost is the converted mana cost of whatever it’s copying."
+          "text": "If a creature is copying something else, its converted mana cost is the converted mana cost of whatever it's copying."
         }
       ],
       "text": "({G/P} can be paid with either {G} or 2 life.)\n{1}{G/P}, {T}, Sacrifice a creature: Search your library for a creature card with converted mana cost equal to 1 plus the sacrificed creature's converted mana cost, put that card onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
@@ -12092,7 +12088,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "subtypes": [
@@ -12214,11 +12210,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({G/P} can be paid with either {G} or 2 life.)\nCorrosive Gale deals X damage to each creature with flying.",
@@ -12432,7 +12428,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Fresh Meat counts all creatures you owned that went to the graveyard this turn, including creature tokens that entered the battlefield under your control and nontoken creatures you owned but didn’t control."
+          "text": "Fresh Meat counts all creatures you owned that went to the graveyard this turn, including creature tokens that entered the battlefield under your control and nontoken creatures you owned but didn't control."
         }
       ],
       "text": "Create a 3/3 green Beast creature token for each creature put into your graveyard from the battlefield this turn.",
@@ -12746,7 +12742,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Once Greenhilt Trainee’s ability is activated, it will resolve as normal even if Greenhilt Trainee’s power is less than 4 at that time (perhaps because an Equipment attached to it was destroyed)."
+          "text": "Once Greenhilt Trainee's ability is activated, it will resolve as normal even if Greenhilt Trainee's power is less than 4 at that time (perhaps because an Equipment attached to it was destroyed)."
         }
       ],
       "subtypes": [
@@ -12861,7 +12857,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If only one of the targeted creatures is still a legal target when Leeching Bite tries to resolve, that creature will still be affected, but the illegal target won’t be."
+          "text": "If only one of the targeted creatures is still a legal target when Leeching Bite tries to resolve, that creature will still be affected, but the illegal target won't be."
         }
       ],
       "text": "Target creature gets +1/+1 until end of turn. Another target creature gets -1/-1 until end of turn.",
@@ -13074,7 +13070,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Melira doesn’t remove any poison counters you already have or any -1/-1 counters already on creatures you control."
+          "text": "Melira doesn't remove any poison counters you already have or any -1/-1 counters already on creatures you control."
         },
         {
           "date": "2011-06-01",
@@ -13082,11 +13078,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If a creature with infect enters the battlefield under an opponent’s control after Melira enters the battlefield, that creature loses infect."
+          "text": "If a creature with infect enters the battlefield under an opponent's control after Melira enters the battlefield, that creature loses infect."
         },
         {
           "date": "2011-06-01",
-          "text": "It’s possible for a creature an opponent controls to gain infect after Melira enters the battlefield. For example, your opponent could cast Glistening Oil on a creature, and then Melira’s ability and Glistening Oil’s ability would be applied in timestamp order, with the most recent effect winning. The damage dealt to you by such a creature won’t result in you losing life (because the creature has infect) or in you getting poison counters (because Melira stops them). Similarly, damage dealt to a creature you control by such a creature won’t result in damage being marked on the creature or in -1/-1 counters. However, abilities that check whether damage was dealt (such as lifelink or Whispering Specter’s triggered ability) will still see that damage."
+          "text": "It's possible for a creature an opponent controls to gain infect after Melira enters the battlefield. For example, your opponent could cast Glistening Oil on a creature, and then Melira's ability and Glistening Oil's ability would be applied in timestamp order, with the most recent effect winning. The damage dealt to you by such a creature won't result in you losing life (because the creature has infect) or in you getting poison counters (because Melira stops them). Similarly, damage dealt to a creature you control by such a creature won't result in damage being marked on the creature or in -1/-1 counters. However, abilities that check whether damage was dealt (such as lifelink or Whispering Specter's triggered ability) will still see that damage."
         }
       ],
       "subtypes": [
@@ -13213,11 +13209,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({G/P} can be paid with either {G} or 2 life.)\nTarget creature gets +2/+2 until end of turn.",
@@ -13440,11 +13436,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "text": "({G/P} can be paid with either {G} or 2 life.)\nPut target card from a graveyard on top of its owner's library.",
@@ -13875,11 +13871,11 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If you’re at 1 life or less, you can’t pay 2 life."
+          "text": "If you're at 1 life or less, you can't pay 2 life."
         },
         {
           "date": "2011-06-01",
-          "text": "Phyrexian mana is not a new color. Players can’t add Phyrexian mana to their mana pools."
+          "text": "Phyrexian mana is not a new color. Players can't add Phyrexian mana to their mana pools."
         }
       ],
       "subtypes": [
@@ -14100,7 +14096,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "The player must be poisoned when Viridian Betrayers deals damage in order for Viridian Betrayers to have infect. If the player has no poison counters, damage dealt to that player by Viridian Betrayers will result in loss of life, even if it’s dealt at the same time as damage from another creature with infect."
+          "text": "The player must be poisoned when Viridian Betrayers deals damage in order for Viridian Betrayers to have infect. If the player has no poison counters, damage dealt to that player by Viridian Betrayers will result in loss of life, even if it's dealt at the same time as damage from another creature with infect."
         }
       ],
       "subtypes": [
@@ -14211,7 +14207,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the enchanted artifact and Viridian Harvest are put into the graveyard at the same time, you’ll still gain 6 life."
+          "text": "If the enchanted artifact and Viridian Harvest are put into the graveyard at the same time, you'll still gain 6 life."
         }
       ],
       "subtypes": [
@@ -14741,7 +14737,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The ability to return Batterskull to its owner’s hand can only be activated if Batterskull is on the battlefield. If Batterskull is no longer on the battlefield when the ability resolves, it will have no effect."
+          "text": "The ability to return Batterskull to its owner's hand can only be activated if Batterskull is on the battlefield. If Batterskull is no longer on the battlefield when the ability resolves, it will have no effect."
         }
       ],
       "subtypes": [
@@ -14948,7 +14944,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Caged Sun’s triggered ability is a mana ability, which means the ability doesn’t use the stack and can’t be responded to."
+          "text": "Caged Sun's triggered ability is a mana ability, which means the ability doesn't use the stack and can't be responded to."
         }
       ],
       "text": "As Caged Sun enters the battlefield, choose a color.\nCreatures you control of the chosen color get +1/+1.\nWhenever a land's ability adds one or more mana of the chosen color to your mana pool, add one additional mana of that color to your mana pool.",
@@ -15047,7 +15043,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the targeted artifact card is no longer in the graveyard when the first ability tries to resolve, it will be countered and none of its effects will happen. You won’t put a charge counter on Conversion Chamber."
+          "text": "If the targeted artifact card is no longer in the graveyard when the first ability tries to resolve, it will be countered and none of its effects will happen. You won't put a charge counter on Conversion Chamber."
         }
       ],
       "text": "{2}, {T}: Exile target artifact card from a graveyard. Put a charge counter on Conversion Chamber.\n{2}, {T}, Remove a charge counter from Conversion Chamber: Create a 3/3 colorless Golem artifact creature token.",
@@ -15446,7 +15442,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You may choose a value for X that’s greater than the number of counters on the targeted permanent. However, Hex Parasite only gets the bonus for counters actually removed."
+          "text": "You may choose a value for X that's greater than the number of counters on the targeted permanent. However, Hex Parasite only gets the bonus for counters actually removed."
         },
         {
           "date": "2011-06-01",
@@ -16251,7 +16247,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "The ability will trigger when Mycosynth Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn’t resolved yet."
+          "text": "The ability will trigger when Mycosynth Wellspring is put into a graveyard from the battlefield, even if the ability that triggered when it entered the battlefield hasn't resolved yet."
         }
       ],
       "text": "When Mycosynth Wellspring enters the battlefield or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
@@ -16357,7 +16353,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Mana produced by abilities of creature cards not on the battlefield, such as Chancellor of the Tangle or Elvish Spirit Guide, can’t be used to cast Myr Superion."
+          "text": "Mana produced by abilities of creature cards not on the battlefield, such as Chancellor of the Tangle or Elvish Spirit Guide, can't be used to cast Myr Superion."
         }
       ],
       "subtypes": [
@@ -16881,7 +16877,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Pristine Talisman has a mana ability. Its ability doesn’t use the stack and can’t be responded to."
+          "text": "Pristine Talisman has a mana ability. Its ability doesn't use the stack and can't be responded to."
         }
       ],
       "text": "{T}: Add {C} to your mana pool. You gain 1 life.",
@@ -17167,11 +17163,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Unlike most abilities that force a player to discard cards, this ability may be activated whenever you could cast an instant, including during your opponent’s draw step after he or she has drawn a card."
+          "text": "Unlike most abilities that force a player to discard cards, this ability may be activated whenever you could cast an instant, including during your opponent's draw step after he or she has drawn a card."
         },
         {
           "date": "2011-06-01",
-          "text": "You can’t force an opponent to discard a card he or she casts by activating the last ability in response. The spell is on the stack by then."
+          "text": "You can't force an opponent to discard a card he or she casts by activating the last ability in response. The spell is on the stack by then."
         }
       ],
       "text": "At the beginning of your upkeep or whenever you cast a black spell, put a charge counter on Shrine of Limitless Power.\n{4}, {T}, Sacrifice Shrine of Limitless Power: Target player discards a card for each charge counter on Shrine of Limitless Power.",
@@ -17555,15 +17551,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If one of the targeted players is an illegal target when the activated ability tries to resolve, the exchange won’t happen. Neither player’s life total will change."
+          "text": "If one of the targeted players is an illegal target when the activated ability tries to resolve, the exchange won't happen. Neither player's life total will change."
         },
         {
           "date": "2011-06-01",
-          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player’s previous life total. For example, if Player A has 5 life and Player B has 3 life before the exchange, Player A will lose 2 life and Player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
+          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player's previous life total. For example, if Player A has 5 life and Player B has 3 life before the exchange, Player A will lose 2 life and Player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
         },
         {
           "date": "2011-06-01",
-          "text": "If a player can’t gain life, that player can’t exchange life totals with a player with a higher life total. If a player can’t lose life, that player can’t exchange life totals with a player with a lower life total. In either of these cases, neither player’s life total will change."
+          "text": "If a player can't gain life, that player can't exchange life totals with a player with a higher life total. If a player can't lose life, that player can't exchange life totals with a player with a lower life total. In either of these cases, neither player's life total will change."
         },
         {
           "date": "2011-06-01",
@@ -17672,7 +17668,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You can activate Spellskite’s ability even if Spellskite wouldn’t be a legal target for the spell or ability. However, the target of that spell or ability will remain unchanged."
+          "text": "You can activate Spellskite's ability even if Spellskite wouldn't be a legal target for the spell or ability. However, the target of that spell or ability will remain unchanged."
         },
         {
           "date": "2011-06-01",
@@ -17680,23 +17676,23 @@
         },
         {
           "date": "2011-06-01",
-          "text": "If the spell or ability has multiple instances of the word “target,” you choose which target you’re changing to Spellskite when Spellskite’s ability resolves."
+          "text": "If the spell or ability has multiple instances of the word \"target,\" you choose which target you're changing to Spellskite when Spellskite's ability resolves."
         },
         {
           "date": "2011-06-01",
-          "text": "By activating Spellskite’s ability multiple times, you can change each target of a spell or ability with multiple instances of the word “target” to Spellskite, one at a time."
+          "text": "By activating Spellskite's ability multiple times, you can change each target of a spell or ability with multiple instances of the word \"target\" to Spellskite, one at a time."
         },
         {
           "date": "2011-06-01",
-          "text": "The target of the spell or ability won’t change unless Spellskite fulfills all the targeting criteria, even if multiple instances of the word “target” are used. For example, you can’t change both targets of Arc Trail to Spellskite."
+          "text": "The target of the spell or ability won't change unless Spellskite fulfills all the targeting criteria, even if multiple instances of the word \"target\" are used. For example, you can't change both targets of Arc Trail to Spellskite."
         },
         {
           "date": "2011-06-01",
-          "text": "If a spell or ability has multiple targets but doesn’t use the word “target” multiple times, such as Fulgent Distraction, you can only successfully change one of the targets to Spellskite."
+          "text": "If a spell or ability has multiple targets but doesn't use the word \"target\" multiple times, such as Fulgent Distraction, you can only successfully change one of the targets to Spellskite."
         },
         {
           "date": "2011-06-01",
-          "text": "If a spell or ability has a variable number of targets, you can’t change the number of targets."
+          "text": "If a spell or ability has a variable number of targets, you can't change the number of targets."
         },
         {
           "date": "2011-06-01",
@@ -17905,7 +17901,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "You count the cards in the each player’s hand when the triggered ability resolves."
+          "text": "You count the cards in the each player's hand when the triggered ability resolves."
         }
       ],
       "subtypes": [
@@ -18008,11 +18004,11 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Torpor Orb stops a creature’s own enters-the-battlefield triggered abilities as well as other triggered abilities that would trigger when a creature enters the battlefield."
+          "text": "Torpor Orb stops a creature's own enters-the-battlefield triggered abilities as well as other triggered abilities that would trigger when a creature enters the battlefield."
         },
         {
           "date": "2011-06-01",
-          "text": "The trigger event doesn’t have to specify “creatures” entering the battlefield. For example, Amulet of Vigor says “Whenever a permanent enters the battlefield tapped and under your control, untap it.” If a creature enters the battlefield tapped and under your control, Amulet of Vigor would not trigger. If a land (that isn’t also a creature) enters the battlefield tapped and under your control, Amulet of Vigor would trigger."
+          "text": "The trigger event doesn't have to specify \"creatures\" entering the battlefield. For example, Amulet of Vigor says \"Whenever a permanent enters the battlefield tapped and under your control, untap it.\" If a creature enters the battlefield tapped and under your control, Amulet of Vigor would not trigger. If a land (that isn't also a creature) enters the battlefield tapped and under your control, Amulet of Vigor would trigger."
         },
         {
           "date": "2011-06-01",
@@ -18020,15 +18016,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Abilities that apply “as [this creature] enters the battlefield,” such as choosing a creature to copy with Clone, are unaffected."
+          "text": "Abilities that apply \"as [this creature] enters the battlefield,\" such as choosing a creature to copy with Clone, are unaffected."
         },
         {
           "date": "2011-06-01",
-          "text": "Look at the permanent as it exists on the battlefield, taking into account continuous effects, to determine whether any triggered abilities will trigger. For example, if you control March of the Machines, which says, in part, “Each noncreature artifact is an artifact creature,” Torpor Orb will be a creature when it enters the battlefield and will not cause triggered abilities to trigger."
+          "text": "Look at the permanent as it exists on the battlefield, taking into account continuous effects, to determine whether any triggered abilities will trigger. For example, if you control March of the Machines, which says, in part, \"Each noncreature artifact is an artifact creature,\" Torpor Orb will be a creature when it enters the battlefield and will not cause triggered abilities to trigger."
         },
         {
           "date": "2011-06-01",
-          "text": "If Torpor Orb and a creature enter the battlefield at the same time, that creature entering the battlefield won’t cause triggered abilities to trigger."
+          "text": "If Torpor Orb and a creature enter the battlefield at the same time, that creature entering the battlefield won't cause triggered abilities to trigger."
         }
       ],
       "text": "Creatures entering the battlefield don't cause abilities to trigger.",
@@ -18231,15 +18227,15 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Those artifacts untap at the same time as the active player’s permanents. You have no choice about what untaps and can’t choose to not untap an artifact you control."
+          "text": "Those artifacts untap at the same time as the active player's permanents. You have no choice about what untaps and can't choose to not untap an artifact you control."
         },
         {
           "date": "2011-06-01",
-          "text": "Some effects, such as the one generated by Rust Tick’s ability, state that an artifact doesn’t untap during its controller’s untap step. These effects won’t apply and stop the artifact from untapping during another player’s untap step."
+          "text": "Some effects, such as the one generated by Rust Tick's ability, state that an artifact doesn't untap during its controller's untap step. These effects won't apply and stop the artifact from untapping during another player's untap step."
         },
         {
           "date": "2011-06-01",
-          "text": "Even if you control more than one Unwinding Clock, you’ll only untap your artifacts once during each other player’s untap step."
+          "text": "Even if you control more than one Unwinding Clock, you'll only untap your artifacts once during each other player's untap step."
         }
       ],
       "text": "Untap all artifacts you control during each other player's untap step.",
@@ -18338,7 +18334,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "Once you activate the ability and sacrifice an artifact, it’s too late for anyone to respond to try and prevent you from paying the cost."
+          "text": "Once you activate the ability and sacrifice an artifact, it's too late for anyone to respond to try and prevent you from paying the cost."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}, {T}, Sacrifice an artifact: You gain 1 life.",

--- a/json/OGW.json
+++ b/json/OGW.json
@@ -139,7 +139,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You may put the card on the bottom of your library in any of the possible scenarios that could occur with this card. It doesn’t matter whether the card is a creature card or not. If it is a creature card, it doesn’t matter whether you chose to have the copy effect apply."
+          "text": "You may put the card on the bottom of your library in any of the possible scenarios that could occur with this card. It doesn't matter whether the card is a creature card or not. If it is a creature card, it doesn't matter whether you chose to have the copy effect apply."
         },
         {
           "date": "2016-01-22",
@@ -151,7 +151,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "If a creature you control becomes a copy of the revealed creature card, it’s neither entering nor leaving the battlefield. Any enters-the-battlefield or leaves-the-battlefield abilities won’t trigger."
+          "text": "If a creature you control becomes a copy of the revealed creature card, it's neither entering nor leaving the battlefield. Any enters-the-battlefield or leaves-the-battlefield abilities won't trigger."
         }
       ],
       "subtypes": [
@@ -264,11 +264,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Use the new creature’s power and toughness at the time the ability resolves to determine the base power and toughness of Eldrazi Mimic. If that creature is no longer on the battlefield at that time, use its power and toughness when it left the battlefield. (Keep in mind that those values may be negative, for example if a spell like Spatial Contortion giving it +3/-3 is what caused it to leave the battlefield.)"
+          "text": "Use the new creature's power and toughness at the time the ability resolves to determine the base power and toughness of Eldrazi Mimic. If that creature is no longer on the battlefield at that time, use its power and toughness when it left the battlefield. (Keep in mind that those values may be negative, for example if a spell like Spatial Contortion giving it +3/-3 is what caused it to leave the battlefield.)"
         },
         {
           "date": "2016-01-22",
-          "text": "Eldrazi Mimic’s ability will overwrite any other effect setting its base power and toughness. Such effects that begin to apply after that ability resolves will similarly overwrite the ability. Effects that modify Eldrazi Mimic’s power and/or toughness but don’t set its base power and/or toughness to specific values will apply no matter when they started to apply. The same is true for any +1/+1 counters it may have."
+          "text": "Eldrazi Mimic's ability will overwrite any other effect setting its base power and toughness. Such effects that begin to apply after that ability resolves will similarly overwrite the ability. Effects that modify Eldrazi Mimic's power and/or toughness but don't set its base power and/or toughness to specific values will apply no matter when they started to apply. The same is true for any +1/+1 counters it may have."
         }
       ],
       "subtypes": [
@@ -374,21 +374,22 @@
       "originalType": "Creature — Eldrazi",
       "power": "5",
       "printings": [
+        "pLPA",
         "OGW"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Endbringer untaps at the same time as the active player’s permanents. You can’t choose to not untap it at that time."
+          "text": "Endbringer untaps at the same time as the active player's permanents. You can't choose to not untap it at that time."
         },
         {
           "date": "2016-01-22",
-          "text": "If an effect states that Endbringer doesn’t untap during your untap step, that effect won’t apply during another player’s untap step."
+          "text": "If an effect states that Endbringer doesn't untap during your untap step, that effect won't apply during another player's untap step."
         },
         {
           "date": "2016-01-22",
-          "text": "Activating the second activated ability after a creature has legally been declared as an attacker or blocker won’t change or undo that attack or block."
+          "text": "Activating the second activated ability after a creature has legally been declared as an attacker or blocker won't change or undo that attack or block."
         }
       ],
       "subtypes": [
@@ -501,19 +502,19 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Kozilek’s triggered ability checks to see if you have fewer than seven cards in hand when you cast it. Kozilek is on the stack at this time and not in your hand. If you don’t, the ability won’t trigger at all. If the ability does trigger, it will check again as it tries to resolve. If you have seven or more cards in hand at that time, the ability won’t do anything."
+          "text": "Kozilek's triggered ability checks to see if you have fewer than seven cards in hand when you cast it. Kozilek is on the stack at this time and not in your hand. If you don't, the ability won't trigger at all. If the ability does trigger, it will check again as it tries to resolve. If you have seven or more cards in hand at that time, the ability won't do anything."
         },
         {
           "date": "2016-01-22",
-          "text": "To activate the last ability, there must be a legal target: a spell on the stack. That target will determine the value of X and the converted mana cost of the card you discard. You can’t activate the ability unless you can match the converted mana cost of a spell on the stack to that of a card in your hand."
+          "text": "To activate the last ability, there must be a legal target: a spell on the stack. That target will determine the value of X and the converted mana cost of the card you discard. You can't activate the ability unless you can match the converted mana cost of a spell on the stack to that of a card in your hand."
         },
         {
           "date": "2016-01-22",
-          "text": "The converted mana cost of a spell doesn’t change, even if it’s been cast using an alternative cost (such as an awaken cost). For example, the converted mana cost of a Sheer Drop (a spell with mana cost {2}{W}) that’s been cast for its awaken cost of {5}{W} is 3."
+          "text": "The converted mana cost of a spell doesn't change, even if it's been cast using an alternative cost (such as an awaken cost). For example, the converted mana cost of a Sheer Drop (a spell with mana cost {2}{W}) that's been cast for its awaken cost of {5}{W} is 3."
         },
         {
           "date": "2016-01-22",
-          "text": "If there’s an {X} in the mana cost of the card you discard, that X is 0. Any {X} in the mana cost of the target spell will have whatever value was determined for it as the spell was cast."
+          "text": "If there's an {X} in the mana cost of the card you discard, that X is 0. Any {X} in the mana cost of the target spell will have whatever value was determined for it as the spell was cast."
         }
       ],
       "subtypes": [
@@ -629,7 +630,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Activating the ability once Kozilek’s Pathfinder has been legally blocked won’t change or undo that block."
+          "text": "Activating the ability once Kozilek's Pathfinder has been legally blocked won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -741,11 +742,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If you put an Aura card onto the battlefield this way, you choose what it enchants as it enters the battlefield. You must be able to choose a legal player or permanent or you can’t put the Aura onto the battlefield."
+          "text": "If you put an Aura card onto the battlefield this way, you choose what it enchants as it enters the battlefield. You must be able to choose a legal player or permanent or you can't put the Aura onto the battlefield."
         },
         {
           "date": "2016-01-22",
-          "text": "If you don’t put the card onto the battlefield for any reason, you put the card into your hand."
+          "text": "If you don't put the card onto the battlefield for any reason, you put the card into your hand."
         }
       ],
       "subtypes": [
@@ -1507,7 +1508,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "After the creature returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won’t be in combat or have any additional abilities it may have had when it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
+          "text": "After the creature returns to the battlefield, it will be a new object with no connection to the creature that was exiled. It won't be in combat or have any additional abilities it may have had when it was exiled. Any +1/+1 counters on it or Auras attached to it are removed, and any Equipment will no longer be attached."
         }
       ],
       "subtypes": [
@@ -2075,11 +2076,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -2209,7 +2210,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Once the last ability resolves, the bonus given doesn’t change, even if the number of colors among your Allies does."
+          "text": "Once the last ability resolves, the bonus given doesn't change, even if the number of colors among your Allies does."
         }
       ],
       "subtypes": [
@@ -2440,7 +2441,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The ability to block an additional creature is cumulative. If a creature is enchanted with two Iona’s Blessings, it can block three creatures each combat. (The +2/+2 is also cumulative, but you knew that.)"
+          "text": "The ability to block an additional creature is cumulative. If a creature is enchanted with two Iona's Blessings, it can block three creatures each combat. (The +2/+2 is also cumulative, but you knew that.)"
         }
       ],
       "subtypes": [
@@ -2557,15 +2558,15 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If Isolation Zone leaves the battlefield before its triggered ability resolves, the target creature or enchantment won’t be exiled."
+          "text": "If Isolation Zone leaves the battlefield before its triggered ability resolves, the target creature or enchantment won't be exiled."
         },
         {
           "date": "2016-01-22",
-          "text": "Auras attached to the exiled creature or enchantment will be put into their owners’ graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+          "text": "Auras attached to the exiled creature or enchantment will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
         },
         {
           "date": "2016-01-22",
-          "text": "If a token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2016-01-22",
@@ -2573,7 +2574,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "In a multiplayer game, if Isolation Zone’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Isolation Zone's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "text": "When Isolation Zone enters the battlefield, exile target creature or enchantment an opponent controls until Isolation Zone leaves the battlefield. (That permanent returns under its owner's control.)",
@@ -2917,11 +2918,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "For each triggered ability, the game checks to see if the condition is true at the moment the ability would trigger. If the condition isn’t true, the ability won’t trigger. If the ability does trigger, the game will check again to see if the condition is true as the ability tries to resolve. If it’s not true at that time, the ability won’t do anything."
+          "text": "For each triggered ability, the game checks to see if the condition is true at the moment the ability would trigger. If the condition isn't true, the ability won't trigger. If the ability does trigger, the game will check again to see if the condition is true as the ability tries to resolve. If it's not true at that time, the ability won't do anything."
         },
         {
           "date": "2016-01-22",
-          "text": "In a multiplayer game, it’s possible for the condition to be true at both times but with respect to two different opponents."
+          "text": "In a multiplayer game, it's possible for the condition to be true at both times but with respect to two different opponents."
         }
       ],
       "subtypes": [
@@ -3277,7 +3278,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
         }
       ],
       "text": "Target creature gets +2/+2 and gains flying until end of turn.",
@@ -3393,7 +3394,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can’t have “summoning sickness.” However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn’t use {T} [the tap symbol].)"
+          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can't have \"summoning sickness.\" However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -3517,7 +3518,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The “legend rule” checks the full names of legendary permanents. You can control Oath of Gideon and Oath of Chandra at the same time, for example."
+          "text": "The \"legend rule\" checks the full names of legendary permanents. You can control Oath of Gideon and Oath of Chandra at the same time, for example."
         },
         {
           "date": "2016-01-22",
@@ -3639,7 +3640,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can’t have “summoning sickness.” However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn’t use {T} [the tap symbol].)"
+          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can't have \"summoning sickness.\" However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -3761,11 +3762,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -3998,11 +3999,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -4121,7 +4122,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can’t have “summoning sickness.” However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn’t use {T} [the tap symbol].)"
+          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can't have \"summoning sickness.\" However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -4355,7 +4356,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The bonuses gained from Stone Haven Outfitter’s abilities are in addition to any bonuses given by the Equipment."
+          "text": "The bonuses gained from Stone Haven Outfitter's abilities are in addition to any bonuses given by the Equipment."
         },
         {
           "date": "2016-01-22",
@@ -4363,7 +4364,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "In this context, “equipped creatures you control” and “equipped creature you control” refer to any creatures you control with Equipment attached to them. In the highly unusual case that Stone Haven Outfitter becomes an Equipment, the meaning of its abilities doesn’t change. The bonuses continue to refer to any equipped creature you control. They aren’t bonuses applied solely to the creature Stone Haven Outfitter is attached to."
+          "text": "In this context, \"equipped creatures you control\" and \"equipped creature you control\" refer to any creatures you control with Equipment attached to them. In the highly unusual case that Stone Haven Outfitter becomes an Equipment, the meaning of its abilities doesn't change. The bonuses continue to refer to any equipped creature you control. They aren't bonuses applied solely to the creature Stone Haven Outfitter is attached to."
         }
       ],
       "subtypes": [
@@ -4484,7 +4485,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can’t have “summoning sickness.” However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn’t use {T} [the tap symbol].)"
+          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can't have \"summoning sickness.\" However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -4604,7 +4605,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If you target a land that’s already a creature with Wall of Resurgence’s triggered ability, that land creature’s base power and toughness will become 0/0, overwriting its previous base power and toughness. Other effects that modify its power and/or toughness (including the new and any previously-existing +1/+1 counters) will continue to apply."
+          "text": "If you target a land that's already a creature with Wall of Resurgence's triggered ability, that land creature's base power and toughness will become 0/0, overwriting its previous base power and toughness. Other effects that modify its power and/or toughness (including the new and any previously-existing +1/+1 counters) will continue to apply."
         }
       ],
       "subtypes": [
@@ -4944,7 +4945,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Some triggered abilities include a cost as part of their resolution. For example, Bearer of Silence’s ability says, in part, “When you cast Bearer of Silence, you may pay {1}{C}.” You may use mana produced by Cultivator Drone to help pay that cost. In fact, you could tap two Cultivator Drones to pay the entire cost."
+          "text": "Some triggered abilities include a cost as part of their resolution. For example, Bearer of Silence's ability says, in part, \"When you cast Bearer of Silence, you may pay {1}{C}.\" You may use mana produced by Cultivator Drone to help pay that cost. In fact, you could tap two Cultivator Drones to pay the entire cost."
         }
       ],
       "subtypes": [
@@ -5061,7 +5062,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Activating Deepfathom Skulker’s last ability after it’s been legally blocked won’t change or undo that block. The declare attackers step is the last time you can activate the ability and have it be effective."
+          "text": "Activating Deepfathom Skulker's last ability after it's been legally blocked won't change or undo that block. The declare attackers step is the last time you can activate the ability and have it be effective."
         }
       ],
       "subtypes": [
@@ -5176,7 +5177,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You choose whether to return Dimensional Infiltrator to its owner’s hand as its ability resolves. If the exiled card is a land card, you can’t wait and return Dimensional Infiltrator at a later time."
+          "text": "You choose whether to return Dimensional Infiltrator to its owner's hand as its ability resolves. If the exiled card is a land card, you can't wait and return Dimensional Infiltrator at a later time."
         }
       ],
       "subtypes": [
@@ -5626,7 +5627,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The Battle for Zendikar colorless creature cards Blight Herder and Ruin Processor each have an ability that triggers when you cast it that allows you to put a card owned by an opponent from exile into that player’s graveyard. Both that ability and Thought Harvester’s ability trigger at the same time, so you can put them on the stack in any order. If Thought Harvester’s ability resolves first (meaning it went on the stack last), the card exiled by that ability can be “processed” by the other ability."
+          "text": "The Battle for Zendikar colorless creature cards Blight Herder and Ruin Processor each have an ability that triggers when you cast it that allows you to put a card owned by an opponent from exile into that player's graveyard. Both that ability and Thought Harvester's ability trigger at the same time, so you can put them on the stack in any order. If Thought Harvester's ability resolves first (meaning it went on the stack last), the card exiled by that ability can be \"processed\" by the other ability."
         }
       ],
       "subtypes": [
@@ -5970,7 +5971,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -5978,7 +5979,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "text": "Surge {2}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nTarget player draws two cards.",
@@ -6091,7 +6092,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Containment Membrane can target and be attached to an untapped creature. It just won’t have any effect until that creature becomes tapped."
+          "text": "Containment Membrane can target and be attached to an untapped creature. It just won't have any effect until that creature becomes tapped."
         },
         {
           "date": "2016-01-22",
@@ -6103,7 +6104,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -6111,7 +6112,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "subtypes": [
@@ -6227,7 +6228,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "All other nonland permanents will already be in their owners’ hands by the time the Octopus token is created. Any triggered abilities or abilities that would have otherwise affected that Octopus won’t be around to matter."
+          "text": "All other nonland permanents will already be in their owners' hands by the time the Octopus token is created. Any triggered abilities or abilities that would have otherwise affected that Octopus won't be around to matter."
         },
         {
           "date": "2016-01-22",
@@ -6235,7 +6236,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -6243,7 +6244,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "text": "Surge {3}{U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nReturn all nonland permanents to their owners' hands. If Crush of Tentacles's surge cost was paid, create an 8/8 blue Octopus creature token.",
@@ -6358,7 +6359,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If you target a land that’s already a creature with Cyclone Sire’s triggered ability, that land creature’s base power and toughness will become 0/0, overwriting its previous base power and toughness. Other effects that modify its power and/or toughness (including the new and any previously-existing +1/+1 counters) will continue to apply."
+          "text": "If you target a land that's already a creature with Cyclone Sire's triggered ability, that land creature's base power and toughness will become 0/0, overwriting its previous base power and toughness. Other effects that modify its power and/or toughness (including the new and any previously-existing +1/+1 counters) will continue to apply."
         }
       ],
       "subtypes": [
@@ -6480,11 +6481,11 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Gift of Tusks overwrites all previous effects that set the creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Gift of Tusks resolves will overwrite this effect."
+          "text": "Gift of Tusks overwrites all previous effects that set the creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Gift of Tusks resolves will overwrite this effect."
         },
         {
           "date": "2016-01-22",
-          "text": "Gift of Tusks doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature’s ability that says “At the beginning of your upkeep,” “When this creature enters the battlefield,” or similar from triggering."
+          "text": "Gift of Tusks doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature's ability that says \"At the beginning of your upkeep,\" \"When this creature enters the battlefield,\" or similar from triggering."
         },
         {
           "date": "2016-01-22",
@@ -6492,7 +6493,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
         }
       ],
       "text": "Until end of turn, target creature loses all abilities and becomes a green Elephant with base power and toughness 3/3.",
@@ -6605,11 +6606,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Grip of the Roil can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Grip of the Roil can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         },
         {
           "date": "2016-01-22",
-          "text": "Grip of the Roil tracks the creature, but not its controller. If the creature changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "Grip of the Roil tracks the creature, but not its controller. If the creature changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2016-01-22",
@@ -6617,7 +6618,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -6625,7 +6626,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "text": "Surge {1}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nTap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
@@ -6738,7 +6739,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The Hedron Alignment in exile must be face up. If it’s face down, it won’t count, even if you are allowed to look at it."
+          "text": "The Hedron Alignment in exile must be face up. If it's face down, it won't count, even if you are allowed to look at it."
         }
       ],
       "text": "Hexproof\nAt the beginning of your upkeep, you may reveal your hand. If you do, you win the game if you own a card named Hedron Alignment in exile, in your hand, in your graveyard, and on the battlefield.\n{1}{U}: Scry 1.",
@@ -6857,7 +6858,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -6865,7 +6866,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "subtypes": [
@@ -7008,7 +7009,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -7122,7 +7123,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If you control no planeswalkers as the last ability resolves, you won’t scry at all. Abilities that trigger whenever you scry won’t trigger."
+          "text": "If you control no planeswalkers as the last ability resolves, you won't scry at all. Abilities that trigger whenever you scry won't trigger."
         },
         {
           "date": "2016-01-22",
@@ -7130,7 +7131,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The “legend rule” checks the full names of legendary permanents. You can control Oath of Gideon and Oath of Chandra at the same time, for example."
+          "text": "The \"legend rule\" checks the full names of legendary permanents. You can control Oath of Gideon and Oath of Chandra at the same time, for example."
         },
         {
           "date": "2016-01-22",
@@ -7254,7 +7255,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -7262,7 +7263,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "text": "Surge {U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nOverwhelming Denial can't be countered by spells or abilities.\nCounter target spell.",
@@ -7485,11 +7486,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "A spell that can’t be countered can still be targeted by spells or abilities that would counter it. The part of their effect that would counter the spell won’t do anything, but any other effects those spells or abilities may have will still happen, if applicable."
+          "text": "A spell that can't be countered can still be targeted by spells or abilities that would counter it. The part of their effect that would counter the spell won't do anything, but any other effects those spells or abilities may have will still happen, if applicable."
         },
         {
           "date": "2016-01-22",
-          "text": "There’s no functional difference between “can’t be countered” and “can’t be countered by spells or abilities,” but the latter is used for classes of spells that might require a target. Spells with targets can still be countered by the game rules if all of their targets become illegal before they resolve."
+          "text": "There's no functional difference between \"can't be countered\" and \"can't be countered by spells or abilities,\" but the latter is used for classes of spells that might require a target. Spells with targets can still be countered by the game rules if all of their targets become illegal before they resolve."
         }
       ],
       "subtypes": [
@@ -7830,11 +7831,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -7949,11 +7950,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Bearer of Silence’s triggered ability targets only the player, not any creature. For example, the player may sacrifice a creature with hexproof."
+          "text": "Bearer of Silence's triggered ability targets only the player, not any creature. For example, the player may sacrifice a creature with hexproof."
         },
         {
           "date": "2016-01-22",
-          "text": "Players can respond to the triggered ability, but once it starts resolving and you decide whether to pay {1}{C}, it’s too late for anyone to respond."
+          "text": "Players can respond to the triggered ability, but once it starts resolving and you decide whether to pay {1}{C}, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -8070,7 +8071,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Use the card’s power as it last existed in your graveyard to determine how much life is lost."
+          "text": "Use the card's power as it last existed in your graveyard to determine how much life is lost."
         },
         {
           "date": "2016-01-22",
@@ -8300,11 +8301,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Only creatures that are on the battlefield as Flaying Tendrils resolves will get -2/-2. However, any creature that would die that turn will be exiled, even if it wasn’t on the battlefield or wasn’t a creature as Flaying Tendrils resolved."
+          "text": "Only creatures that are on the battlefield as Flaying Tendrils resolves will get -2/-2. However, any creature that would die that turn will be exiled, even if it wasn't on the battlefield or wasn't a creature as Flaying Tendrils resolved."
         },
         {
           "date": "2016-01-22",
-          "text": "Creatures that Flaying Tendrils would cause to die will be exiled instead. The game doesn’t check to see which creatures die until after Flaying Tendrils has finished resolving."
+          "text": "Creatures that Flaying Tendrils would cause to die will be exiled instead. The game doesn't check to see which creatures die until after Flaying Tendrils has finished resolving."
         }
       ],
       "text": "Devoid (This card has no color.)\nAll creatures get -2/-2 until end of turn. If a creature would die this turn, exile it instead.",
@@ -8527,11 +8528,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "No player can look at the cards once they’re exiled."
+          "text": "No player can look at the cards once they're exiled."
         },
         {
           "date": "2016-01-22",
-          "text": "If your opponent puts one of the face-down exiled cards into your graveyard (for example, to activate an ability of an Eldrazi Processor), choose one of the cards at random. The card is revealed only after the cost is fully paid. That is, your opponent can’t learn what card was chosen and decide to back up (not cast the spell, activate the ability, or so on, as applicable)."
+          "text": "If your opponent puts one of the face-down exiled cards into your graveyard (for example, to activate an ability of an Eldrazi Processor), choose one of the cards at random. The card is revealed only after the cost is fully paid. That is, your opponent can't learn what card was chosen and decide to back up (not cast the spell, activate the ability, or so on, as applicable)."
         }
       ],
       "subtypes": [
@@ -8647,7 +8648,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If Kozilek’s Shrieker gains menace after it’s been legally blocked by one creature, it will remain blocked."
+          "text": "If Kozilek's Shrieker gains menace after it's been legally blocked by one creature, it will remain blocked."
         },
         {
           "date": "2016-01-22",
@@ -9757,7 +9758,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Corpse Churn doesn’t target the creature card in your graveyard. You may choose one of the three cards you put there from your library."
+          "text": "Corpse Churn doesn't target the creature card in your graveyard. You may choose one of the three cards you put there from your library."
         }
       ],
       "text": "Put the top three cards of your library into your graveyard, then you may return a creature card from your graveyard to your hand.",
@@ -9872,7 +9873,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can’t have “summoning sickness.” However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn’t use {T} [the tap symbol].)"
+          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can't have \"summoning sickness.\" However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -10105,19 +10106,19 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Abilities that trigger whenever a creature an opponent controls dies won’t trigger unless that creature is a token (see below)."
+          "text": "Abilities that trigger whenever a creature an opponent controls dies won't trigger unless that creature is a token (see below)."
         },
         {
           "date": "2016-01-22",
-          "text": "If a creature token an opponent controls dies, it goes to that player’s graveyard as normal before ceasing to exist."
+          "text": "If a creature token an opponent controls dies, it goes to that player's graveyard as normal before ceasing to exist."
         },
         {
           "date": "2016-01-22",
-          "text": "If Kalitas dies at the same time as creatures your opponents control, those creature cards will be exiled and you’ll get that many Zombies."
+          "text": "If Kalitas dies at the same time as creatures your opponents control, those creature cards will be exiled and you'll get that many Zombies."
         },
         {
           "date": "2016-01-22",
-          "text": "You can’t sacrifice Kalitas to activate the last ability, even if it’s somehow become a Zombie."
+          "text": "You can't sacrifice Kalitas to activate the last ability, even if it's somehow become a Zombie."
         }
       ],
       "subtypes": [
@@ -10240,7 +10241,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can’t have “summoning sickness.” However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn’t use {T} [the tap symbol].)"
+          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can't have \"summoning sickness.\" However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -10361,7 +10362,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Once you activate the ability, it’s too late for anyone to interrupt you by trying to remove the creature card from your graveyard."
+          "text": "Once you activate the ability, it's too late for anyone to interrupt you by trying to remove the creature card from your graveyard."
         }
       ],
       "subtypes": [
@@ -10480,7 +10481,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The player can’t choose to discard two cards unless he or she has at least two cards in hand. Similarly, that player can’t choose to sacrifice a creature or planeswalker unless he or she controls one. This means that if the target opponent doesn’t have two cards in hand and doesn’t control a creature or planeswalker, that player will lose 5 life and then lose 5 life again."
+          "text": "The player can't choose to discard two cards unless he or she has at least two cards in hand. Similarly, that player can't choose to sacrifice a creature or planeswalker unless he or she controls one. This means that if the target opponent doesn't have two cards in hand and doesn't control a creature or planeswalker, that player will lose 5 life and then lose 5 life again."
         },
         {
           "date": "2016-01-22",
@@ -10492,7 +10493,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The same player chooses both times. In a multiplayer game, you can’t choose a different opponent to repeat the process."
+          "text": "The same player chooses both times. In a multiplayer game, you can't choose a different opponent to repeat the process."
         }
       ],
       "text": "Target opponent loses 5 life unless that player discards two cards or sacrifices a creature or planeswalker. Repeat this process once.",
@@ -10827,7 +10828,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Vampire Envoy’s last ability will trigger if it becomes tapped for any reason, including attacking. However, if it enters the battlefield tapped for some reason, the ability won’t trigger."
+          "text": "Vampire Envoy's last ability will trigger if it becomes tapped for any reason, including attacking. However, if it enters the battlefield tapped for some reason, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -10948,7 +10949,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can’t have “summoning sickness.” However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn’t use {T} [the tap symbol].)"
+          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can't have \"summoning sickness.\" However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -11065,7 +11066,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "A “land creature” is a permanent that’s both a land and a creature."
+          "text": "A \"land creature\" is a permanent that's both a land and a creature."
         }
       ],
       "text": "Devoid (This card has no color.)\nChoose one —\n• Exile target land creature.\n• Consuming Sinkhole deals 4 damage to target player.",
@@ -11177,7 +11178,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If it’s the turn Eldrazi Aggressor comes under your control, and it loses haste after being declared as an attacker, it will continue to attack. It won’t be removed from combat."
+          "text": "If it's the turn Eldrazi Aggressor comes under your control, and it loses haste after being declared as an attacker, it will continue to attack. It won't be removed from combat."
         }
       ],
       "subtypes": [
@@ -11293,7 +11294,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You may choose any creature as the target of Eldrazi Obligator’s triggered ability, including one that’s untapped or one you already control."
+          "text": "You may choose any creature as the target of Eldrazi Obligator's triggered ability, including one that's untapped or one you already control."
         }
       ],
       "subtypes": [
@@ -11409,11 +11410,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You compare the power and toughness as you declare blockers, not as Immobilizer Eldrazi’s ability resolves. For example, if you control a 3/3 creature as the ability resolves, then later that turn it gets +0/+1 such that it’s 3/4 as blockers are declared, it won’t be able to block."
+          "text": "You compare the power and toughness as you declare blockers, not as Immobilizer Eldrazi's ability resolves. For example, if you control a 3/3 creature as the ability resolves, then later that turn it gets +0/+1 such that it's 3/4 as blockers are declared, it won't be able to block."
         },
         {
           "date": "2016-01-22",
-          "text": "If a creature has already been legally declared as a blocker, Immobilizer Eldrazi’s ability won’t change or undo that block."
+          "text": "If a creature has already been legally declared as a blocker, Immobilizer Eldrazi's ability won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -11528,11 +11529,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The last ability triggers only if Kozilek’s Return is in your graveyard as you cast the Eldrazi creature spell. That ability will resolve before the Eldrazi creature spell does. In other words, that Eldrazi won’t be on the battlefield yet and won’t be dealt damage by Kozilek’s Return."
+          "text": "The last ability triggers only if Kozilek's Return is in your graveyard as you cast the Eldrazi creature spell. That ability will resolve before the Eldrazi creature spell does. In other words, that Eldrazi won't be on the battlefield yet and won't be dealt damage by Kozilek's Return."
         },
         {
           "date": "2016-01-22",
-          "text": "Exiling Kozilek’s Return due to the last ability isn’t the same as casting it as a spell. Cards that say “Counter target spell” won’t work."
+          "text": "Exiling Kozilek's Return due to the last ability isn't the same as casting it as a spell. Cards that say \"Counter target spell\" won't work."
         }
       ],
       "text": "Devoid (This card has no color.)\nKozilek's Return deals 2 damage to each creature.\nWhenever you cast an Eldrazi creature spell with converted mana cost 7 or greater, you may exile Kozilek's Return from your graveyard. If you do, Kozilek's Return deals 5 damage to each creature.",
@@ -11863,11 +11864,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Discarding a card is part of the ability’s effect and isn’t optional. As the cohort ability resolves, if you have a card in your hand, you must discard one, even if the card you may have wanted to discard as you activated the ability is no longer in your hand."
+          "text": "Discarding a card is part of the ability's effect and isn't optional. As the cohort ability resolves, if you have a card in your hand, you must discard one, even if the card you may have wanted to discard as you activated the ability is no longer in your hand."
         },
         {
           "date": "2016-01-22",
-          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can’t have “summoning sickness.” However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn’t use {T} [the tap symbol].)"
+          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can't have \"summoning sickness.\" However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -11991,7 +11992,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -11999,7 +12000,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "text": "Surge {1}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nBoulder Salvo deals 4 damage to target creature.",
@@ -12226,11 +12227,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can activate Chandra’s second ability while you have an empty hand. If you do, you’ll draw one card."
+          "text": "You can activate Chandra's second ability while you have an empty hand. If you do, you'll draw one card."
         },
         {
           "date": "2016-04-08",
-          "text": "For Chandra’s second ability, it doesn’t matter if the cards don’t go to your graveyard because of a replacement effect. For example, cards with madness discarded this way will still count toward the number of cards you discarded."
+          "text": "For Chandra's second ability, it doesn't matter if the cards don't go to your graveyard because of a replacement effect. For example, cards with madness discarded this way will still count toward the number of cards you discarded."
         }
       ],
       "subtypes": [
@@ -12460,7 +12461,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Once you announce that you’re casting Devour in Flames, it’s too late for anyone to interrupt you by trying to remove the land you’re returning."
+          "text": "Once you announce that you're casting Devour in Flames, it's too late for anyone to interrupt you by trying to remove the land you're returning."
         }
       ],
       "text": "As an additional cost to cast Devour in Flames, return a land you control to its owner's hand.\nDevour in Flames deals 5 damage to target creature or planeswalker.",
@@ -12574,11 +12575,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "A “land creature” is a permanent that’s both a land and a creature."
+          "text": "A \"land creature\" is a permanent that's both a land and a creature."
         },
         {
           "date": "2016-01-22",
-          "text": "You may target a land that’s already a creature. For example, if you target a land that’s also a 0/0 creature and has three +1/+1 counters on it, the resulting land creature will be 6/6."
+          "text": "You may target a land that's already a creature. For example, if you target a land that's also a 0/0 creature and has three +1/+1 counters on it, the resulting land creature will be 6/6."
         }
       ],
       "subtypes": [
@@ -12804,11 +12805,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If one of the targets is a player, you can redirect the damage dealt by Fall of the Titans to a planeswalker that player controls. However, Fall of the Titans can’t be used to deal damage to both a player and a planeswalker he or she controls (unless a separate redirection effect applies)."
+          "text": "If one of the targets is a player, you can redirect the damage dealt by Fall of the Titans to a planeswalker that player controls. However, Fall of the Titans can't be used to deal damage to both a player and a planeswalker he or she controls (unless a separate redirection effect applies)."
         },
         {
           "date": "2016-01-22",
-          "text": "Fall of the Titan’s converted mana cost is based on its mana cost of {X}{X}{R}, even if you’re casting it for its surge cost. For example, if you cast Fall of the Titans for its surge cost and choose 4 for X, its converted mana cost will be 9."
+          "text": "Fall of the Titan's converted mana cost is based on its mana cost of {X}{X}{R}, even if you're casting it for its surge cost. For example, if you cast Fall of the Titans for its surge cost and choose 4 for X, its converted mana cost will be 9."
         },
         {
           "date": "2016-01-22",
@@ -12816,7 +12817,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -12824,7 +12825,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "text": "Surge {X}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nFall of the Titans deals X damage to each of up to two target creatures and/or players.",
@@ -12939,15 +12940,15 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You cast the card during the resolution of the enters-the-battlefield ability, not later in the turn. If it’s a sorcery card, ignore the timing restrictions based on it being a sorcery card. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "You cast the card during the resolution of the enters-the-battlefield ability, not later in the turn. If it's a sorcery card, ignore the timing restrictions based on it being a sorcery card. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2016-01-22",
-          "text": "If you can’t cast the target instant or sorcery card, perhaps because there are no legal targets available, or if you choose not to cast it, it will remain in your graveyard."
+          "text": "If you can't cast the target instant or sorcery card, perhaps because there are no legal targets available, or if you choose not to cast it, it will remain in your graveyard."
         },
         {
           "date": "2016-01-22",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay alternative costs such as surge costs. You can pay additional costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as surge costs. You can pay additional costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2016-01-22",
@@ -12959,7 +12960,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "If an instant or sorcery card you cast this way goes to a zone other than exile or a graveyard, perhaps because one of its abilities says to put it into its owner’s hand, it won’t be exiled. This is true even if the card would be put into a graveyard later that turn."
+          "text": "If an instant or sorcery card you cast this way goes to a zone other than exile or a graveyard, perhaps because one of its abilities says to put it into its owner's hand, it won't be exiled. This is true even if the card would be put into a graveyard later that turn."
         }
       ],
       "subtypes": [
@@ -13082,7 +13083,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -13090,7 +13091,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "subtypes": [
@@ -13324,7 +13325,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Oath of Chandra’s last ability will trigger even if the planeswalker that entered the battlefield under your control is no longer on the battlefield, no longer under your control, or no longer a planeswalker. This is also true if Oath of Chandra wasn’t on the battlefield when the planeswalker entered."
+          "text": "Oath of Chandra's last ability will trigger even if the planeswalker that entered the battlefield under your control is no longer on the battlefield, no longer under your control, or no longer a planeswalker. This is also true if Oath of Chandra wasn't on the battlefield when the planeswalker entered."
         },
         {
           "date": "2016-01-22",
@@ -13336,7 +13337,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The “legend rule” checks the full names of legendary permanents. You can control Oath of Gideon and Oath of Chandra at the same time, for example."
+          "text": "The \"legend rule\" checks the full names of legendary permanents. You can control Oath of Gideon and Oath of Chandra at the same time, for example."
         },
         {
           "date": "2016-01-22",
@@ -13456,11 +13457,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The last target of Press into Service can be any creature, even one that’s untapped, one you already control, or one targeted by the support part of the spell."
+          "text": "The last target of Press into Service can be any creature, even one that's untapped, one you already control, or one targeted by the support part of the spell."
         },
         {
           "date": "2016-01-22",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2016-01-22",
@@ -13468,11 +13469,11 @@
         },
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -13590,7 +13591,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The ability can trigger only once each turn. The ability will resolve before the second spell resolves. It doesn’t matter if the first spell you cast that turn has resolved, was countered, or is still on the stack."
+          "text": "The ability can trigger only once each turn. The ability will resolve before the second spell resolves. It doesn't matter if the first spell you cast that turn has resolved, was countered, or is still on the stack."
         }
       ],
       "text": "Whenever you cast your second spell each turn, Pyromancer's Assault deals 2 damage to target creature or player.",
@@ -13708,7 +13709,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -13716,7 +13717,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "subtypes": [
@@ -13836,11 +13837,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If Sparkmage’s Gambit has two targets, and one of them is illegal as Sparkmage’s Gambit resolves, only the remaining legal target will be affected. The illegal target won’t be dealt damage and will be able to block that turn. If both targets are illegal as Sparkmage’s Gambit tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If Sparkmage's Gambit has two targets, and one of them is illegal as Sparkmage's Gambit resolves, only the remaining legal target will be affected. The illegal target won't be dealt damage and will be able to block that turn. If both targets are illegal as Sparkmage's Gambit tries to resolve, it will be countered and none of its effects will happen."
         },
         {
           "date": "2016-01-22",
-          "text": "If Sparkmage’s Gambit resolves, but the damage is prevented or redirected, the target creatures still won’t be able to block that turn."
+          "text": "If Sparkmage's Gambit resolves, but the damage is prevented or redirected, the target creatures still won't be able to block that turn."
         }
       ],
       "text": "Sparkmage's Gambit deals 1 damage to each of up to two target creatures. Those creatures can't block this turn.",
@@ -14067,7 +14068,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The other spell that you or a teammate cast can be one that’s resolved, one that was countered, or (for instants with surge) one that’s still on the stack."
+          "text": "The other spell that you or a teammate cast can be one that's resolved, one that was countered, or (for instants with surge) one that's still on the stack."
         },
         {
           "date": "2016-01-22",
@@ -14075,7 +14076,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Casting a spell for its surge cost doesn’t change its mana cost or its converted mana cost."
+          "text": "Casting a spell for its surge cost doesn't change its mana cost or its converted mana cost."
         }
       ],
       "subtypes": [
@@ -14097,7 +14098,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"There's a word for someone who brings too much gear to battle: ‘survivor.'\"\n—Zada of Slab Haven",
+      "flavor": "\"There's a word for someone who brings too much gear to battle: 'survivor.'\"\n—Zada of Slab Haven",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -14194,7 +14195,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can’t have “summoning sickness.” However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn’t use {T} [the tap symbol].)"
+          "text": "To activate a cohort ability, the Ally with that ability must have been under your control continuously since the beginning of your most recent turn. Informally, it can't have \"summoning sickness.\" However, the other Ally you tap can be one that just came under your control. (Note that tapping the second Ally doesn't use {T} [the tap symbol].)"
         }
       ],
       "subtypes": [
@@ -14746,11 +14747,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Vile Redeemer’s last ability will count any nontoken creature that died while under your control, even if you weren’t the creature’s owner. It doesn’t matter where the card is as the ability resolves. It doesn’t have to still be in a graveyard."
+          "text": "Vile Redeemer's last ability will count any nontoken creature that died while under your control, even if you weren't the creature's owner. It doesn't matter where the card is as the ability resolves. It doesn't have to still be in a graveyard."
         },
         {
           "date": "2016-01-22",
-          "text": "Vile Redeemer’s last ability won’t count nontoken creatures that didn’t go to a graveyard because of a replacement effect (for example, a creature that was exiled or went to the command zone instead)."
+          "text": "Vile Redeemer's last ability won't count nontoken creatures that didn't go to a graveyard because of a replacement effect (for example, a creature that was exiled or went to the command zone instead)."
         }
       ],
       "subtypes": [
@@ -15100,7 +15101,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Damage dealt to a creature with indestructible is still marked on that creature. If that creature loses indestructible, and the marked damage is lethal, it will be destroyed. However, if a creature with indestructible is dealt damage by a source with deathtouch and then later loses indestructible, that creature won’t be destroyed."
+          "text": "Damage dealt to a creature with indestructible is still marked on that creature. If that creature loses indestructible, and the marked damage is lethal, it will be destroyed. However, if a creature with indestructible is dealt damage by a source with deathtouch and then later loses indestructible, that creature won't be destroyed."
         }
       ],
       "text": "When Bonds of Mortality enters the battlefield, draw a card.\n{G}: Creatures your opponents control lose hexproof and indestructible until end of turn.",
@@ -15329,7 +15330,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "You may target a land that’s already a creature. For example, if you target a land that’s also a 0/0 creature and has three +1/+1 counters on it, the resulting land creature will be 7/7."
+          "text": "You may target a land that's already a creature. For example, if you target a land that's also a 0/0 creature and has three +1/+1 counters on it, the resulting land creature will be 7/7."
         }
       ],
       "text": "Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land. It must be blocked this turn if able.",
@@ -15443,11 +15444,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "A “land creature” is a permanent that’s both a land and a creature."
+          "text": "A \"land creature\" is a permanent that's both a land and a creature."
         },
         {
           "date": "2016-01-22",
-          "text": "You may target a land that’s already a creature. For example, if you target a land that’s also a 0/0 creature and has three +1/+1 counters on it, the resulting land creature will be 6/6."
+          "text": "You may target a land that's already a creature. For example, if you target a land that's also a 0/0 creature and has three +1/+1 counters on it, the resulting land creature will be 6/6."
         }
       ],
       "subtypes": [
@@ -15578,11 +15579,11 @@
         },
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -15706,7 +15707,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Players can respond to the enters-the-battlefield ability (notably, while Harvester Troll is still 2/3), but once that ability starts resolving, it’s too late for any player to respond. You don’t choose which creature or land you’re sacrificing, if any, until the ability resolves."
+          "text": "Players can respond to the enters-the-battlefield ability (notably, while Harvester Troll is still 2/3), but once that ability starts resolving, it's too late for any player to respond. You don't choose which creature or land you're sacrificing, if any, until the ability resolves."
         }
       ],
       "subtypes": [
@@ -15824,11 +15825,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -16404,15 +16405,15 @@
         },
         {
           "date": "2016-01-22",
-          "text": "As Nissa’s Judgment resolves, if at least one of its targets is still legal, it will resolve, affecting only targets that are still legal at that time. If none of its targets are still legal at that time, it will be countered and none of its effects will happen."
+          "text": "As Nissa's Judgment resolves, if at least one of its targets is still legal, it will resolve, affecting only targets that are still legal at that time. If none of its targets are still legal at that time, it will be countered and none of its effects will happen."
         },
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -16534,7 +16535,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "The “legend rule” checks the full names of legendary permanents. You can control Oath of Gideon and Oath of Chandra at the same time, for example."
+          "text": "The \"legend rule\" checks the full names of legendary permanents. You can control Oath of Gideon and Oath of Chandra at the same time, for example."
         },
         {
           "date": "2016-01-22",
@@ -16765,11 +16766,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -16892,11 +16893,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Use the number of creature cards in your graveyard as the ability resolves to determine the value of X. Seed Guardian will count toward this number as long as it’s still in your graveyard at that time."
+          "text": "Use the number of creature cards in your graveyard as the ability resolves to determine the value of X. Seed Guardian will count toward this number as long as it's still in your graveyard at that time."
         },
         {
           "date": "2016-01-22",
-          "text": "Once the Elemental is created, the number of creature cards in your graveyard changing won’t cause the Elemental’s power or toughness to change."
+          "text": "Once the Elemental is created, the number of creature cards in your graveyard changing won't cause the Elemental's power or toughness to change."
         }
       ],
       "subtypes": [
@@ -17015,11 +17016,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "A “land creature” is a permanent that’s both a land and a creature."
+          "text": "A \"land creature\" is a permanent that's both a land and a creature."
         },
         {
           "date": "2016-01-22",
-          "text": "Damage remains marked on creatures until the turn ends. If Sylvan Advocate’s ability stops applying (because Sylvan Advocate leaves the battlefield or you no longer control six or more lands), then any land creatures that needed the toughness bonus to stay alive will be destroyed."
+          "text": "Damage remains marked on creatures until the turn ends. If Sylvan Advocate's ability stops applying (because Sylvan Advocate leaves the battlefield or you no longer control six or more lands), then any land creatures that needed the toughness bonus to stay alive will be destroyed."
         }
       ],
       "subtypes": [
@@ -17369,7 +17370,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "If the land’s mana ability produces more than one type of mana, choose one of those types to determine what mana Zendikar Resurgent produces."
+          "text": "If the land's mana ability produces more than one type of mana, choose one of those types to determine what mana Zendikar Resurgent produces."
         },
         {
           "date": "2016-01-22",
@@ -17822,15 +17823,15 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Once you’ve announced either activated ability, it’s too late for anyone to interrupt you by trying to remove the creature you sacrifice."
+          "text": "Once you've announced either activated ability, it's too late for anyone to interrupt you by trying to remove the creature you sacrifice."
         },
         {
           "date": "2016-01-22",
-          "text": "Once you’ve legally activated the last ability, it doesn’t matter what happens to your life total."
+          "text": "Once you've legally activated the last ability, it doesn't matter what happens to your life total."
         },
         {
           "date": "2016-01-22",
-          "text": "Your starting life total is the life total you began the game with. For most two-player formats, this is 20. For Two-Headed Giant, it’s the life total your team started with, usually 30. In Commander games, your starting life total is 40."
+          "text": "Your starting life total is the life total you began the game with. For most two-player formats, this is 20. For Two-Headed Giant, it's the life total your team started with, usually 30. In Commander games, your starting life total is 40."
         }
       ],
       "subtypes": [
@@ -18075,11 +18076,11 @@
         },
         {
           "date": "2016-01-22",
-          "text": "A creature with lifelink dealing combat damage causes a single life-gaining event. For example, if a single creature with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), Cliffhaven Vampire’s triggered ability will trigger only once. However, if two creatures you control with lifelink deal combat damage at the same time, the ability will trigger twice."
+          "text": "A creature with lifelink dealing combat damage causes a single life-gaining event. For example, if a single creature with lifelink deals combat damage to multiple creatures, players, and/or planeswalkers at the same time (perhaps because it has trample or was blocked by more than one creature), Cliffhaven Vampire's triggered ability will trigger only once. However, if two creatures you control with lifelink deal combat damage at the same time, the ability will trigger twice."
         },
         {
           "date": "2016-01-22",
-          "text": "In a Two-Headed Giant game, life gained by your teammate won’t cause the ability to trigger, even though it causes your team’s life total to increase."
+          "text": "In a Two-Headed Giant game, life gained by your teammate won't cause the ability to trigger, even though it causes your team's life total to increase."
         }
       ],
       "subtypes": [
@@ -18202,11 +18203,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You can’t put more than one +1/+1 counter on any one target using the support action."
+          "text": "You can't put more than one +1/+1 counter on any one target using the support action."
         },
         {
           "date": "2016-01-22",
-          "text": "Support can target a creature you don’t control."
+          "text": "Support can target a creature you don't control."
         },
         {
           "date": "2016-01-22",
@@ -18335,11 +18336,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Jori En’s ability can trigger only once each turn. The ability will resolve before the second spell resolves. It doesn’t matter if the first spell you cast that turn has resolved, was countered, or is still on the stack."
+          "text": "Jori En's ability can trigger only once each turn. The ability will resolve before the second spell resolves. It doesn't matter if the first spell you cast that turn has resolved, was countered, or is still on the stack."
         },
         {
           "date": "2016-01-22",
-          "text": "Jori En must be on the battlefield in order for the ability to function. Notably, the ability won’t trigger if Jori En is the second spell you cast in a turn."
+          "text": "Jori En must be on the battlefield in order for the ability to function. Notably, the ability won't trigger if Jori En is the second spell you cast in a turn."
         }
       ],
       "subtypes": [
@@ -18464,7 +18465,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Once you announce that you’re activating the last ability, it’s too late for anyone to interrupt you by trying to remove the land you returned."
+          "text": "Once you announce that you're activating the last ability, it's too late for anyone to interrupt you by trying to remove the land you returned."
         }
       ],
       "subtypes": [
@@ -18588,11 +18589,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Reflector Mage’s ability doesn’t stop any player from playing lands (in the case that the returned creature was also a land)."
+          "text": "Reflector Mage's ability doesn't stop any player from playing lands (in the case that the returned creature was also a land)."
         },
         {
           "date": "2016-01-22",
-          "text": "In several cases, the name of the creature that was returned won’t match the name of that card once it’s back in its owner’s hand. For example, if the card was copying another creature, it will probably have a different name in its owner’s hand and can be cast again before your next turn. The same is true if a double-faced card with its back face up is returned to its owner’s hand this way."
+          "text": "In several cases, the name of the creature that was returned won't match the name of that card once it's back in its owner's hand. For example, if the card was copying another creature, it will probably have a different name in its owner's hand and can be cast again before your next turn. The same is true if a double-faced card with its back face up is returned to its owner's hand this way."
         },
         {
           "date": "2016-01-22",
@@ -18951,7 +18952,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The ability applies even if the Equipment isn’t attached to anything."
+          "text": "The ability applies even if the Equipment isn't attached to anything."
         }
       ],
       "subtypes": [
@@ -19175,11 +19176,11 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "You choose which opponent or planeswalker controlled by an opponent the token is attacking as it enters the battlefield. It doesn’t have to be the same opponent or planeswalker that the equipped creature is attacking."
+          "text": "You choose which opponent or planeswalker controlled by an opponent the token is attacking as it enters the battlefield. It doesn't have to be the same opponent or planeswalker that the equipped creature is attacking."
         },
         {
           "date": "2016-01-22",
-          "text": "The token is never declared as an attacking creature. It simply enters the battlefield attacking. This won’t cause any abilities that trigger “whenever a creature attacks” to trigger."
+          "text": "The token is never declared as an attacking creature. It simply enters the battlefield attacking. This won't cause any abilities that trigger \"whenever a creature attacks\" to trigger."
         }
       ],
       "subtypes": [
@@ -19938,7 +19939,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The mana produced by the last ability can’t be spent on a colorless spell unless that spell specifically has the devoid ability."
+          "text": "The mana produced by the last ability can't be spent on a colorless spell unless that spell specifically has the devoid ability."
         }
       ],
       "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{T}, Pay 1 life: Add one mana of any color to your mana pool. Spend this mana only to cast a spell with devoid.",
@@ -20146,7 +20147,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
         },
         {
           "date": "2016-01-22",
@@ -20154,11 +20155,11 @@
         },
         {
           "date": "2016-01-22",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2016-01-22",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Hissing Quagmire has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 5/5 creature that’s still a land."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Hissing Quagmire has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 5/5 creature that's still a land."
         }
       ],
       "text": "Hissing Quagmire enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.\n{1}{B}{G}: Hissing Quagmire becomes a 2/2 black and green Elemental creature with deathtouch until end of turn. It's still a land.",
@@ -20264,7 +20265,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "To activate the last ability, you may tap any untapped creature you control, including one you haven’t controlled continuously since the beginning of your most recent turn. (Note that tapping the creature doesn’t use {T} [the tap symbol].)"
+          "text": "To activate the last ability, you may tap any untapped creature you control, including one you haven't controlled continuously since the beginning of your most recent turn. (Note that tapping the creature doesn't use {T} [the tap symbol].)"
         }
       ],
       "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
@@ -20478,19 +20479,19 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "Mirrorpool’s third ability can target (and copy) any instant or sorcery spell, not just one with targets."
+          "text": "Mirrorpool's third ability can target (and copy) any instant or sorcery spell, not just one with targets."
         },
         {
           "date": "2016-01-22",
-          "text": "The copy is created on the stack, so it’s not cast. Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "The copy is created on the stack, so it's not cast. Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2016-01-22",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2016-01-22",
-          "text": "If the copied spell is modal (that is, it says “Choose one —” or the like), the copy will have the same modes. You can’t choose different ones."
+          "text": "If the copied spell is modal (that is, it says \"Choose one —\" or the like), the copy will have the same modes. You can't choose different ones."
         },
         {
           "date": "2016-01-22",
@@ -20498,15 +20499,15 @@
         },
         {
           "date": "2016-01-22",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy, too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy, too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2016-01-22",
-          "text": "For Mirrorpool’s last ability, the token copies exactly what’s printed on the original creature and nothing else (unless that creature is copying something else; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "For Mirrorpool's last ability, the token copies exactly what's printed on the original creature and nothing else (unless that creature is copying something else; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2016-01-22",
-          "text": "For example, if a token copies a Plains that’s been affected by a spell with awaken, the token will be just a land, even though the object being copied is currently a land creature. The same is true if the land has an ability that animates it."
+          "text": "For example, if a token copies a Plains that's been affected by a spell with awaken, the token will be just a land, even though the object being copied is currently a land creature. The same is true if the land has an ability that animates it."
         },
         {
           "date": "2016-01-22",
@@ -20518,7 +20519,7 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         }
       ],
       "text": "Mirrorpool enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{2}{C}, {T}, Sacrifice Mirrorpool: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n{4}{C}, {T}, Sacrifice Mirrorpool: Create a token that's a copy of target creature you control.",
@@ -20627,7 +20628,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
         },
         {
           "date": "2016-01-22",
@@ -20635,11 +20636,11 @@
         },
         {
           "date": "2016-01-22",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2016-01-22",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Needle Spires has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 5/4 creature that’s still a land."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Needle Spires has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 5/4 creature that's still a land."
         }
       ],
       "text": "Needle Spires enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.\n{2}{R}{W}: Needle Spires becomes a 2/1 red and white Elemental creature with double strike until end of turn. It's still a land.",
@@ -20744,7 +20745,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The target of the last ability didn’t necessarily have to be a colorless creature as it entered the battlefield, provided it entered the battlefield during that turn. However, it does have to be a colorless creature to be a legal target of the ability."
+          "text": "The target of the last ability didn't necessarily have to be a colorless creature as it entered the battlefield, provided it entered the battlefield during that turn. However, it does have to be a colorless creature to be a legal target of the ability."
         }
       ],
       "text": "Ruins of Oran-Rief enters the battlefield tapped.\n{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{T}: Put a +1/+1 counter on target colorless creature that entered the battlefield this turn.",
@@ -20850,7 +20851,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "It doesn’t matter how many cards are in your hand as the last ability resolves. For example, if you have no cards in hand and control two Sea Gate Wreckages, you can activate the last ability of each of them. You’ll draw a card as each ability resolves."
+          "text": "It doesn't matter how many cards are in your hand as the last ability resolves. For example, if you have no cards in hand and control two Sea Gate Wreckages, you can activate the last ability of each of them. You'll draw a card as each ability resolves."
         }
       ],
       "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{2}{C}, {T}: Draw a card. Activate this ability only if you have no cards in hand.",
@@ -21405,11 +21406,11 @@
         },
         {
           "date": "2016-01-22",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         },
         {
           "date": "2016-01-22",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature nor when it entered the battlefield."
         },
         {
           "date": "2016-01-22",
@@ -21417,11 +21418,11 @@
         },
         {
           "date": "2016-01-22",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2016-01-22",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Wandering Fumarole has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 4/7 creature that’s still a land."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature (for example, if it was the target of a spell with awaken), this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness will continue to apply no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness. For example, if Wandering Fumarole has been made a 0/0 creature with three +1/+1 counters on it, activating its last ability will turn it into a 4/7 creature that's still a land."
         }
       ],
       "text": "Wandering Fumarole enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.\n{2}{U}{R}: Until end of turn, Wandering Fumarole becomes a 1/4 blue and red Elemental creature with \"{0}: Switch this creature's power and toughness until end of turn.\" It's still a land.",
@@ -21600,7 +21601,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The mana ability of Wastes doesn’t appear on the printed cards, but it is in its official Oracle text. (A card’s Oracle text (in English) can be found using the Gatherer card database at Gatherer.Wizards.com.) The printed cards display a large colorless mana symbol in a design that’s similar to other basic land cards."
+          "text": "The mana ability of Wastes doesn't appear on the printed cards, but it is in its official Oracle text. (A card's Oracle text (in English) can be found using the Gatherer card database at Gatherer.Wizards.com.) The printed cards display a large colorless mana symbol in a design that's similar to other basic land cards."
         },
         {
           "date": "2016-01-22",
@@ -21608,15 +21609,15 @@
         },
         {
           "date": "2016-01-22",
-          "text": "In Limited events (including Sealed Deck and Booster Draft), Wastes must be in your card pool to be included in your deck. You can’t add Wastes to your card pool in the same way that you can add other basic lands."
+          "text": "In Limited events (including Sealed Deck and Booster Draft), Wastes must be in your card pool to be included in your deck. You can't add Wastes to your card pool in the same way that you can add other basic lands."
         },
         {
           "date": "2016-01-22",
-          "text": "Wastes is not a land type. If something asks you to name a land type, you can’t choose Wastes."
+          "text": "Wastes is not a land type. If something asks you to name a land type, you can't choose Wastes."
         },
         {
           "date": "2016-01-22",
-          "text": "Similarly, colorless is not a color. If something asks you to choose a color, you can’t choose colorless."
+          "text": "Similarly, colorless is not a color. If something asks you to choose a color, you can't choose colorless."
         }
       ],
       "supertypes": [
@@ -21804,7 +21805,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The mana ability of Wastes doesn’t appear on the printed cards, but it is in its official Oracle text. (A card’s Oracle text (in English) can be found using the Gatherer card database at Gatherer.Wizards.com.) The printed cards display a large colorless mana symbol in a design that’s similar to other basic land cards."
+          "text": "The mana ability of Wastes doesn't appear on the printed cards, but it is in its official Oracle text. (A card's Oracle text (in English) can be found using the Gatherer card database at Gatherer.Wizards.com.) The printed cards display a large colorless mana symbol in a design that's similar to other basic land cards."
         },
         {
           "date": "2016-01-22",
@@ -21812,15 +21813,15 @@
         },
         {
           "date": "2016-01-22",
-          "text": "In Limited events (including Sealed Deck and Booster Draft), Wastes must be in your card pool to be included in your deck. You can’t add Wastes to your card pool in the same way that you can add other basic lands."
+          "text": "In Limited events (including Sealed Deck and Booster Draft), Wastes must be in your card pool to be included in your deck. You can't add Wastes to your card pool in the same way that you can add other basic lands."
         },
         {
           "date": "2016-01-22",
-          "text": "Wastes is not a land type. If something asks you to name a land type, you can’t choose Wastes."
+          "text": "Wastes is not a land type. If something asks you to name a land type, you can't choose Wastes."
         },
         {
           "date": "2016-01-22",
-          "text": "Similarly, colorless is not a color. If something asks you to choose a color, you can’t choose colorless."
+          "text": "Similarly, colorless is not a color. If something asks you to choose a color, you can't choose colorless."
         }
       ],
       "supertypes": [
@@ -22008,7 +22009,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The mana ability of Wastes doesn’t appear on the printed cards, but it is in its official Oracle text. (A card’s Oracle text (in English) can be found using the Gatherer card database at Gatherer.Wizards.com.) The printed cards display a large colorless mana symbol in a design that’s similar to other basic land cards."
+          "text": "The mana ability of Wastes doesn't appear on the printed cards, but it is in its official Oracle text. (A card's Oracle text (in English) can be found using the Gatherer card database at Gatherer.Wizards.com.) The printed cards display a large colorless mana symbol in a design that's similar to other basic land cards."
         },
         {
           "date": "2016-01-22",
@@ -22016,15 +22017,15 @@
         },
         {
           "date": "2016-01-22",
-          "text": "In Limited events (including Sealed Deck and Booster Draft), Wastes must be in your card pool to be included in your deck. You can’t add Wastes to your card pool in the same way that you can add other basic lands."
+          "text": "In Limited events (including Sealed Deck and Booster Draft), Wastes must be in your card pool to be included in your deck. You can't add Wastes to your card pool in the same way that you can add other basic lands."
         },
         {
           "date": "2016-01-22",
-          "text": "Wastes is not a land type. If something asks you to name a land type, you can’t choose Wastes."
+          "text": "Wastes is not a land type. If something asks you to name a land type, you can't choose Wastes."
         },
         {
           "date": "2016-01-22",
-          "text": "Similarly, colorless is not a color. If something asks you to choose a color, you can’t choose colorless."
+          "text": "Similarly, colorless is not a color. If something asks you to choose a color, you can't choose colorless."
         }
       ],
       "supertypes": [
@@ -22212,7 +22213,7 @@
       "rulings": [
         {
           "date": "2016-01-22",
-          "text": "The mana ability of Wastes doesn’t appear on the printed cards, but it is in its official Oracle text. (A card’s Oracle text (in English) can be found using the Gatherer card database at Gatherer.Wizards.com.) The printed cards display a large colorless mana symbol in a design that’s similar to other basic land cards."
+          "text": "The mana ability of Wastes doesn't appear on the printed cards, but it is in its official Oracle text. (A card's Oracle text (in English) can be found using the Gatherer card database at Gatherer.Wizards.com.) The printed cards display a large colorless mana symbol in a design that's similar to other basic land cards."
         },
         {
           "date": "2016-01-22",
@@ -22220,15 +22221,15 @@
         },
         {
           "date": "2016-01-22",
-          "text": "In Limited events (including Sealed Deck and Booster Draft), Wastes must be in your card pool to be included in your deck. You can’t add Wastes to your card pool in the same way that you can add other basic lands."
+          "text": "In Limited events (including Sealed Deck and Booster Draft), Wastes must be in your card pool to be included in your deck. You can't add Wastes to your card pool in the same way that you can add other basic lands."
         },
         {
           "date": "2016-01-22",
-          "text": "Wastes is not a land type. If something asks you to name a land type, you can’t choose Wastes."
+          "text": "Wastes is not a land type. If something asks you to name a land type, you can't choose Wastes."
         },
         {
           "date": "2016-01-22",
-          "text": "Similarly, colorless is not a color. If something asks you to choose a color, you can’t choose colorless."
+          "text": "Similarly, colorless is not a color. If something asks you to choose a color, you can't choose colorless."
         }
       ],
       "supertypes": [

--- a/json/ONS.json
+++ b/json/ONS.json
@@ -365,7 +365,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a player cycles a card during the end step, the creature that is exiled won’t come back until the end of the next turn."
+          "text": "If a player cycles a card during the end step, the creature that is exiled won't come back until the end of the next turn."
         },
         {
           "date": "2008-08-01",
@@ -530,7 +530,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Aurification gives the creature type “Wall” to creatures with gold counters on them in addition to granting them defender."
+          "text": "Aurification gives the creature type \"Wall\" to creatures with gold counters on them in addition to granting them defender."
         }
       ],
       "text": "Whenever a creature deals damage to you, put a gold counter on it.\nEach creature with a gold counter on it is a Wall in addition to its other creature types and has defender. (Those creatures can't attack.)\nWhen Aurification leaves the battlefield, remove all gold counters from all creatures.",
@@ -803,7 +803,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"There's no ‘I' in ‘team,' but there's a ‘we' in ‘weapon.'\"",
+      "flavor": "\"There's no 'I' in 'team,' but there's a 'we' in 'weapon.'\"",
       "foreignNames": [
         {
           "language": "French",
@@ -4168,6 +4168,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -4196,7 +4200,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2017-04-18",
@@ -4204,15 +4208,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Triggered abilities from cycling a card and the cycling ability itself aren’t spells. Effects that interact with spells (such as that of Cancel) won’t affect them."
+          "text": "Triggered abilities from cycling a card and the cycling ability itself aren't spells. Effects that interact with spells (such as that of Cancel) won't affect them."
         },
         {
           "date": "2017-04-18",
-          "text": "You can cycle a card even if it has a triggered ability from cycling that won’t have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability’s targets have become illegal), the other ability will still resolve."
+          "text": "You can cycle a card even if it has a triggered ability from cycling that won't have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability's targets have become illegal), the other ability will still resolve."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
@@ -4703,11 +4707,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Prevent the next 4 damage that would be dealt to target creature or player this turn.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Sunfire Balm, you may prevent the next 1 damage that would be dealt to target creature or player this turn.",
@@ -5537,7 +5541,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Arcanis’s last ability can only be activated while it’s on the battlefield."
+          "text": "Arcanis's last ability can only be activated while it's on the battlefield."
         }
       ],
       "subtypes": [
@@ -5624,7 +5628,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a creature’s creature type has been changed by a spell or ability, changing the card’s text won’t affect or alter the new creature type."
+          "text": "If a creature's creature type has been changed by a spell or ability, changing the card's text won't affect or alter the new creature type."
         },
         {
           "date": "2004-10-04",
@@ -5636,7 +5640,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -5648,7 +5652,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
@@ -5979,7 +5983,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a permanent changes controller after being targeted but before this spell resolves, you won’t gain control of that permanent."
+          "text": "If a permanent changes controller after being targeted but before this spell resolves, you won't gain control of that permanent."
         },
         {
           "date": "2004-10-04",
@@ -6226,11 +6230,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Tap up to four target creatures.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Choking Tethers, you may tap target creature.",
@@ -6336,7 +6340,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Clone enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2009-10-01",
@@ -6344,11 +6348,11 @@
         },
         {
           "date": "2012-07-01",
-          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Clone copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-07-01",
-          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Clone somehow enters the battlefield at the same time as another creature, Clone can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-07-01",
@@ -6356,7 +6360,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Clone’s ability doesn’t target the chosen creature."
+          "text": "Clone's ability doesn't target the chosen creature."
         }
       ],
       "subtypes": [
@@ -6448,11 +6452,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Counter target spell unless its controller pays {3}.\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)\nWhen you cycle Complicate, you may counter target spell unless its controller pays {1}.",
@@ -6540,7 +6544,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you increase the power of the targeted creature after the ability resolves, it still can’t be blocked that turn."
+          "text": "If you increase the power of the targeted creature after the ability resolves, it still can't be blocked that turn."
         }
       ],
       "subtypes": [
@@ -6641,7 +6645,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"I said ‘pick his brain,' not ‘tear off his head.'\"\n—Riptide Project researcher",
+      "flavor": "\"I said 'pick his brain,' not 'tear off his head.'\"\n—Riptide Project researcher",
       "foreignNames": [
         {
           "language": "French",
@@ -7105,7 +7109,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2016-06-08",
@@ -7117,7 +7121,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability (perhaps because that top card is the card you’re casting) the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability (perhaps because that top card is the card you're casting) the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2016-06-08",
@@ -8824,7 +8828,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Target player shuffles his or her graveyard into his or her library.",
@@ -9394,7 +9398,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “If you do” means “If you search”."
+          "text": "The \"If you do\" means \"If you search\"."
         }
       ],
       "subtypes": [
@@ -9649,7 +9653,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Only you get to look. You can’t show them to others."
+          "text": "Only you get to look. You can't show them to others."
         }
       ],
       "text": "Look at target player's hand, the top card of that player's library, and any face-down creatures he or she controls. Look at the top four cards of your library, then put them back in any order.",
@@ -10144,7 +10148,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t target yourself."
+          "text": "You can't target yourself."
         }
       ],
       "text": "Any number of target opponents each discard their hands, then draw seven cards.\nDraw a card.",
@@ -11453,11 +11457,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Target creature gets -4/-4 until end of turn.\nCycling {1}{B}{B} ({1}{B}{B}, Discard this card: Draw a card.)\nWhen you cycle Death Pulse, you may have target creature get -1/-1 until end of turn.",
@@ -11546,11 +11550,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "All creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)\nWhen you cycle Dirge of Dread, you may have target creature gain fear until end of turn.",
@@ -12137,7 +12141,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Protection from clerics prevents damage from cleric sources, can’t have any clerics assigned to block it, and can’t be targeted by the abilities of clerics."
+          "text": "Protection from clerics prevents damage from cleric sources, can't have any clerics assigned to block it, and can't be targeted by the abilities of clerics."
         }
       ],
       "subtypes": [
@@ -14191,7 +14195,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is copying something else; see below). If its mana cost includes {X}, X is considered to be 0. If it has no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is copying something else; see below). If its mana cost includes {X}, X is considered to be 0. If it has no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
         },
         {
           "date": "2010-03-01",
@@ -14199,7 +14203,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If a creature is copying something else, its converted mana cost is the converted mana cost of whatever it’s copying."
+          "text": "If a creature is copying something else, its converted mana cost is the converted mana cost of whatever it's copying."
         }
       ],
       "text": "Destroy target creature with converted mana cost 3 or less. It can't be regenerated.",
@@ -15978,7 +15982,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If it is blocked but then all of its blockers are removed before combat damage is assigned, then it won’t be able to deal combat damage and you won’t be able to use its ability."
+          "text": "If it is blocked but then all of its blockers are removed before combat damage is assigned, then it won't be able to deal combat damage and you won't be able to use its ability."
         },
         {
           "date": "2004-10-04",
@@ -15986,7 +15990,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you choose to use the ability to divide up the damage (and there is at least one point of damage to be assigned), you must choose at least one creature or the defending player, and can’t choose more total creatures and players than the amount of damage being assigned (minimum 1 point per player or creature)."
+          "text": "If you choose to use the ability to divide up the damage (and there is at least one point of damage to be assigned), you must choose at least one creature or the defending player, and can't choose more total creatures and players than the amount of damage being assigned (minimum 1 point per player or creature)."
         }
       ],
       "subtypes": [
@@ -17308,7 +17312,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Let's play ‘sled.' Here's how it works: you're the sled.\"",
+      "flavor": "\"Let's play 'sled.' Here's how it works: you're the sled.\"",
       "foreignNames": [
         {
           "language": "French",
@@ -18103,7 +18107,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You either get zero mana or all the mana. You can’t choose an amount in between."
+          "text": "You either get zero mana or all the mana. You can't choose an amount in between."
         },
         {
           "date": "2004-10-04",
@@ -19292,7 +19296,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Slice and Dice deals 4 damage to each creature.\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle Slice and Dice, you may have it deal 1 damage to each creature.",
@@ -19460,11 +19464,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Solar Blast deals 3 damage to target creature or player.\nCycling {1}{R}{R} ({1}{R}{R}, Discard this card: Draw a card.)\nWhen you cycle Solar Blast, you may have it deal 1 damage to target creature or player.",
@@ -20780,7 +20784,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can choose to put zero tokens or all the tokens onto the battlefield. You can’t choose a number in between."
+          "text": "You can choose to put zero tokens or all the tokens onto the battlefield. You can't choose a number in between."
         }
       ],
       "subtypes": [
@@ -21106,7 +21110,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -22282,7 +22286,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -22622,7 +22626,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [

--- a/json/ORI.json
+++ b/json/ORI.json
@@ -25,7 +25,10 @@
     "common",
     "common",
     "land",
-    "marketing"
+    [
+      "marketing",
+      "checklist"
+    ]
   ],
   "translations": {
     "de": "Magic Ursprünge",
@@ -462,7 +465,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "In a Two-Headed Giant game, if one player controls Archangel of Tithes, creatures can’t attack that player’s team or a planeswalker that player controls unless their controller pays {1} for each of those creatures he or she controls. Creatures can attack planeswalkers controlled by that player’s teammate without having to pay this cost."
+          "text": "In a Two-Headed Giant game, if one player controls Archangel of Tithes, creatures can't attack that player's team or a planeswalker that player controls unless their controller pays {1} for each of those creatures he or she controls. Creatures can attack planeswalkers controlled by that player's teammate without having to pay this cost."
         }
       ],
       "subtypes": [
@@ -796,7 +799,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Blessed Spirits’s ability will resolve before the enchantment spell that caused it to trigger."
+          "text": "Blessed Spirits's ability will resolve before the enchantment spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -912,7 +915,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the player sacrifices a blocking creature, any attacking creature it was blocking remains blocked. Unless that attacking creature has trample or is being blocked by another creature, it won’t assign or deal combat damage."
+          "text": "If the player sacrifices a blocking creature, any attacking creature it was blocking remains blocked. Unless that attacking creature has trample or is being blocked by another creature, it won't assign or deal combat damage."
         },
         {
           "date": "2013-07-01",
@@ -1240,7 +1243,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -1248,7 +1251,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -1565,7 +1568,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "If the spell mastery ability applies, the four Knight tokens will also gain indestructible until end of turn."
+        },
+        {
+          "date": "2015-06-22",
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Create four 2/2 white Knight creature tokens with vigilance.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, creatures you control gain indestructible until end of turn.",
@@ -1676,7 +1683,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The enchanted creature is the source of the triggered ability it gains, not Grasp of the Hieromancer. If the enchanted creature isn’t white, that ability can target a creature with protection from white, for example."
+          "text": "The enchanted creature is the source of the triggered ability it gains, not Grasp of the Hieromancer. If the enchanted creature isn't white, that ability can target a creature with protection from white, for example."
         }
       ],
       "subtypes": [
@@ -1785,11 +1792,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "After Hallowed Moonlight resolves, if a creature token would be put onto the battlefield, it’s put into exile instead and then ceases to exist. Creature tokens are never cast, even if the spell that created them was."
+          "text": "After Hallowed Moonlight resolves, if a creature token would be put onto the battlefield, it's put into exile instead and then ceases to exist. Creature tokens are never cast, even if the spell that created them was."
         },
         {
           "date": "2015-06-22",
-          "text": "Hallowed Moonlight won’t affect any creature that was cast, no matter which zone it was cast from and whether or not its mana cost was paid."
+          "text": "Hallowed Moonlight won't affect any creature that was cast, no matter which zone it was cast from and whether or not its mana cost was paid."
         }
       ],
       "text": "Until end of turn, if a creature would enter the battlefield and it wasn't cast, exile it instead.\nDraw a card.",
@@ -2103,19 +2110,19 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Hixus’s ability causes a zone change with a duration, a style of ability that’s somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Hixus have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Hixus leaves the battlefield."
+          "text": "Hixus's ability causes a zone change with a duration, a style of ability that's somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Hixus have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Hixus leaves the battlefield."
         },
         {
           "date": "2015-06-22",
-          "text": "If Hixus leaves the battlefield before its triggered ability resolves, the creature that dealt combat damage to you won’t be exiled."
+          "text": "If Hixus leaves the battlefield before its triggered ability resolves, the creature that dealt combat damage to you won't be exiled."
         },
         {
           "date": "2015-06-22",
-          "text": "Auras attached to the exiled creatures will be put into their owners’ graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled creatures will cease to exist."
+          "text": "Auras attached to the exiled creatures will be put into their owners' graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled creatures will cease to exist."
         },
         {
           "date": "2015-06-22",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2015-06-22",
@@ -2123,7 +2130,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "In a multiplayer game, if Hixus’s owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Hixus's owner leaves the game, the exiled cards will return to the battlefield. Because the one-shot effect that returns the cards isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "subtypes": [
@@ -2238,7 +2245,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -2246,7 +2253,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -2364,11 +2371,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Knight of the White Orchid’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
+          "text": "Knight of the White Orchid's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless any one of your opponents controls more lands than you, and (2) the ability will do nothing if you control at least as many lands as each of your opponents by the time it resolves."
         },
         {
           "date": "2015-06-22",
-          "text": "The Plains you search for doesn’t have to be basic. For example, you could put a Sacred Foundry onto the battlefield."
+          "text": "The Plains you search for doesn't have to be basic. For example, you could put a Sacred Foundry onto the battlefield."
         }
       ],
       "subtypes": [
@@ -2483,7 +2490,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "You must target a creature to cast Knightly Valor. If that creature is an illegal target when Knightly Valor tries to resolve, it will be countered and won’t enter the battlefield. You won’t get the Knight token."
+          "text": "You must target a creature to cast Knightly Valor. If that creature is an illegal target when Knightly Valor tries to resolve, it will be countered and won't enter the battlefield. You won't get the Knight token."
         }
       ],
       "subtypes": [
@@ -2597,11 +2604,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Kytheon’s first ability will count creatures that attacked but are no longer on the battlefield (perhaps because they didn’t survive combat damage being dealt). It will not count any creatures that were put onto the battlefield attacking, as those creatures were never declared as attackers."
+          "text": "Kytheon's first ability will count creatures that attacked but are no longer on the battlefield (perhaps because they didn't survive combat damage being dealt). It will not count any creatures that were put onto the battlefield attacking, as those creatures were never declared as attackers."
         },
         {
           "date": "2015-06-22",
-          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that’s currently up. The other set of characteristics is ignored. While a double-faced card isn’t on the battlefield, consider only the characteristics of its front face."
+          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that's currently up. The other set of characteristics is ignored. While a double-faced card isn't on the battlefield, consider only the characteristics of its front face."
         },
         {
           "date": "2015-06-22",
@@ -2609,11 +2616,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can’t be cast."
+          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can't be cast."
         },
         {
           "date": "2015-06-22",
-          "text": "Although the two rules are similar, the “legend rule” and the “planeswalker uniqueness rule” affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you’ll then control two planeswalkers with the same subtype. You’ll choose one to remain on the battlefield, and the other will be put into its owner’s graveyard."
+          "text": "Although the two rules are similar, the \"legend rule\" and the \"planeswalker uniqueness rule\" affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you'll then control two planeswalkers with the same subtype. You'll choose one to remain on the battlefield, and the other will be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
@@ -2625,19 +2632,19 @@
         },
         {
           "date": "2015-06-22",
-          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it’s a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won’t have any loyalty counters on it and will subsequently be put into its owner’s graveyard."
+          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it's a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won't have any loyalty counters on it and will subsequently be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "You can activate one of the planeswalker’s loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
+          "text": "You can activate one of the planeswalker's loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
         },
         {
           "date": "2015-06-22",
-          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it’s put onto the battlefield face down some other way). Note that “face down” is not synonymous with “with its back face up.” A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can’t transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can’t be turned face down."
+          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it's put onto the battlefield face down some other way). Note that \"face down\" is not synonymous with \"with its back face up.\" A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can't transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can't be turned face down."
         },
         {
           "date": "2016-04-08",
-          "text": "The back face of a double-faced card doesn’t have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
+          "text": "The back face of a double-faced card doesn't have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
         },
         {
           "date": "2016-07-13",
@@ -2758,31 +2765,31 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Gideon’s first ability causes a creature to attack him if able. If, during its controller’s declare attackers step, that creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under its controller’s control continuously since that player’s turn began, then that creature doesn’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost. If he or she doesn’t, the creature doesn’t have to attack."
+          "text": "Gideon's first ability causes a creature to attack him if able. If, during its controller's declare attackers step, that creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under its controller's control continuously since that player's turn began, then that creature doesn't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost. If he or she doesn't, the creature doesn't have to attack."
         },
         {
           "date": "2015-06-22",
-          "text": "If Gideon can’t be attacked, perhaps because he has left the battlefield before the creature’s controller’s next combat, the creature targeted by Gideon’s first ability can attack you or another planeswalker you control, or its controller can choose to have it not attack at all."
+          "text": "If Gideon can't be attacked, perhaps because he has left the battlefield before the creature's controller's next combat, the creature targeted by Gideon's first ability can attack you or another planeswalker you control, or its controller can choose to have it not attack at all."
         },
         {
           "date": "2015-06-22",
-          "text": "If the creature targeted by Gideon’s first ability changes controllers before it has the chance to attack Gideon, the ability will apply to it during its new controller’s next turn."
+          "text": "If the creature targeted by Gideon's first ability changes controllers before it has the chance to attack Gideon, the ability will apply to it during its new controller's next turn."
         },
         {
           "date": "2015-06-22",
-          "text": "If Gideon becomes a creature due to his third ability, that doesn’t count as having a creature enter the battlefield. Gideon was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "If Gideon becomes a creature due to his third ability, that doesn't count as having a creature enter the battlefield. Gideon was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2015-06-22",
-          "text": "Gideon’s third ability causes him to become a creature with the creature types Human Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
+          "text": "Gideon's third ability causes him to become a creature with the creature types Human Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
         },
         {
           "date": "2015-06-22",
-          "text": "If you activate Gideon’s third ability and then damage is dealt to him that can’t be prevented, that damage has all applicable results: specifically, the damage is marked on Gideon (since he’s a creature) and that damage causes that many loyalty counters to be removed from him (since he’s a planeswalker). If Gideon has no loyalty counters on him, he’s put into his owner’s graveyard as a state-based action. (As long as he still has indestructible, the marked damage won’t cause him to be destroyed.)"
+          "text": "If you activate Gideon's third ability and then damage is dealt to him that can't be prevented, that damage has all applicable results: specifically, the damage is marked on Gideon (since he's a creature) and that damage causes that many loyalty counters to be removed from him (since he's a planeswalker). If Gideon has no loyalty counters on him, he's put into his owner's graveyard as a state-based action. (As long as he still has indestructible, the marked damage won't cause him to be destroyed.)"
         },
         {
           "date": "2015-06-22",
-          "text": "Say you activate Gideon’s third ability, then an opponent gains control of him before combat. You may have any of your creatures attack Gideon (since he’s still a planeswalker). Then Gideon may block (since he’s a creature). He may block any eligible attacking creature, including one that’s attacking him. During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he’s blocking, but he doesn’t deal combat damage to any unblocked creatures that are attacking him."
+          "text": "Say you activate Gideon's third ability, then an opponent gains control of him before combat. You may have any of your creatures attack Gideon (since he's still a planeswalker). Then Gideon may block (since he's a creature). He may block any eligible attacking creature, including one that's attacking him. During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he's blocking, but he doesn't deal combat damage to any unblocked creatures that are attacking him."
         }
       ],
       "subtypes": [
@@ -2893,7 +2900,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -2901,7 +2908,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -3012,7 +3019,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Creatures you control get +2/+1 until end of turn.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, those creatures also gain vigilance until end of turn. (Attacking doesn't cause them to tap.)",
@@ -3138,7 +3145,7 @@
       "rulings": [
         {
           "date": "2017-04-18",
-          "text": "Giving a creature flying after it’s already been blocked won’t change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
+          "text": "Giving a creature flying after it's already been blocked won't change or undo that block. If you want to affect what can block the creature, you must cast Mighty Leap during the declare attackers step at the latest."
         }
       ],
       "text": "Target creature gets +2/+2 and gains flying until end of turn.",
@@ -3253,7 +3260,7 @@
         },
         {
           "date": "2013-01-24",
-          "text": "If another player gains control of either Murder Investigation or the enchanted creature (but not both), Murder Investigation will be enchanting an illegal permanent. The Aura will be put into its owner’s graveyard as a state-based action."
+          "text": "If another player gains control of either Murder Investigation or the enchanted creature (but not both), Murder Investigation will be enchanting an illegal permanent. The Aura will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -3469,7 +3476,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -3477,7 +3484,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -3706,11 +3713,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can’t play an Aura spell intending to enchant the Angel that will be created as a result."
+          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can't play an Aura spell intending to enchant the Angel that will be created as a result."
         },
         {
           "date": "2009-02-01",
-          "text": "Casting Sigil of the Empty Throne won’t trigger its own ability. It has to be on the battlefield for its ability to work."
+          "text": "Casting Sigil of the Empty Throne won't trigger its own ability. It has to be on the battlefield for its ability to work."
         }
       ],
       "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
@@ -3816,7 +3823,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -3824,7 +3831,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -3934,15 +3941,15 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If the first ability returns an Aura card to the battlefield, you choose what that Aura will enchant as it enters the battlefield. If the Aura can’t legally enchant anything, it stays in the graveyard."
+          "text": "If the first ability returns an Aura card to the battlefield, you choose what that Aura will enchant as it enters the battlefield. If the Aura can't legally enchant anything, it stays in the graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "Note that if an Aura is returned to the battlefield this way, whatever the Aura enchants isn’t a target of Starfield of Nyx’s ability, nor is it a target of the Aura card itself. You could put an Aura onto the battlefield this way enchanting a creature with hexproof controlled by an opponent, for example."
+          "text": "Note that if an Aura is returned to the battlefield this way, whatever the Aura enchants isn't a target of Starfield of Nyx's ability, nor is it a target of the Aura card itself. You could put an Aura onto the battlefield this way enchanting a creature with hexproof controlled by an opponent, for example."
         },
         {
           "date": "2015-06-22",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "At the beginning of your upkeep, you may return target enchantment card from your graveyard to the battlefield.\nAs long as you control five or more enchantments, each other non-Aura enchantment you control is a creature in addition to its other types and has base power and base toughness each equal to its converted mana cost.",
@@ -4052,7 +4059,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder texts. The loyalty abilities of planeswalkers are activated abilities."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder texts. The loyalty abilities of planeswalkers are activated abilities."
         }
       ],
       "subtypes": [
@@ -4160,11 +4167,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The number of instant and/or sorcery cards in your graveyard matters only as you begin to cast Swift Reckoning. Once it’s cast, that number doesn’t matter and will have no effect on Swift Reckoning resolving."
+          "text": "The number of instant and/or sorcery cards in your graveyard matters only as you begin to cast Swift Reckoning. Once it's cast, that number doesn't matter and will have no effect on Swift Reckoning resolving."
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, you may cast Swift Reckoning as though it had flash. (You may cast it any time you could cast an instant.)\nDestroy target tapped creature.",
@@ -4271,7 +4278,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -4279,7 +4286,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -4505,7 +4512,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a permanent has more than one of the affected types, it can count for any of them. For example, you could choose an artifact creature as the artifact you’re sparing, another creature as the creature, and an enchantment creature as the enchantment. Similarly, you could choose an enchantment creature as both the creature and the enchantment that you’re sparing, even if the player controls another creature and/or another enchantment."
+          "text": "If a permanent has more than one of the affected types, it can count for any of them. For example, you could choose an artifact creature as the artifact you're sparing, another creature as the creature, and an enchantment creature as the enchantment. Similarly, you could choose an enchantment creature as both the creature and the enchantment that you're sparing, even if the player controls another creature and/or another enchantment."
         }
       ],
       "text": "For each player, you choose from among the permanents that player controls an artifact, a creature, an enchantment, and a planeswalker. Then each player sacrifices all other nonland permanents he or she controls.",
@@ -4713,15 +4720,15 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The ability affects each spell that’s not a creature spell, including your own."
+          "text": "The ability affects each spell that's not a creature spell, including your own."
         },
         {
           "date": "2015-06-22",
-          "text": "The ability affects what you pay to cast each noncreature spell (its total cost), but it doesn’t change that spell’s mana cost or converted mana cost."
+          "text": "The ability affects what you pay to cast each noncreature spell (its total cost), but it doesn't change that spell's mana cost or converted mana cost."
         },
         {
           "date": "2015-06-22",
-          "text": "When determining a spell’s total cost, effects that increase the cost are applied before effects that reduce the cost."
+          "text": "When determining a spell's total cost, effects that increase the cost are applied before effects that reduce the cost."
         }
       ],
       "subtypes": [
@@ -4832,7 +4839,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -4840,7 +4847,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -5061,7 +5068,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Alhammarret’s second ability happens as Alhammarret enters the battlefield. No one can cast spells or activate abilities between the time a card is named and the time that Alhammarret’s last ability starts to work."
+          "text": "Alhammarret's second ability happens as Alhammarret enters the battlefield. No one can cast spells or activate abilities between the time a card is named and the time that Alhammarret's last ability starts to work."
         },
         {
           "date": "2015-06-22",
@@ -5069,11 +5076,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Although spells with the chosen name can’t be cast, permanent cards with that name can still be put onto the battlefield by a spell or ability."
+          "text": "Although spells with the chosen name can't be cast, permanent cards with that name can still be put onto the battlefield by a spell or ability."
         },
         {
           "date": "2015-06-22",
-          "text": "If your opponents have no nonland cards in their hands, you can’t choose a card name. Alhammarret’s last ability won’t stop any spells from being cast in that case."
+          "text": "If your opponents have no nonland cards in their hands, you can't choose a card name. Alhammarret's last ability won't stop any spells from being cast in that case."
         },
         {
           "date": "2015-06-22",
@@ -5288,7 +5295,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If you control at least one artifact as Artificer’s Epiphany resolves, you can’t discard a card, even if you want to."
+          "text": "If you control at least one artifact as Artificer's Epiphany resolves, you can't discard a card, even if you want to."
         }
       ],
       "text": "Draw two cards. If you control no artifacts, discard a card.",
@@ -5504,11 +5511,11 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If the creature spell is an illegal target (because it’s left the stack, for example) when Bone to Ash tries to resolve, Bone to Ash will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the creature spell is an illegal target (because it's left the stack, for example) when Bone to Ash tries to resolve, Bone to Ash will be countered and none of its effects will happen. You won't draw a card."
         },
         {
           "date": "2011-01-22",
-          "text": "A creature spell that can’t be countered by spells and abilities is a legal target for Bone to Ash. The creature spell won’t be countered when Bone to Ash resolves, but you’ll still draw a card."
+          "text": "A creature spell that can't be countered by spells and abilities is a legal target for Bone to Ash. The creature spell won't be countered when Bone to Ash resolves, but you'll still draw a card."
         }
       ],
       "text": "Counter target creature spell.\nDraw a card.",
@@ -5613,15 +5620,15 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If the spell mastery ability applies, you’ll scry 2 even if the controller of the spell pays {3}."
+          "text": "If the spell mastery ability applies, you'll scry 2 even if the controller of the spell pays {3}."
         },
         {
           "date": "2015-06-22",
-          "text": "In one unusual situation, you can cast Calculated Dismissal targeting an instant or sorcery spell you control while there is one instant or sorcery card in your graveyard. In this situation, if you decline to pay {3}, the spell will be countered and put into your graveyard. The spell mastery ability will then apply and you’ll scry 2."
+          "text": "In one unusual situation, you can cast Calculated Dismissal targeting an instant or sorcery spell you control while there is one instant or sorcery card in your graveyard. In this situation, if you decline to pay {3}, the spell will be countered and put into your graveyard. The spell mastery ability will then apply and you'll scry 2."
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Counter target spell unless its controller pays {3}.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -5839,7 +5846,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The enchanted creature can still be untapped in other ways. Claustrophobia will remain attached, and the creature will continue to not untap during its controller’s untap step."
+          "text": "The enchanted creature can still be untapped in other ways. Claustrophobia will remain attached, and the creature will continue to not untap during its controller's untap step."
         }
       ],
       "subtypes": [
@@ -5947,27 +5954,27 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Ending the turn this way means the following things happen in order: 1) All spells and abilities on the stack are exiled. This includes spells and abilities that can’t be countered. 2) If there are any attacking and blocking creatures, they’re removed from combat. 3) State-based actions are checked. No player gets priority, and no triggered abilities are put onto the stack. 4) The current phase and/or step ends. The game skips straight to the cleanup step. 5) The cleanup step happens in its entirety."
+          "text": "Ending the turn this way means the following things happen in order: 1) All spells and abilities on the stack are exiled. This includes spells and abilities that can't be countered. 2) If there are any attacking and blocking creatures, they're removed from combat. 3) State-based actions are checked. No player gets priority, and no triggered abilities are put onto the stack. 4) The current phase and/or step ends. The game skips straight to the cleanup step. 5) The cleanup step happens in its entirety."
         },
         {
           "date": "2015-06-22",
-          "text": "If any triggered abilities do trigger during the process of ending the turn, they’re put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn ends."
+          "text": "If any triggered abilities do trigger during the process of ending the turn, they're put onto the stack during the cleanup step. If this happens, players will have a chance to cast spells and activate abilities, then there will be another cleanup step before the turn ends."
         },
         {
           "date": "2015-06-22",
-          "text": "Though other spells and abilities that are exiled won’t get a chance to resolve, they don’t count as being countered."
+          "text": "Though other spells and abilities that are exiled won't get a chance to resolve, they don't count as being countered."
         },
         {
           "date": "2015-06-22",
-          "text": "Any “at the beginning of the next end step” triggered abilities won’t get the chance to trigger that turn because the end step is skipped. Those abilities will trigger at the beginning of the end step of the next turn. The same is true of abilities that trigger at the beginning of other phases or steps."
+          "text": "Any \"at the beginning of the next end step\" triggered abilities won't get the chance to trigger that turn because the end step is skipped. Those abilities will trigger at the beginning of the end step of the next turn. The same is true of abilities that trigger at the beginning of other phases or steps."
         },
         {
           "date": "2015-06-22",
-          "text": "If both your hand and graveyard are empty as Day’s Undoing starts resolving, you’ll still shuffle your library before drawing seven cards."
+          "text": "If both your hand and graveyard are empty as Day's Undoing starts resolving, you'll still shuffle your library before drawing seven cards."
         },
         {
           "date": "2017-04-18",
-          "text": "If any abilities trigger while players are shuffling cards into their library or drawing seven cards, those abilities cease to exist when the turn ends. They won’t be put on the stack."
+          "text": "If any abilities trigger while players are shuffling cards into their library or drawing seven cards, those abilities cease to exist when the turn ends. They won't be put on the stack."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. If it's your turn, end the turn. (Exile all spells and abilities on the stack, including this card. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
@@ -6074,7 +6081,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Deep-Sea Terror’s ability only checks as attackers are declared. After Deep-Sea Terror legally attacks, reducing the number of cards in your graveyard won’t cause it to stop attacking."
+          "text": "Deep-Sea Terror's ability only checks as attackers are declared. After Deep-Sea Terror legally attacks, reducing the number of cards in your graveyard won't cause it to stop attacking."
         }
       ],
       "subtypes": [
@@ -6409,7 +6416,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "A token has converted mana cost 0 unless it’s a copy of something else, in which case it has the mana cost of whatever it’s copying."
+          "text": "A token has converted mana cost 0 unless it's a copy of something else, in which case it has the mana cost of whatever it's copying."
         }
       ],
       "text": "Return all nonland permanents with converted mana cost X or less to their owners' hands.",
@@ -6627,7 +6634,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Faerie Miscreant’s triggered ability checks to see if you control another creature named Faerie Miscreant at the time the new Faerie Miscreant enters the battlefield. If you don’t, the ability won’t trigger at all. The ability will check again as it tries to resolve. If, at that time, you don’t control another creature named Faerie Miscreant, the ability will have no effect."
+          "text": "Faerie Miscreant's triggered ability checks to see if you control another creature named Faerie Miscreant at the time the new Faerie Miscreant enters the battlefield. If you don't, the ability won't trigger at all. The ability will check again as it tries to resolve. If, at that time, you don't control another creature named Faerie Miscreant, the ability will have no effect."
         },
         {
           "date": "2015-06-22",
@@ -6848,7 +6855,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "You may cast Hydrolash even if there aren’t any attacking creatures simply to draw a card."
+          "text": "You may cast Hydrolash even if there aren't any attacking creatures simply to draw a card."
         }
       ],
       "text": "Attacking creatures get -2/-0 until end of turn.\nDraw a card.",
@@ -6960,11 +6967,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The activated ability of Jace, Vryn’s Prodigy checks to see if there are five or more cards in your graveyard after you discard a card. Putting a fifth card into your graveyard at other times won’t cause Jace to be exiled, nor will Jace entering the battlefield while there are five or more cards in your graveyard."
+          "text": "The activated ability of Jace, Vryn's Prodigy checks to see if there are five or more cards in your graveyard after you discard a card. Putting a fifth card into your graveyard at other times won't cause Jace to be exiled, nor will Jace entering the battlefield while there are five or more cards in your graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that’s currently up. The other set of characteristics is ignored. While a double-faced card isn’t on the battlefield, consider only the characteristics of its front face."
+          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that's currently up. The other set of characteristics is ignored. While a double-faced card isn't on the battlefield, consider only the characteristics of its front face."
         },
         {
           "date": "2015-06-22",
@@ -6972,11 +6979,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can’t be cast."
+          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can't be cast."
         },
         {
           "date": "2015-06-22",
-          "text": "Although the two rules are similar, the “legend rule” and the “planeswalker uniqueness rule” affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you’ll then control two planeswalkers with the same subtype. You’ll choose one to remain on the battlefield, and the other will be put into its owner’s graveyard."
+          "text": "Although the two rules are similar, the \"legend rule\" and the \"planeswalker uniqueness rule\" affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you'll then control two planeswalkers with the same subtype. You'll choose one to remain on the battlefield, and the other will be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
@@ -6988,23 +6995,23 @@
         },
         {
           "date": "2015-06-22",
-          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it’s a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won’t have any loyalty counters on it and will subsequently be put into its owner’s graveyard."
+          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it's a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won't have any loyalty counters on it and will subsequently be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "You can activate one of the planeswalker’s loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
+          "text": "You can activate one of the planeswalker's loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
         },
         {
           "date": "2015-06-22",
-          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it’s put onto the battlefield face down some other way). Note that “face down” is not synonymous with “with its back face up.” A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can’t transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can’t be turned face down."
+          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it's put onto the battlefield face down some other way). Note that \"face down\" is not synonymous with \"with its back face up.\" A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can't transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can't be turned face down."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness while resolving the ability of Jace, Vryn’s Prodigy, you’ll need to already have five other cards in your graveyard to satisfy that ability’s condition. You can’t choose to put the card directly into your graveyard to satisfy it."
+          "text": "If you discard a card with madness while resolving the ability of Jace, Vryn's Prodigy, you'll need to already have five other cards in your graveyard to satisfy that ability's condition. You can't choose to put the card directly into your graveyard to satisfy it."
         },
         {
           "date": "2016-04-08",
-          "text": "The back face of a double-faced card doesn’t have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
+          "text": "The back face of a double-faced card doesn't have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
         },
         {
           "date": "2016-07-13",
@@ -7125,15 +7132,15 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If you activate the second ability of Jace, Telepath Unbound, you must follow the timing rules for the card’s types. For example, if you target a sorcery card, you may cast it during your main phase when the stack is empty. You pay all the spell’s costs."
+          "text": "If you activate the second ability of Jace, Telepath Unbound, you must follow the timing rules for the card's types. For example, if you target a sorcery card, you may cast it during your main phase when the stack is empty. You pay all the spell's costs."
         },
         {
           "date": "2015-06-22",
-          "text": "If you don’t cast the card that turn, nothing happens. It remains in your graveyard."
+          "text": "If you don't cast the card that turn, nothing happens. It remains in your graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "The card is exiled only if it’s cast from the graveyard and put back into the graveyard (either by resolving or being countered). If, at any time, the card goes to a hidden zone (such as your hand or your library), the effect loses track of the card. It won’t be exiled, even if that card is put into your graveyard later that turn."
+          "text": "The card is exiled only if it's cast from the graveyard and put back into the graveyard (either by resolving or being countered). If, at any time, the card goes to a hidden zone (such as your hand or your library), the effect loses track of the card. It won't be exiled, even if that card is put into your graveyard later that turn."
         }
       ],
       "subtypes": [
@@ -7241,7 +7248,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The first ability of Jace’s Sanctum can’t reduce the colored mana requirement of an instant or sorcery spell."
+          "text": "The first ability of Jace's Sanctum can't reduce the colored mana requirement of an instant or sorcery spell."
         },
         {
           "date": "2015-06-22",
@@ -7249,11 +7256,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Jace’s Sanctum can reduce alternative costs such as miracle or overload costs."
+          "text": "Jace's Sanctum can reduce alternative costs such as miracle or overload costs."
         },
         {
           "date": "2015-06-22",
-          "text": "Jace’s Sanctum’s scry ability will resolve before the instant or sorcery spell that caused it to trigger."
+          "text": "Jace's Sanctum's scry ability will resolve before the instant or sorcery spell that caused it to trigger."
         }
       ],
       "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -7360,7 +7367,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2015-06-22",
@@ -7368,7 +7375,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -7580,6 +7587,7 @@
       "power": "1",
       "printings": [
         "pPRE",
+        "pLPA",
         "ORI"
       ],
       "rarity": "Rare",
@@ -7590,15 +7598,15 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If the spell or ability has multiple instances of the word “target,” you choose which target you’re changing to Mizzium Meddler as Mizium Meddler’s ability resolves."
+          "text": "If the spell or ability has multiple instances of the word \"target,\" you choose which target you're changing to Mizzium Meddler as Mizium Meddler's ability resolves."
         },
         {
           "date": "2015-06-22",
-          "text": "The target of the spell or ability won’t change unless Mizzium Meddler fulfills all the targeting criteria. If a spell or ability has multiple targets, such as Send to Sleep, you can change only one of the targets to Mizzium Meddler."
+          "text": "The target of the spell or ability won't change unless Mizzium Meddler fulfills all the targeting criteria. If a spell or ability has multiple targets, such as Send to Sleep, you can change only one of the targets to Mizzium Meddler."
         },
         {
           "date": "2015-06-22",
-          "text": "If a spell or ability has a variable number of targets, you can’t change the number of targets."
+          "text": "If a spell or ability has a variable number of targets, you can't change the number of targets."
         },
         {
           "date": "2015-06-22",
@@ -7606,11 +7614,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Mizzium Meddler’s triggered ability can target a spell or ability even if Mizzium Meddler wouldn’t be a legal target for that spell or ability. However, the target of that spell or ability will remain unchanged."
+          "text": "Mizzium Meddler's triggered ability can target a spell or ability even if Mizzium Meddler wouldn't be a legal target for that spell or ability. However, the target of that spell or ability will remain unchanged."
         },
         {
           "date": "2015-06-22",
-          "text": "If Mizzium Meddler’s triggered ability targets a spell or ability with no targets, nothing happens."
+          "text": "If Mizzium Meddler's triggered ability targets a spell or ability with no targets, nothing happens."
         }
       ],
       "subtypes": [
@@ -7754,7 +7762,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature spell” is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
+          "text": "A \"creature spell\" is any spell with the type creature, even if it has other types such as artifact or enchantment. Older cards of type summon are also creature spells."
         }
       ],
       "text": "Counter target noncreature spell.",
@@ -7969,19 +7977,19 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If the spell mastery ability applies, you’ll create a copy of the instant or sorcery spell only if Psychic Rebuttal counters that spell. If that spell can’t be countered by spells or abilities, you won’t get a copy."
+          "text": "If the spell mastery ability applies, you'll create a copy of the instant or sorcery spell only if Psychic Rebuttal counters that spell. If that spell can't be countered by spells or abilities, you won't get a copy."
         },
         {
           "date": "2015-06-22",
-          "text": "If Psychic Rebuttal creates a copy of the spell, you control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "If Psychic Rebuttal creates a copy of the spell, you control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2015-06-22",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2015-06-22",
-          "text": "If the copied spell is modal (that is, it says “Choose one –” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the copied spell is modal (that is, it says \"Choose one –\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2015-06-22",
@@ -7989,15 +7997,15 @@
         },
         {
           "date": "2015-06-22",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2015-06-22",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Counter target instant or sorcery spell that targets you.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, you may copy the spell countered this way. You may choose new targets for the copy.",
@@ -8104,7 +8112,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2015-06-22",
@@ -8112,7 +8120,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -8445,19 +8453,19 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If the spell mastery ability applies and a creature affected by Send to Sleep changes controllers before its old controller’s next untap step, Send to Sleep will prevent it from becoming untapped during its new controller’s next untap step."
+          "text": "If the spell mastery ability applies and a creature affected by Send to Sleep changes controllers before its old controller's next untap step, Send to Sleep will prevent it from becoming untapped during its new controller's next untap step."
         },
         {
           "date": "2015-06-22",
-          "text": "Send to Sleep can target tapped creatures. If a targeted creature is already tapped when the spell resolves (and the spell mastery ability applies), that creature remains tapped and doesn’t untap during its controller’s next untap step."
+          "text": "Send to Sleep can target tapped creatures. If a targeted creature is already tapped when the spell resolves (and the spell mastery ability applies), that creature remains tapped and doesn't untap during its controller's next untap step."
         },
         {
           "date": "2015-06-22",
-          "text": "If you chose two targets and one is an illegal target when Send to Sleep resolves, that creature won’t become tapped and it won’t be stopped from untapping during its controller’s next untap step (if the spell mastery ability applies). It won’t be affected by Send to Sleep in any way."
+          "text": "If you chose two targets and one is an illegal target when Send to Sleep resolves, that creature won't become tapped and it won't be stopped from untapping during its controller's next untap step (if the spell mastery ability applies). It won't be affected by Send to Sleep in any way."
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Tap up to two target creatures.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, those creatures don't untap during their controllers' next untap steps.",
@@ -8564,7 +8572,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Separatist Voidmage’s ability can target itself."
+          "text": "Separatist Voidmage's ability can target itself."
         }
       ],
       "subtypes": [
@@ -8898,11 +8906,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Any spell you cast that doesn’t have the type creature will cause Soulblade Djinn’s ability to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause the ability to trigger. Playing a land also won’t cause it to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause Soulblade Djinn's ability to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause the ability to trigger. Playing a land also won't cause it to trigger."
         },
         {
           "date": "2015-06-22",
-          "text": "Soulblade Djinn’s ability goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell."
+          "text": "Soulblade Djinn's ability goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell."
         }
       ],
       "subtypes": [
@@ -9012,7 +9020,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Colorless is not a color, so putting two colorless cards into a graveyard won’t cause the process to repeat."
+          "text": "Colorless is not a color, so putting two colorless cards into a graveyard won't cause the process to repeat."
         },
         {
           "date": "2015-06-22",
@@ -9229,23 +9237,23 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If the spell mastery ability applies, you’ll cast the two cards in order. The one you cast last will be the one that resolves first."
+          "text": "If the spell mastery ability applies, you'll cast the two cards in order. The one you cast last will be the one that resolves first."
         },
         {
           "date": "2015-06-22",
-          "text": "You cast the instant and/or sorcery card(s) from your opponent’s library as Talent of the Telepath is resolving. Ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "You cast the instant and/or sorcery card(s) from your opponent's library as Talent of the Telepath is resolving. Ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2015-06-22",
-          "text": "The cards will be put into their owner’s graveyard after they resolve, not yours."
+          "text": "The cards will be put into their owner's graveyard after they resolve, not yours."
         },
         {
           "date": "2015-06-22",
-          "text": "If you can’t cast any instant or sorcery cards (perhaps because there are no legal targets available) or if you choose not to cast one, then Talent of the Telepath finishes resolving. Any of the revealed cards you didn’t cast will be put into that player’s graveyard."
+          "text": "If you can't cast any instant or sorcery cards (perhaps because there are no legal targets available) or if you choose not to cast one, then Talent of the Telepath finishes resolving. Any of the revealed cards you didn't cast will be put into that player's graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2015-06-22",
@@ -9253,7 +9261,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Target opponent reveals the top seven cards of his or her library. You may cast an instant or sorcery card from among them without paying its mana cost. Then that player puts the rest into his or her graveyard.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, you may cast up to two revealed instant and/or sorcery cards instead of one.",
@@ -9359,11 +9367,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Thopter Spy Network’s first ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control an artifact as your upkeep begins, and (2) the ability will do nothing if you don’t control an artifact as it resolves."
+          "text": "Thopter Spy Network's first ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control an artifact as your upkeep begins, and (2) the ability will do nothing if you don't control an artifact as it resolves."
         },
         {
           "date": "2015-06-22",
-          "text": "The last ability will trigger, at most, once per combat damage step. However, if at least one artifact creature you control has first strike and others don’t, or if an artifact creature you control has double strike, the ability could trigger twice per combat: once in each combat damage step."
+          "text": "The last ability will trigger, at most, once per combat damage step. However, if at least one artifact creature you control has first strike and others don't, or if an artifact creature you control has double strike, the ability could trigger twice per combat: once in each combat damage step."
         }
       ],
       "text": "At the beginning of your upkeep, if you control an artifact, create a 1/1 colorless Thopter artifact creature token with flying.\nWhenever one or more artifact creatures you control deal combat damage to a player, draw a card.",
@@ -9476,7 +9484,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "If there’s only one card in your library when Tower Geist enters the battlefield, you’ll look at that card and put it into your hand."
+          "text": "If there's only one card in your library when Tower Geist enters the battlefield, you'll look at that card and put it into your hand."
         }
       ],
       "subtypes": [
@@ -9593,11 +9601,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Turn to Frog overwrites all previous effects that set the creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Turn to Frog resolves will overwrite this effect."
+          "text": "Turn to Frog overwrites all previous effects that set the creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Turn to Frog resolves will overwrite this effect."
         },
         {
           "date": "2014-07-18",
-          "text": "Turn to Frog doesn’t counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature’s ability that says “At the beginning of your upkeep,” “When this creature enters the battlefield,” or similar from triggering."
+          "text": "Turn to Frog doesn't counter abilities that have already triggered or been activated. In particular, there is no way to cast this spell to stop a creature's ability that says \"At the beginning of your upkeep,\" \"When this creature enters the battlefield,\" or similar from triggering."
         },
         {
           "date": "2014-07-18",
@@ -9605,11 +9613,11 @@
         },
         {
           "date": "2014-07-18",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the effect of Titanic Growth, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
         },
         {
           "date": "2014-07-18",
-          "text": "If one of the Theros block Gods is affected by Turn to Frog, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God’s type-changing ability is applied before the effect that removes that ability is applied."
+          "text": "If one of the Theros block Gods is affected by Turn to Frog, it will be a legendary 1/1 blue Frog enchantment creature with no abilities. If it stops being a creature, perhaps because your devotion to its color(s) decreased, it will be a legendary blue enchantment with no abilities. The way continuous effects work, the God's type-changing ability is applied before the effect that removes that ability is applied."
         }
       ],
       "text": "Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
@@ -9821,11 +9829,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "You may tap any two untapped artifacts you control, including artifact creatures that haven’t been under your control continuously since the beginning of your most recent turn."
+          "text": "You may tap any two untapped artifacts you control, including artifact creatures that haven't been under your control continuously since the beginning of your most recent turn."
         },
         {
           "date": "2015-06-22",
-          "text": "Activating the second ability of Whirler Rogue after a creature has become blocked won’t cause it to become unblocked."
+          "text": "Activating the second ability of Whirler Rogue after a creature has become blocked won't cause it to become unblocked."
         }
       ],
       "subtypes": [
@@ -9943,11 +9951,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If you lose control of Willbreaker before its ability resolves, you won’t gain control of the creature at all."
+          "text": "If you lose control of Willbreaker before its ability resolves, you won't gain control of the creature at all."
         },
         {
           "date": "2015-06-22",
-          "text": "If another player gains control of Willbreaker, its control-change effect ends. Regaining control of Willbreaker won’t cause you to regain control of the creature."
+          "text": "If another player gains control of Willbreaker, its control-change effect ends. Regaining control of Willbreaker won't cause you to regain control of the creature."
         }
       ],
       "subtypes": [
@@ -10060,15 +10068,15 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If you are the only player who controls a creature when Blightcaster’s ability triggers, you must choose one as the target, although you can choose not to give it -2/-2."
+          "text": "If you are the only player who controls a creature when Blightcaster's ability triggers, you must choose one as the target, although you can choose not to give it -2/-2."
         },
         {
           "date": "2015-06-22",
-          "text": "Blightcaster’s ability will resolve before the enchantment spell that caused it to trigger."
+          "text": "Blightcaster's ability will resolve before the enchantment spell that caused it to trigger."
         },
         {
           "date": "2015-06-22",
-          "text": "If you are the only player who controls a creature when Blightcaster’s ability triggers, you must choose one of those creatures as the target, although you can choose to not give it -2/-2."
+          "text": "If you are the only player who controls a creature when Blightcaster's ability triggers, you must choose one of those creatures as the target, although you can choose to not give it -2/-2."
         }
       ],
       "subtypes": [
@@ -10286,7 +10294,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If the regeneration ability is activated before combat damage is dealt, the two creatures you sacrifice won’t deal combat damage. However, you must regenerate a creature before it would be destroyed, so if you wait for combat damage to be dealt, the enchanted creature may be destroyed by that damage before it has the chance to regenerate."
+          "text": "If the regeneration ability is activated before combat damage is dealt, the two creatures you sacrifice won't deal combat damage. However, you must regenerate a creature before it would be destroyed, so if you wait for combat damage to be dealt, the enchanted creature may be destroyed by that damage before it has the chance to regenerate."
         }
       ],
       "subtypes": [
@@ -10504,11 +10512,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Whether the spell mastery applies or not, Dark Dabbling targets only one creature. If that creature becomes an illegal target by the time Dark Dabbling tries to resolve, Dark Dabbling will be countered and none of its effects will happen. No creature will regenerate and you won’t draw a card."
+          "text": "Whether the spell mastery applies or not, Dark Dabbling targets only one creature. If that creature becomes an illegal target by the time Dark Dabbling tries to resolve, Dark Dabbling will be countered and none of its effects will happen. No creature will regenerate and you won't draw a card."
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Regenerate target creature. Draw a card. (The next time the creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, also regenerate each other creature you control.",
@@ -10614,7 +10622,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Search your library for a card and put that card into your hand. Then shuffle your library.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, add {B}{B}{B} to your mana pool.",
@@ -10834,11 +10842,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The phrase “that hasn’t been chosen” refers only to that specific Demonic Pact. If you control one and cast another one, you can choose any mode for the second one the first time its ability triggers."
+          "text": "The phrase \"that hasn't been chosen\" refers only to that specific Demonic Pact. If you control one and cast another one, you can choose any mode for the second one the first time its ability triggers."
         },
         {
           "date": "2015-06-22",
-          "text": "It doesn’t matter who has chosen any particular mode. For example, say you control Demonic Pact and have chosen the first two modes. If an opponent gains control of Demonic Pact, that player can choose only the third or fourth mode."
+          "text": "It doesn't matter who has chosen any particular mode. For example, say you control Demonic Pact and have chosen the first two modes. If an opponent gains control of Demonic Pact, that player can choose only the third or fourth mode."
         },
         {
           "date": "2015-06-22",
@@ -11059,15 +11067,15 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Damage dealt to a creature with indestructible remains marked on that creature. If Erebos’s Titan has lethal damage marked on it and it loses indestructible (perhaps because your opponent controlled no creatures and then gained control of one), Erebos’s Titan will be destroyed."
+          "text": "Damage dealt to a creature with indestructible remains marked on that creature. If Erebos's Titan has lethal damage marked on it and it loses indestructible (perhaps because your opponent controlled no creatures and then gained control of one), Erebos's Titan will be destroyed."
         },
         {
           "date": "2015-06-22",
-          "text": "The last ability triggers only if Erebos’s Titan is in your graveyard."
+          "text": "The last ability triggers only if Erebos's Titan is in your graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "In a multiplayer game, the last ability won’t trigger when a player with a creature card in his or her graveyard leaves the game."
+          "text": "In a multiplayer game, the last ability won't trigger when a player with a creature card in his or her graveyard leaves the game."
         }
       ],
       "subtypes": [
@@ -11499,11 +11507,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you’ll have to sacrifice Fleshbag Marauder."
+          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you'll have to sacrifice Fleshbag Marauder."
         },
         {
           "date": "2015-06-22",
-          "text": "As Fleshbag Marauder’s ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
+          "text": "As Fleshbag Marauder's ability resolves, first you choose a creature to sacrifice, then each other player in turn order chooses a creature to sacrifice, then all those creatures are sacrificed simultaneously."
         }
       ],
       "subtypes": [
@@ -11615,7 +11623,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Once an attacking creature with menace is legally blocked by two or more creatures, removing one or more of those blockers from combat won’t change or undo that block."
+          "text": "Once an attacking creature with menace is legally blocked by two or more creatures, removing one or more of those blockers from combat won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -12155,11 +12163,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "It doesn’t matter who controlled the permanent when it was put into a graveyard."
+          "text": "It doesn't matter who controlled the permanent when it was put into a graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "The triggered ability is mandatory. You can’t decline to draw the card and lose life, even if you want to."
+          "text": "The triggered ability is mandatory. You can't decline to draw the card and lose life, even if you want to."
         }
       ],
       "subtypes": [
@@ -12380,11 +12388,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If multiple nontoken creatures you control die, then Liliana, Heretical Healer’s ability will trigger that many times. However, since Liliana can be exiled and returned to the battlefield only once, only the first ability to resolve will create a Zombie token. The other abilities will resolve but won’t do anything."
+          "text": "If multiple nontoken creatures you control die, then Liliana, Heretical Healer's ability will trigger that many times. However, since Liliana can be exiled and returned to the battlefield only once, only the first ability to resolve will create a Zombie token. The other abilities will resolve but won't do anything."
         },
         {
           "date": "2015-06-22",
-          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that’s currently up. The other set of characteristics is ignored. While a double-faced card isn’t on the battlefield, consider only the characteristics of its front face."
+          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that's currently up. The other set of characteristics is ignored. While a double-faced card isn't on the battlefield, consider only the characteristics of its front face."
         },
         {
           "date": "2015-06-22",
@@ -12392,11 +12400,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can’t be cast."
+          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can't be cast."
         },
         {
           "date": "2015-06-22",
-          "text": "Although the two rules are similar, the “legend rule” and the “planeswalker uniqueness rule” affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you’ll then control two planeswalkers with the same subtype. You’ll choose one to remain on the battlefield, and the other will be put into its owner’s graveyard."
+          "text": "Although the two rules are similar, the \"legend rule\" and the \"planeswalker uniqueness rule\" affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you'll then control two planeswalkers with the same subtype. You'll choose one to remain on the battlefield, and the other will be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
@@ -12408,19 +12416,19 @@
         },
         {
           "date": "2015-06-22",
-          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it’s a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won’t have any loyalty counters on it and will subsequently be put into its owner’s graveyard."
+          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it's a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won't have any loyalty counters on it and will subsequently be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "You can activate one of the planeswalker’s loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
+          "text": "You can activate one of the planeswalker's loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
         },
         {
           "date": "2015-06-22",
-          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it’s put onto the battlefield face down some other way). Note that “face down” is not synonymous with “with its back face up.” A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can’t transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can’t be turned face down."
+          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it's put onto the battlefield face down some other way). Note that \"face down\" is not synonymous with \"with its back face up.\" A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can't transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can't be turned face down."
         },
         {
           "date": "2016-04-08",
-          "text": "The back face of a double-faced card doesn’t have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
+          "text": "The back face of a double-faced card doesn't have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
         },
         {
           "date": "2016-07-13",
@@ -12541,7 +12549,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "When Liliana, Defiant Necromancer’s first ability resolves, first you choose a card to discard, then each other player in turn order chooses a card to discard, then all those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
+          "text": "When Liliana, Defiant Necromancer's first ability resolves, first you choose a card to discard, then each other player in turn order chooses a card to discard, then all those cards are discarded simultaneously. No one sees what the other players are discarding before deciding which card to discard."
         }
       ],
       "subtypes": [
@@ -12664,11 +12672,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If you have no other cards in hand, you’ll have to discard one of the creature cards you return to your hand."
+          "text": "If you have no other cards in hand, you'll have to discard one of the creature cards you return to your hand."
         },
         {
           "date": "2016-04-08",
-          "text": "You may cast Macabre Waltz targeting one or zero creature cards. You’ll still discard a card, even if you target no creature cards."
+          "text": "You may cast Macabre Waltz targeting one or zero creature cards. You'll still discard a card, even if you target no creature cards."
         }
       ],
       "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
@@ -12999,7 +13007,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, that creature enters the battlefield with two additional +1/+1 counters on it.",
@@ -13105,7 +13113,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If you don’t choose a nonland card for the player to discard, that player chooses which two cards he or she will discard."
+          "text": "If you don't choose a nonland card for the player to discard, that player chooses which two cards he or she will discard."
         }
       ],
       "text": "Target opponent reveals his or her hand. You may choose a nonland card from it. If you do, that player discards that card. If you don't, that player discards two cards.",
@@ -13431,7 +13439,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The loss of life is part of the spell’s effect. It’s not an additional cost. If Read the Bones is countered, you won’t lose life."
+          "text": "The loss of life is part of the spell's effect. It's not an additional cost. If Read the Bones is countered, you won't lose life."
         },
         {
           "date": "2013-09-15",
@@ -13443,11 +13451,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -13773,7 +13781,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The ability that defines Revenant’s power and toughness applies in all zones, not just the battlefield. If Revenant is in your graveyard, its ability will count itself."
+          "text": "The ability that defines Revenant's power and toughness applies in all zones, not just the battlefield. If Revenant is in your graveyard, its ability will count itself."
         }
       ],
       "subtypes": [
@@ -13883,7 +13891,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Once you legally activate the last ability, it doesn’t matter how many creature cards are in your graveyard as it resolves."
+          "text": "Once you legally activate the last ability, it doesn't matter how many creature cards are in your graveyard as it resolves."
         }
       ],
       "text": "Whenever a creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{4}{B}: Each opponent loses 2 life and you gain 2 life. Activate this ability only if there are four or more creature cards in your graveyard.",
@@ -14094,11 +14102,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If more than one replacement effect tries to apply to a life gain event, the player who would gain life chooses the order in which they apply. For example, if a player who controls Alhammarret’s Archive would gain 3 life while Tainted Remedy is on the battlefield, that player may choose to have the 3 life become doubled to 6 life and then lose 6 life. The player may also choose to apply Tainted Remedy first, turning “gain 3 life” into “lose 3 life.” Alhammarret’s Archive would then not apply."
+          "text": "If more than one replacement effect tries to apply to a life gain event, the player who would gain life chooses the order in which they apply. For example, if a player who controls Alhammarret's Archive would gain 3 life while Tainted Remedy is on the battlefield, that player may choose to have the 3 life become doubled to 6 life and then lose 6 life. The player may also choose to apply Tainted Remedy first, turning \"gain 3 life\" into \"lose 3 life.\" Alhammarret's Archive would then not apply."
         },
         {
           "date": "2015-06-22",
-          "text": "Having more than one Tainted Remedy on the battlefield doesn’t have any noticeable effect on life gain. Once the effect of one Tainted Remedy applies, there is no life gain for the others to apply to."
+          "text": "Having more than one Tainted Remedy on the battlefield doesn't have any noticeable effect on life gain. Once the effect of one Tainted Remedy applies, there is no life gain for the others to apply to."
         }
       ],
       "text": "If an opponent would gain life, that player loses that much life instead.",
@@ -14327,7 +14335,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "You must sacrifice exactly one creature to cast Tormented Thoughts. You can’t cast it without sacrificing a creature, and you can’t sacrifice additional creatures."
+          "text": "You must sacrifice exactly one creature to cast Tormented Thoughts. You can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
         },
         {
           "date": "2015-06-22",
@@ -14653,7 +14661,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Destroy target creature.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, you gain 2 life.",
@@ -14868,7 +14876,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The card exiled by Abbot of Keral Keep’s ability is exiled face up."
+          "text": "The card exiled by Abbot of Keral Keep's ability is exiled face up."
         },
         {
           "date": "2015-06-22",
@@ -14876,19 +14884,19 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Playing the card exiled with Abbot of Keral Keep’s ability follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if the card is a creature card, you can cast that card by paying its mana cost only during your main phase while the stack is empty."
+          "text": "Playing the card exiled with Abbot of Keral Keep's ability follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if the card is a creature card, you can cast that card by paying its mana cost only during your main phase while the stack is empty."
         },
         {
           "date": "2015-06-22",
-          "text": "Unless an effect allows you to play additional lands that turn, you can play a land card exiled with Abbot of Keral Keep’s ability only if you haven’t played a land yet that turn."
+          "text": "Unless an effect allows you to play additional lands that turn, you can play a land card exiled with Abbot of Keral Keep's ability only if you haven't played a land yet that turn."
         },
         {
           "date": "2015-06-22",
-          "text": "If you don’t play the card, it will remain exiled."
+          "text": "If you don't play the card, it will remain exiled."
         },
         {
           "date": "2015-06-22",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2015-06-22",
@@ -14896,7 +14904,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -15007,15 +15015,15 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Acolyte of the Inferno’s last ability will trigger once for each creature that blocks it. Each of those creatures will be dealt 2 damage."
+          "text": "Acolyte of the Inferno's last ability will trigger once for each creature that blocks it. Each of those creatures will be dealt 2 damage."
         },
         {
           "date": "2015-06-22",
-          "text": "Acolyte of the Inferno’s last ability triggers and resolves before combat damage is dealt. If that causes each creature blocking Acolyte of the Inferno to be destroyed, Acolyte of the Inferno will remain blocked and neither deal nor be dealt combat damage."
+          "text": "Acolyte of the Inferno's last ability triggers and resolves before combat damage is dealt. If that causes each creature blocking Acolyte of the Inferno to be destroyed, Acolyte of the Inferno will remain blocked and neither deal nor be dealt combat damage."
         },
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -15023,7 +15031,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -15150,15 +15158,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Act of Treason can target any creature, even one that’s untapped or one you already control."
+          "text": "Act of Treason can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         },
         {
           "date": "2013-07-01",
-          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you’ll choose one to remain on the battlefield and put the other into its owner’s graveyard."
+          "text": "If you control a legendary creature and gain control of another legendary creature with the same name, you'll choose one to remain on the battlefield and put the other into its owner's graveyard."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
@@ -15264,7 +15272,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -15272,7 +15280,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -15599,7 +15607,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Once an attacking creature with menace is legally blocked by two or more creatures, removing one or more of those blockers from combat won’t change or undo that block."
+          "text": "Once an attacking creature with menace is legally blocked by two or more creatures, removing one or more of those blockers from combat won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -15709,11 +15717,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Call of the Full Moon’s last ability will look at the entire previous turn, even if Call of the Moon wasn’t on the battlefield for some or all of that turn. For example, if you cast Call of the Full Moon and another spell on the same turn, you’ll have to sacrifice Call of the Full Moon at the beginning of the upkeep of the following turn."
+          "text": "Call of the Full Moon's last ability will look at the entire previous turn, even if Call of the Moon wasn't on the battlefield for some or all of that turn. For example, if you cast Call of the Full Moon and another spell on the same turn, you'll have to sacrifice Call of the Full Moon at the beginning of the upkeep of the following turn."
         },
         {
           "date": "2015-06-22",
-          "text": "A single player must have cast two or more spells during the previous turn for Call of the Full Moon’s last ability to trigger. If multiple players each cast just one spell during that turn, the ability won’t trigger."
+          "text": "A single player must have cast two or more spells during the previous turn for Call of the Full Moon's last ability to trigger. If multiple players each cast just one spell during that turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -15827,15 +15835,15 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Chandra, Fire of Kaladesh’s activated ability will count any damage Chandra has dealt during the turn to any permanent or player, including combat damage."
+          "text": "Chandra, Fire of Kaladesh's activated ability will count any damage Chandra has dealt during the turn to any permanent or player, including combat damage."
         },
         {
           "date": "2015-06-22",
-          "text": "The last sentence of Chandra, Fire of Kaladesh’s activated ability isn’t a separate ability. The check happens only as that activated ability resolves. You must activate the ability in order to exile Chandra and return her to the battlefield transformed, even if Chandra has already dealt 3 or more damage during the turn."
+          "text": "The last sentence of Chandra, Fire of Kaladesh's activated ability isn't a separate ability. The check happens only as that activated ability resolves. You must activate the ability in order to exile Chandra and return her to the battlefield transformed, even if Chandra has already dealt 3 or more damage during the turn."
         },
         {
           "date": "2015-06-22",
-          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that’s currently up. The other set of characteristics is ignored. While a double-faced card isn’t on the battlefield, consider only the characteristics of its front face."
+          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that's currently up. The other set of characteristics is ignored. While a double-faced card isn't on the battlefield, consider only the characteristics of its front face."
         },
         {
           "date": "2015-06-22",
@@ -15843,11 +15851,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can’t be cast."
+          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can't be cast."
         },
         {
           "date": "2015-06-22",
-          "text": "Although the two rules are similar, the “legend rule” and the “planeswalker uniqueness rule” affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you’ll then control two planeswalkers with the same subtype. You’ll choose one to remain on the battlefield, and the other will be put into its owner’s graveyard."
+          "text": "Although the two rules are similar, the \"legend rule\" and the \"planeswalker uniqueness rule\" affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you'll then control two planeswalkers with the same subtype. You'll choose one to remain on the battlefield, and the other will be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
@@ -15859,19 +15867,19 @@
         },
         {
           "date": "2015-06-22",
-          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it’s a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won’t have any loyalty counters on it and will subsequently be put into its owner’s graveyard."
+          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it's a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won't have any loyalty counters on it and will subsequently be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "You can activate one of the planeswalker’s loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
+          "text": "You can activate one of the planeswalker's loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
         },
         {
           "date": "2015-06-22",
-          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it’s put onto the battlefield face down some other way). Note that “face down” is not synonymous with “with its back face up.” A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can’t transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can’t be turned face down."
+          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it's put onto the battlefield face down some other way). Note that \"face down\" is not synonymous with \"with its back face up.\" A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can't transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can't be turned face down."
         },
         {
           "date": "2016-04-08",
-          "text": "The back face of a double-faced card doesn’t have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
+          "text": "The back face of a double-faced card doesn't have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
         },
         {
           "date": "2016-07-13",
@@ -15996,11 +16004,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Only players actually dealt damage by the third ability of Chandra, Roaring Flame will get an emblem. If all of that damage to a player is prevented, that player won’t get an emblem. If any of that damage is redirected to Chandra’s controller, that player will get an emblem."
+          "text": "Only players actually dealt damage by the third ability of Chandra, Roaring Flame will get an emblem. If all of that damage to a player is prevented, that player won't get an emblem. If any of that damage is redirected to Chandra's controller, that player will get an emblem."
         },
         {
           "date": "2015-06-22",
-          "text": "Each player who gets Chandra’s emblem is the owner of that emblem. In multiplayer games, that emblem will remain in the game as long as its owner does, even if Chandra’s owner leaves the game."
+          "text": "Each player who gets Chandra's emblem is the owner of that emblem. In multiplayer games, that emblem will remain in the game as long as its owner does, even if Chandra's owner leaves the game."
         }
       ],
       "subtypes": [
@@ -16111,7 +16119,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Chandra’s Fury targets only the player, not any creature. Chandra’s Fury will deal 1 damage to a creature with hexproof, for example."
+          "text": "Chandra's Fury targets only the player, not any creature. Chandra's Fury will deal 1 damage to a creature with hexproof, for example."
         }
       ],
       "text": "Chandra's Fury deals 4 damage to target player and 1 damage to each creature that player controls.",
@@ -16218,15 +16226,15 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The creature is the source of the damage, not Chandra’s Ignition. For example, Chandra’s Ignition can have a white creature deal damage to a creature with protection from red."
+          "text": "The creature is the source of the damage, not Chandra's Ignition. For example, Chandra's Ignition can have a white creature deal damage to a creature with protection from red."
         },
         {
           "date": "2015-06-22",
-          "text": "Use the power of the target creature as Chandra’s Ignition resolves to determine how much damage it deals to each other creature and each opponent."
+          "text": "Use the power of the target creature as Chandra's Ignition resolves to determine how much damage it deals to each other creature and each opponent."
         },
         {
           "date": "2015-06-22",
-          "text": "If the creature becomes an illegal target by the time Chandra’s Ignition tries to resolve (perhaps because another player controls it or it’s left the battlefield), Chandra’s Ignition will be countered and none of its effects will happen. No damage will be dealt."
+          "text": "If the creature becomes an illegal target by the time Chandra's Ignition tries to resolve (perhaps because another player controls it or it's left the battlefield), Chandra's Ignition will be countered and none of its effects will happen. No damage will be dealt."
         }
       ],
       "text": "Target creature you control deals damage equal to its power to each other creature and each opponent.",
@@ -16689,15 +16697,15 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Embermaw Hellion’s last ability doesn’t cause Embermaw Hellion to deal damage; it affects the amount of damage dealt by the original red source."
+          "text": "Embermaw Hellion's last ability doesn't cause Embermaw Hellion to deal damage; it affects the amount of damage dealt by the original red source."
         },
         {
           "date": "2015-06-22",
-          "text": "If the player or permanent being dealt damage is also affected by a damage prevention effect, that player or the controller of that permanent can apply that effect and Embermaw Hellion’s effect in any order. If all of the damage is prevented, Embermaw Hellion’s effect can’t apply to it."
+          "text": "If the player or permanent being dealt damage is also affected by a damage prevention effect, that player or the controller of that permanent can apply that effect and Embermaw Hellion's effect in any order. If all of the damage is prevented, Embermaw Hellion's effect can't apply to it."
         },
         {
           "date": "2015-06-22",
-          "text": "Multiple Embermaw Hellions are cumulative. If you control two of them, you’ll add 2 to the damage dealt by another red source you control. In this case, you would also add 1 to the damage dealt by either Embermaw Hellion."
+          "text": "Multiple Embermaw Hellions are cumulative. If you control two of them, you'll add 2 to the damage dealt by another red source you control. In this case, you would also add 1 to the damage dealt by either Embermaw Hellion."
         }
       ],
       "subtypes": [
@@ -16808,11 +16816,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Once Enthralling Victor’s ability resolves and you gain control of a creature, raising its power above 2 won’t cause you to lose control of it. Similarly, it doesn’t matter if Enthralling Victor leaves the battlefield or you lose control of Enthralling Victor. You’ll keep control of the creature that was the target of the ability until the end of the turn."
+          "text": "Once Enthralling Victor's ability resolves and you gain control of a creature, raising its power above 2 won't cause you to lose control of it. Similarly, it doesn't matter if Enthralling Victor leaves the battlefield or you lose control of Enthralling Victor. You'll keep control of the creature that was the target of the ability until the end of the turn."
         },
         {
           "date": "2015-06-22",
-          "text": "Enthralling Victor’s ability can target a creature that’s already untapped. You’ll still gain control of it and it will gain haste."
+          "text": "Enthralling Victor's ability can target a creature that's already untapped. You'll still gain control of it and it will gain haste."
         }
       ],
       "subtypes": [
@@ -16924,11 +16932,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Even if the spell mastery ability applies, Exquisite Firecraft can be targeted by spells or abilities that would counter it. The part of their effect that would counter Exquisite Firecraft won’t do anything, but any other effects those spells or abilities may have will still happen, if applicable."
+          "text": "Even if the spell mastery ability applies, Exquisite Firecraft can be targeted by spells or abilities that would counter it. The part of their effect that would counter Exquisite Firecraft won't do anything, but any other effects those spells or abilities may have will still happen, if applicable."
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Exquisite Firecraft deals 4 damage to target creature or player.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, Exquisite Firecraft can't be countered by spells or abilities.",
@@ -17151,7 +17159,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Fiery Impulse deals 2 damage to target creature.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, Fiery Impulse deals 3 damage to that creature instead.",
@@ -17257,7 +17265,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -17265,7 +17273,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -17374,7 +17382,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The token copies exactly what’s printed on the original creature and nothing else (unless that creature is copying something else; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "The token copies exactly what's printed on the original creature and nothing else (unless that creature is copying something else; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2015-06-22",
@@ -17386,7 +17394,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the copied creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the copied creature will also work."
         },
         {
           "date": "2015-06-22",
@@ -17394,15 +17402,15 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If the ability resolves during a turn’s end step, the token will be exiled at the beginning of the next turn’s end step."
+          "text": "If the ability resolves during a turn's end step, the token will be exiled at the beginning of the next turn's end step."
         },
         {
           "date": "2015-06-22",
-          "text": "If the token isn’t exiled at the beginning of the next end step (perhaps because the delayed triggered ability is countered), it remains on the battlefield indefinitely. It continues to have haste."
+          "text": "If the token isn't exiled at the beginning of the next end step (perhaps because the delayed triggered ability is countered), it remains on the battlefield indefinitely. It continues to have haste."
         },
         {
           "date": "2015-06-22",
-          "text": "If another creature becomes or enters the battlefield as a copy of the token, that creature won’t have haste and it won’t be exiled."
+          "text": "If another creature becomes or enters the battlefield as a copy of the token, that creature won't have haste and it won't be exiled."
         }
       ],
       "text": "Whenever a nontoken creature enters the battlefield under your control, you may pay {R}. If you do, create a token that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step.",
@@ -17507,7 +17515,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "You may tap any two untapped artifacts you control, including artifact creatures that haven’t been under your control continuously since the beginning of your most recent turn."
+          "text": "You may tap any two untapped artifacts you control, including artifact creatures that haven't been under your control continuously since the beginning of your most recent turn."
         }
       ],
       "text": "Tap two untapped artifacts you control: Ghirapur Aether Grid deals 1 damage to target creature or player.",
@@ -17719,7 +17727,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -17727,11 +17735,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         },
         {
           "date": "2015-06-22",
-          "text": "Once an attacking creature with menace is legally blocked by two or more creatures, removing one or more of those blockers from combat won’t change or undo that block."
+          "text": "Once an attacking creature with menace is legally blocked by two or more creatures, removing one or more of those blockers from combat won't change or undo that block."
         }
       ],
       "subtypes": [
@@ -17960,7 +17968,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If, during its controller’s declare attackers step, the enchanted creature is tapped or is affected by a spell or ability that says it can’t attack, then that creature doesn’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost. If he or she doesn’t, the creature doesn’t have to attack."
+          "text": "If, during its controller's declare attackers step, the enchanted creature is tapped or is affected by a spell or ability that says it can't attack, then that creature doesn't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost. If he or she doesn't, the creature doesn't have to attack."
         }
       ],
       "subtypes": [
@@ -18170,11 +18178,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If, during its controller’s declare attackers step, Mage-Ring Bully is tapped or is affected by a spell or ability that says it can’t attack, then Mage-Ring Bully doesn’t attack. If there’s a cost associated with having it attack, its controller isn’t forced to pay that cost. If he or she doesn’t, Mage-Ring Bully doesn’t have to attack."
+          "text": "If, during its controller's declare attackers step, Mage-Ring Bully is tapped or is affected by a spell or ability that says it can't attack, then Mage-Ring Bully doesn't attack. If there's a cost associated with having it attack, its controller isn't forced to pay that cost. If he or she doesn't, Mage-Ring Bully doesn't have to attack."
         },
         {
           "date": "2015-06-22",
-          "text": "Any spell you cast that doesn’t have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won’t cause prowess to trigger. Playing a land also won’t cause prowess to trigger."
+          "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
         },
         {
           "date": "2015-06-22",
@@ -18182,7 +18190,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Once it triggers, prowess isn’t connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+          "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
         }
       ],
       "subtypes": [
@@ -18293,7 +18301,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "You must discard exactly one land card to cast Magmatic Insight. You can’t cast it without discarding a land card, and you can’t discard additional cards."
+          "text": "You must discard exactly one land card to cast Magmatic Insight. You can't cast it without discarding a land card, and you can't discard additional cards."
         }
       ],
       "text": "As an additional cost to cast Magmatic Insight, discard a land card.\nDraw two cards.",
@@ -18714,7 +18722,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Ravaging Blaze targets only the creature. It doesn’t target any player, even if the spell mastery ability applies."
+          "text": "Ravaging Blaze targets only the creature. It doesn't target any player, even if the spell mastery ability applies."
         },
         {
           "date": "2015-06-22",
@@ -18722,10 +18730,10 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
-      "text": "Ravaging Blaze deals X damage to target creature. \nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, Ravaging Blaze also deals X damage to that creature's controller.",
+      "text": "Ravaging Blaze deals X damage to target creature.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, Ravaging Blaze also deals X damage to that creature's controller.",
       "type": "Instant",
       "types": [
         "Instant"
@@ -18829,7 +18837,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -18837,7 +18845,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -18949,7 +18957,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "No creature without flying will be able to block that turn, including creatures that lose flying after Seismic Elemental’s ability resolves and creatures without flying that enter the battlefield after that ability resolves."
+          "text": "No creature without flying will be able to block that turn, including creatures that lose flying after Seismic Elemental's ability resolves and creatures without flying that enter the battlefield after that ability resolves."
         }
       ],
       "subtypes": [
@@ -19489,6 +19497,24 @@
         "ORI"
       ],
       "rarity": "Common",
+      "rulings": [
+        {
+          "date": "2013-09-15",
+          "text": "When you scry, you may put all the cards you look at back on top of your library, you may put all of those cards on the bottom of your library, or you may put some of those cards on top and the rest of them on the bottom."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "You choose how to order cards returned to your library after scrying no matter where you put them."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
+        }
+      ],
       "text": "Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
       "type": "Instant",
       "types": [
@@ -19806,19 +19832,19 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "No player will know the order of the cards put on the bottom of your library. Practically speaking, the cards should be shuffled (although this is not the game action of “shuffling”)."
+          "text": "No player will know the order of the cards put on the bottom of your library. Practically speaking, the cards should be shuffled (although this is not the game action of \"shuffling\")."
         },
         {
           "date": "2015-06-22",
-          "text": "If the spell mastery ability applies, you untap only the lands put onto the battlefield with Animist’s Awakening."
+          "text": "If the spell mastery ability applies, you untap only the lands put onto the battlefield with Animist's Awakening."
         },
         {
           "date": "2015-06-22",
-          "text": "If you have X or less cards in your library, you’ll reveal all the cards from your library, put all land cards from among them onto the battlefield tapped, and then put the rest of the cards back in your library in a random order. (This is effectively the same as shuffling your library, although it’s still not technically a shuffle.)"
+          "text": "If you have X or less cards in your library, you'll reveal all the cards from your library, put all land cards from among them onto the battlefield tapped, and then put the rest of the cards back in your library in a random order. (This is effectively the same as shuffling your library, although it's still not technically a shuffle.)"
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Reveal the top X cards of your library. Put all land cards from among them onto the battlefield tapped and the rest on the bottom of your library in a random order.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, untap those lands.",
@@ -20138,7 +20164,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Count the number of attacking Elves you control as Dwynen’s last ability resolves to determine how much life to gain."
+          "text": "Count the number of attacking Elves you control as Dwynen's last ability resolves to determine how much life to gain."
         }
       ],
       "subtypes": [
@@ -20358,7 +20384,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The creature must have power 3 or greater as it enters the battlefield, or Elemental Bond’s ability won’t trigger. Static abilities that raise (or lower) a creature’s power are taken into account. However, you can’t have a creature with power 2 or less enter the battlefield and try to raise its power with a spell, an activated ability, or a triggered ability."
+          "text": "The creature must have power 3 or greater as it enters the battlefield, or Elemental Bond's ability won't trigger. Static abilities that raise (or lower) a creature's power are taken into account. However, you can't have a creature with power 2 or less enter the battlefield and try to raise its power with a spell, an activated ability, or a triggered ability."
         }
       ],
       "text": "Whenever a creature with power 3 or greater enters the battlefield under your control, draw a card.",
@@ -20584,11 +20610,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "No player will know the order of the cards put on the bottom of your library. Practically speaking, the cards should be shuffled (although this is not the game action of “shuffling”)."
+          "text": "No player will know the order of the cards put on the bottom of your library. Practically speaking, the cards should be shuffled (although this is not the game action of \"shuffling\")."
         },
         {
           "date": "2015-06-22",
-          "text": "If you don’t reveal a creature card, you’ll reveal all the cards from your library and then put them back in your library in a random order. (This is effectively the same as shuffling your library, although it’s still not technically a shuffle.)"
+          "text": "If you don't reveal a creature card, you'll reveal all the cards from your library and then put them back in your library in a random order. (This is effectively the same as shuffling your library, although it's still not technically a shuffle.)"
         }
       ],
       "text": "{G}, Sacrifice a creature: Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
@@ -20696,19 +20722,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Gaea’s Revenge’s first ability works only while it’s a spell on the stack. Gaea’s Revenge’s last ability works only while it’s on the battlefield."
+          "text": "Gaea's Revenge's first ability works only while it's a spell on the stack. Gaea's Revenge's last ability works only while it's on the battlefield."
         },
         {
           "date": "2010-08-15",
-          "text": "A Gaea’s Revenge spell can be targeted by spells and abilities that would counter it. The part of their effect that would counter Gaea’s Revenge won’t do anything, but any other effects those spells or abilities may have will still happen, if applicable."
+          "text": "A Gaea's Revenge spell can be targeted by spells and abilities that would counter it. The part of their effect that would counter Gaea's Revenge won't do anything, but any other effects those spells or abilities may have will still happen, if applicable."
         },
         {
           "date": "2010-08-15",
-          "text": "Gaea’s Revenge’s last ability applies to all nongreen spells and abilities from nongreen sources, including ones you control. For example, you can’t target it with the equip ability of an Equipment you control (unless the Equipment is somehow green)."
+          "text": "Gaea's Revenge's last ability applies to all nongreen spells and abilities from nongreen sources, including ones you control. For example, you can't target it with the equip ability of an Equipment you control (unless the Equipment is somehow green)."
         },
         {
           "date": "2015-06-22",
-          "text": "If a spell is one or more colors, and one of those colors is green, that spell can target Gaea’s Revenge."
+          "text": "If a spell is one or more colors, and one of those colors is green, that spell can target Gaea's Revenge."
         }
       ],
       "subtypes": [
@@ -20817,7 +20843,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Reveal the top five cards of your library. You may put a creature card from among them into your hand. Put the rest into your graveyard.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, put up to two creature cards from among the revealed cards into your hand instead of one.",
@@ -20926,7 +20952,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "A token is owned by the player under whose control it entered the battlefield. Tokens shuffled into a library count toward the number of cards drawn, though they cease to exist upon becoming part of a library. Regardless of what you’re using to represent tokens, you won’t shuffle that physical object into your library."
+          "text": "A token is owned by the player under whose control it entered the battlefield. Tokens shuffled into a library count toward the number of cards drawn, though they cease to exist upon becoming part of a library. Regardless of what you're using to represent tokens, you won't shuffle that physical object into your library."
         },
         {
           "date": "2015-06-22",
@@ -21041,7 +21067,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Herald of the Pantheon’s first ability can’t reduce the colored mana requirement of an enchantment spell."
+          "text": "Herald of the Pantheon's first ability can't reduce the colored mana requirement of an enchantment spell."
         },
         {
           "date": "2015-06-22",
@@ -21267,7 +21293,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -21275,7 +21301,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -21386,11 +21412,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If multiple attacking creatures must be blocked if able, the defending player must assign at least one blocker to each of them if possible. For example, if two such creatures were attacking and there were two potential blockers, they couldn’t both be assigned to block the same attacker."
+          "text": "If multiple attacking creatures must be blocked if able, the defending player must assign at least one blocker to each of them if possible. For example, if two such creatures were attacking and there were two potential blockers, they couldn't both be assigned to block the same attacker."
         },
         {
           "date": "2015-06-22",
-          "text": "Joraga Invocation doesn’t force any specific creature to block any specific attacking creature. The defending player still chooses how creatures he or she controls block."
+          "text": "Joraga Invocation doesn't force any specific creature to block any specific attacking creature. The defending player still chooses how creatures he or she controls block."
         }
       ],
       "text": "Each creature you control gets +3/+3 until end of turn and must be blocked this turn if able.",
@@ -21720,7 +21746,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Managorger Hydra’s last ability will resolve before the spell that caused it to trigger."
+          "text": "Managorger Hydra's last ability will resolve before the spell that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -21938,7 +21964,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The bonus is determined as Might of the Masses resolves. It won’t change if the number of creatures you control changes later in the turn."
+          "text": "The bonus is determined as Might of the Masses resolves. It won't change if the number of creatures you control changes later in the turn."
         },
         {
           "date": "2015-06-22",
@@ -22053,11 +22079,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Nissa, Vastwood Seer is exiled as a result of her second triggered ability. If she enters the battlefield while you control seven or more lands, she won’t automatically be exiled and transform."
+          "text": "Nissa, Vastwood Seer is exiled as a result of her second triggered ability. If she enters the battlefield while you control seven or more lands, she won't automatically be exiled and transform."
         },
         {
           "date": "2015-06-22",
-          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that’s currently up. The other set of characteristics is ignored. While a double-faced card isn’t on the battlefield, consider only the characteristics of its front face."
+          "text": "Each face of a double-faced card has its own set of characteristics: name, types, subtypes, power and toughness, loyalty, abilities, and so on. While a double-faced card is on the battlefield, consider only the characteristics of the face that's currently up. The other set of characteristics is ignored. While a double-faced card isn't on the battlefield, consider only the characteristics of its front face."
         },
         {
           "date": "2015-06-22",
@@ -22065,11 +22091,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can’t be cast."
+          "text": "The back face of a double-faced card (in the case of Magic Origins, the planeswalker face) can't be cast."
         },
         {
           "date": "2015-06-22",
-          "text": "Although the two rules are similar, the “legend rule” and the “planeswalker uniqueness rule” affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you’ll then control two planeswalkers with the same subtype. You’ll choose one to remain on the battlefield, and the other will be put into its owner’s graveyard."
+          "text": "Although the two rules are similar, the \"legend rule\" and the \"planeswalker uniqueness rule\" affect different kinds of permanents. You can control two of this permanent, one front face-up and the other back-face up at the same time. However, if the former is exiled and enters the battlefield transformed, you'll then control two planeswalkers with the same subtype. You'll choose one to remain on the battlefield, and the other will be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
@@ -22081,19 +22107,19 @@
         },
         {
           "date": "2015-06-22",
-          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it’s a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won’t have any loyalty counters on it and will subsequently be put into its owner’s graveyard."
+          "text": "In some rare cases, a spell or ability may cause one of these five cards to transform while it's a creature (front face up) on the battlefield. If this happens, the resulting planeswalker won't have any loyalty counters on it and will subsequently be put into its owner's graveyard."
         },
         {
           "date": "2015-06-22",
-          "text": "You can activate one of the planeswalker’s loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
+          "text": "You can activate one of the planeswalker's loyalty abilities the turn it enters the battlefield. However, you may do so only during one of your main phases when the stack is empty. For example, if the planeswalker enters the battlefield during combat, there will be an opportunity for your opponent to remove it before you can activate one of its abilities."
         },
         {
           "date": "2015-06-22",
-          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it’s put onto the battlefield face down some other way). Note that “face down” is not synonymous with “with its back face up.” A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can’t transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can’t be turned face down."
+          "text": "If a double-faced card is manifested, it will be put onto the battlefield face down (this is also true if it's put onto the battlefield face down some other way). Note that \"face down\" is not synonymous with \"with its back face up.\" A manifested double-faced card is a 2/2 creature with no name, mana cost, creature types, or abilities. While face down, it can't transform. If the front face of a manifested double-faced card is a creature card, you can turn it face up by paying its mana cost. If you do, its front face will be up. A double-faced card on the battlefield can't be turned face down."
         },
         {
           "date": "2016-04-08",
-          "text": "The back face of a double-faced card doesn’t have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
+          "text": "The back face of a double-faced card doesn't have a mana cost. A double-faced permanent with its back face up has a converted mana cost equal to the converted mana cost of its front face. Each back face has a color indicator that defines its color."
         },
         {
           "date": "2016-07-13",
@@ -22214,11 +22240,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "You can activate Nissa, Sage Animist’s second ability even if you already control an Ashaya, the Awoken World. Just after the second token is created, you’ll choose one to remain on the battlefield. The other will be put into your graveyard and subsequently cease to exist."
+          "text": "You can activate Nissa, Sage Animist's second ability even if you already control an Ashaya, the Awoken World. Just after the second token is created, you'll choose one to remain on the battlefield. The other will be put into your graveyard and subsequently cease to exist."
         },
         {
           "date": "2015-06-22",
-          "text": "If a land becomes a creature but hasn’t continuously been under its controller’s control since that player’s most recent turn began, it won’t be able to attack and its abilities with {T} in the cost (including mana abilities) won’t be able to be activated. In other words, look at how long the permanent itself has been under your control, not how long it’s been a creature."
+          "text": "If a land becomes a creature but hasn't continuously been under its controller's control since that player's most recent turn began, it won't be able to attack and its abilities with {T} in the cost (including mana abilities) won't be able to be activated. In other words, look at how long the permanent itself has been under your control, not how long it's been a creature."
         }
       ],
       "subtypes": [
@@ -22327,7 +22353,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If you only find one basic Forest card, you’ll put it onto the battlefield tapped. You won’t be able to put it into your hand, even if you want to."
+          "text": "If you only find one basic Forest card, you'll put it onto the battlefield tapped. You won't be able to put it into your hand, even if you want to."
         },
         {
           "date": "2015-06-22",
@@ -22335,7 +22361,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won’t count because it’s still on the stack as you make this check."
+          "text": "Check to see if there are two or more instant and/or sorcery cards in your graveyard as the spell resolves to determine whether the spell mastery ability applies. The spell itself won't count because it's still on the stack as you make this check."
         }
       ],
       "text": "Search your library for up to two basic Forest cards, reveal those cards, and put one onto the battlefield tapped and the rest into your hand. Then shuffle your library.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, search your library for up to three basic Forest cards instead of two.",
@@ -22442,7 +22468,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If the top card of your library isn’t a creature card or it’s a creature card with power 0 or less, you won’t draw any cards. Otherwise, the first card you draw will be the card you revealed."
+          "text": "If the top card of your library isn't a creature card or it's a creature card with power 0 or less, you won't draw any cards. Otherwise, the first card you draw will be the card you revealed."
         }
       ],
       "text": "Scry 5, then reveal the top card of your library. If it's a creature card, you draw cards equal to its power and you gain life equal to its toughness.",
@@ -22659,7 +22685,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -22667,7 +22693,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -22777,7 +22803,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -22785,7 +22811,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -23004,7 +23030,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -23012,7 +23038,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -23228,7 +23254,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Somberwald Alpha’s first ability will give each creature you control that becomes blocked +1/+1 until end of turn. It doesn’t matter how many of your opponent’s creatures are blocking each of your creatures."
+          "text": "Somberwald Alpha's first ability will give each creature you control that becomes blocked +1/+1 until end of turn. It doesn't matter how many of your opponent's creatures are blocking each of your creatures."
         }
       ],
       "subtypes": [
@@ -23658,7 +23684,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -23666,7 +23692,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -23776,7 +23802,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -23784,7 +23810,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -24005,7 +24031,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Check the power of each creature as it would deal combat damage to determine if that damage is prevented. It doesn’t matter what any creature’s power is as Vine Snare resolves."
+          "text": "Check the power of each creature as it would deal combat damage to determine if that damage is prevented. It doesn't matter what any creature's power is as Vine Snare resolves."
         }
       ],
       "text": "Prevent all combat damage that would be dealt this turn by creatures with power 4 or less.",
@@ -24115,7 +24141,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If the creature an opponent controls is an illegal target as Wild Instincts tries to resolve, but the creature you control is still a legal target, the creature you control will get +2/+2, but the creatures won’t fight. Neither creature will deal or be dealt damage during the resolution of Wild Instincts."
+          "text": "If the creature an opponent controls is an illegal target as Wild Instincts tries to resolve, but the creature you control is still a legal target, the creature you control will get +2/+2, but the creatures won't fight. Neither creature will deal or be dealt damage during the resolution of Wild Instincts."
         }
       ],
       "text": "Target creature you control gets +2/+2 until end of turn. It fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
@@ -24333,7 +24359,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Yeva’s Forcemage’s ability is mandatory, although you can choose Yeva’s Forcemage as the target."
+          "text": "Yeva's Forcemage's ability is mandatory, although you can choose Yeva's Forcemage as the target."
         }
       ],
       "subtypes": [
@@ -24655,7 +24681,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If you cast an Aura spell targeting a creature controlled by an opponent, you still control that Aura. It will count for Blood-Cursed Knight’s ability."
+          "text": "If you cast an Aura spell targeting a creature controlled by an opponent, you still control that Aura. It will count for Blood-Cursed Knight's ability."
         }
       ],
       "subtypes": [
@@ -24877,7 +24903,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Renown won’t trigger when a creature deals combat damage to a planeswalker or another creature. It also won’t trigger when a creature deals noncombat damage to a player."
+          "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
         },
         {
           "date": "2015-06-22",
@@ -24885,7 +24911,7 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn’t become renowned. Any ability that triggers “whenever a creature becomes renowned” won’t trigger."
+          "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
         }
       ],
       "subtypes": [
@@ -25107,7 +25133,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Possessed Skaab’s last ability will apply no matter what caused it to die (lethal damage, being sacrificed, enough -1/-1 counters, and so on). Possessed Skaab won’t go to the graveyard. It will be put from the battlefield into exile. Abilities that trigger whenever a creature dies won’t trigger."
+          "text": "Possessed Skaab's last ability will apply no matter what caused it to die (lethal damage, being sacrificed, enough -1/-1 counters, and so on). Possessed Skaab won't go to the graveyard. It will be put from the battlefield into exile. Abilities that trigger whenever a creature dies won't trigger."
         }
       ],
       "subtypes": [
@@ -25219,11 +25245,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Count the number of artifacts you control as Reclusive Artificer’s triggered ability resolves to determine how much damage it deals."
+          "text": "Count the number of artifacts you control as Reclusive Artificer's triggered ability resolves to determine how much damage it deals."
         },
         {
           "date": "2015-06-22",
-          "text": "If you are the only player who controls a creature when Reclusive Artificer’s second ability triggers, you must choose one of those creatures as the target, although you can choose to not deal it damage."
+          "text": "If you are the only player who controls a creature when Reclusive Artificer's second ability triggers, you must choose one of those creatures as the target, although you can choose to not deal it damage."
         }
       ],
       "subtypes": [
@@ -25338,7 +25364,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Count the number of Elves you control as Shaman of the Pack’s ability resolves, including Shaman of the Pack if it’s still on the battlefield, to determine how much life is lost."
+          "text": "Count the number of Elves you control as Shaman of the Pack's ability resolves, including Shaman of the Pack if it's still on the battlefield, to determine how much life is lost."
         }
       ],
       "subtypes": [
@@ -25560,7 +25586,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The ability defining Zendikar Incarnate’s power works in all zones, not just the battlefield. Zendikar Incarnate’s power changes as the number of lands you control does."
+          "text": "The ability defining Zendikar Incarnate's power works in all zones, not just the battlefield. Zendikar Incarnate's power changes as the number of lands you control does."
         }
       ],
       "subtypes": [
@@ -25664,7 +25690,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Activating the last ability of Alchemist’s Vial targeting a creature that’s already attacking or blocking won’t cause that creature to stop attacking or blocking. It will prevent that creature from attacking or blocking in any additional combat phases the turn may have (although this is unusual)."
+          "text": "Activating the last ability of Alchemist's Vial targeting a creature that's already attacking or blocking won't cause that creature to stop attacking or blocking. It will prevent that creature from attacking or blocking in any additional combat phases the turn may have (although this is unusual)."
         }
       ],
       "text": "When Alchemist's Vial enters the battlefield, draw a card.\n{1}, {T}, Sacrifice Alchemist's Vial: Target creature can't attack or block this turn.",
@@ -25764,7 +25790,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If an effect would set your life total to a specific number that’s higher than your current life total, that effect would cause you to gain life equal to the difference. Alhammarret’s Archive will then double the amount of life that effect would cause you to gain. For example, if you have 3 life and an effect says that your life total “becomes 10,” your life total will actually become 17."
+          "text": "If an effect would set your life total to a specific number that's higher than your current life total, that effect would cause you to gain life equal to the difference. Alhammarret's Archive will then double the amount of life that effect would cause you to gain. For example, if you have 3 life and an effect says that your life total \"becomes 10,\" your life total will actually become 17."
         },
         {
           "date": "2015-06-22",
@@ -25772,15 +25798,15 @@
         },
         {
           "date": "2015-06-22",
-          "text": "Because Alhammarret’s Archive is legendary, it’s unlikely that one player will control two. However, if that happens, life gained by that player will be multiplied by four. Three Archives will multiply that life gain by eight, and so on."
+          "text": "Because Alhammarret's Archive is legendary, it's unlikely that one player will control two. However, if that happens, life gained by that player will be multiplied by four. Three Archives will multiply that life gain by eight, and so on."
         },
         {
           "date": "2015-06-22",
-          "text": "Similarly, the effects of the last abilities of multiple Archives are cumulative. If you control two, you’ll draw four times the number of cards, and so on."
+          "text": "Similarly, the effects of the last abilities of multiple Archives are cumulative. If you control two, you'll draw four times the number of cards, and so on."
         },
         {
           "date": "2015-06-22",
-          "text": "In a Two-Headed Giant game, only the controller of Alhammarret’s Archive is affected by it. If that player’s teammate gains life, Alhammarret’s Archive will have no effect, even when that life gain is applied to the team’s shared life total."
+          "text": "In a Two-Headed Giant game, only the controller of Alhammarret's Archive is affected by it. If that player's teammate gains life, Alhammarret's Archive will have no effect, even when that life gain is applied to the team's shared life total."
         }
       ],
       "supertypes": [
@@ -25888,11 +25914,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If Angel’s Tomb is already a creature when a creature enters the battlefield under your control, its ability will override any effects that set its base power and toughness to specific values, but other changes to its power and toughness (such as the one created by Titanic Growth) will still apply."
+          "text": "If Angel's Tomb is already a creature when a creature enters the battlefield under your control, its ability will override any effects that set its base power and toughness to specific values, but other changes to its power and toughness (such as the one created by Titanic Growth) will still apply."
         },
         {
           "date": "2015-06-22",
-          "text": "Effects setting Angel’s Tomb’s base power and toughness to specific values that begin to apply after Angel’s Tomb has become a creature will override the effect of Angel’s Tomb. For example, if an effect causes a 3/3 Angel’s Tomb to become 0/1, it will remain 0/1 until another effect (such as triggering the ability of Angel’s Tomb a second time or targeting it with Titanic Growth) causes those values to change."
+          "text": "Effects setting Angel's Tomb's base power and toughness to specific values that begin to apply after Angel's Tomb has become a creature will override the effect of Angel's Tomb. For example, if an effect causes a 3/3 Angel's Tomb to become 0/1, it will remain 0/1 until another effect (such as triggering the ability of Angel's Tomb a second time or targeting it with Titanic Growth) causes those values to change."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, you may have Angel's Tomb become a 3/3 white Angel artifact creature with flying until end of turn.",
@@ -25997,15 +26023,15 @@
         },
         {
           "date": "2015-06-22",
-          "text": "If you control more than one creature that can’t attack alone, they can attack together, even if no other creatures attack."
+          "text": "If you control more than one creature that can't attack alone, they can attack together, even if no other creatures attack."
         },
         {
           "date": "2015-06-22",
-          "text": "Although Bonded Construct can’t attack alone, other attacking creatures don’t have to attack the same player or planeswalker. For example, Bonded Construct could attack an opponent and another creature could attack a planeswalker that opponent controls."
+          "text": "Although Bonded Construct can't attack alone, other attacking creatures don't have to attack the same player or planeswalker. For example, Bonded Construct could attack an opponent and another creature could attack a planeswalker that opponent controls."
         },
         {
           "date": "2015-06-22",
-          "text": "If a creature that can’t attack alone also must attack if able, its controller must attack with it and another creature if able."
+          "text": "If a creature that can't attack alone also must attack if able, its controller must attack with it and another creature if able."
         },
         {
           "date": "2015-06-22",
@@ -26426,7 +26452,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If Guardian Automaton dies at the same time as your life total is reduced to 0 or less, you’ll lose the game before the triggered ability resolves."
+          "text": "If Guardian Automaton dies at the same time as your life total is reduced to 0 or less, you'll lose the game before the triggered ability resolves."
         }
       ],
       "subtypes": [
@@ -26637,11 +26663,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The value of each X in Hangarback Walker’s mana cost must be equal. For example, if X is 2, you’ll pay {4} to cast Hangarback Walker and it will enter the battlefield with two +1/+1 counters on it."
+          "text": "The value of each X in Hangarback Walker's mana cost must be equal. For example, if X is 2, you'll pay {4} to cast Hangarback Walker and it will enter the battlefield with two +1/+1 counters on it."
         },
         {
           "date": "2015-06-22",
-          "text": "If enough -1/-1 counters are put on Hangarback Walker at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got any -1/-1 counters will be used to determine how many Thopter tokens you get. For example, if there are three +1/+1 counters on Hangarback Walker and it gets four -1/-1 counters, you’ll get three Thopter tokens. That’s because Hangarback Walker’s triggered ability checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If enough -1/-1 counters are put on Hangarback Walker at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got any -1/-1 counters will be used to determine how many Thopter tokens you get. For example, if there are three +1/+1 counters on Hangarback Walker and it gets four -1/-1 counters, you'll get three Thopter tokens. That's because Hangarback Walker's triggered ability checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -26958,7 +26984,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The last ability triggers and resolves before blockers are declared. If the target creature is destroyed by the damage, it won’t be on the battlefield to block."
+          "text": "The last ability triggers and resolves before blockers are declared. If the target creature is destroyed by the damage, it won't be on the battlefield to block."
         }
       ],
       "subtypes": [
@@ -27158,11 +27184,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "As long as you have hexproof, your opponents can’t target you with spells that deal damage or abilities that cause their sources to deal damage, even if they intend to redirect the damage to a planeswalker you control."
+          "text": "As long as you have hexproof, your opponents can't target you with spells that deal damage or abilities that cause their sources to deal damage, even if they intend to redirect the damage to a planeswalker you control."
         },
         {
           "date": "2015-06-22",
-          "text": "Orbs of Warding won’t prevent damage dealt by creatures to a planeswalker you control. However, if a creature controlled by an opponent would deal noncombat damage to you, you can apply Orbs of Warding’s effect to prevent 1 of that damage before your opponent chooses whether to redirect that damage to a planeswalker you control."
+          "text": "Orbs of Warding won't prevent damage dealt by creatures to a planeswalker you control. However, if a creature controlled by an opponent would deal noncombat damage to you, you can apply Orbs of Warding's effect to prevent 1 of that damage before your opponent chooses whether to redirect that damage to a planeswalker you control."
         },
         {
           "date": "2015-06-22",
@@ -27363,7 +27389,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The mana produced by Pyromancer’s Goggles can be spent on anything, not just a red instant or sorcery spell."
+          "text": "The mana produced by Pyromancer's Goggles can be spent on anything, not just a red instant or sorcery spell."
         },
         {
           "date": "2015-06-22",
@@ -27371,23 +27397,23 @@
         },
         {
           "date": "2015-06-22",
-          "text": "The delayed triggered ability will trigger whether Pyromancer’s Goggles is still on the battlefield or not."
+          "text": "The delayed triggered ability will trigger whether Pyromancer's Goggles is still on the battlefield or not."
         },
         {
           "date": "2015-06-22",
-          "text": "If more than one red mana produced by a Pyromancer’s Goggles is spent to cast a single red instant or sorcery spell, the delayed triggered ability associated with each mana spent will trigger. That many copies will be created. It doesn’t matter if this red mana was produced by one Pyromancer’s Goggles or by multiple Pyromancer’s Goggles."
+          "text": "If more than one red mana produced by a Pyromancer's Goggles is spent to cast a single red instant or sorcery spell, the delayed triggered ability associated with each mana spent will trigger. That many copies will be created. It doesn't matter if this red mana was produced by one Pyromancer's Goggles or by multiple Pyromancer's Goggles."
         },
         {
           "date": "2015-06-22",
-          "text": "If a copy is created, you control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "If a copy is created, you control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2015-06-22",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2015-06-22",
-          "text": "If the copied spell is modal (that is, it says “Choose one –” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the copied spell is modal (that is, it says \"Choose one –\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2015-06-22",
@@ -27395,11 +27421,11 @@
         },
         {
           "date": "2015-06-22",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you sacrifice a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you sacrifice a 3/3 creature to cast Fling, and you copy it, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2015-06-22",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "supertypes": [
@@ -27503,7 +27529,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "If, during its controller’s declare attackers step, Ramroller is tapped or is affected by a spell or ability that says it can’t attack, then Ramroller doesn’t attack. If there’s a cost associated with having it attack, its controller isn’t forced to pay that cost. If he or she doesn’t, Ramroller doesn’t have to attack."
+          "text": "If, during its controller's declare attackers step, Ramroller is tapped or is affected by a spell or ability that says it can't attack, then Ramroller doesn't attack. If there's a cost associated with having it attack, its controller isn't forced to pay that cost. If he or she doesn't, Ramroller doesn't have to attack."
         }
       ],
       "subtypes": [
@@ -27718,11 +27744,11 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Count the number of creatures you control other than the equipped creature as Sigil of Valor’s ability resolves to determine the amount of the bonus. Once the ability resolves, the bonus won’t change, even if the number of creatures you control does."
+          "text": "Count the number of creatures you control other than the equipped creature as Sigil of Valor's ability resolves to determine the amount of the bonus. Once the ability resolves, the bonus won't change, even if the number of creatures you control does."
         },
         {
           "date": "2015-06-22",
-          "text": "A creature attacks alone if it’s the only creature declared as an attacker during the declare attackers step (including creatures controlled by your teammates, if applicable). For example, Sigil of Valor’s ability won’t trigger if you attack with multiple creatures and all but one of them are removed from combat."
+          "text": "A creature attacks alone if it's the only creature declared as an attacker during the declare attackers step (including creatures controlled by your teammates, if applicable). For example, Sigil of Valor's ability won't trigger if you attack with multiple creatures and all but one of them are removed from combat."
         }
       ],
       "subtypes": [
@@ -27925,7 +27951,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "Throwing Knife’s triggered ability triggers before blockers are declared. If you use the ability and destroy the targeted creature with lethal damage, it won’t be on the battlefield to block."
+          "text": "Throwing Knife's triggered ability triggers before blockers are declared. If you use the ability and destroy the targeted creature with lethal damage, it won't be on the battlefield to block."
         },
         {
           "date": "2015-06-22",
@@ -28232,7 +28258,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -28347,7 +28373,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -28690,7 +28716,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -28891,7 +28917,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Activating the second ability of Rogue’s Passage after a creature has become blocked won’t cause it to become unblocked."
+          "text": "Activating the second ability of Rogue's Passage after a creature has become blocked won't cause it to become unblocked."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}, {T}: Target creature can't be blocked this turn.",
@@ -29000,7 +29026,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -29113,7 +29139,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The damage dealt to you is part of the second mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The damage dealt to you is part of the second mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2015-06-22",
@@ -33325,11 +33351,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "沼泽",
-          "multiverseid": 398749
-        },
-        {
           "language": "Chinese Traditional",
           "name": "沼澤",
           "multiverseid": 399026
@@ -33435,19 +33456,24 @@
           "multiverseid": 400411
         },
         {
-          "language": "Korean",
-          "name": "늪",
-          "multiverseid": 400446
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 401242
         },
         {
-          "language": "Korean",
-          "name": "늪",
-          "multiverseid": 400494
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 401277
         },
         {
-          "language": "Korean",
-          "name": "늪",
-          "multiverseid": 400616
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 401325
+        },
+        {
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 401447
         }
       ],
       "id": "56a0b6e4ec0158edea4e3ced48516a8a287c40f1",
@@ -34094,11 +34120,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "山脉",
-          "multiverseid": 398689
-        },
-        {
           "language": "Chinese Traditional",
           "name": "山脈",
           "multiverseid": 398966
@@ -34122,21 +34143,6 @@
           "language": "French",
           "name": "Montagne",
           "multiverseid": 399520
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 399533
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 399598
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 399618
         },
         {
           "language": "German",
@@ -34217,6 +34223,26 @@
           "language": "Korean",
           "name": "산",
           "multiverseid": 400449
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 401182
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 401195
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 401260
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 401280
         }
       ],
       "id": "46768ba25029cb3d29d1228d323b3c90cada9660",
@@ -34479,11 +34505,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "山脉",
-          "multiverseid": 398689
-        },
-        {
           "language": "Chinese Traditional",
           "name": "山脈",
           "multiverseid": 398966
@@ -34507,21 +34528,6 @@
           "language": "French",
           "name": "Montagne",
           "multiverseid": 399520
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 399533
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 399598
-        },
-        {
-          "language": "French",
-          "name": "Montagne",
-          "multiverseid": 399618
         },
         {
           "language": "German",
@@ -34602,6 +34608,26 @@
           "language": "Korean",
           "name": "산",
           "multiverseid": 400449
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 401182
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 401195
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 401260
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 401280
         }
       ],
       "id": "c7f325a5424dea2eb419fcafe2bea24deedde298",
@@ -35369,9 +35395,9 @@
           "multiverseid": 400556
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 401191
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 400914
         }
       ],
       "id": "3f8c62afa29220918df5d32117357f64d6042030",
@@ -35752,9 +35778,9 @@
           "multiverseid": 400556
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 401191
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 400914
         }
       ],
       "id": "aa72ec9fef27f544320ed84b8fa4cc9e6d834ec0",
@@ -36135,9 +36161,9 @@
           "multiverseid": 400556
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 401191
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 400914
         }
       ],
       "id": "7c18c9495a5bc915fdfa7f8cc155545ac84922ef",
@@ -36483,21 +36509,6 @@
           "multiverseid": 400083
         },
         {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 400116
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 400232
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 400279
-        },
-        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 400360
@@ -36521,6 +36532,21 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 401191
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 401224
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 401340
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 401387
         }
       ],
       "id": "1dc6054b454815aefaa6f4ecb2ae2c58810bcced",
@@ -37007,15 +37033,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         },
         {
           "date": "2012-07-01",
-          "text": "Destroying a blocking creature won’t cause any of the creatures it was blocking to become unblocked. They won’t deal combat damage to the defending player or planeswalker (unless they have trample)."
+          "text": "Destroying a blocking creature won't cause any of the creatures it was blocking to become unblocked. They won't deal combat damage to the defending player or planeswalker (unless they have trample)."
         }
       ],
       "starter": true,
@@ -37283,7 +37309,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"The cathars have their swords, the inquisitors their axes. I prefer the ‘diplomatic' approach.\"\n—Terhold, archmage of Drunau",
+      "flavor": "\"The cathars have their swords, the inquisitors their axes. I prefer the 'diplomatic' approach.\"\n—Terhold, archmage of Drunau",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -37966,19 +37992,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "starter": true,
@@ -38119,15 +38145,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "starter": true,
@@ -38603,11 +38629,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Prized Unicorn doesn’t give a creature the ability to block it. It just forces those creatures that are already able to block it to do so. For example, it can’t force a creature that’s tapped or affected by a spell or ability that says it can’t block to block it. If there’s a cost associated with having a creature block, its controller isn’t forced to pay that cost, so the creature doesn’t have to block Prized Unicorn in that case either."
+          "text": "Prized Unicorn doesn't give a creature the ability to block it. It just forces those creatures that are already able to block it to do so. For example, it can't force a creature that's tapped or affected by a spell or ability that says it can't block to block it. If there's a cost associated with having a creature block, its controller isn't forced to pay that cost, so the creature doesn't have to block Prized Unicorn in that case either."
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature the defending player controls can’t block Prized Unicorn, it can block any attacking creature, or not block at all."
+          "text": "If a creature the defending player controls can't block Prized Unicorn, it can block any attacking creature, or not block at all."
         },
         {
           "date": "2009-10-01",
@@ -38729,7 +38755,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Terra Stomper can be targeted by spells that try to counter it (such as Cancel). Those spells will resolve, but the part of their effect that would counter Terra Stomper won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Terra Stomper can be targeted by spells that try to counter it (such as Cancel). Those spells will resolve, but the part of their effect that would counter Terra Stomper won't do anything. Any other effects those spells have will work as normal."
         }
       ],
       "starter": true,

--- a/json/PC2.json
+++ b/json/PC2.json
@@ -60,11 +60,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "While Chaotic Aether’s effect applies, rolling any blank face of the planar die will cause chaos abilities to trigger."
+          "text": "While Chaotic Aether's effect applies, rolling any blank face of the planar die will cause chaos abilities to trigger."
         },
         {
           "date": "2012-06-01",
-          "text": "Planeswalking away from a phenomenon (as you do when resolving Chaotic Aether’s ability) doesn’t cause Chaotic Aether’s effect to expire."
+          "text": "Planeswalking away from a phenomenon (as you do when resolving Chaotic Aether's ability) doesn't cause Chaotic Aether's effect to expire."
         }
       ],
       "text": "When you encounter Chaotic Aether, each blank roll of the planar die is a CHAOS roll until a player planeswalks away from a plane. (Then planeswalk away from this phenomenon.)",
@@ -197,7 +197,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "The plane card you put on top of your planar deck is the one you’ll planeswalk to after planeswalking away from Interplanar Tunnel."
+          "text": "The plane card you put on top of your planar deck is the one you'll planeswalk to after planeswalking away from Interplanar Tunnel."
         }
       ],
       "text": "When you encounter Interplanar Tunnel, reveal cards from the top of your planar deck until you reveal five plane cards. Put a plane card from among them on top of your planar deck, then put the rest of the revealed cards on the bottom in a random order. (Then planeswalk away from this phenomenon.)",
@@ -351,19 +351,19 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Cards such as Sakashima’s Student that can enter the battlefield as a copy of another permanent won’t be able to enter the battlefield as a copy of a permanent that’s entering the battlefield at the same time."
+          "text": "Cards such as Sakashima's Student that can enter the battlefield as a copy of another permanent won't be able to enter the battlefield as a copy of a permanent that's entering the battlefield at the same time."
         },
         {
           "date": "2012-06-01",
-          "text": "After all permanents are put onto the battlefield and you planeswalk away from Morphic Tide, any abilities that triggered from those permanents entering the battlefield, from the previous generation of permanents leaving the battlefield, and from the new plane or phenomenon will be put onto the stack. You’ll put all of your triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
+          "text": "After all permanents are put onto the battlefield and you planeswalk away from Morphic Tide, any abilities that triggered from those permanents entering the battlefield, from the previous generation of permanents leaving the battlefield, and from the new plane or phenomenon will be put onto the stack. You'll put all of your triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
         },
         {
           "date": "2012-06-01",
-          "text": "The permanents will enter the battlefield while Morphic Tide is face up. This means the game won’t be on any plane when determining if any abilities trigger because those permanents entered the battlefield, for example. However, you’ll planeswalk away from Morphic Tide before any such abilities are put on the stack. After you turn the next card of the planar deck face up, any abilities that triggered during the resolution of Morphic Tide (including any abilities that triggered because you encountered another phenomenon or planeswalked to the next plane) will be put on the stack. The planar controller will put his or her abilities on the stack in any order, followed by each other player in turn order. The last ability put on the stack will be the first one to resolve."
+          "text": "The permanents will enter the battlefield while Morphic Tide is face up. This means the game won't be on any plane when determining if any abilities trigger because those permanents entered the battlefield, for example. However, you'll planeswalk away from Morphic Tide before any such abilities are put on the stack. After you turn the next card of the planar deck face up, any abilities that triggered during the resolution of Morphic Tide (including any abilities that triggered because you encountered another phenomenon or planeswalked to the next plane) will be put on the stack. The planar controller will put his or her abilities on the stack in any order, followed by each other player in turn order. The last ability put on the stack will be the first one to resolve."
         },
         {
           "date": "2012-06-01",
-          "text": "Token permanents a player owns will count toward the number of cards that player reveals. They’ll be shuffled into that player’s library and subsequently cease to exist. A token’s owner is the player under whose control it first entered the battlefield."
+          "text": "Token permanents a player owns will count toward the number of cards that player reveals. They'll be shuffled into that player's library and subsequently cease to exist. A token's owner is the player under whose control it first entered the battlefield."
         }
       ],
       "text": "When you encounter Morphic Tide, each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, land, and planeswalker cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of his or her library in any order. (Then planeswalk away from this phenomenon.)",
@@ -450,7 +450,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Any Aura card you find must be able to enchant Auratouched Mage as it currently exists, or as it most recently existed on the battlefield if it’s no longer on the battlefield. If an effect has made the Mage an artifact, for example, you could search for an Aura with “enchant artifact.”"
+          "text": "Any Aura card you find must be able to enchant Auratouched Mage as it currently exists, or as it most recently existed on the battlefield if it's no longer on the battlefield. If an effect has made the Mage an artifact, for example, you could search for an Aura with \"enchant artifact.\""
         }
       ],
       "subtypes": [
@@ -776,11 +776,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "First, you may put a permanent card onto the battlefield, then each other player in turn order may do the same. Cards such as Sakashima’s Student that can enter the battlefield as a copy of another creature could copy a creature put onto the battlefield earlier in the resolution of the ability."
+          "text": "First, you may put a permanent card onto the battlefield, then each other player in turn order may do the same. Cards such as Sakashima's Student that can enter the battlefield as a copy of another creature could copy a creature put onto the battlefield earlier in the resolution of the ability."
         },
         {
           "date": "2012-06-01",
-          "text": "Each player will know what permanent cards were put onto the battlefield earlier in the ability’s resolution."
+          "text": "Each player will know what permanent cards were put onto the battlefield earlier in the ability's resolution."
         },
         {
           "date": "2012-06-01",
@@ -788,7 +788,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "After all permanents are put onto the battlefield and you planeswalk away from Reality Shaping, any abilities that triggered from those permanents entering the battlefield will be put onto the stack. You’ll put all of your triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
+          "text": "After all permanents are put onto the battlefield and you planeswalk away from Reality Shaping, any abilities that triggered from those permanents entering the battlefield will be put onto the stack. You'll put all of your triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
         }
       ],
       "text": "When you encounter Reality Shaping, starting with you, each player may put a permanent card from his or her hand onto the battlefield. (Then planeswalk away from this phenomenon.)",
@@ -865,11 +865,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If Felidar Umbra is enchanting a creature with first strike, you can activate its ability and attach it to a creature without first strike during the first combat damage step. Each of those creatures will have lifelink when dealing combat damage and you’ll gain life accordingly."
+          "text": "If Felidar Umbra is enchanting a creature with first strike, you can activate its ability and attach it to a creature without first strike during the first combat damage step. Each of those creatures will have lifelink when dealing combat damage and you'll gain life accordingly."
         },
         {
           "date": "2012-06-01",
-          "text": "It’s not possible for Felidar Umbra to save two creatures that are being destroyed simultaneously."
+          "text": "It's not possible for Felidar Umbra to save two creatures that are being destroyed simultaneously."
         }
       ],
       "subtypes": [
@@ -934,7 +934,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "The next time a player planeswalks, he or she planeswalks away from both planes. Their owner puts them on the bottom of his or her planar deck in an order of his or her choice. This order isn’t revealed to other players."
+          "text": "The next time a player planeswalks, he or she planeswalks away from both planes. Their owner puts them on the bottom of his or her planar deck in an order of his or her choice. This order isn't revealed to other players."
         }
       ],
       "text": "When you encounter Spatial Merging, reveal cards from the top of your planar deck until you reveal two plane cards. Simultaneously planeswalk to both of them. Put all other cards revealed this way on the bottom of your planar deck in any order.",
@@ -1029,7 +1029,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -1087,7 +1087,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If the game’s turn order is reversed again, it will return to the default order used at the beginning of the game."
+          "text": "If the game's turn order is reversed again, it will return to the default order used at the beginning of the game."
         }
       ],
       "text": "When you encounter Time Distortion, reverse the game's turn order. (For example, if play had proceeded clockwise around the table, it now goes counterclockwise. Then planeswalk away from this phenomenon.)",
@@ -1173,11 +1173,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -1185,15 +1185,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -1201,15 +1201,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -1270,11 +1270,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "A creature that’s enchanted can’t be chosen as the target of the chaos ability."
+          "text": "A creature that's enchanted can't be chosen as the target of the chaos ability."
         },
         {
           "date": "2012-06-01",
-          "text": "If a creature that isn’t enchanted is targeted by the chaos ability, but that creature is enchanted when that ability tries to resolve, the ability will be countered for having an illegal target."
+          "text": "If a creature that isn't enchanted is targeted by the chaos ability, but that creature is enchanted when that ability tries to resolve, the ability will be countered for having an illegal target."
         }
       ],
       "subtypes": [
@@ -1365,7 +1365,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an Aura spell, Kor Spiritdancer’s second ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an Aura spell, Kor Spiritdancer's second ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         },
         {
           "date": "2010-06-15",
@@ -1517,11 +1517,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -1529,15 +1529,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -1545,15 +1545,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -1614,7 +1614,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Astral Arena’s abilities stop more than one creature from being declared as an attacker or as a blocker each combat. However, it doesn’t affect creatures that are put onto the battlefield attacking or blocking."
+          "text": "Astral Arena's abilities stop more than one creature from being declared as an attacker or as a blocker each combat. However, it doesn't affect creatures that are put onto the battlefield attacking or blocking."
         },
         {
           "date": "2012-06-01",
@@ -1714,11 +1714,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can’t play an Aura spell intending to enchant the Angel that will be created as a result."
+          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can't play an Aura spell intending to enchant the Angel that will be created as a result."
         },
         {
           "date": "2009-02-01",
-          "text": "Casting Sigil of the Empty Throne won’t trigger its own ability. It has to be on the battlefield for its ability to work."
+          "text": "Casting Sigil of the Empty Throne won't trigger its own ability. It has to be on the battlefield for its ability to work."
         }
       ],
       "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
@@ -1772,7 +1772,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If a creature you’ve gained control of temporarily (because of Act of Treason, for example) is exiled and returns to the battlefield under your control, you will control that creature indefinitely."
+          "text": "If a creature you've gained control of temporarily (because of Act of Treason, for example) is exiled and returns to the battlefield under your control, you will control that creature indefinitely."
         }
       ],
       "subtypes": [
@@ -1909,15 +1909,15 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "While Edge of Malacol is face up, the normal turn-based action of untapping your creatures is replaced. Those creatures won’t untap. Other tapped permanents you control will untap as normal."
+          "text": "While Edge of Malacol is face up, the normal turn-based action of untapping your creatures is replaced. Those creatures won't untap. Other tapped permanents you control will untap as normal."
         },
         {
           "date": "2012-06-01",
-          "text": "Other spells and abilities can untap creatures as normal. In that case, they’ll just untap. You won’t put any +1/+1 counters on them."
+          "text": "Other spells and abilities can untap creatures as normal. In that case, they'll just untap. You won't put any +1/+1 counters on them."
         },
         {
           "date": "2012-06-01",
-          "text": "If you untap a creature you control during another player’s untap step (perhaps due to Seedborn Muse’s ability), that creature will untap normally. You won’t put any +1/+1 counters on it."
+          "text": "If you untap a creature you control during another player's untap step (perhaps due to Seedborn Muse's ability), that creature will untap normally. You won't put any +1/+1 counters on it."
         }
       ],
       "subtypes": [
@@ -2059,7 +2059,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If the target player has no cards in his or her hand when the ability resolves, nothing happens. That player won’t lose any life."
+          "text": "If the target player has no cards in his or her hand when the ability resolves, nothing happens. That player won't lose any life."
         }
       ],
       "subtypes": [
@@ -2284,6 +2284,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Time Spiral Block",
           "legality": "Legal"
         },
@@ -2373,7 +2377,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If either target is no longer on the battlefield or is otherwise an illegal target when the chaos ability resolves, the exchange won’t happen. No creatures will change controllers. If both targets are illegal, the ability will be countered."
+          "text": "If either target is no longer on the battlefield or is otherwise an illegal target when the chaos ability resolves, the exchange won't happen. No creatures will change controllers. If both targets are illegal, the ability will be countered."
         }
       ],
       "subtypes": [
@@ -2517,7 +2521,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Any target that is illegal when the first ability resolves won’t get any +1/+1 counters. Those counters are essentially lost; you won’t get to put them on another creature."
+          "text": "Any target that is illegal when the first ability resolves won't get any +1/+1 counters. Those counters are essentially lost; you won't get to put them on another creature."
         },
         {
           "date": "2012-06-01",
@@ -2666,11 +2670,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Both abilities are mandatory. You must put the creature card onto the battlefield, even if you don’t want to."
+          "text": "Both abilities are mandatory. You must put the creature card onto the battlefield, even if you don't want to."
         },
         {
           "date": "2012-06-01",
-          "text": "If you don’t reveal any creature cards from your library, you’ll put the cards from your library on the bottom of your library in a random order. Essentially, this will shuffle your library, although you are not shuffling it for purposes of effects that care about a player shuffling a library."
+          "text": "If you don't reveal any creature cards from your library, you'll put the cards from your library on the bottom of your library in a random order. Essentially, this will shuffle your library, although you are not shuffling it for purposes of effects that care about a player shuffling a library."
         }
       ],
       "subtypes": [
@@ -2760,7 +2764,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "If Higure deals regular combat damage and you use its ability to search for another Ninja, that card won’t be in your hand in time to activate its ninjutsu ability to put it onto the battlefield and deal damage. However, the card you searched for could still be swapped for an unblocked creature, including Higure, as long as you activate its ninjutsu ability before the end of combat."
+          "text": "If Higure deals regular combat damage and you use its ability to search for another Ninja, that card won't be in your hand in time to activate its ninjutsu ability to put it onto the battlefield and deal damage. However, the card you searched for could still be swapped for an unblocked creature, including Higure, as long as you activate its ninjutsu ability before the end of combat."
         },
         {
           "date": "2005-02-01",
@@ -2826,7 +2830,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "A creature’s power is checked when attackers or blockers are declared. Increasing the power of an attacking or blocking creature to 7 or greater won’t remove that creature from combat."
+          "text": "A creature's power is checked when attackers or blockers are declared. Increasing the power of an attacking or blocking creature to 7 or greater won't remove that creature from combat."
         }
       ],
       "subtypes": [
@@ -2913,11 +2917,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Notably, if you exile Illusory Angel because of a cascade ability of a spell with converted mana cost 4 or greater, you’ll be able to cast Illusory Angel."
+          "text": "Notably, if you exile Illusory Angel because of a cascade ability of a spell with converted mana cost 4 or greater, you'll be able to cast Illusory Angel."
         },
         {
           "date": "2014-07-18",
-          "text": "It doesn’t matter whether the other spell resolved. It could have been countered or, if you’ve somehow cast Illusory Angel as though it had flash, it could still be on the stack."
+          "text": "It doesn't matter whether the other spell resolved. It could have been countered or, if you've somehow cast Illusory Angel as though it had flash, it could still be on the stack."
         }
       ],
       "subtypes": [
@@ -2980,7 +2984,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If the creature spell already has devour, you may sacrifice creatures using either ability. Each creature you sacrifice counts for only one devour ability. Under most circumstances, you’ll pick the devour ability that gives the greatest number of +1/+1 counters."
+          "text": "If the creature spell already has devour, you may sacrifice creatures using either ability. Each creature you sacrifice counts for only one devour ability. Under most circumstances, you'll pick the devour ability that gives the greatest number of +1/+1 counters."
         }
       ],
       "subtypes": [
@@ -3123,11 +3127,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "A “non-Werewolf creature” is a creature that doesn’t have the Werewolf creature type. A creature with additional types, such as a Human Werewolf, is not a non-Werewolf creature."
+          "text": "A \"non-Werewolf creature\" is a creature that doesn't have the Werewolf creature type. A creature with additional types, such as a Human Werewolf, is not a non-Werewolf creature."
         },
         {
           "date": "2012-06-01",
-          "text": "Creatures that you gain control of after the chaos ability resolves won’t get any of that ability’s bonuses."
+          "text": "Creatures that you gain control of after the chaos ability resolves won't get any of that ability's bonuses."
         }
       ],
       "subtypes": [
@@ -3271,19 +3275,19 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "The first ability doesn’t trigger when a creature attacks a planeswalker, and the token copies can’t be put onto the battlefield attacking a planeswalker."
+          "text": "The first ability doesn't trigger when a creature attacks a planeswalker, and the token copies can't be put onto the battlefield attacking a planeswalker."
         },
         {
           "date": "2012-06-01",
-          "text": "As each token is created, it checks the printed values of the creature it’s copying, as well as any copy effects that have been applied to it."
+          "text": "As each token is created, it checks the printed values of the creature it's copying, as well as any copy effects that have been applied to it."
         },
         {
           "date": "2012-06-01",
-          "text": "The copiable values of each token’s characteristics are the same as the copiable values of the characteristics of the creature it’s copying."
+          "text": "The copiable values of each token's characteristics are the same as the copiable values of the characteristics of the creature it's copying."
         },
         {
           "date": "2012-06-01",
-          "text": "You choose the target of the chaos ability as you put that ability on the stack. You don’t sacrifice any creatures until that ability resolves."
+          "text": "You choose the target of the chaos ability as you put that ability on the stack. You don't sacrifice any creatures until that ability resolves."
         }
       ],
       "subtypes": [
@@ -3371,7 +3375,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -3436,7 +3440,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "You choose the target of the chaos ability as you put that ability on the stack. When the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it’s too late for any player to respond since the ability is already in the midst of resolving."
+          "text": "You choose the target of the chaos ability as you put that ability on the stack. When the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it's too late for any player to respond since the ability is already in the midst of resolving."
         }
       ],
       "subtypes": [
@@ -3528,7 +3532,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
         },
         {
           "date": "2007-02-01",
@@ -3540,7 +3544,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         }
       ],
       "subtypes": [
@@ -3684,11 +3688,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Because you return the unblocked attacking creature to its owner’s hand while activating the ninjutsu ability, you can’t have Sakashima’s Student enter the battlefield as a copy of that creature."
+          "text": "Because you return the unblocked attacking creature to its owner's hand while activating the ninjutsu ability, you can't have Sakashima's Student enter the battlefield as a copy of that creature."
         },
         {
           "date": "2012-06-01",
-          "text": "Sakashima’s Student copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it is a Ninja in addition to its other types. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Sakashima's Student copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it is a Ninja in addition to its other types. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-06-01",
@@ -3696,23 +3700,23 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If the chosen creature is copying something else (for example, if the chosen creature is another Sakashima’s Student), then your Sakashima’s Student enters the battlefield as whatever the chosen creature copied."
+          "text": "If the chosen creature is copying something else (for example, if the chosen creature is another Sakashima's Student), then your Sakashima's Student enters the battlefield as whatever the chosen creature copied."
         },
         {
           "date": "2012-06-01",
-          "text": "If the chosen creature is a token, Sakashima’s Student copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Sakashima’s Student is not a token."
+          "text": "If the chosen creature is a token, Sakashima's Student copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Sakashima's Student is not a token."
         },
         {
           "date": "2012-06-01",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Sakashima’s Student enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature (like devour) will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Sakashima's Student enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature (like devour) will also work."
         },
         {
           "date": "2012-06-01",
-          "text": "If Sakashima’s Student somehow enters the battlefield at the same time as another creature, Sakashima’s Student can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Sakashima's Student somehow enters the battlefield at the same time as another creature, Sakashima's Student can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-06-01",
-          "text": "You can choose not to copy anything. In that case, Sakashima’s Student enters the battlefield as a 0/0 creature, and is probably put into the graveyard immediately."
+          "text": "You can choose not to copy anything. In that case, Sakashima's Student enters the battlefield as a 0/0 creature, and is probably put into the graveyard immediately."
         }
       ],
       "subtypes": [
@@ -3771,7 +3775,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If you roll {CHAOS}, Mount Keralia’s damage-prevention effect will last for the rest of the game. It will apply to damage dealt by any plane named Mount Keralia, regardless of who owns that plane."
+          "text": "If you roll {CHAOS}, Mount Keralia's damage-prevention effect will last for the rest of the game. It will apply to damage dealt by any plane named Mount Keralia, regardless of who owns that plane."
         }
       ],
       "subtypes": [
@@ -3861,11 +3865,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The card you shuffle into your library may be any card from your hand. It doesn’t have to be one of the cards you drew with the spell."
+          "text": "The card you shuffle into your library may be any card from your hand. It doesn't have to be one of the cards you drew with the spell."
         },
         {
           "date": "2010-06-15",
-          "text": "You have to shuffle a card from your hand into your library even if you don’t draw any cards (due to replacement effects or Maralen of the Mornsong’s ability, for example). If your hand is empty, you don’t shuffle your library."
+          "text": "You have to shuffle a card from your hand into your library even if you don't draw any cards (due to replacement effects or Maralen of the Mornsong's ability, for example). If your hand is empty, you don't shuffle your library."
         }
       ],
       "text": "Draw two cards, then shuffle a card from your hand into your library.",
@@ -3919,7 +3923,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Nephalia’s first ability doesn’t target any card, and players don’t get priority to cast spells or activate abilities in between putting cards into your graveyard and choosing a card to return."
+          "text": "Nephalia's first ability doesn't target any card, and players don't get priority to cast spells or activate abilities in between putting cards into your graveyard and choosing a card to return."
         }
       ],
       "subtypes": [
@@ -4205,7 +4209,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Creatures that you gain control of after the chaos ability resolves won’t get any of that ability’s bonuses."
+          "text": "Creatures that you gain control of after the chaos ability resolves won't get any of that ability's bonuses."
         }
       ],
       "subtypes": [
@@ -4296,11 +4300,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Frost’s ability tracks the creature, not the creature’s controller. That is, if the creature changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "Wall of Frost's ability tracks the creature, not the creature's controller. That is, if the creature changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-07-18",
-          "text": "If the creature isn’t tapped during its controller’s next untap step (perhaps because it was untapped by a spell), Wall of Frost’s ability has no effect at that time. It won’t try to keep the creature tapped on subsequent turns."
+          "text": "If the creature isn't tapped during its controller's next untap step (perhaps because it was untapped by a spell), Wall of Frost's ability has no effect at that time. It won't try to keep the creature tapped on subsequent turns."
         }
       ],
       "subtypes": [
@@ -4773,15 +4777,15 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "You play the card (meaning it play it if it’s a land card or cast it if it’s a nonland card) as part of the resolution of the chaos ability. Timing restrictions based on the card’s type are ignored. Other restrictions, such as “Cast [this card] only during combat,” are not."
+          "text": "You play the card (meaning it play it if it's a land card or cast it if it's a nonland card) as part of the resolution of the chaos ability. Timing restrictions based on the card's type are ignored. Other restrictions, such as \"Cast [this card] only during combat,\" are not."
         },
         {
           "date": "2012-06-01",
-          "text": "If you reveal a land card when resolving the chaos ability, you may play it only if you haven’t played a land yet that turn."
+          "text": "If you reveal a land card when resolving the chaos ability, you may play it only if you haven't played a land yet that turn."
         },
         {
           "date": "2012-06-01",
-          "text": "If you cast a card without paying its mana cost, you can’t pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. If it has {X} in its mana cost, X must be 0. However, you can pay optional additional costs, such as kicker, and you must still pay mandatory additional costs, such as the one on Fling."
+          "text": "If you cast a card without paying its mana cost, you can't pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. If it has {X} in its mana cost, X must be 0. However, you can pay optional additional costs, such as kicker, and you must still pay mandatory additional costs, such as the one on Fling."
         }
       ],
       "subtypes": [
@@ -4925,7 +4929,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Adding loyalty counters to a planeswalker in order to activate a loyalty ability isn’t an effect, so those counters are not doubled."
+          "text": "Adding loyalty counters to a planeswalker in order to activate a loyalty ability isn't an effect, so those counters are not doubled."
         },
         {
           "date": "2012-06-01",
@@ -5025,7 +5029,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "If, during the combat damage step, a creature is destroyed during combat and Ink-Eyes also deals combat damage to a player, the destroyed creature can be a legal target for Ink-Eyes’s ability."
+          "text": "If, during the combat damage step, a creature is destroyed during combat and Ink-Eyes also deals combat damage to a player, the destroyed creature can be a legal target for Ink-Eyes's ability."
         }
       ],
       "subtypes": [
@@ -5091,7 +5095,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Unlike the Vampires in the _Innistrad_(TM) block, Stensia’s ability triggers whenever a creature deals any damage, not just combat damage."
+          "text": "Unlike the Vampires in the _Innistrad_(TM) block, Stensia's ability triggers whenever a creature deals any damage, not just combat damage."
         }
       ],
       "subtypes": [
@@ -5375,7 +5379,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Exiling a nonland card from your hand this way is a special action. It doesn’t use the stack and doesn’t count as casting a spell or activating an ability. Players can’t respond to this action, although they can respond when you cast the spell after the last time counter is removed."
+          "text": "Exiling a nonland card from your hand this way is a special action. It doesn't use the stack and doesn't count as casting a spell or activating an ability. Players can't respond to this action, although they can respond when you cast the spell after the last time counter is removed."
         },
         {
           "date": "2012-06-01",
@@ -5473,7 +5477,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Skullsnatcher’s ability can target zero, one, or two cards in that player’s graveyard."
+          "text": "Skullsnatcher's ability can target zero, one, or two cards in that player's graveyard."
         }
       ],
       "subtypes": [
@@ -5532,15 +5536,15 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Rebound’s delayed triggered ability will let you cast the spell at the beginning of your next upkeep even if the game has left Trail of the Mage-Rings by then."
+          "text": "Rebound's delayed triggered ability will let you cast the spell at the beginning of your next upkeep even if the game has left Trail of the Mage-Rings by then."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2013-04-15",
@@ -5548,23 +5552,23 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2013-04-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2013-04-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2013-04-15",
@@ -5576,7 +5580,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell moves itself into another zone as part of its resolution (as Arc Blade, All Suns’ Dawn, and Beacon of Unrest do), rebound won’t get a chance to apply."
+          "text": "If a spell moves itself into another zone as part of its resolution (as Arc Blade, All Suns' Dawn, and Beacon of Unrest do), rebound won't get a chance to apply."
         },
         {
           "date": "2013-04-15",
@@ -5584,27 +5588,27 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You’ll be able to cast a spell with flashback three times this way. First you can cast it from your hand. It will be exiled due to rebound as it resolves. Then you can cast it from exile due to rebound’s delayed triggered ability. It will be put into your graveyard as it resolves. Then you can cast it from your graveyard due to flashback. It will be exiled due to flashback as it resolves."
+          "text": "You'll be able to cast a spell with flashback three times this way. First you can cast it from your hand. It will be exiled due to rebound as it resolves. Then you can cast it from exile due to rebound's delayed triggered ability. It will be put into your graveyard as it resolves. Then you can cast it from your graveyard due to flashback. It will be exiled due to flashback as it resolves."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast an instant or sorcery spell from your hand and it’s exiled due to rebound, the delayed triggered ability will allow you to cast it during your next upkeep even if Trail of the Mage-Rings has been turned face down by then."
+          "text": "If you cast an instant or sorcery spell from your hand and it's exiled due to rebound, the delayed triggered ability will allow you to cast it during your next upkeep even if Trail of the Mage-Rings has been turned face down by then."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a card from exile “without paying its mana cost,” you can’t pay any alternative costs. Any X in the mana cost will be 0. On the other hand, if the card has optional additional costs (such as kicker or multikicker), you may pay those when you cast the card. If the card has mandatory additional costs (such as Momentous Fall does), you must pay those if you choose to cast the card."
+          "text": "If you cast a card from exile \"without paying its mana cost,\" you can't pay any alternative costs. Any X in the mana cost will be 0. On the other hand, if the card has optional additional costs (such as kicker or multikicker), you may pay those when you cast the card. If the card has mandatory additional costs (such as Momentous Fall does), you must pay those if you choose to cast the card."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell has restrictions on when it can be cast (for example, “Cast [this spell] only during the declare blockers step”), those restrictions may prevent you from casting it from exile during your upkeep."
+          "text": "If a spell has restrictions on when it can be cast (for example, \"Cast [this spell] only during the declare blockers step\"), those restrictions may prevent you from casting it from exile during your upkeep."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a spell using the madness or suspend abilities, you’re casting it from exile, not from your hand. Although those spells will have rebound, the ability won’t have any effect."
+          "text": "If you cast a spell using the madness or suspend abilities, you're casting it from exile, not from your hand. Although those spells will have rebound, the ability won't have any effect."
         },
         {
           "date": "2013-04-15",
-          "text": "Similarly, if you gain control of an instant or sorcery spell with Commandeer, it will have rebound, but the ability won’t do anything because that spell wasn’t cast from your hand."
+          "text": "Similarly, if you gain control of an instant or sorcery spell with Commandeer, it will have rebound, but the ability won't do anything because that spell wasn't cast from your hand."
         }
       ],
       "subtypes": [
@@ -5882,19 +5886,19 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "You can only play the top cards of players’ libraries when you are the planar controller. Generally, this means as long as it’s your turn. When another player begins his or her turn, that player becomes the planar controller and can play the top card of players’ libraries. You won’t be able to until you again become the planar controller."
+          "text": "You can only play the top cards of players' libraries when you are the planar controller. Generally, this means as long as it's your turn. When another player begins his or her turn, that player becomes the planar controller and can play the top card of players' libraries. You won't be able to until you again become the planar controller."
         },
         {
           "date": "2012-06-01",
-          "text": "You may play the top card of any player’s library, including your own. This effect doesn’t change when you can play any of these cards (meaning play it if it’s a land card or cast it if it’s a nonland card). You can still cast creature spells only on your turn during your main phase and so on."
+          "text": "You may play the top card of any player's library, including your own. This effect doesn't change when you can play any of these cards (meaning play it if it's a land card or cast it if it's a nonland card). You can still cast creature spells only on your turn during your main phase and so on."
         },
         {
           "date": "2012-06-01",
-          "text": "If the top card of a player’s library is a land card, you may play it only if you haven’t played a land yet that turn."
+          "text": "If the top card of a player's library is a land card, you may play it only if you haven't played a land yet that turn."
         },
         {
           "date": "2012-06-01",
-          "text": "As soon as you finish playing the card on top of a player’s library, the next card in that library becomes revealed."
+          "text": "As soon as you finish playing the card on top of a player's library, the next card in that library becomes revealed."
         },
         {
           "date": "2012-06-01",
@@ -5902,7 +5906,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Other players won’t be able to play the top card of their libraries unless another effect allows it. If you and another player can play the top card of that player’s library (because of some other effect), you’ll be able to in most cases. This is because you have priority first at the beginning of each phase and step and after each spell or ability resolves. Once you play that card, it immediately moves from that library to the appropriate zone (the battlefield if it’s a land card or the stack if it’s a nonland card). The other player can’t respond by playing that card."
+          "text": "Other players won't be able to play the top card of their libraries unless another effect allows it. If you and another player can play the top card of that player's library (because of some other effect), you'll be able to in most cases. This is because you have priority first at the beginning of each phase and step and after each spell or ability resolves. Once you play that card, it immediately moves from that library to the appropriate zone (the battlefield if it's a land card or the stack if it's a nonland card). The other player can't respond by playing that card."
         }
       ],
       "subtypes": [
@@ -6387,7 +6391,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -6470,6 +6474,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -6500,11 +6508,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its power."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         },
         {
           "date": "2013-04-15",
@@ -6768,7 +6776,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target a creature you already control. You may target a creature that’s already untapped."
+          "text": "You may target a creature you already control. You may target a creature that's already untapped."
         },
         {
           "date": "2009-10-01",
@@ -6851,11 +6859,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "The phrase “up to one” was inadvertently omitted from Mass Mutiny’s rules text. The card has received errata to correct this."
+          "text": "The phrase \"up to one\" was inadvertently omitted from Mass Mutiny's rules text. The card has received errata to correct this."
         },
         {
           "date": "2012-06-01",
-          "text": "You can cast Mass Mutiny even if an opponent doesn’t control any creatures. You simply won’t choose a target for that opponent."
+          "text": "You can cast Mass Mutiny even if an opponent doesn't control any creatures. You simply won't choose a target for that opponent."
         },
         {
           "date": "2012-06-01",
@@ -6863,7 +6871,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it. However, if you gain control of a creature enchanted by an Aura with totem armor and that creature would be destroyed that turn, instead the Aura will be destroyed and the creature will survive."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it. However, if you gain control of a creature enchanted by an Aura with totem armor and that creature would be destroyed that turn, instead the Aura will be destroyed and the creature will survive."
         }
       ],
       "text": "For each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn.",
@@ -7032,7 +7040,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Preyseizer Dragon’s ability counts the number of +1/+1 counters on it when the ability resolves. It counts any +1/+1 counters, not just ones put on it due to devour."
+          "text": "Preyseizer Dragon's ability counts the number of +1/+1 counters on it when the ability resolves. It counts any +1/+1 counters, not just ones put on it due to devour."
         }
       ],
       "subtypes": [
@@ -7127,11 +7135,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If either one of the creatures leaves the battlefield before Rivals’ Duel resolves, no damage is dealt to or by the remaining creature. If both creatures leave the battlefield before Rivals’ Duel resolves, the spell is countered for having no legal targets."
+          "text": "If either one of the creatures leaves the battlefield before Rivals' Duel resolves, no damage is dealt to or by the remaining creature. If both creatures leave the battlefield before Rivals' Duel resolves, the spell is countered for having no legal targets."
         },
         {
           "date": "2008-04-01",
-          "text": "If, by the time Rivals’ Duel resolves, an effect has caused the two target creatures to share a creature type, Rivals’ Duel is countered for having no legal targets."
+          "text": "If, by the time Rivals' Duel resolves, an effect has caused the two target creatures to share a creature type, Rivals' Duel is countered for having no legal targets."
         }
       ],
       "text": "Choose two target creatures that share no creature types. Those creatures fight each other. (Each deals damage equal to its power to the other.)",
@@ -7223,15 +7231,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         }
       ],
       "subtypes": [
@@ -7328,15 +7336,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         }
       ],
       "subtypes": [
@@ -7426,11 +7434,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it’s no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
+          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it's no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2011-09-22",
-          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn’t target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
+          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn't target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to target creature or player.",
@@ -7518,11 +7526,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The power of each potential blocking creature is checked against Aura Gnarlid’s power only as blockers are declared. Once a creature blocks Aura Gnarlid, increasing the Gnarlid’s power or decreasing the blocking creature’s power won’t undo that block."
+          "text": "The power of each potential blocking creature is checked against Aura Gnarlid's power only as blockers are declared. Once a creature blocks Aura Gnarlid, increasing the Gnarlid's power or decreasing the blocking creature's power won't undo that block."
         },
         {
           "date": "2010-06-15",
-          "text": "Aura Gnarlid’s second ability counts each Aura regardless of who controls it."
+          "text": "Aura Gnarlid's second ability counts each Aura regardless of who controls it."
         }
       ],
       "subtypes": [
@@ -7698,7 +7706,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent’s controller won’t get a Beast token."
+          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent's controller won't get a Beast token."
         },
         {
           "date": "2013-07-01",
@@ -7789,11 +7797,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -7801,15 +7809,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -7817,15 +7825,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -8336,11 +8344,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Dreampod Druid’s ability checks to see if it’s enchanted at the beginning of each upkeep. If it’s not, the ability won’t trigger. If the ability triggers but Dreampod Druid isn’t enchanted when that ability resolves, the ability will do nothing."
+          "text": "Dreampod Druid's ability checks to see if it's enchanted at the beginning of each upkeep. If it's not, the ability won't trigger. If the ability triggers but Dreampod Druid isn't enchanted when that ability resolves, the ability will do nothing."
         },
         {
           "date": "2012-06-01",
-          "text": "Notably, if Dreampod Druid leaves the battlefield while its ability is on the stack, that ability will use Dreampod Druid’s last known information to determine whether or not it was enchanted. If it was enchanted when it left the battlefield, the ability will resolve and create a Saproling."
+          "text": "Notably, if Dreampod Druid leaves the battlefield while its ability is on the stack, that ability will use Dreampod Druid's last known information to determine whether or not it was enchanted. If it was enchanted when it left the battlefield, the ability will resolve and create a Saproling."
         }
       ],
       "subtypes": [
@@ -8693,19 +8701,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         },
         {
           "date": "2008-10-01",
-          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn’t matter where the +1/+1 counters came from."
+          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn't matter where the +1/+1 counters came from."
         }
       ],
       "subtypes": [
@@ -8881,7 +8889,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t activate this ability unless a single opponent has at least two cards in their graveyard to target."
+          "text": "You can't activate this ability unless a single opponent has at least two cards in their graveyard to target."
         }
       ],
       "subtypes": [
@@ -9078,7 +9086,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -9257,11 +9265,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the enchanted creature’s ability is activated, that creature is the one that will deal and be dealt damage when the ability resolves. It doesn’t matter if Predatory Urge leaves the battlefield or somehow becomes attached to another creature by that time."
+          "text": "If the enchanted creature's ability is activated, that creature is the one that will deal and be dealt damage when the ability resolves. It doesn't matter if Predatory Urge leaves the battlefield or somehow becomes attached to another creature by that time."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature leaves the battlefield (or otherwise becomes an illegal target) before the ability resolves, the ability is countered. The enchanted creature isn’t dealt damage."
+          "text": "If the targeted creature leaves the battlefield (or otherwise becomes an illegal target) before the ability resolves, the ability is countered. The enchanted creature isn't dealt damage."
         },
         {
           "date": "2009-10-01",
@@ -9359,11 +9367,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you choose the “destroy” mode and Quiet Disrepair is moved to a different permanent while the ability is on the stack, the newly enchanted permanent will be destroyed when the ability resolves."
+          "text": "If you choose the \"destroy\" mode and Quiet Disrepair is moved to a different permanent while the ability is on the stack, the newly enchanted permanent will be destroyed when the ability resolves."
         },
         {
           "date": "2007-05-01",
-          "text": "If you choose the “destroy” mode and Quiet Disrepair leaves the battlefield while the ability is on the stack, the last permanent it enchanted will be destroyed."
+          "text": "If you choose the \"destroy\" mode and Quiet Disrepair leaves the battlefield while the ability is on the stack, the last permanent it enchanted will be destroyed."
         }
       ],
       "subtypes": [
@@ -9458,7 +9466,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -9549,7 +9557,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -9640,11 +9648,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -9652,15 +9660,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -9668,11 +9676,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2010-06-15",
-          "text": "Snake Umbra grants the triggered ability to the creature. It triggers whenever the enchanted creature deals damage to an opponent of its controller (who is not necessarily an opponent of the Aura’s controller). In other words, if your Snake Umbra winds up enchanting your opponent’s creature, that opponent will draw a card whenever that creature damages you."
+          "text": "Snake Umbra grants the triggered ability to the creature. It triggers whenever the enchanted creature deals damage to an opponent of its controller (who is not necessarily an opponent of the Aura's controller). In other words, if your Snake Umbra winds up enchanting your opponent's creature, that opponent will draw a card whenever that creature damages you."
         },
         {
           "date": "2010-06-15",
@@ -9680,11 +9688,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -10147,11 +10155,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -10263,11 +10271,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -10380,11 +10388,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -10562,7 +10570,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "The triggered ability won’t be affected if the spell that caused it to trigger is countered."
+          "text": "The triggered ability won't be affected if the spell that caused it to trigger is countered."
         }
       ],
       "subtypes": [
@@ -10647,11 +10655,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "None of Elderwood Scion’s abilities affect abilities that target it."
+          "text": "None of Elderwood Scion's abilities affect abilities that target it."
         },
         {
           "date": "2012-06-01",
-          "text": "Aura spells require a target when they are cast. Elderwood Scion’s cost-reduction ability will affect Aura spells cast targeting it."
+          "text": "Aura spells require a target when they are cast. Elderwood Scion's cost-reduction ability will affect Aura spells cast targeting it."
         },
         {
           "date": "2012-06-01",
@@ -10659,11 +10667,11 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Elderwood Scion’s cost-reduction ability can’t reduce the colored mana requirement of a spell."
+          "text": "Elderwood Scion's cost-reduction ability can't reduce the colored mana requirement of a spell."
         },
         {
           "date": "2012-06-01",
-          "text": "Elderwood Scion’s cost-reduction ability can apply to any cost of a spell, including additional or alternative costs."
+          "text": "Elderwood Scion's cost-reduction ability can apply to any cost of a spell, including additional or alternative costs."
         }
       ],
       "subtypes": [
@@ -10774,23 +10782,23 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2009-05-01",
-          "text": "After Enigma Sphinx’s middle ability triggers, if Enigma Sphinx is removed from your graveyard in response, it won’t be put into your library."
+          "text": "After Enigma Sphinx's middle ability triggers, if Enigma Sphinx is removed from your graveyard in response, it won't be put into your library."
         },
         {
           "date": "2009-05-01",
-          "text": "If you have zero or one card left in your library when Enigma Sphinx’s middle ability resolves, Enigma Sphinx is put on the bottom of your library."
+          "text": "If you have zero or one card left in your library when Enigma Sphinx's middle ability resolves, Enigma Sphinx is put on the bottom of your library."
         },
         {
           "date": "2009-05-01",
-          "text": "If you control an Enigma Sphinx that’s owned by another player, it’s put into that player’s graveyard from the battlefield, so Enigma Sphinx’s middle ability won’t trigger."
+          "text": "If you control an Enigma Sphinx that's owned by another player, it's put into that player's graveyard from the battlefield, so Enigma Sphinx's middle ability won't trigger."
         },
         {
           "date": "2017-04-18",
@@ -10905,11 +10913,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -10999,7 +11007,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Etherium-Horn Sorcerer’s first ability can only be activated when it is on the battlefield. If Etherium-Horn Sorcerer isn’t on the battlefield when the ability resolves, the ability won’t do anything."
+          "text": "Etherium-Horn Sorcerer's first ability can only be activated when it is on the battlefield. If Etherium-Horn Sorcerer isn't on the battlefield when the ability resolves, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -11366,7 +11374,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Hellkite Hatchling has flying and trample if at least one creature was sacrificed as a result of the Hatchling’s devour ability as it entered the battlefield. It retains those abilities even if its +1/+1 counters are somehow removed."
+          "text": "Hellkite Hatchling has flying and trample if at least one creature was sacrificed as a result of the Hatchling's devour ability as it entered the battlefield. It retains those abilities even if its +1/+1 counters are somehow removed."
         },
         {
           "date": "2009-02-01",
@@ -11457,7 +11465,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If, during a player’s declare blockers step, a creature is tapped or it’s affected by a spell or ability that says it can’t block, then it doesn’t block. If there’s a cost associated with having a creature block, its controller isn’t forced to pay that cost. The creature doesn’t have to block."
+          "text": "If, during a player's declare blockers step, a creature is tapped or it's affected by a spell or ability that says it can't block, then it doesn't block. If there's a cost associated with having a creature block, its controller isn't forced to pay that cost. The creature doesn't have to block."
         }
       ],
       "subtypes": [
@@ -11550,15 +11558,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An “unblocked creature” is a creature that attacked and wasn’t blocked. Creatures aren’t “blocked” or “unblocked” until the declare blockers step, so activating this ability before then (or after combat ends) will have no effect."
+          "text": "An \"unblocked creature\" is a creature that attacked and wasn't blocked. Creatures aren't \"blocked\" or \"unblocked\" until the declare blockers step, so activating this ability before then (or after combat ends) will have no effect."
         },
         {
           "date": "2008-05-01",
-          "text": "Creatures stop being unblocked as the combat phase ends. However, they’ll stay 4/1 until turn ends."
+          "text": "Creatures stop being unblocked as the combat phase ends. However, they'll stay 4/1 until turn ends."
         },
         {
           "date": "2008-05-01",
-          "text": "Inkfathom Witch doesn’t cause creatures to lose their abilities."
+          "text": "Inkfathom Witch doesn't cause creatures to lose their abilities."
         },
         {
           "date": "2008-05-01",
@@ -11566,7 +11574,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -11676,11 +11684,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -11770,7 +11778,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If Krond isn’t enchanted when it’s declared as an attacking creature, the ability won’t trigger. If Krond isn’t enchanted when the ability resolves, the ability won’t do anything."
+          "text": "If Krond isn't enchanted when it's declared as an attacking creature, the ability won't trigger. If Krond isn't enchanted when the ability resolves, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -11953,7 +11961,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "No matter what spell you cast with the first cascade trigger (or with any cascade triggers that result from casting that spell), the second cascade trigger will look for a spell with converted mana cost less than Maelstrom Wanderer’s converted mana cost of 8."
+          "text": "No matter what spell you cast with the first cascade trigger (or with any cascade triggers that result from casting that spell), the second cascade trigger will look for a spell with converted mana cost less than Maelstrom Wanderer's converted mana cost of 8."
         }
       ],
       "subtypes": [
@@ -12301,15 +12309,15 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If you cast a permanent spell this way, it will enter the battlefield under your control when it resolves. If you cast an instant or sorcery spell this way, that card will be put into its owner’s graveyard when it resolves."
+          "text": "If you cast a permanent spell this way, it will enter the battlefield under your control when it resolves. If you cast an instant or sorcery spell this way, that card will be put into its owner's graveyard when it resolves."
         },
         {
           "date": "2012-06-01",
-          "text": "The nonland card you cast via the triggered ability is cast as part of the resolution of that ability. Timing restrictions based on the card’s type are ignored. Other restrictions, such as “Cast [this card] only during an opponent’s turn,” are not."
+          "text": "The nonland card you cast via the triggered ability is cast as part of the resolution of that ability. Timing restrictions based on the card's type are ignored. Other restrictions, such as \"Cast [this card] only during an opponent's turn,\" are not."
         },
         {
           "date": "2012-06-01",
-          "text": "If you cast a card without paying its mana cost, you can’t pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. If it has {X} in its mana cost, X must be 0. However, you can pay optional additional costs, such as kicker, and you must still pay mandatory additional costs, such as the one on Fling."
+          "text": "If you cast a card without paying its mana cost, you can't pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. If it has {X} in its mana cost, X must be 0. However, you can pay optional additional costs, such as kicker, and you must still pay mandatory additional costs, such as the one on Fling."
         }
       ],
       "subtypes": [
@@ -12664,7 +12672,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Each instance of each creature’s combat damage is counted separately. If three creatures with double strike attack you and all of them are unblocked, you may draw up to six cards."
+          "text": "Each instance of each creature's combat damage is counted separately. If three creatures with double strike attack you and all of them are unblocked, you may draw up to six cards."
         }
       ],
       "text": "Whenever a source an opponent controls deals damage to you, if Farsight Mask is untapped, you may draw a card.",
@@ -12814,11 +12822,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "In non-Planechase games, Fractured Powerstone’s second ability will have no effect."
+          "text": "In non-Planechase games, Fractured Powerstone's second ability will have no effect."
         },
         {
           "date": "2012-06-01",
-          "text": "Rolling the planar die this way doesn’t count when determining the cost of the special action of rolling the planar die. For example, if you roll the planar die twice in a turn, then activate Fractured Powerstone to roll it a third time, rolling the planar die again that turn will cost {2}."
+          "text": "Rolling the planar die this way doesn't count when determining the cost of the special action of rolling the planar die. For example, if you roll the planar die twice in a turn, then activate Fractured Powerstone to roll it a third time, rolling the planar die again that turn will cost {2}."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}: Roll the planar die. Activate this ability only any time you could cast a sorcery.",
@@ -12898,7 +12906,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "That player loses half his or her life after combat damage has been subtracted from the player’s life total. The amount of life the player loses is determined as the triggered ability resolves."
+          "text": "That player loses half his or her life after combat damage has been subtracted from the player's life total. The amount of life the player loses is determined as the triggered ability resolves."
         },
         {
           "date": "2008-10-01",
@@ -12906,7 +12914,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, if a creature equipped with Quietus Spike would assign combat damage to the defending team, its damage is assigned to only one of the defending players. After combat damage is dealt, Quietus Spike looks at that player’s life total (which is the same as the team’s life total) when determining how much life the team will lose, which basically means the team’s life total is halved. Here’s an example of the math: The team has 19 life, so the player has 19 life. Quietus Spike causes the team to lose 10 life (19 divided by 2, rounded up). The team’s life total becomes 9 (19 minus 10)."
+          "text": "In a Two-Headed Giant game, if a creature equipped with Quietus Spike would assign combat damage to the defending team, its damage is assigned to only one of the defending players. After combat damage is dealt, Quietus Spike looks at that player's life total (which is the same as the team's life total) when determining how much life the team will lose, which basically means the team's life total is halved. Here's an example of the math: The team has 19 life, so the player has 19 life. Quietus Spike causes the team to lose 10 life (19 divided by 2, rounded up). The team's life total becomes 9 (19 minus 10)."
         }
       ],
       "subtypes": [
@@ -12981,7 +12989,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If you choose not to attach Sai of the Shinobi to the creature, or if you can’t (perhaps because the creature has protection from artifacts or has left the battlefield by the time the trigger resolves), Sai of the Shinobi doesn’t move."
+          "text": "If you choose not to attach Sai of the Shinobi to the creature, or if you can't (perhaps because the creature has protection from artifacts or has left the battlefield by the time the trigger resolves), Sai of the Shinobi doesn't move."
         }
       ],
       "subtypes": [
@@ -13316,23 +13324,23 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-02-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there are more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there are more than one, consider them in any possible order."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Exotic Orchard doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Lands that produce mana based only on what other lands “could produce” won’t help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent’s Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent’s Reflecting Pool can each produce {G} because your opponent’s Exotic Orchard can produce {G}."
+          "text": "Lands that produce mana based only on what other lands \"could produce\" won't help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent's Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent's Reflecting Pool can each produce {G} because your opponent's Exotic Orchard can produce {G}."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
@@ -21702,31 +21710,6 @@
         {
           "language": "Italian",
           "name": "Foresta",
-          "multiverseid": 288295
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288297
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288301
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288305
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288308
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
           "multiverseid": 288309
         },
         {
@@ -21763,6 +21746,31 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 288139
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288141
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288145
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288149
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288152
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288153
         }
       ],
       "id": "1a9ae3a4303b6aad3735354e5f1db2d51834e7b4",
@@ -22087,31 +22095,6 @@
         {
           "language": "Italian",
           "name": "Foresta",
-          "multiverseid": 288295
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288297
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288301
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288305
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288308
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
           "multiverseid": 288309
         },
         {
@@ -22148,6 +22131,31 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 288139
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288141
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288145
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288149
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288152
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288153
         }
       ],
       "id": "36ca89675a148ba15bbbbfe4c1be8e6a53ce3b6c",
@@ -22472,31 +22480,6 @@
         {
           "language": "Italian",
           "name": "Foresta",
-          "multiverseid": 288295
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288297
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288301
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288305
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288308
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
           "multiverseid": 288309
         },
         {
@@ -22533,6 +22516,31 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 288139
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288141
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288145
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288149
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288152
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288153
         }
       ],
       "id": "f961281d4be61086bc67d767c19ca16d79cdace5",
@@ -22857,31 +22865,6 @@
         {
           "language": "Italian",
           "name": "Foresta",
-          "multiverseid": 288295
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288297
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288301
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288305
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
-          "multiverseid": 288308
-        },
-        {
-          "language": "Italian",
-          "name": "Foresta",
           "multiverseid": 288309
         },
         {
@@ -22918,6 +22901,31 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 288139
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288141
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288145
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288149
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288152
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 288153
         }
       ],
       "id": "8ed94a68f441c63e5d2c301a363670b6d5270be7",

--- a/json/PCA.json
+++ b/json/PCA.json
@@ -74,11 +74,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "While Chaotic Aether’s effect applies, rolling any blank face of the planar die will cause chaos abilities to trigger."
+          "text": "While Chaotic Aether's effect applies, rolling any blank face of the planar die will cause chaos abilities to trigger."
         },
         {
           "date": "2012-06-01",
-          "text": "Planeswalking away from a phenomenon (as you do when resolving Chaotic Aether’s ability) doesn’t cause Chaotic Aether’s effect to expire."
+          "text": "Planeswalking away from a phenomenon (as you do when resolving Chaotic Aether's ability) doesn't cause Chaotic Aether's effect to expire."
         }
       ],
       "text": "When you encounter Chaotic Aether, each blank roll of the planar die is a CHAOS roll until a player planeswalks away from a plane. (Then planeswalk away from this phenomenon.)",
@@ -169,7 +169,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "The plane card you put on top of your planar deck is the one you’ll planeswalk to after planeswalking away from Interplanar Tunnel."
+          "text": "The plane card you put on top of your planar deck is the one you'll planeswalk to after planeswalking away from Interplanar Tunnel."
         }
       ],
       "text": "When you encounter Interplanar Tunnel, reveal cards from the top of your planar deck until you reveal five plane cards. Put a plane card from among them on top of your planar deck, then put the rest of the revealed cards on the bottom in a random order. (Then planeswalk away from this phenomenon.)",
@@ -228,7 +228,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Any Aura card you find must be able to enchant Auratouched Mage as it currently exists, or as it most recently existed on the battlefield if it’s no longer on the battlefield. If an effect has made the Mage an artifact, for example, you could search for an Aura with “enchant artifact.”"
+          "text": "Any Aura card you find must be able to enchant Auratouched Mage as it currently exists, or as it most recently existed on the battlefield if it's no longer on the battlefield. If an effect has made the Mage an artifact, for example, you could search for an Aura with \"enchant artifact.\""
         }
       ],
       "subtypes": [
@@ -268,19 +268,19 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Cards such as Sakashima’s Student that can enter the battlefield as a copy of another permanent won’t be able to enter the battlefield as a copy of a permanent that’s entering the battlefield at the same time."
+          "text": "Cards such as Sakashima's Student that can enter the battlefield as a copy of another permanent won't be able to enter the battlefield as a copy of a permanent that's entering the battlefield at the same time."
         },
         {
           "date": "2012-06-01",
-          "text": "After all permanents are put onto the battlefield and you planeswalk away from Morphic Tide, any abilities that triggered from those permanents entering the battlefield, from the previous generation of permanents leaving the battlefield, and from the new plane or phenomenon will be put onto the stack. You’ll put all of your triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
+          "text": "After all permanents are put onto the battlefield and you planeswalk away from Morphic Tide, any abilities that triggered from those permanents entering the battlefield, from the previous generation of permanents leaving the battlefield, and from the new plane or phenomenon will be put onto the stack. You'll put all of your triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
         },
         {
           "date": "2012-06-01",
-          "text": "The permanents will enter the battlefield while Morphic Tide is face up. This means the game won’t be on any plane when determining if any abilities trigger because those permanents entered the battlefield, for example. However, you’ll planeswalk away from Morphic Tide before any such abilities are put on the stack. After you turn the next card of the planar deck face up, any abilities that triggered during the resolution of Morphic Tide (including any abilities that triggered because you encountered another phenomenon or planeswalked to the next plane) will be put on the stack. The planar controller will put his or her abilities on the stack in any order, followed by each other player in turn order. The last ability put on the stack will be the first one to resolve."
+          "text": "The permanents will enter the battlefield while Morphic Tide is face up. This means the game won't be on any plane when determining if any abilities trigger because those permanents entered the battlefield, for example. However, you'll planeswalk away from Morphic Tide before any such abilities are put on the stack. After you turn the next card of the planar deck face up, any abilities that triggered during the resolution of Morphic Tide (including any abilities that triggered because you encountered another phenomenon or planeswalked to the next plane) will be put on the stack. The planar controller will put his or her abilities on the stack in any order, followed by each other player in turn order. The last ability put on the stack will be the first one to resolve."
         },
         {
           "date": "2012-06-01",
-          "text": "Token permanents a player owns will count toward the number of cards that player reveals. They’ll be shuffled into that player’s library and subsequently cease to exist. A token’s owner is the player under whose control it first entered the battlefield."
+          "text": "Token permanents a player owns will count toward the number of cards that player reveals. They'll be shuffled into that player's library and subsequently cease to exist. A token's owner is the player under whose control it first entered the battlefield."
         }
       ],
       "text": "When you encounter Morphic Tide, each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, land, and planeswalker cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of his or her library in any order. (Then planeswalk away from this phenomenon.)",
@@ -486,11 +486,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If Felidar Umbra is enchanting a creature with first strike, you can activate its ability and attach it to a creature without first strike during the first combat damage step. Each of those creatures will have lifelink when dealing combat damage and you’ll gain life accordingly."
+          "text": "If Felidar Umbra is enchanting a creature with first strike, you can activate its ability and attach it to a creature without first strike during the first combat damage step. Each of those creatures will have lifelink when dealing combat damage and you'll gain life accordingly."
         },
         {
           "date": "2012-06-01",
-          "text": "It’s not possible for Felidar Umbra to save two creatures that are being destroyed simultaneously."
+          "text": "It's not possible for Felidar Umbra to save two creatures that are being destroyed simultaneously."
         }
       ],
       "subtypes": [
@@ -520,11 +520,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "First, you may put a permanent card onto the battlefield, then each other player in turn order may do the same. Cards such as Sakashima’s Student that can enter the battlefield as a copy of another creature could copy a creature put onto the battlefield earlier in the resolution of the ability."
+          "text": "First, you may put a permanent card onto the battlefield, then each other player in turn order may do the same. Cards such as Sakashima's Student that can enter the battlefield as a copy of another creature could copy a creature put onto the battlefield earlier in the resolution of the ability."
         },
         {
           "date": "2012-06-01",
-          "text": "Each player will know what permanent cards were put onto the battlefield earlier in the ability’s resolution."
+          "text": "Each player will know what permanent cards were put onto the battlefield earlier in the ability's resolution."
         },
         {
           "date": "2012-06-01",
@@ -532,7 +532,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "After all permanents are put onto the battlefield and you planeswalk away from Reality Shaping, any abilities that triggered from those permanents entering the battlefield will be put onto the stack. You’ll put all of your triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
+          "text": "After all permanents are put onto the battlefield and you planeswalk away from Reality Shaping, any abilities that triggered from those permanents entering the battlefield will be put onto the stack. You'll put all of your triggered abilities on the stack in any order, then each other player in turn order will do the same. (The last ability put on the stack will be the first one that resolves.)"
         }
       ],
       "text": "When you encounter Reality Shaping, starting with you, each player may put a permanent card from his or her hand onto the battlefield. (Then planeswalk away from this phenomenon.)",
@@ -599,7 +599,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -634,7 +634,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "The next time a player planeswalks, he or she planeswalks away from both planes. Their owner puts them on the bottom of his or her planar deck in an order of his or her choice. This order isn’t revealed to other players."
+          "text": "The next time a player planeswalks, he or she planeswalks away from both planes. Their owner puts them on the bottom of his or her planar deck in an order of his or her choice. This order isn't revealed to other players."
         }
       ],
       "text": "When you encounter Spatial Merging, reveal cards from the top of your planar deck until you reveal two plane cards. Simultaneously planeswalk to both of them. Put all other cards revealed this way on the bottom of your planar deck in any order.",
@@ -692,11 +692,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -704,15 +704,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -720,15 +720,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -766,7 +766,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If the game’s turn order is reversed again, it will return to the default order used at the beginning of the game."
+          "text": "If the game's turn order is reversed again, it will return to the default order used at the beginning of the game."
         }
       ],
       "text": "When you encounter Time Distortion, reverse the game's turn order. (For example, if play had proceeded clockwise around the table, it now goes counterclockwise. Then planeswalk away from this phenomenon.)",
@@ -826,7 +826,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an Aura spell, Kor Spiritdancer’s second ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an Aura spell, Kor Spiritdancer's second ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         },
         {
           "date": "2010-06-15",
@@ -862,27 +862,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Academy at Tolaria West’s first ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you have no cards in hand as your end step begins, and (2) the ability will do nothing unless you have no cards in hand by the time it resolves."
+          "text": "Academy at Tolaria West's first ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you have no cards in hand as your end step begins, and (2) the ability will do nothing unless you have no cards in hand by the time it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "If you discard your hand as a result of rolling {CHAOS}, Academy at Tolaria West’s first ability will then trigger at the beginning of your end step (unless you planeswalk or somehow put a card in your hand before then)."
+          "text": "If you discard your hand as a result of rolling {CHAOS}, Academy at Tolaria West's first ability will then trigger at the beginning of your end step (unless you planeswalk or somehow put a card in your hand before then)."
         }
       ],
       "subtypes": [
@@ -943,11 +943,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -955,15 +955,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -971,15 +971,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -1013,27 +1013,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The first ability of The Aether Flues doesn’t target a creature. You don’t choose a creature to sacrifice until the ability resolves. Once you choose a creature to sacrifice, it’s too late for players to respond."
+          "text": "The first ability of The Aether Flues doesn't target a creature. You don't choose a creature to sacrifice until the ability resolves. Once you choose a creature to sacrifice, it's too late for players to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the first ability of The Aether Flues but there are no creatures in your library, you’ll reveal your entire library then shuffle it."
+          "text": "If you use the first ability of The Aether Flues but there are no creatures in your library, you'll reveal your entire library then shuffle it."
         }
       ],
       "subtypes": [
@@ -1101,11 +1101,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can’t play an Aura spell intending to enchant the Angel that will be created as a result."
+          "text": "When you cast an Aura spell, you have to choose a target for it before this ability puts an Angel token onto the battlefield. In other words, you can't play an Aura spell intending to enchant the Angel that will be created as a result."
         },
         {
           "date": "2009-02-01",
-          "text": "Casting Sigil of the Empty Throne won’t trigger its own ability. It has to be on the battlefield for its ability to work."
+          "text": "Casting Sigil of the Empty Throne won't trigger its own ability. It has to be on the battlefield for its ability to work."
         }
       ],
       "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
@@ -1132,27 +1132,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Agyrem’s first and second abilities each set up a delayed triggered ability. These abilities will trigger at the beginning of the next end step even if Agyrem is no longer the face-up plane card."
+          "text": "Agyrem's first and second abilities each set up a delayed triggered ability. These abilities will trigger at the beginning of the next end step even if Agyrem is no longer the face-up plane card."
         },
         {
           "date": "2009-10-01",
-          "text": "Agyrem’s first ability will return a card to the battlefield only if it’s still in the graveyard by the time the delayed triggered ability resolves. Similarly, Agyrem’s second ability will return a card to its owner’s hand only if it’s still in the graveyard by the time the delayed triggered ability resolves."
+          "text": "Agyrem's first ability will return a card to the battlefield only if it's still in the graveyard by the time the delayed triggered ability resolves. Similarly, Agyrem's second ability will return a card to its owner's hand only if it's still in the graveyard by the time the delayed triggered ability resolves."
         },
         {
           "date": "2009-10-01",
@@ -1160,19 +1160,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A creature that caused either of Agyrem’s first two abilities to trigger will be returned at the beginning of the next end step even if it’s not a creature card. (For example, if it’s a Treetop Village.)"
+          "text": "A creature that caused either of Agyrem's first two abilities to trigger will be returned at the beginning of the next end step even if it's not a creature card. (For example, if it's a Treetop Village.)"
         },
         {
           "date": "2009-10-01",
-          "text": "If a token creature is put into a graveyard from the battlefield, one of Agyrem’s first two abilities will trigger, but the token will cease to exist long before it would be returned somewhere."
+          "text": "If a token creature is put into a graveyard from the battlefield, one of Agyrem's first two abilities will trigger, but the token will cease to exist long before it would be returned somewhere."
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple creatures are put into their owners’ graveyards at the same time (due to combat damage or Planar Cleansing, for example), Agyrem’s first two abilities trigger that many times. At the beginning of the next end step, the player whose turn it is at that time puts all of his or her Agyrem delayed triggered abilities on the stack in any order, then each other player in turn order does the same. The last ability put on the stack is the first one that resolves. The creatures are returned one at a time."
+          "text": "If multiple creatures are put into their owners' graveyards at the same time (due to combat damage or Planar Cleansing, for example), Agyrem's first two abilities trigger that many times. At the beginning of the next end step, the player whose turn it is at that time puts all of his or her Agyrem delayed triggered abilities on the stack in any order, then each other player in turn order does the same. The last ability put on the stack is the first one that resolves. The creatures are returned one at a time."
         },
         {
           "date": "2009-10-01",
-          "text": "If you’re affected by the chaos ability, creatures will still be able to attack planeswalkers you control."
+          "text": "If you're affected by the chaos ability, creatures will still be able to attack planeswalkers you control."
         }
       ],
       "subtypes": [
@@ -1254,11 +1254,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "A creature that’s enchanted can’t be chosen as the target of the chaos ability."
+          "text": "A creature that's enchanted can't be chosen as the target of the chaos ability."
         },
         {
           "date": "2012-06-01",
-          "text": "If a creature that isn’t enchanted is targeted by the chaos ability, but that creature is enchanted when that ability tries to resolve, the ability will be countered for having an illegal target."
+          "text": "If a creature that isn't enchanted is targeted by the chaos ability, but that creature is enchanted when that ability tries to resolve, the ability will be countered for having an illegal target."
         }
       ],
       "subtypes": [
@@ -1425,7 +1425,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Astral Arena’s abilities stop more than one creature from being declared as an attacker or as a blocker each combat. However, it doesn’t affect creatures that are put onto the battlefield attacking or blocking."
+          "text": "Astral Arena's abilities stop more than one creature from being declared as an attacker or as a blocker each combat. However, it doesn't affect creatures that are put onto the battlefield attacking or blocking."
         },
         {
           "date": "2012-06-01",
@@ -1481,6 +1481,10 @@
         },
         {
           "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -1545,19 +1549,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -1565,7 +1569,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2009-10-01",
@@ -1573,7 +1577,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2009-10-01",
@@ -1581,7 +1585,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         },
         {
           "date": "2013-07-01",
@@ -1589,7 +1593,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If all divinity counters on a creature are moved to a different creature, the indestructible ability doesn’t move along with them. The first creature no longer has indestructible because it no longer has a divinity counter on it. The second creature doesn’t have indestructible because the chaos ability didn’t target it."
+          "text": "If all divinity counters on a creature are moved to a different creature, the indestructible ability doesn't move along with them. The first creature no longer has indestructible because it no longer has a divinity counter on it. The second creature doesn't have indestructible because the chaos ability didn't target it."
         }
       ],
       "subtypes": [
@@ -1674,7 +1678,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If a creature you’ve gained control of temporarily (because of Act of Treason, for example) is exiled and returns to the battlefield under your control, you will control that creature indefinitely."
+          "text": "If a creature you've gained control of temporarily (because of Act of Treason, for example) is exiled and returns to the battlefield under your control, you will control that creature indefinitely."
         }
       ],
       "subtypes": [
@@ -1819,7 +1823,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "If Higure deals regular combat damage and you use its ability to search for another Ninja, that card won’t be in your hand in time to activate its ninjutsu ability to put it onto the battlefield and deal damage. However, the card you searched for could still be swapped for an unblocked creature, including Higure, as long as you activate its ninjutsu ability before the end of combat."
+          "text": "If Higure deals regular combat damage and you use its ability to search for another Ninja, that card won't be in your hand in time to activate its ninjutsu ability to put it onto the battlefield and deal damage. However, the card you searched for could still be swapped for an unblocked creature, including Higure, as long as you activate its ninjutsu ability before the end of combat."
         },
         {
           "date": "2005-02-01",
@@ -1858,23 +1862,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "For two players to exchange life totals, what actually happens is that each player gains or loses the amount of life necessary to equal the other player’s previous life total. For example, if Player A has 5 life and Player B has 3 life before the exchange, Player A will lose 2 life and Player B will gain 2 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For two players to exchange life totals, what actually happens is that each player gains or loses the amount of life necessary to equal the other player's previous life total. For example, if Player A has 5 life and Player B has 3 life before the exchange, Player A will lose 2 life and Player B will gain 2 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2009-10-01",
@@ -1890,7 +1894,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If either permanent targeted by the chaos ability is an illegal target by the time the ability resolves, the exchange doesn’t happen. If both targets become illegal, the ability is countered."
+          "text": "If either permanent targeted by the chaos ability is an illegal target by the time the ability resolves, the exchange doesn't happen. If both targets become illegal, the ability is countered."
         }
       ],
       "subtypes": [
@@ -1949,11 +1953,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Notably, if you exile Illusory Angel because of a cascade ability of a spell with converted mana cost 4 or greater, you’ll be able to cast Illusory Angel."
+          "text": "Notably, if you exile Illusory Angel because of a cascade ability of a spell with converted mana cost 4 or greater, you'll be able to cast Illusory Angel."
         },
         {
           "date": "2014-07-18",
-          "text": "It doesn’t matter whether the other spell resolved. It could have been countered or, if you’ve somehow cast Illusory Angel as though it had flash, it could still be on the stack."
+          "text": "It doesn't matter whether the other spell resolved. It could have been countered or, if you've somehow cast Illusory Angel as though it had flash, it could still be on the stack."
         }
       ],
       "subtypes": [
@@ -1985,23 +1989,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The Dark Barony’s first ability doesn’t behave like a leaves-the-battlefield triggered ability, since the card put into a graveyard may come from anywhere. If a card is put into a graveyard from the battlefield, its color is checked in the graveyard, not as it last existed on the battlefield."
+          "text": "The Dark Barony's first ability doesn't behave like a leaves-the-battlefield triggered ability, since the card put into a graveyard may come from anywhere. If a card is put into a graveyard from the battlefield, its color is checked in the graveyard, not as it last existed on the battlefield."
         }
       ],
       "subtypes": [
@@ -2089,15 +2093,15 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "While Edge of Malacol is face up, the normal turn-based action of untapping your creatures is replaced. Those creatures won’t untap. Other tapped permanents you control will untap as normal."
+          "text": "While Edge of Malacol is face up, the normal turn-based action of untapping your creatures is replaced. Those creatures won't untap. Other tapped permanents you control will untap as normal."
         },
         {
           "date": "2012-06-01",
-          "text": "Other spells and abilities can untap creatures as normal. In that case, they’ll just untap. You won’t put any +1/+1 counters on them."
+          "text": "Other spells and abilities can untap creatures as normal. In that case, they'll just untap. You won't put any +1/+1 counters on them."
         },
         {
           "date": "2012-06-01",
-          "text": "If you untap a creature you control during another player’s untap step (perhaps due to Seedborn Muse’s ability), that creature will untap normally. You won’t put any +1/+1 counters on it."
+          "text": "If you untap a creature you control during another player's untap step (perhaps due to Seedborn Muse's ability), that creature will untap normally. You won't put any +1/+1 counters on it."
         }
       ],
       "subtypes": [
@@ -2186,27 +2190,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "You’re “tapping a permanent for mana” only if you’re activating an activated ability of that permanent that includes the {T} symbol in its cost and produces mana as part of its effect."
+          "text": "You're \"tapping a permanent for mana\" only if you're activating an activated ability of that permanent that includes the {T} symbol in its cost and produces mana as part of its effect."
         },
         {
           "date": "2009-10-01",
-          "text": "Eloren Wilds’s first ability affects any permanent players tap for mana, not just lands they tap for mana."
+          "text": "Eloren Wilds's first ability affects any permanent players tap for mana, not just lands they tap for mana."
         },
         {
           "date": "2009-10-01",
@@ -2214,7 +2218,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability prevents the affected player from casting permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It doesn’t stop the player from playing lands or activating abilities (such as cycling or unearth)."
+          "text": "The chaos ability prevents the affected player from casting permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It doesn't stop the player from playing lands or activating abilities (such as cycling or unearth)."
         }
       ],
       "subtypes": [
@@ -2274,7 +2278,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -2305,19 +2309,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -2381,7 +2385,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
         },
         {
           "date": "2007-02-01",
@@ -2393,7 +2397,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         }
       ],
       "subtypes": [
@@ -2425,19 +2429,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -2494,11 +2498,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Because you return the unblocked attacking creature to its owner’s hand while activating the ninjutsu ability, you can’t have Sakashima’s Student enter the battlefield as a copy of that creature."
+          "text": "Because you return the unblocked attacking creature to its owner's hand while activating the ninjutsu ability, you can't have Sakashima's Student enter the battlefield as a copy of that creature."
         },
         {
           "date": "2012-06-01",
-          "text": "Sakashima’s Student copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it is a Ninja in addition to its other types. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Sakashima's Student copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below) and it is a Ninja in addition to its other types. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2012-06-01",
@@ -2506,23 +2510,23 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If the chosen creature is copying something else (for example, if the chosen creature is another Sakashima’s Student), then your Sakashima’s Student enters the battlefield as whatever the chosen creature copied."
+          "text": "If the chosen creature is copying something else (for example, if the chosen creature is another Sakashima's Student), then your Sakashima's Student enters the battlefield as whatever the chosen creature copied."
         },
         {
           "date": "2012-06-01",
-          "text": "If the chosen creature is a token, Sakashima’s Student copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Sakashima’s Student is not a token."
+          "text": "If the chosen creature is a token, Sakashima's Student copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Sakashima's Student is not a token."
         },
         {
           "date": "2012-06-01",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Sakashima’s Student enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature (like devour) will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Sakashima's Student enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature (like devour) will also work."
         },
         {
           "date": "2012-06-01",
-          "text": "If Sakashima’s Student somehow enters the battlefield at the same time as another creature, Sakashima’s Student can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Sakashima's Student somehow enters the battlefield at the same time as another creature, Sakashima's Student can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2012-06-01",
-          "text": "You can choose not to copy anything. In that case, Sakashima’s Student enters the battlefield as a 0/0 creature, and is probably put into the graveyard immediately."
+          "text": "You can choose not to copy anything. In that case, Sakashima's Student enters the battlefield as a 0/0 creature, and is probably put into the graveyard immediately."
         }
       ],
       "subtypes": [
@@ -2554,19 +2558,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -2628,11 +2632,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The card you shuffle into your library may be any card from your hand. It doesn’t have to be one of the cards you drew with the spell."
+          "text": "The card you shuffle into your library may be any card from your hand. It doesn't have to be one of the cards you drew with the spell."
         },
         {
           "date": "2010-06-15",
-          "text": "You have to shuffle a card from your hand into your library even if you don’t draw any cards (due to replacement effects or Maralen of the Mornsong’s ability, for example). If your hand is empty, you don’t shuffle your library."
+          "text": "You have to shuffle a card from your hand into your library even if you don't draw any cards (due to replacement effects or Maralen of the Mornsong's ability, for example). If your hand is empty, you don't shuffle your library."
         }
       ],
       "text": "Draw two cards, then shuffle a card from your hand into your library.",
@@ -2659,19 +2663,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -2759,7 +2763,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If the target player has no cards in his or her hand when the ability resolves, nothing happens. That player won’t lose any life."
+          "text": "If the target player has no cards in his or her hand when the ability resolves, nothing happens. That player won't lose any life."
         }
       ],
       "subtypes": [
@@ -2914,11 +2918,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Frost’s ability tracks the creature, not the creature’s controller. That is, if the creature changes controllers before its first controller’s next untap step, then it won’t untap during its new controller’s next untap step."
+          "text": "Wall of Frost's ability tracks the creature, not the creature's controller. That is, if the creature changes controllers before its first controller's next untap step, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2014-07-18",
-          "text": "If the creature isn’t tapped during its controller’s next untap step (perhaps because it was untapped by a spell), Wall of Frost’s ability has no effect at that time. It won’t try to keep the creature tapped on subsequent turns."
+          "text": "If the creature isn't tapped during its controller's next untap step (perhaps because it was untapped by a spell), Wall of Frost's ability has no effect at that time. It won't try to keep the creature tapped on subsequent turns."
         }
       ],
       "subtypes": [
@@ -2949,7 +2953,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If either target is no longer on the battlefield or is otherwise an illegal target when the chaos ability resolves, the exchange won’t happen. No creatures will change controllers. If both targets are illegal, the ability will be countered."
+          "text": "If either target is no longer on the battlefield or is otherwise an illegal target when the chaos ability resolves, the exchange won't happen. No creatures will change controllers. If both targets are illegal, the ability will be countered."
         }
       ],
       "subtypes": [
@@ -3034,59 +3038,59 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell targets multiple things, it won’t cause Glimmervoid Basin’s first ability to trigger, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, it won't cause Glimmervoid Basin's first ability to trigger, even if all but one of those targets has become illegal."
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell targets the same player or object multiple times, it won’t cause Glimmervoid Basin’s first ability to trigger."
+          "text": "If a spell targets the same player or object multiple times, it won't cause Glimmervoid Basin's first ability to trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "Other than choices involving modes or additional costs, the copies are created based on what they could target if the spell were cast anew. For example, if a player casts Naturalize (“Destroy target artifact or enchantment”) targeting an artifact, Glimmervoid Basin’s first ability will copy it for each artifact and enchantment it could target (and each copy will target a different one of those), not just for each artifact it could target."
+          "text": "Other than choices involving modes or additional costs, the copies are created based on what they could target if the spell were cast anew. For example, if a player casts Naturalize (\"Destroy target artifact or enchantment\") targeting an artifact, Glimmervoid Basin's first ability will copy it for each artifact and enchantment it could target (and each copy will target a different one of those), not just for each artifact it could target."
         },
         {
           "date": "2009-10-01",
-          "text": "Anything that couldn’t be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Glimmervoid Basin’s first ability."
+          "text": "Anything that couldn't be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Glimmervoid Basin's first ability."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of the spell that caused Glimmervoid Basin’s first ability to trigger also controls all the copies. That player chooses the order the copies are put onto the stack. The original spell will be on the stack beneath those copies and resolves last."
+          "text": "The controller of the spell that caused Glimmervoid Basin's first ability to trigger also controls all the copies. That player chooses the order the copies are put onto the stack. The original spell will be on the stack beneath those copies and resolves last."
         },
         {
           "date": "2009-10-01",
-          "text": "The copies that Glimmervoid Basin’s first ability creates are created on the stack, so they’re not “cast.” Abilities that trigger when a player casts a spell (like Glimmervoid Basin’s first ability itself) won’t trigger."
+          "text": "The copies that Glimmervoid Basin's first ability creates are created on the stack, so they're not \"cast.\" Abilities that trigger when a player casts a spell (like Glimmervoid Basin's first ability itself) won't trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. Its controller can’t choose a different one."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. Its controller can't choose a different one."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a copy can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
+          "text": "The controller of a copy can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
         },
         {
           "date": "2009-10-01",
-          "text": "As a token is created by the chaos ability, it checks the printed values of the creature it’s copying, as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, and so on."
+          "text": "As a token is created by the chaos ability, it checks the printed values of the creature it's copying, as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, and so on."
         }
       ],
       "subtypes": [
@@ -3173,19 +3177,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -3279,7 +3283,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Any target that is illegal when the first ability resolves won’t get any +1/+1 counters. Those counters are essentially lost; you won’t get to put them on another creature."
+          "text": "Any target that is illegal when the first ability resolves won't get any +1/+1 counters. Those counters are essentially lost; you won't get to put them on another creature."
         },
         {
           "date": "2012-06-01",
@@ -3368,27 +3372,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The Great Forest’s first ability means, for example, that a 2/3 creature will assign 3 damage in combat instead of 2."
+          "text": "The Great Forest's first ability means, for example, that a 2/3 creature will assign 3 damage in combat instead of 2."
         },
         {
           "date": "2009-10-01",
-          "text": "The Great Forest’s first ability doesn’t actually change creatures’ power; it changes only the value of the combat damage they assign. All other rules and effects that check power or toughness use the real values."
+          "text": "The Great Forest's first ability doesn't actually change creatures' power; it changes only the value of the combat damage they assign. All other rules and effects that check power or toughness use the real values."
         }
       ],
       "subtypes": [
@@ -3452,7 +3456,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "If, during the combat damage step, a creature is destroyed during combat and Ink-Eyes also deals combat damage to a player, the destroyed creature can be a legal target for Ink-Eyes’s ability."
+          "text": "If, during the combat damage step, a creature is destroyed during combat and Ink-Eyes also deals combat damage to a player, the destroyed creature can be a legal target for Ink-Eyes's ability."
         }
       ],
       "subtypes": [
@@ -3487,27 +3491,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Despite the appearance of the reminder text, the unearth abilities that Grixis grants are activated abilities of each individual blue, black, and/or red creature card in a graveyard. They’re not activated abilities of Grixis."
+          "text": "Despite the appearance of the reminder text, the unearth abilities that Grixis grants are activated abilities of each individual blue, black, and/or red creature card in a graveyard. They're not activated abilities of Grixis."
         },
         {
           "date": "2009-10-01",
-          "text": "A card’s mana cost includes its color."
+          "text": "A card's mana cost includes its color."
         },
         {
           "date": "2009-10-01",
@@ -3515,23 +3519,23 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you activate a creature card’s unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
+          "text": "If you activate a creature card's unearth ability but that card is removed from your graveyard before the ability resolves, that unearth ability will resolve and do nothing."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating a creature card’s unearth ability isn’t the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Essence Scatter) will not."
+          "text": "Activating a creature card's unearth ability isn't the same as casting the creature card. The unearth ability is put on the stack, but the creature card is not. Spells and abilities that interact with activated abilities (such as Stifle) will interact with unearth, but spells and abilities that interact with spells (such as Essence Scatter) will not."
         },
         {
           "date": "2009-10-01",
-          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the ability won’t trigger again. However, the replacement effect will still exile the creature if it would eventually leave the battlefield."
+          "text": "At the beginning of the end step, a creature returned to the battlefield with unearth is exiled. This is a delayed triggered ability, and it can be countered by effects such as Stifle or Voidslime that counter triggered abilities. If the ability is countered, the creature will stay on the battlefield and the ability won't trigger again. However, the replacement effect will still exile the creature if it would eventually leave the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "Unearth grants haste to the creature that’s returned to the battlefield. However, neither of the exile abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Unearth grants haste to the creature that's returned to the battlefield. However, neither of the exile abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it’s exiled instead — unless the spell or ability that’s causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new permanent with no relation to its previous existence. The unearth effect will no longer apply to it."
+          "text": "If a creature returned to the battlefield with unearth would leave the battlefield for any reason, it's exiled instead — unless the spell or ability that's causing the creature to leave the battlefield is actually trying to exile it! In that case, it succeeds at exiling it. If it later returns the creature card to the battlefield (as Oblivion Ring or Flickerwisp might, for example), the creature card will return to the battlefield as a new permanent with no relation to its previous existence. The unearth effect will no longer apply to it."
         },
         {
           "date": "2009-10-01",
@@ -3621,11 +3625,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Both abilities are mandatory. You must put the creature card onto the battlefield, even if you don’t want to."
+          "text": "Both abilities are mandatory. You must put the creature card onto the battlefield, even if you don't want to."
         },
         {
           "date": "2012-06-01",
-          "text": "If you don’t reveal any creature cards from your library, you’ll put the cards from your library on the bottom of your library in a random order. Essentially, this will shuffle your library, although you are not shuffling it for purposes of effects that care about a player shuffling a library."
+          "text": "If you don't reveal any creature cards from your library, you'll put the cards from your library on the bottom of your library in a random order. Essentially, this will shuffle your library, although you are not shuffling it for purposes of effects that care about a player shuffling a library."
         }
       ],
       "subtypes": [
@@ -3719,7 +3723,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "A creature’s power is checked when attackers or blockers are declared. Increasing the power of an attacking or blocking creature to 7 or greater won’t remove that creature from combat."
+          "text": "A creature's power is checked when attackers or blockers are declared. Increasing the power of an attacking or blocking creature to 7 or greater won't remove that creature from combat."
         }
       ],
       "subtypes": [
@@ -3781,7 +3785,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Skullsnatcher’s ability can target zero, one, or two cards in that player’s graveyard."
+          "text": "Skullsnatcher's ability can target zero, one, or two cards in that player's graveyard."
         }
       ],
       "subtypes": [
@@ -3813,19 +3817,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -3833,11 +3837,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A creature that would assign 0 or less combat damage (due to having power 0 or less) doesn’t assign combat damage at all."
+          "text": "A creature that would assign 0 or less combat damage (due to having power 0 or less) doesn't assign combat damage at all."
         },
         {
           "date": "2009-10-01",
-          "text": "You may target any creature with The Hippodrome’s chaos ability. Whether its power is 0 or less isn’t checked until the ability resolves."
+          "text": "You may target any creature with The Hippodrome's chaos ability. Whether its power is 0 or less isn't checked until the ability resolves."
         }
       ],
       "subtypes": [
@@ -4004,23 +4008,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature controlled by a player other than the planar controller enters the battlefield, the planar controller (not the creature’s controller) controls Immersturm’s triggered ability. That means that if multiple creatures enter the battlefield at the same time, that player controls all of Immersturm’s triggered abilities and may put them on the stack in whichever order he or she likes. The last one put on the stack is the first one to resolve."
+          "text": "If a creature controlled by a player other than the planar controller enters the battlefield, the planar controller (not the creature's controller) controls Immersturm's triggered ability. That means that if multiple creatures enter the battlefield at the same time, that player controls all of Immersturm's triggered abilities and may put them on the stack in whichever order he or she likes. The last one put on the stack is the first one to resolve."
         },
         {
           "date": "2009-10-01",
@@ -4028,11 +4032,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Any “as [this permanent] enters the battlefield” choices for the card returned by the chaos ability are made by that card’s owner, not its old controller or the controller of the chaos ability."
+          "text": "Any \"as [this permanent] enters the battlefield\" choices for the card returned by the chaos ability are made by that card's owner, not its old controller or the controller of the chaos ability."
         },
         {
           "date": "2009-10-01",
-          "text": "A token that has left the battlefield can’t come back onto the battlefield. If the chaos ability exiles a token, that token remains in exile until state-based actions are checked, then it ceases to exist."
+          "text": "A token that has left the battlefield can't come back onto the battlefield. If the chaos ability exiles a token, that token remains in exile until state-based actions are checked, then it ceases to exist."
         }
       ],
       "subtypes": [
@@ -4116,31 +4120,31 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "As a token is created by Isle of Vesuva’s first ability, it checks the printed values of the creature it’s copying, as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, and so on."
+          "text": "As a token is created by Isle of Vesuva's first ability, it checks the printed values of the creature it's copying, as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, and so on."
         },
         {
           "date": "2009-10-01",
-          "text": "If the creature that caused Isle of Vesuva’s first ability to trigger has already left the battlefield by the time the ability resolves, the ability still creates a token. It will have the copiable values of the characteristics of that nontoken creature as it last existed on the battlefield."
+          "text": "If the creature that caused Isle of Vesuva's first ability to trigger has already left the battlefield by the time the ability resolves, the ability still creates a token. It will have the copiable values of the characteristics of that nontoken creature as it last existed on the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability will destroy all creatures with the same name as the target creature, not just tokens created by Isle of Vesuva’s first ability. It doesn’t matter who controls them."
+          "text": "The chaos ability will destroy all creatures with the same name as the target creature, not just tokens created by Isle of Vesuva's first ability. It doesn't matter who controls them."
         },
         {
           "date": "2009-10-01",
@@ -4148,15 +4152,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s name is the same as the creature types listed by the effect that created it, unless the token copies a permanent or that effect specifically gives that token a name. For example, the effect of The Fourth Sphere’s chaos ability creates a token with the name “Zombie.”"
+          "text": "A token's name is the same as the creature types listed by the effect that created it, unless the token copies a permanent or that effect specifically gives that token a name. For example, the effect of The Fourth Sphere's chaos ability creates a token with the name \"Zombie.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-down creature has no name, so it doesn’t have the same name as anything else."
+          "text": "A face-down creature has no name, so it doesn't have the same name as anything else."
         },
         {
           "date": "2013-07-01",
-          "text": "If the permanent targeted by the chaos ability isn’t destroyed (because it regenerates, or because it has indestructible), all other permanents with the same name as it will still be destroyed."
+          "text": "If the permanent targeted by the chaos ability isn't destroyed (because it regenerates, or because it has indestructible), all other permanents with the same name as it will still be destroyed."
         }
       ],
       "subtypes": [
@@ -4240,55 +4244,55 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect of Izzet Steam Maze’s first ability is mandatory. You must copy the spell whether you want to or not."
+          "text": "The effect of Izzet Steam Maze's first ability is mandatory. You must copy the spell whether you want to or not."
         },
         {
           "date": "2009-10-01",
-          "text": "Izzet Steam Maze’s first ability will copy any instant or sorcery spell, not just one with targets."
+          "text": "Izzet Steam Maze's first ability will copy any instant or sorcery spell, not just one with targets."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of the spell that caused Izzet Steam Maze’s first ability to trigger also controls the copy. The copy resolves before the original spell."
+          "text": "The controller of the spell that caused Izzet Steam Maze's first ability to trigger also controls the copy. The copy resolves before the original spell."
         },
         {
           "date": "2009-10-01",
-          "text": "A copy is created even if the spell that caused Izzet Steam Maze’s first ability to trigger has been countered by the time that ability resolves."
+          "text": "A copy is created even if the spell that caused Izzet Steam Maze's first ability to trigger has been countered by the time that ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. The new targets must be legal."
+          "text": "The copy will have the same targets as the spell it's copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. The new targets must be legal."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. Its controller can’t choose a different one."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. Its controller can't choose a different one."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Earthquake does), the copy has the same value of X."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of the copy can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
+          "text": "The controller of the copy can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
         },
         {
           "date": "2009-10-01",
-          "text": "The copy that Izzet Steam Maze’s first ability creates is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell (like Izzet Steam Maze’s first ability itself) won’t trigger."
+          "text": "The copy that Izzet Steam Maze's first ability creates is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell (like Izzet Steam Maze's first ability itself) won't trigger."
         }
       ],
       "subtypes": [
@@ -4376,7 +4380,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If the creature spell already has devour, you may sacrifice creatures using either ability. Each creature you sacrifice counts for only one devour ability. Under most circumstances, you’ll pick the devour ability that gives the greatest number of +1/+1 counters."
+          "text": "If the creature spell already has devour, you may sacrifice creatures using either ability. Each creature you sacrifice counts for only one devour ability. Under most circumstances, you'll pick the devour ability that gives the greatest number of +1/+1 counters."
         }
       ],
       "subtypes": [
@@ -4470,11 +4474,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "A “non-Werewolf creature” is a creature that doesn’t have the Werewolf creature type. A creature with additional types, such as a Human Werewolf, is not a non-Werewolf creature."
+          "text": "A \"non-Werewolf creature\" is a creature that doesn't have the Werewolf creature type. A creature with additional types, such as a Human Werewolf, is not a non-Werewolf creature."
         },
         {
           "date": "2012-06-01",
-          "text": "Creatures that you gain control of after the chaos ability resolves won’t get any of that ability’s bonuses."
+          "text": "Creatures that you gain control of after the chaos ability resolves won't get any of that ability's bonuses."
         }
       ],
       "subtypes": [
@@ -4542,7 +4546,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, basic landcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a basic land card. You don’t choose the type of basic land card you’ll find until you’re performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, basic landcycling doesn't allow you to draw a card. Instead, it lets you search your library for a basic land card. You don't choose the type of basic land card you'll find until you're performing the search. After you choose a basic land card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -4581,19 +4585,19 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "The first ability doesn’t trigger when a creature attacks a planeswalker, and the token copies can’t be put onto the battlefield attacking a planeswalker."
+          "text": "The first ability doesn't trigger when a creature attacks a planeswalker, and the token copies can't be put onto the battlefield attacking a planeswalker."
         },
         {
           "date": "2012-06-01",
-          "text": "As each token is created, it checks the printed values of the creature it’s copying, as well as any copy effects that have been applied to it."
+          "text": "As each token is created, it checks the printed values of the creature it's copying, as well as any copy effects that have been applied to it."
         },
         {
           "date": "2012-06-01",
-          "text": "The copiable values of each token’s characteristics are the same as the copiable values of the characteristics of the creature it’s copying."
+          "text": "The copiable values of each token's characteristics are the same as the copiable values of the characteristics of the creature it's copying."
         },
         {
           "date": "2012-06-01",
-          "text": "You choose the target of the chaos ability as you put that ability on the stack. You don’t sacrifice any creatures until that ability resolves."
+          "text": "You choose the target of the chaos ability as you put that ability on the stack. You don't sacrifice any creatures until that ability resolves."
         }
       ],
       "subtypes": [
@@ -4640,6 +4644,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -4669,11 +4677,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its power."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         },
         {
           "date": "2013-04-15",
@@ -4715,7 +4723,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "You choose the target of the chaos ability as you put that ability on the stack. When the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it’s too late for any player to respond since the ability is already in the midst of resolving."
+          "text": "You choose the target of the chaos ability as you put that ability on the stack. When the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it's too late for any player to respond since the ability is already in the midst of resolving."
         }
       ],
       "subtypes": [
@@ -4806,19 +4814,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -4973,7 +4981,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target a creature you already control. You may target a creature that’s already untapped."
+          "text": "You may target a creature you already control. You may target a creature that's already untapped."
         },
         {
           "date": "2009-10-01",
@@ -5004,23 +5012,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If you don’t have ten cards in your library, you’ll put all the cards in your library into your graveyard. The same is true if the targeted player doesn’t have ten cards in his or her library."
+          "text": "If you don't have ten cards in your library, you'll put all the cards in your library into your graveyard. The same is true if the targeted player doesn't have ten cards in his or her library."
         }
       ],
       "subtypes": [
@@ -5074,11 +5082,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "The phrase “up to one” was inadvertently omitted from Mass Mutiny’s rules text. The card has received errata to correct this."
+          "text": "The phrase \"up to one\" was inadvertently omitted from Mass Mutiny's rules text. The card has received errata to correct this."
         },
         {
           "date": "2012-06-01",
-          "text": "You can cast Mass Mutiny even if an opponent doesn’t control any creatures. You simply won’t choose a target for that opponent."
+          "text": "You can cast Mass Mutiny even if an opponent doesn't control any creatures. You simply won't choose a target for that opponent."
         },
         {
           "date": "2012-06-01",
@@ -5086,7 +5094,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it. However, if you gain control of a creature enchanted by an Aura with totem armor and that creature would be destroyed that turn, instead the Aura will be destroyed and the creature will survive."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it. However, if you gain control of a creature enchanted by an Aura with totem armor and that creature would be destroyed that turn, instead the Aura will be destroyed and the creature will survive."
         }
       ],
       "text": "For each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn.",
@@ -5116,19 +5124,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -5221,19 +5229,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -5241,11 +5249,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "As The Maelstrom’s first ability resolves, you choose whether or not to reveal the top card of your library. If you reveal it and it’s a permanent card, you have two choices: Put it onto the battlefield, or put it on the bottom of your library. It can’t remain on top of your library. On the other hand, if you reveal it and it’s an instant or sorcery card, it must be put on the bottom of your library. There is no way you can leave a card revealed this way on top of your library."
+          "text": "As The Maelstrom's first ability resolves, you choose whether or not to reveal the top card of your library. If you reveal it and it's a permanent card, you have two choices: Put it onto the battlefield, or put it on the bottom of your library. It can't remain on top of your library. On the other hand, if you reveal it and it's an instant or sorcery card, it must be put on the bottom of your library. There is no way you can leave a card revealed this way on top of your library."
         },
         {
           "date": "2009-10-01",
-          "text": "If you reveal a permanent card that can’t enter the battlefield (because it’s an Aura and there’s nothing it can enchant, for example), then you must put it on the bottom of your library."
+          "text": "If you reveal a permanent card that can't enter the battlefield (because it's an Aura and there's nothing it can enchant, for example), then you must put it on the bottom of your library."
         }
       ],
       "subtypes": [
@@ -5298,7 +5306,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Preyseizer Dragon’s ability counts the number of +1/+1 counters on it when the ability resolves. It counts any +1/+1 counters, not just ones put on it due to devour."
+          "text": "Preyseizer Dragon's ability counts the number of +1/+1 counters on it when the ability resolves. It counts any +1/+1 counters, not just ones put on it due to devour."
         }
       ],
       "subtypes": [
@@ -5329,33 +5337,33 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Minamo’s first ability resolves before the spell that caused it to trigger."
+          "text": "Minamo's first ability resolves before the spell that caused it to trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability doesn’t target the cards it will return, so they’re not chosen until resolution. As the ability resolves, first the active player may choose a blue card in his or her graveyard, then each other player in turn order does the same, then all cards chosen this way are returned to their owners’ hands. Once a card is chosen, it’s too late for players to respond."
+          "text": "The chaos ability doesn't target the cards it will return, so they're not chosen until resolution. As the ability resolves, first the active player may choose a blue card in his or her graveyard, then each other player in turn order does the same, then all cards chosen this way are returned to their owners' hands. Once a card is chosen, it's too late for players to respond."
         }
       ],
       "subtypes": [
         "Kamigawa"
       ],
-      "text": "Whenever a player casts a spell, that player may draw a card. \nWhenever you roll {CHAOS}, each player may return a blue card from his or her graveyard to his or her hand.",
+      "text": "Whenever a player casts a spell, that player may draw a card.\nWhenever you roll {CHAOS}, each player may return a blue card from his or her graveyard to his or her hand.",
       "type": "Plane — Kamigawa",
       "types": [
         "Plane"
@@ -5415,11 +5423,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If either one of the creatures leaves the battlefield before Rivals’ Duel resolves, no damage is dealt to or by the remaining creature. If both creatures leave the battlefield before Rivals’ Duel resolves, the spell is countered for having no legal targets."
+          "text": "If either one of the creatures leaves the battlefield before Rivals' Duel resolves, no damage is dealt to or by the remaining creature. If both creatures leave the battlefield before Rivals' Duel resolves, the spell is countered for having no legal targets."
         },
         {
           "date": "2008-04-01",
-          "text": "If, by the time Rivals’ Duel resolves, an effect has caused the two target creatures to share a creature type, Rivals’ Duel is countered for having no legal targets."
+          "text": "If, by the time Rivals' Duel resolves, an effect has caused the two target creatures to share a creature type, Rivals' Duel is countered for having no legal targets."
         }
       ],
       "text": "Choose two target creatures that share no creature types. Those creatures fight each other. (Each deals damage equal to its power to the other.)",
@@ -5506,15 +5514,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         }
       ],
       "subtypes": [
@@ -5546,7 +5554,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If you roll {CHAOS}, Mount Keralia’s damage-prevention effect will last for the rest of the game. It will apply to damage dealt by any plane named Mount Keralia, regardless of who owns that plane."
+          "text": "If you roll {CHAOS}, Mount Keralia's damage-prevention effect will last for the rest of the game. It will apply to damage dealt by any plane named Mount Keralia, regardless of who owns that plane."
         }
       ],
       "subtypes": [
@@ -5613,15 +5621,15 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         }
       ],
       "subtypes": [
@@ -5653,23 +5661,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect of the chaos ability has no duration. The affected land will remain a creature until the end of the game, it leaves the battlefield, or some other effect changes its card types, whichever comes first. It doesn’t matter whether Murasa remains the face-up plane card."
+          "text": "The effect of the chaos ability has no duration. The affected land will remain a creature until the end of the game, it leaves the battlefield, or some other effect changes its card types, whichever comes first. It doesn't matter whether Murasa remains the face-up plane card."
         }
       ],
       "subtypes": [
@@ -5729,11 +5737,11 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it’s no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
+          "text": "The creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it's no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2011-09-22",
-          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn’t target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
+          "text": "Warstorm Surge is the source of the ability, but the creature is the source of the damage. The ability couldn't target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, abilities like lifelink, deathtouch and infect are taken into account, even if the creature has left the battlefield by the time it deals damage."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to target creature or player.",
@@ -5760,19 +5768,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -5835,11 +5843,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The power of each potential blocking creature is checked against Aura Gnarlid’s power only as blockers are declared. Once a creature blocks Aura Gnarlid, increasing the Gnarlid’s power or decreasing the blocking creature’s power won’t undo that block."
+          "text": "The power of each potential blocking creature is checked against Aura Gnarlid's power only as blockers are declared. Once a creature blocks Aura Gnarlid, increasing the Gnarlid's power or decreasing the blocking creature's power won't undo that block."
         },
         {
           "date": "2010-06-15",
-          "text": "Aura Gnarlid’s second ability counts each Aura regardless of who controls it."
+          "text": "Aura Gnarlid's second ability counts each Aura regardless of who controls it."
         }
       ],
       "subtypes": [
@@ -5870,27 +5878,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If you play lands using Naya’s first ability, and then you planeswalk away from Naya, the lands you played still count as additional land plays for the turn. If you haven’t already, you can still play a land using your standard land play."
+          "text": "If you play lands using Naya's first ability, and then you planeswalk away from Naya, the lands you played still count as additional land plays for the turn. If you haven't already, you can still play a land using your standard land play."
         },
         {
           "date": "2009-10-01",
-          "text": "The bonus granted by the chaos ability is determined at the time it resolves. It won’t change if the number of lands you control changes later in the turn."
+          "text": "The bonus granted by the chaos ability is determined at the time it resolves. It won't change if the number of lands you control changes later in the turn."
         }
       ],
       "subtypes": [
@@ -5974,7 +5982,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Nephalia’s first ability doesn’t target any card, and players don’t get priority to cast spells or activate abilities in between putting cards into your graveyard and choosing a card to return."
+          "text": "Nephalia's first ability doesn't target any card, and players don't get priority to cast spells or activate abilities in between putting cards into your graveyard and choosing a card to return."
         }
       ],
       "subtypes": [
@@ -6039,7 +6047,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent’s controller won’t get a Beast token."
+          "text": "If the permanent is an illegal target when Beast Within tries to resolve, the spell will be countered and none of its effects will happen. The permanent's controller won't get a Beast token."
         },
         {
           "date": "2013-07-01",
@@ -6132,11 +6140,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -6144,15 +6152,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -6160,15 +6168,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -6206,7 +6214,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Creatures that you gain control of after the chaos ability resolves won’t get any of that ability’s bonuses."
+          "text": "Creatures that you gain control of after the chaos ability resolves won't get any of that ability's bonuses."
         }
       ],
       "subtypes": [
@@ -6449,43 +6457,43 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use a card’s flashback ability, you’re actually casting that card. It moves from your graveyard to the stack. Abilities that trigger when you cast a spell will trigger. That spell can be countered."
+          "text": "If you use a card's flashback ability, you're actually casting that card. It moves from your graveyard to the stack. Abilities that trigger when you cast a spell will trigger. That spell can be countered."
         },
         {
           "date": "2009-10-01",
-          "text": "If you cast a card by using flashback, you cast that card from your graveyard rather than your hand, and you pay an alternative cost rather than its mana cost, but everything else about casting that spell works normally. You must follow timing restrictions based on the card’s type (if it’s a sorcery), as well as other restrictions (such as “Cast [this card] only before blockers are declared”). You may pay additional costs (such as kicker). Effects that cause you to pay more or less for a spell will apply."
+          "text": "If you cast a card by using flashback, you cast that card from your graveyard rather than your hand, and you pay an alternative cost rather than its mana cost, but everything else about casting that spell works normally. You must follow timing restrictions based on the card's type (if it's a sorcery), as well as other restrictions (such as \"Cast [this card] only before blockers are declared\"). You may pay additional costs (such as kicker). Effects that cause you to pay more or less for a spell will apply."
         },
         {
           "date": "2009-10-01",
-          "text": "As a spell cast with flashback resolves, it never goes to its owner’s graveyard, so abilities that trigger on cards being put in a graveyard won’t trigger. The card is exiled instead."
+          "text": "As a spell cast with flashback resolves, it never goes to its owner's graveyard, so abilities that trigger on cards being put in a graveyard won't trigger. The card is exiled instead."
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell cast by using flashback is countered, it’s still exiled rather than being put into its owner’s graveyard."
+          "text": "If a spell cast by using flashback is countered, it's still exiled rather than being put into its owner's graveyard."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the flashback ability granted by Otaria to cast a split card from your graveyard, the flashback cost you pay is equal to the mana cost of the half that you’re casting."
+          "text": "If you use the flashback ability granted by Otaria to cast a split card from your graveyard, the flashback cost you pay is equal to the mana cost of the half that you're casting."
         },
         {
           "date": "2009-10-01",
-          "text": "If you use the flashback ability granted by Otaria to cast a card with X in its mana cost from your graveyard, you choose the value of X as you cast it. You’ll still have to pay that X."
+          "text": "If you use the flashback ability granted by Otaria to cast a card with X in its mana cost from your graveyard, you choose the value of X as you cast it. You'll still have to pay that X."
         },
         {
           "date": "2009-10-01",
@@ -6493,7 +6501,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you roll {CHAOS} multiple times in the same turn, you’ll take that many extra turns after this one."
+          "text": "If you roll {CHAOS} multiple times in the same turn, you'll take that many extra turns after this one."
         }
       ],
       "subtypes": [
@@ -6583,19 +6591,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -6684,23 +6692,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "The face-up plane card isn’t currently part of its owner’s planar deck. If the chaos ability is rolled by the owner of Pools of Becoming, Pools of Becoming is not one of the three cards that are revealed."
+          "text": "The face-up plane card isn't currently part of its owner's planar deck. If the chaos ability is rolled by the owner of Pools of Becoming, Pools of Becoming is not one of the three cards that are revealed."
         },
         {
           "date": "2009-10-01",
@@ -6708,7 +6716,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If one of the revealed plane cards is another Pools of Becoming, its chaos ability triggers. When it resolves, you’ll reveal three more cards from the top of your planar deck, their chaos abilities will trigger, and you’ll put them on the stack in any order on top of any remaining chaos abilities from the first Pools of Becoming’s effect."
+          "text": "If one of the revealed plane cards is another Pools of Becoming, its chaos ability triggers. When it resolves, you'll reveal three more cards from the top of your planar deck, their chaos abilities will trigger, and you'll put them on the stack in any order on top of any remaining chaos abilities from the first Pools of Becoming's effect."
         }
       ],
       "subtypes": [
@@ -6763,11 +6771,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Dreampod Druid’s ability checks to see if it’s enchanted at the beginning of each upkeep. If it’s not, the ability won’t trigger. If the ability triggers but Dreampod Druid isn’t enchanted when that ability resolves, the ability will do nothing."
+          "text": "Dreampod Druid's ability checks to see if it's enchanted at the beginning of each upkeep. If it's not, the ability won't trigger. If the ability triggers but Dreampod Druid isn't enchanted when that ability resolves, the ability will do nothing."
         },
         {
           "date": "2012-06-01",
-          "text": "Notably, if Dreampod Druid leaves the battlefield while its ability is on the stack, that ability will use Dreampod Druid’s last known information to determine whether or not it was enchanted. If it was enchanted when it left the battlefield, the ability will resolve and create a Saproling."
+          "text": "Notably, if Dreampod Druid leaves the battlefield while its ability is on the stack, that ability will use Dreampod Druid's last known information to determine whether or not it was enchanted. If it was enchanted when it left the battlefield, the ability will resolve and create a Saproling."
         }
       ],
       "subtypes": [
@@ -6887,15 +6895,15 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "You play the card (meaning it play it if it’s a land card or cast it if it’s a nonland card) as part of the resolution of the chaos ability. Timing restrictions based on the card’s type are ignored. Other restrictions, such as “Cast [this card] only during combat,” are not."
+          "text": "You play the card (meaning it play it if it's a land card or cast it if it's a nonland card) as part of the resolution of the chaos ability. Timing restrictions based on the card's type are ignored. Other restrictions, such as \"Cast [this card] only during combat,\" are not."
         },
         {
           "date": "2012-06-01",
-          "text": "If you reveal a land card when resolving the chaos ability, you may play it only if you haven’t played a land yet that turn."
+          "text": "If you reveal a land card when resolving the chaos ability, you may play it only if you haven't played a land yet that turn."
         },
         {
           "date": "2012-06-01",
-          "text": "If you cast a card without paying its mana cost, you can’t pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. If it has {X} in its mana cost, X must be 0. However, you can pay optional additional costs, such as kicker, and you must still pay mandatory additional costs, such as the one on Fling."
+          "text": "If you cast a card without paying its mana cost, you can't pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. If it has {X} in its mana cost, X must be 0. However, you can pay optional additional costs, such as kicker, and you must still pay mandatory additional costs, such as the one on Fling."
         }
       ],
       "subtypes": [
@@ -6983,19 +6991,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -7003,11 +7011,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The -1/-1 counters that result from wither remain on the damaged creature indefinitely. They won’t be removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters that result from wither remain on the damaged creature indefinitely. They won't be removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2009-10-01",
-          "text": "Since damage from a creature with wither is real damage, it follows all the other rules for damage. It can be prevented or redirected. When it’s dealt, it will cause “Whenever [this creature] deals damage” and “Whenever [this creature] is dealt damage” abilities to trigger."
+          "text": "Since damage from a creature with wither is real damage, it follows all the other rules for damage. It can be prevented or redirected. When it's dealt, it will cause \"Whenever [this creature] deals damage\" and \"Whenever [this creature] is dealt damage\" abilities to trigger."
         },
         {
           "date": "2009-10-01",
@@ -7023,7 +7031,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You must target three different creatures when the chaos ability triggers, even if that means you have to target creatures you control. If you can’t target three creatures (because there are just two creatures on the battlefield, perhaps), the ability is removed from the stack and does nothing."
+          "text": "You must target three different creatures when the chaos ability triggers, even if that means you have to target creatures you control. If you can't target three creatures (because there are just two creatures on the battlefield, perhaps), the ability is removed from the stack and does nothing."
         }
       ],
       "subtypes": [
@@ -7107,19 +7115,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -7127,7 +7135,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "For a player’s life total to become 20, what actually happens is that the player gains or loses the appropriate amount of life. For example, if your life total is 14 when this ability resolves, it will cause you to gain 6 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For a player's life total to become 20, what actually happens is that the player gains or loses the appropriate amount of life. For example, if your life total is 14 when this ability resolves, it will cause you to gain 6 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         }
       ],
       "subtypes": [
@@ -7196,19 +7204,19 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can’t be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
+          "text": "If you cast this as a spell, you choose how many and which creatures to devour as part of the resolution of that spell. (It can't be countered at this point.) The same is true of a spell or ability that lets you put a creature with devour onto the battlefield."
         },
         {
           "date": "2008-10-01",
-          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can’t devour that other creature. The creature with devour also can’t devour itself."
+          "text": "You may sacrifice only creatures that are already on the battlefield. If a creature with devour and another creature are entering the battlefield under your control at the same time, the creature with devour can't devour that other creature. The creature with devour also can't devour itself."
         },
         {
           "date": "2008-10-01",
-          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one’s devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can’t sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
+          "text": "If multiple creatures with devour are entering the battlefield under your control at the same time, you may use each one's devour ability. A creature you already control can be devoured by only one of them, however. (In other words, you can't sacrifice the same creature to satisfy multiple devour abilities.) All creatures devoured this way are sacrificed at the same time."
         },
         {
           "date": "2008-10-01",
-          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn’t matter where the +1/+1 counters came from."
+          "text": "The number of Saproling tokens created by the triggered ability is based on the number of +1/+1 counters on Mycoloth, not on the number of creatures Mycoloth devoured. It doesn't matter where the +1/+1 counters came from."
         }
       ],
       "subtypes": [
@@ -7239,19 +7247,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -7345,7 +7353,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Adding loyalty counters to a planeswalker in order to activate a loyalty ability isn’t an effect, so those counters are not doubled."
+          "text": "Adding loyalty counters to a planeswalker in order to activate a loyalty ability isn't an effect, so those counters are not doubled."
         },
         {
           "date": "2012-06-01",
@@ -7412,7 +7420,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t activate this ability unless a single opponent has at least two cards in their graveyard to target."
+          "text": "You can't activate this ability unless a single opponent has at least two cards in their graveyard to target."
         }
       ],
       "subtypes": [
@@ -7447,19 +7455,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -7549,19 +7557,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -7569,11 +7577,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, the new top card won’t be revealed until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
+          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, the new top card won't be revealed until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
         },
         {
           "date": "2009-10-01",
-          "text": "Skybreen’s second ability prevents each player from casting spells that share a card type with a card on top of any library, not just the one on top of that player’s own library. This includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It doesn’t stop players from playing lands or activating abilities (such as cycling or unearth)."
+          "text": "Skybreen's second ability prevents each player from casting spells that share a card type with a card on top of any library, not just the one on top of that player's own library. This includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It doesn't stop players from playing lands or activating abilities (such as cycling or unearth)."
         }
       ],
       "subtypes": [
@@ -7652,7 +7660,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -7679,19 +7687,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -7845,11 +7853,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the enchanted creature’s ability is activated, that creature is the one that will deal and be dealt damage when the ability resolves. It doesn’t matter if Predatory Urge leaves the battlefield or somehow becomes attached to another creature by that time."
+          "text": "If the enchanted creature's ability is activated, that creature is the one that will deal and be dealt damage when the ability resolves. It doesn't matter if Predatory Urge leaves the battlefield or somehow becomes attached to another creature by that time."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature leaves the battlefield (or otherwise becomes an illegal target) before the ability resolves, the ability is countered. The enchanted creature isn’t dealt damage."
+          "text": "If the targeted creature leaves the battlefield (or otherwise becomes an illegal target) before the ability resolves, the ability is countered. The enchanted creature isn't dealt damage."
         },
         {
           "date": "2009-10-01",
@@ -7891,7 +7899,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Unlike the Vampires in the _Innistrad_(TM) block, Stensia’s ability triggers whenever a creature deals any damage, not just combat damage."
+          "text": "Unlike the Vampires in the _Innistrad_(TM) block, Stensia's ability triggers whenever a creature deals any damage, not just combat damage."
         }
       ],
       "subtypes": [
@@ -7952,11 +7960,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you choose the “destroy” mode and Quiet Disrepair is moved to a different permanent while the ability is on the stack, the newly enchanted permanent will be destroyed when the ability resolves."
+          "text": "If you choose the \"destroy\" mode and Quiet Disrepair is moved to a different permanent while the ability is on the stack, the newly enchanted permanent will be destroyed when the ability resolves."
         },
         {
           "date": "2007-05-01",
-          "text": "If you choose the “destroy” mode and Quiet Disrepair leaves the battlefield while the ability is on the stack, the last permanent it enchanted will be destroyed."
+          "text": "If you choose the \"destroy\" mode and Quiet Disrepair leaves the battlefield while the ability is on the stack, the last permanent it enchanted will be destroyed."
         }
       ],
       "subtypes": [
@@ -7986,35 +7994,35 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Stronghold Furnace’s first ability interacts with all damage, not just combat damage. Notably, it doubles the damage from its own chaos ability."
+          "text": "Stronghold Furnace's first ability interacts with all damage, not just combat damage. Notably, it doubles the damage from its own chaos ability."
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn.” Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Stronghold Furnace’s effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn.\" Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Stronghold Furnace's effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         },
         {
           "date": "2009-10-01",
-          "text": "Combat damage that a source would deal to a planeswalker is not doubled. However, if a source a player controls would deal noncombat damage to an opponent who controls a planeswalker, and that opponent chooses to apply Stronghold Furnace’s replacement effect before applying the planeswalker redirection effect, the damage will be doubled before the source’s controller chooses whether to deal it to a planeswalker that opponent controls. (If players always apply the planeswalker redirection effect first, Stronghold Furnace’s effect will never double damage that a source would deal to a planeswalker.)"
+          "text": "Combat damage that a source would deal to a planeswalker is not doubled. However, if a source a player controls would deal noncombat damage to an opponent who controls a planeswalker, and that opponent chooses to apply Stronghold Furnace's replacement effect before applying the planeswalker redirection effect, the damage will be doubled before the source's controller chooses whether to deal it to a planeswalker that opponent controls. (If players always apply the planeswalker redirection effect first, Stronghold Furnace's effect will never double damage that a source would deal to a planeswalker.)"
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell or ability divides damage among multiple recipients (such as Pyrotechnics does), the damage is divided before Stronghold Furnace’s effect doubles it. The same is true for combat damage."
+          "text": "If a spell or ability divides damage among multiple recipients (such as Pyrotechnics does), the damage is divided before Stronghold Furnace's effect doubles it. The same is true for combat damage."
         }
       ],
       "subtypes": [
@@ -8081,7 +8089,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -8168,7 +8176,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -8200,7 +8208,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Exiling a nonland card from your hand this way is a special action. It doesn’t use the stack and doesn’t count as casting a spell or activating an ability. Players can’t respond to this action, although they can respond when you cast the spell after the last time counter is removed."
+          "text": "Exiling a nonland card from your hand this way is a special action. It doesn't use the stack and doesn't count as casting a spell or activating an ability. Players can't respond to this action, although they can respond when you cast the spell after the last time counter is removed."
         },
         {
           "date": "2012-06-01",
@@ -8269,11 +8277,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -8281,15 +8289,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -8297,11 +8305,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2010-06-15",
-          "text": "Snake Umbra grants the triggered ability to the creature. It triggers whenever the enchanted creature deals damage to an opponent of its controller (who is not necessarily an opponent of the Aura’s controller). In other words, if your Snake Umbra winds up enchanting your opponent’s creature, that opponent will draw a card whenever that creature damages you."
+          "text": "Snake Umbra grants the triggered ability to the creature. It triggers whenever the enchanted creature deals damage to an opponent of its controller (who is not necessarily an opponent of the Aura's controller). In other words, if your Snake Umbra winds up enchanting your opponent's creature, that opponent will draw a card whenever that creature damages you."
         },
         {
           "date": "2010-06-15",
@@ -8309,11 +8317,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -8347,19 +8355,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         }
       ],
       "subtypes": [
@@ -8531,15 +8539,15 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Rebound’s delayed triggered ability will let you cast the spell at the beginning of your next upkeep even if the game has left Trail of the Mage-Rings by then."
+          "text": "Rebound's delayed triggered ability will let you cast the spell at the beginning of your next upkeep even if the game has left Trail of the Mage-Rings by then."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2013-04-15",
@@ -8547,23 +8555,23 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2013-04-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2013-04-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2013-04-15",
@@ -8575,7 +8583,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell moves itself into another zone as part of its resolution (as Arc Blade, All Suns’ Dawn, and Beacon of Unrest do), rebound won’t get a chance to apply."
+          "text": "If a spell moves itself into another zone as part of its resolution (as Arc Blade, All Suns' Dawn, and Beacon of Unrest do), rebound won't get a chance to apply."
         },
         {
           "date": "2013-04-15",
@@ -8583,27 +8591,27 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You’ll be able to cast a spell with flashback three times this way. First you can cast it from your hand. It will be exiled due to rebound as it resolves. Then you can cast it from exile due to rebound’s delayed triggered ability. It will be put into your graveyard as it resolves. Then you can cast it from your graveyard due to flashback. It will be exiled due to flashback as it resolves."
+          "text": "You'll be able to cast a spell with flashback three times this way. First you can cast it from your hand. It will be exiled due to rebound as it resolves. Then you can cast it from exile due to rebound's delayed triggered ability. It will be put into your graveyard as it resolves. Then you can cast it from your graveyard due to flashback. It will be exiled due to flashback as it resolves."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast an instant or sorcery spell from your hand and it’s exiled due to rebound, the delayed triggered ability will allow you to cast it during your next upkeep even if Trail of the Mage-Rings has been turned face down by then."
+          "text": "If you cast an instant or sorcery spell from your hand and it's exiled due to rebound, the delayed triggered ability will allow you to cast it during your next upkeep even if Trail of the Mage-Rings has been turned face down by then."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a card from exile “without paying its mana cost,” you can’t pay any alternative costs. Any X in the mana cost will be 0. On the other hand, if the card has optional additional costs (such as kicker or multikicker), you may pay those when you cast the card. If the card has mandatory additional costs (such as Momentous Fall does), you must pay those if you choose to cast the card."
+          "text": "If you cast a card from exile \"without paying its mana cost,\" you can't pay any alternative costs. Any X in the mana cost will be 0. On the other hand, if the card has optional additional costs (such as kicker or multikicker), you may pay those when you cast the card. If the card has mandatory additional costs (such as Momentous Fall does), you must pay those if you choose to cast the card."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell has restrictions on when it can be cast (for example, “Cast [this spell] only during the declare blockers step”), those restrictions may prevent you from casting it from exile during your upkeep."
+          "text": "If a spell has restrictions on when it can be cast (for example, \"Cast [this spell] only during the declare blockers step\"), those restrictions may prevent you from casting it from exile during your upkeep."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a spell using the madness or suspend abilities, you’re casting it from exile, not from your hand. Although those spells will have rebound, the ability won’t have any effect."
+          "text": "If you cast a spell using the madness or suspend abilities, you're casting it from exile, not from your hand. Although those spells will have rebound, the ability won't have any effect."
         },
         {
           "date": "2013-04-15",
-          "text": "Similarly, if you gain control of an instant or sorcery spell with Commandeer, it will have rebound, but the ability won’t do anything because that spell wasn’t cast from your hand."
+          "text": "Similarly, if you gain control of an instant or sorcery spell with Commandeer, it will have rebound, but the ability won't do anything because that spell wasn't cast from your hand."
         }
       ],
       "subtypes": [
@@ -8775,27 +8783,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Turri Island’s first ability can’t reduce the cost to cast a creature spell to less than {0}."
+          "text": "Turri Island's first ability can't reduce the cost to cast a creature spell to less than {0}."
         },
         {
           "date": "2009-10-01",
-          "text": "If there are fewer than three cards in your library as the chaos ability resolves, you’ll reveal all the cards in your library."
+          "text": "If there are fewer than three cards in your library as the chaos ability resolves, you'll reveal all the cards in your library."
         }
       ],
       "subtypes": [
@@ -8877,11 +8885,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -8912,19 +8920,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
@@ -8936,11 +8944,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability’s effect continues to apply even after Undercity Reaches stops being the face-up plane card."
+          "text": "The chaos ability's effect continues to apply even after Undercity Reaches stops being the face-up plane card."
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then roll {CHAOS} while Undercity Reaches is the face-up plane card, you’ll have no maximum hand size. However, if those events had happened in the opposite order, your maximum hand size would be two for as long as Null Profusion is on the battlefield."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then roll {CHAOS} while Undercity Reaches is the face-up plane card, you'll have no maximum hand size. However, if those events had happened in the opposite order, your maximum hand size would be two for as long as Null Profusion is on the battlefield."
         }
       ],
       "subtypes": [
@@ -9023,11 +9031,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -9063,27 +9071,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A plane card is treated as if its text box included “When you roll {PW}, put this card on the bottom of its owner’s planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.” This is called the “planeswalking ability.”"
+          "text": "A plane card is treated as if its text box included \"When you roll {PW}, put this card on the bottom of its owner's planar deck face down, then move the top card of your planar deck off that planar deck and turn it face up.\" This is called the \"planeswalking ability.\""
         },
         {
           "date": "2009-10-01",
-          "text": "A face-up plane card that’s turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
+          "text": "A face-up plane card that's turned face down becomes a new object with no relation to its previous existence. In particular, it loses all counters it may have had."
         },
         {
           "date": "2009-10-01",
-          "text": "The controller of a face-up plane card is the player designated as the “planar controller.” Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn’t leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
+          "text": "The controller of a face-up plane card is the player designated as the \"planar controller.\" Normally, the planar controller is whoever the active player is. However, if the current planar controller would leave the game, instead the next player in turn order that wouldn't leave the game becomes the planar controller, then the old planar controller leaves the game. The new planar controller retains that designation until he or she leaves the game or a different player becomes the active player, whichever comes first."
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability of a plane refers to “you,” it’s referring to whoever the plane’s controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
+          "text": "If an ability of a plane refers to \"you,\" it's referring to whoever the plane's controller is at the time, not to the player that started the game with that plane card in his or her deck. Many abilities of plane cards affect all players, while many others affect only the planar controller, so read each ability carefully."
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Velis Vel’s first ability counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Velis Vel's first ability counts creatures, not creature types."
         },
         {
           "date": "2009-10-01",
-          "text": "The chaos ability doesn’t give a creature changeling."
+          "text": "The chaos ability doesn't give a creature changeling."
         }
       ],
       "subtypes": [
@@ -9162,11 +9170,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -9197,19 +9205,19 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "You can only play the top cards of players’ libraries when you are the planar controller. Generally, this means as long as it’s your turn. When another player begins his or her turn, that player becomes the planar controller and can play the top card of players’ libraries. You won’t be able to until you again become the planar controller."
+          "text": "You can only play the top cards of players' libraries when you are the planar controller. Generally, this means as long as it's your turn. When another player begins his or her turn, that player becomes the planar controller and can play the top card of players' libraries. You won't be able to until you again become the planar controller."
         },
         {
           "date": "2012-06-01",
-          "text": "You may play the top card of any player’s library, including your own. This effect doesn’t change when you can play any of these cards (meaning play it if it’s a land card or cast it if it’s a nonland card). You can still cast creature spells only on your turn during your main phase and so on."
+          "text": "You may play the top card of any player's library, including your own. This effect doesn't change when you can play any of these cards (meaning play it if it's a land card or cast it if it's a nonland card). You can still cast creature spells only on your turn during your main phase and so on."
         },
         {
           "date": "2012-06-01",
-          "text": "If the top card of a player’s library is a land card, you may play it only if you haven’t played a land yet that turn."
+          "text": "If the top card of a player's library is a land card, you may play it only if you haven't played a land yet that turn."
         },
         {
           "date": "2012-06-01",
-          "text": "As soon as you finish playing the card on top of a player’s library, the next card in that library becomes revealed."
+          "text": "As soon as you finish playing the card on top of a player's library, the next card in that library becomes revealed."
         },
         {
           "date": "2012-06-01",
@@ -9217,7 +9225,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Other players won’t be able to play the top card of their libraries unless another effect allows it. If you and another player can play the top card of that player’s library (because of some other effect), you’ll be able to in most cases. This is because you have priority first at the beginning of each phase and step and after each spell or ability resolves. Once you play that card, it immediately moves from that library to the appropriate zone (the battlefield if it’s a land card or the stack if it’s a nonland card). The other player can’t respond by playing that card."
+          "text": "Other players won't be able to play the top card of their libraries unless another effect allows it. If you and another player can play the top card of that player's library (because of some other effect), you'll be able to in most cases. This is because you have priority first at the beginning of each phase and step and after each spell or ability resolves. Once you play that card, it immediately moves from that library to the appropriate zone (the battlefield if it's a land card or the stack if it's a nonland card). The other player can't respond by playing that card."
         }
       ],
       "subtypes": [
@@ -9362,7 +9370,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "The triggered ability won’t be affected if the spell that caused it to trigger is countered."
+          "text": "The triggered ability won't be affected if the spell that caused it to trigger is countered."
         }
       ],
       "subtypes": [
@@ -9419,11 +9427,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "None of Elderwood Scion’s abilities affect abilities that target it."
+          "text": "None of Elderwood Scion's abilities affect abilities that target it."
         },
         {
           "date": "2012-06-01",
-          "text": "Aura spells require a target when they are cast. Elderwood Scion’s cost-reduction ability will affect Aura spells cast targeting it."
+          "text": "Aura spells require a target when they are cast. Elderwood Scion's cost-reduction ability will affect Aura spells cast targeting it."
         },
         {
           "date": "2012-06-01",
@@ -9431,11 +9439,11 @@
         },
         {
           "date": "2012-06-01",
-          "text": "Elderwood Scion’s cost-reduction ability can’t reduce the colored mana requirement of a spell."
+          "text": "Elderwood Scion's cost-reduction ability can't reduce the colored mana requirement of a spell."
         },
         {
           "date": "2012-06-01",
-          "text": "Elderwood Scion’s cost-reduction ability can apply to any cost of a spell, including additional or alternative costs."
+          "text": "Elderwood Scion's cost-reduction ability can apply to any cost of a spell, including additional or alternative costs."
         }
       ],
       "subtypes": [
@@ -9518,23 +9526,23 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2009-05-01",
-          "text": "After Enigma Sphinx’s middle ability triggers, if Enigma Sphinx is removed from your graveyard in response, it won’t be put into your library."
+          "text": "After Enigma Sphinx's middle ability triggers, if Enigma Sphinx is removed from your graveyard in response, it won't be put into your library."
         },
         {
           "date": "2009-05-01",
-          "text": "If you have zero or one card left in your library when Enigma Sphinx’s middle ability resolves, Enigma Sphinx is put on the bottom of your library."
+          "text": "If you have zero or one card left in your library when Enigma Sphinx's middle ability resolves, Enigma Sphinx is put on the bottom of your library."
         },
         {
           "date": "2009-05-01",
-          "text": "If you control an Enigma Sphinx that’s owned by another player, it’s put into that player’s graveyard from the battlefield, so Enigma Sphinx’s middle ability won’t trigger."
+          "text": "If you control an Enigma Sphinx that's owned by another player, it's put into that player's graveyard from the battlefield, so Enigma Sphinx's middle ability won't trigger."
         },
         {
           "date": "2017-04-18",
@@ -9621,11 +9629,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -9687,7 +9695,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Etherium-Horn Sorcerer’s first ability can only be activated when it is on the battlefield. If Etherium-Horn Sorcerer isn’t on the battlefield when the ability resolves, the ability won’t do anything."
+          "text": "Etherium-Horn Sorcerer's first ability can only be activated when it is on the battlefield. If Etherium-Horn Sorcerer isn't on the battlefield when the ability resolves, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -9942,7 +9950,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Hellkite Hatchling has flying and trample if at least one creature was sacrificed as a result of the Hatchling’s devour ability as it entered the battlefield. It retains those abilities even if its +1/+1 counters are somehow removed."
+          "text": "Hellkite Hatchling has flying and trample if at least one creature was sacrificed as a result of the Hatchling's devour ability as it entered the battlefield. It retains those abilities even if its +1/+1 counters are somehow removed."
         },
         {
           "date": "2009-02-01",
@@ -10005,7 +10013,7 @@
         },
         {
           "date": "2012-06-01",
-          "text": "If, during a player’s declare blockers step, a creature is tapped or it’s affected by a spell or ability that says it can’t block, then it doesn’t block. If there’s a cost associated with having a creature block, its controller isn’t forced to pay that cost. The creature doesn’t have to block."
+          "text": "If, during a player's declare blockers step, a creature is tapped or it's affected by a spell or ability that says it can't block, then it doesn't block. If there's a cost associated with having a creature block, its controller isn't forced to pay that cost. The creature doesn't have to block."
         }
       ],
       "subtypes": [
@@ -10070,15 +10078,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An “unblocked creature” is a creature that attacked and wasn’t blocked. Creatures aren’t “blocked” or “unblocked” until the declare blockers step, so activating this ability before then (or after combat ends) will have no effect."
+          "text": "An \"unblocked creature\" is a creature that attacked and wasn't blocked. Creatures aren't \"blocked\" or \"unblocked\" until the declare blockers step, so activating this ability before then (or after combat ends) will have no effect."
         },
         {
           "date": "2008-05-01",
-          "text": "Creatures stop being unblocked as the combat phase ends. However, they’ll stay 4/1 until turn ends."
+          "text": "Creatures stop being unblocked as the combat phase ends. However, they'll stay 4/1 until turn ends."
         },
         {
           "date": "2008-05-01",
-          "text": "Inkfathom Witch doesn’t cause creatures to lose their abilities."
+          "text": "Inkfathom Witch doesn't cause creatures to lose their abilities."
         },
         {
           "date": "2008-05-01",
@@ -10086,7 +10094,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -10168,11 +10176,11 @@
         },
         {
           "date": "2009-05-01",
-          "text": "If you cast the last exiled card, you’re casting it as a spell. It can be countered. If that card has cascade, the new spell’s cascade ability will trigger, and you’ll repeat the process for the new spell."
+          "text": "If you cast the last exiled card, you're casting it as a spell. It can be countered. If that card has cascade, the new spell's cascade ability will trigger, and you'll repeat the process for the new spell."
         },
         {
           "date": "2009-05-01",
-          "text": "After you’re done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
+          "text": "After you're done exiling cards and casting the last one if you chose to do so, the remaining exiled cards are randomly placed on the bottom of your library. Neither you nor any other player is allowed to know the order of those cards."
         },
         {
           "date": "2017-04-18",
@@ -10234,7 +10242,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If Krond isn’t enchanted when it’s declared as an attacking creature, the ability won’t trigger. If Krond isn’t enchanted when the ability resolves, the ability won’t do anything."
+          "text": "If Krond isn't enchanted when it's declared as an attacking creature, the ability won't trigger. If Krond isn't enchanted when the ability resolves, the ability won't do anything."
         }
       ],
       "subtypes": [
@@ -10361,7 +10369,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "No matter what spell you cast with the first cascade trigger (or with any cascade triggers that result from casting that spell), the second cascade trigger will look for a spell with converted mana cost less than Maelstrom Wanderer’s converted mana cost of 8."
+          "text": "No matter what spell you cast with the first cascade trigger (or with any cascade triggers that result from casting that spell), the second cascade trigger will look for a spell with converted mana cost less than Maelstrom Wanderer's converted mana cost of 8."
         }
       ],
       "subtypes": [
@@ -10597,15 +10605,15 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If you cast a permanent spell this way, it will enter the battlefield under your control when it resolves. If you cast an instant or sorcery spell this way, that card will be put into its owner’s graveyard when it resolves."
+          "text": "If you cast a permanent spell this way, it will enter the battlefield under your control when it resolves. If you cast an instant or sorcery spell this way, that card will be put into its owner's graveyard when it resolves."
         },
         {
           "date": "2012-06-01",
-          "text": "The nonland card you cast via the triggered ability is cast as part of the resolution of that ability. Timing restrictions based on the card’s type are ignored. Other restrictions, such as “Cast [this card] only during an opponent’s turn,” are not."
+          "text": "The nonland card you cast via the triggered ability is cast as part of the resolution of that ability. Timing restrictions based on the card's type are ignored. Other restrictions, such as \"Cast [this card] only during an opponent's turn,\" are not."
         },
         {
           "date": "2012-06-01",
-          "text": "If you cast a card without paying its mana cost, you can’t pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. If it has {X} in its mana cost, X must be 0. However, you can pay optional additional costs, such as kicker, and you must still pay mandatory additional costs, such as the one on Fling."
+          "text": "If you cast a card without paying its mana cost, you can't pay any alternative costs, such as evoke or the alternative cost provided by the morph ability. If it has {X} in its mana cost, X must be 0. However, you can pay optional additional costs, such as kicker, and you must still pay mandatory additional costs, such as the one on Fling."
         }
       ],
       "subtypes": [
@@ -10848,7 +10856,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Each instance of each creature’s combat damage is counted separately. If three creatures with double strike attack you and all of them are unblocked, you may draw up to six cards."
+          "text": "Each instance of each creature's combat damage is counted separately. If three creatures with double strike attack you and all of them are unblocked, you may draw up to six cards."
         }
       ],
       "text": "Whenever a source an opponent controls deals damage to you, if Farsight Mask is untapped, you may draw a card.",
@@ -10942,11 +10950,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "In non-Planechase games, Fractured Powerstone’s second ability will have no effect."
+          "text": "In non-Planechase games, Fractured Powerstone's second ability will have no effect."
         },
         {
           "date": "2012-06-01",
-          "text": "Rolling the planar die this way doesn’t count when determining the cost of the special action of rolling the planar die. For example, if you roll the planar die twice in a turn, then activate Fractured Powerstone to roll it a third time, rolling the planar die again that turn will cost {2}."
+          "text": "Rolling the planar die this way doesn't count when determining the cost of the special action of rolling the planar die. For example, if you roll the planar die twice in a turn, then activate Fractured Powerstone to roll it a third time, rolling the planar die again that turn will cost {2}."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}: Roll the planar die. Activate this ability only any time you could cast a sorcery.",
@@ -10998,7 +11006,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "That player loses half his or her life after combat damage has been subtracted from the player’s life total. The amount of life the player loses is determined as the triggered ability resolves."
+          "text": "That player loses half his or her life after combat damage has been subtracted from the player's life total. The amount of life the player loses is determined as the triggered ability resolves."
         },
         {
           "date": "2008-10-01",
@@ -11006,7 +11014,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, if a creature equipped with Quietus Spike would assign combat damage to the defending team, its damage is assigned to only one of the defending players. After combat damage is dealt, Quietus Spike looks at that player’s life total (which is the same as the team’s life total) when determining how much life the team will lose, which basically means the team’s life total is halved. Here’s an example of the math: The team has 19 life, so the player has 19 life. Quietus Spike causes the team to lose 10 life (19 divided by 2, rounded up). The team’s life total becomes 9 (19 minus 10)."
+          "text": "In a Two-Headed Giant game, if a creature equipped with Quietus Spike would assign combat damage to the defending team, its damage is assigned to only one of the defending players. After combat damage is dealt, Quietus Spike looks at that player's life total (which is the same as the team's life total) when determining how much life the team will lose, which basically means the team's life total is halved. Here's an example of the math: The team has 19 life, so the player has 19 life. Quietus Spike causes the team to lose 10 life (19 divided by 2, rounded up). The team's life total becomes 9 (19 minus 10)."
         }
       ],
       "subtypes": [
@@ -11053,7 +11061,7 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "If you choose not to attach Sai of the Shinobi to the creature, or if you can’t (perhaps because the creature has protection from artifacts or has left the battlefield by the time the trigger resolves), Sai of the Shinobi doesn’t move."
+          "text": "If you choose not to attach Sai of the Shinobi to the creature, or if you can't (perhaps because the creature has protection from artifacts or has left the battlefield by the time the trigger resolves), Sai of the Shinobi doesn't move."
         }
       ],
       "subtypes": [
@@ -11276,23 +11284,23 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can’t be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
+          "text": "The colors of mana are white, blue, black, red, and green. Exotic Orchard can't be tapped for colorless mana, even if a land an opponent controls could produce colorless mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn’t check their costs. For example, Vivid Crag has the ability “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Exotic Orchard checks the effects of all mana-producing abilities of lands your opponents control, but it doesn't check their costs. For example, Vivid Crag has the ability \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If an opponent controls Vivid Crag and you control Exotic Orchard, you can tap Exotic Orchard for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2009-02-01",
-          "text": "When determining what colors of mana your opponents’ lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands’ mana abilities (such as Contamination’s effect, for example). If there are more than one, consider them in any possible order."
+          "text": "When determining what colors of mana your opponents' lands could produce, Exotic Orchard takes into account any applicable replacement effects that would apply to those lands' mana abilities (such as Contamination's effect, for example). If there are more than one, consider them in any possible order."
         },
         {
           "date": "2009-02-01",
-          "text": "Exotic Orchard doesn’t care about any restrictions or riders your opponents’ lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
+          "text": "Exotic Orchard doesn't care about any restrictions or riders your opponents' lands (such as Ancient Ziggurat or Hall of the Bandit Lord) put on the mana they produce. It just cares about colors of mana."
         },
         {
           "date": "2009-02-01",
-          "text": "Lands that produce mana based only on what other lands “could produce” won’t help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent’s Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent’s Reflecting Pool can each produce {G} because your opponent’s Exotic Orchard can produce {G}."
+          "text": "Lands that produce mana based only on what other lands \"could produce\" won't help each other unless some other land allows one of them to actually produce some type of mana. For example, if you control an Exotic Orchard and your opponent controls an Exotic Orchard and a Reflecting Pool, none of those lands would produce mana if their mana abilities were activated. On the other hand, if you control a Forest and an Exotic Orchard, and your opponent controls an Exotic Orchard and a Reflecting Pool, then each of those lands can be tapped to produce {G}. Your opponent's Exotic Orchard can produce {G} because you control a Forest. Your Exotic Orchard and your opponent's Reflecting Pool can each produce {G} because your opponent's Exotic Orchard can produce {G}."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",

--- a/json/PCY.json
+++ b/json/PCY.json
@@ -450,7 +450,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature’s controller gets the option to pay when this spell resolves."
+          "text": "The creature's controller gets the option to pay when this spell resolves."
         }
       ],
       "text": "Exile target attacking creature unless its controller pays {X}.",
@@ -504,7 +504,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land’s controller gets to activate the ability."
+          "text": "The land's controller gets to activate the ability."
         }
       ],
       "subtypes": [
@@ -1043,7 +1043,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t be used to prevent damage to your creatures, just to you."
+          "text": "Can't be used to prevent damage to your creatures, just to you."
         }
       ],
       "text": "{1}: Any player may pay {1}. If no one does, the next time a source of your choice would deal damage to you this turn, prevent that damage.",
@@ -1252,7 +1252,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the ability is used twice, it will cause the next two attacks this turn (which only happens if something gives a player two attacks) from the creature to “reflect” back to itself. It will not result in double damage back from a single attack."
+          "text": "If the ability is used twice, it will cause the next two attacks this turn (which only happens if something gives a player two attacks) from the creature to \"reflect\" back to itself. It will not result in double damage back from a single attack."
         }
       ],
       "subtypes": [
@@ -2167,7 +2167,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can cast the instant or sorcery during the End step after you put the “at the beginning of the end step” trigger on the stack, as long as you do so before that trigger resolves."
+          "text": "You can cast the instant or sorcery during the End step after you put the \"at the beginning of the end step\" trigger on the stack, as long as you do so before that trigger resolves."
         },
         {
           "date": "2004-10-04",
@@ -2282,7 +2282,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The spell’s controller gets the option to pay when this spell resolves."
+          "text": "The spell's controller gets the option to pay when this spell resolves."
         }
       ],
       "text": "Counter target spell unless its controller pays {X}, where X is its converted mana cost.",
@@ -2336,7 +2336,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature’s controller gets the option to pay when this ability resolves."
+          "text": "The creature's controller gets the option to pay when this ability resolves."
         }
       ],
       "text": "{U}: Tap target creature unless its controller pays {1}.",
@@ -2449,7 +2449,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t have to decide whether or not you are drawing until after the player decides whether or not to pay."
+          "text": "You don't have to decide whether or not you are drawing until after the player decides whether or not to pay."
         }
       ],
       "text": "Whenever an opponent casts a spell, you may draw a card unless that player pays {1}.",
@@ -2610,7 +2610,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The spell’s controller gets the option to pay when this ability resolves."
+          "text": "The spell's controller gets the option to pay when this ability resolves."
         }
       ],
       "subtypes": [
@@ -2675,7 +2675,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The spell’s controller gets the option to pay when this ability resolves."
+          "text": "The spell's controller gets the option to pay when this ability resolves."
         }
       ],
       "subtypes": [
@@ -2786,7 +2786,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The spell’s controller gets the option to pay when the ability resolves."
+          "text": "The spell's controller gets the option to pay when the ability resolves."
         }
       ],
       "subtypes": [
@@ -2950,7 +2950,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature’s controller gets the option to pay when the spell resolves."
+          "text": "The creature's controller gets the option to pay when the spell resolves."
         },
         {
           "date": "2004-10-04",
@@ -3078,7 +3078,8 @@
         "ARC",
         "CMD",
         "PD3",
-        "CN2"
+        "CN2",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -3195,7 +3196,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -3734,7 +3735,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the card has no mana cost (for instance, if it’s a land), then its converted mana cost is 0. This means no tokens will be created."
+          "text": "If the card has no mana cost (for instance, if it's a land), then its converted mana cost is 0. This means no tokens will be created."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player puts the top card of his or her library into his or her graveyard. Then he or she creates X 1/1 black Minion creature tokens, where X is that card's converted mana cost.",
@@ -3847,7 +3848,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land are normally colorless, so effects that care about the color of the damage’s source will not find a color."
+          "text": "Land are normally colorless, so effects that care about the color of the damage's source will not find a color."
         }
       ],
       "subtypes": [
@@ -4006,7 +4007,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature’s controller gets the option to pay when the triggered ability resolves."
+          "text": "The creature's controller gets the option to pay when the triggered ability resolves."
         }
       ],
       "subtypes": [
@@ -4539,7 +4540,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land are normally colorless, so effects that care about the color of the damage’s source will not find a color."
+          "text": "Land are normally colorless, so effects that care about the color of the damage's source will not find a color."
         }
       ],
       "subtypes": [
@@ -4650,7 +4651,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Activated abilities of nontoken Rebels cost an additional \"Sacrifice a land\" to activate.",
@@ -4912,7 +4913,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose zero targets. You must choose at least one target."
+          "text": "You can't choose zero targets. You must choose at least one target."
         }
       ],
       "text": "You may discard a Mountain card rather than pay Flameshot's mana cost.\nFlameshot deals 3 damage divided as you choose among one, two, or three target creatures.",
@@ -6111,15 +6112,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the original creature has any “enters the battlefield” abilities, the copy will also have those."
+          "text": "If the original creature has any \"enters the battlefield\" abilities, the copy will also have those."
         },
         {
           "date": "2009-10-01",
-          "text": "The token is not considered to have been kicked, even if the creature it’s a copy of was kicked."
+          "text": "The token is not considered to have been kicked, even if the creature it's a copy of was kicked."
         },
         {
           "date": "2013-07-01",
-          "text": "If a legendary creature enters the battlefield, the token is put onto the battlefield and then the “legend rule” forces its controller to put either the original or the token into its owner’s graveyard before any player can take any actions."
+          "text": "If a legendary creature enters the battlefield, the token is put onto the battlefield and then the \"legend rule\" forces its controller to put either the original or the token into its owner's graveyard before any player can take any actions."
         }
       ],
       "text": "Whenever a nontoken creature enters the battlefield, its controller creates a token that's a copy of that creature.\nWhenever a nontoken creature leaves the battlefield, exile all tokens with the same name as that creature.\nWhen Dual Nature leaves the battlefield, exile all tokens created with Dual Nature.",
@@ -6172,7 +6173,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The token creatures’ power and toughness continuously adjust. They are not “locked in” when the spell resolves. This is because the tokens get an ability, rather than simply having their power and toughness set."
+          "text": "The token creatures' power and toughness continuously adjust. They are not \"locked in\" when the spell resolves. This is because the tokens get an ability, rather than simply having their power and toughness set."
         }
       ],
       "text": "Each player creates a green Elephant creature token. Those creatures have \"This creature's power and toughness are each equal to the number of creature cards in its controller's graveyard.\"",
@@ -6295,7 +6296,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -6421,7 +6422,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -7077,7 +7078,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It means X different creatures. You can’t give more than one +1/+1 counter to a creature with this spell."
+          "text": "It means X different creatures. You can't give more than one +1/+1 counter to a creature with this spell."
         }
       ],
       "text": "Put a +1/+1 counter on each of X target creatures.",
@@ -7443,7 +7444,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{0}: Tap all lands you control. Chimeric Idol becomes a 3/3 Turtle artifact creature until end of turn.",
@@ -7540,7 +7541,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card can’t tap itself to allow itself to attack or block. You have to tap a different creature which is not being declared as an attacker or blocker."
+          "text": "This card can't tap itself to allow itself to attack or block. You have to tap a different creature which is not being declared as an attacker or blocker."
         }
       ],
       "subtypes": [
@@ -7731,7 +7732,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The card’s ability has errata so you can’t activate the ability during casting of a spell or activating of an ability. This prevents you from getting into a position where someone paying {1} could stop you from having enough mana to pay for the spell. If you want to use it pay for a spell or ability, you need to use this card before you start the casting or activating."
+          "text": "The card's ability has errata so you can't activate the ability during casting of a spell or activating of an ability. This prevents you from getting into a position where someone paying {1} could stop you from having enough mana to pay for the spell. If you want to use it pay for a spell or ability, you need to use this card before you start the casting or activating."
         }
       ],
       "text": "{T}: Choose a color. Add one mana of that color to your mana pool unless any player pays {1}. Activate this ability only any time you could cast an instant.",

--- a/json/PD2.json
+++ b/json/PD2.json
@@ -62,7 +62,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The two cards are exiled as the cost of Grim Lavamancer’s ability is paid. Players can’t respond to the paying of costs by trying to move those cards to another zone."
+          "text": "The two cards are exiled as the cost of Grim Lavamancer's ability is paid. Players can't respond to the paying of costs by trying to move those cards to another zone."
         }
       ],
       "subtypes": [
@@ -190,7 +190,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it’s too late to activate its ability before it’s destroyed."
+          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it's too late to activate its ability before it's destroyed."
         }
       ],
       "subtypes": [
@@ -321,19 +321,19 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Figure of Destiny’s abilities overwrite its power, toughness, and creature types. Typically, those abilities are activated in the order they appear on the card. However, if Figure of Destiny is an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike, and you activate its first ability, it will become a 2/2 Kithkin Spirit that still has flying and first strike."
+          "text": "Figure of Destiny's abilities overwrite its power, toughness, and creature types. Typically, those abilities are activated in the order they appear on the card. However, if Figure of Destiny is an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike, and you activate its first ability, it will become a 2/2 Kithkin Spirit that still has flying and first strike."
         },
         {
           "date": "2008-08-01",
-          "text": "You can activate Figure of Destiny’s second and third abilities regardless of what creature types it is. Each of those abilities checks Figure of Destiny’s creature types when that ability resolves. If Figure of Destiny isn’t the appropriate creature type at that time, the ability does nothing."
+          "text": "You can activate Figure of Destiny's second and third abilities regardless of what creature types it is. Each of those abilities checks Figure of Destiny's creature types when that ability resolves. If Figure of Destiny isn't the appropriate creature type at that time, the ability does nothing."
         },
         {
           "date": "2008-08-01",
-          "text": "Figure of Destiny’s second ability checks whether it’s a Spirit, and its third ability checks whether it’s a Warrior. It doesn’t matter how it became the appropriate creature type."
+          "text": "Figure of Destiny's second ability checks whether it's a Spirit, and its third ability checks whether it's a Warrior. It doesn't matter how it became the appropriate creature type."
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -527,7 +527,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Although Mogg Flunkies can’t attack alone, other attacking creature(s) don’t have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
+          "text": "Although Mogg Flunkies can't attack alone, other attacking creature(s) don't have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
         },
         {
           "date": "2017-03-14",
@@ -535,7 +535,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player’s blocking creatures."
+          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player's blocking creatures."
         }
       ],
       "subtypes": [
@@ -960,19 +960,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Fire Servant’s ability applies no matter who or what the damage would be dealt to: a creature, a player, or a planeswalker."
+          "text": "Fire Servant's ability applies no matter who or what the damage would be dealt to: a creature, a player, or a planeswalker."
         },
         {
           "date": "2010-08-15",
-          "text": "If a red instant or sorcery spell you control causes damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Lightning Bolt says “Lightning Bolt deals 3 damage to target creature or player.” Such a spell is affected by Fire Servant’s ability. If the source of the damage is something else (for example, if the spell is Soul’s Fire, which says “Target creature you control on the battlefield deals damage equal to its power to target creature or player”), it isn’t affected by Fire Servant’s ability."
+          "text": "If a red instant or sorcery spell you control causes damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Lightning Bolt says \"Lightning Bolt deals 3 damage to target creature or player.\" Such a spell is affected by Fire Servant's ability. If the source of the damage is something else (for example, if the spell is Soul's Fire, which says \"Target creature you control on the battlefield deals damage equal to its power to target creature or player\"), it isn't affected by Fire Servant's ability."
         },
         {
           "date": "2010-08-15",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the permanent that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn” and Lava Axe is a red sorcery that says “Lava Axe deals 5 damage to target player.” Suppose a Lava Axe controlled by a player who controls Fire Servant would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Fire Servant’s effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the permanent that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn\" and Lava Axe is a red sorcery that says \"Lava Axe deals 5 damage to target player.\" Suppose a Lava Axe controlled by a player who controls Fire Servant would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Fire Servant's effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         },
         {
           "date": "2010-08-15",
-          "text": "If a red instant or sorcery spell you control divides damage among multiple recipients (such as Fireball does), the damage is divided before Fire Servant’s effect doubles it."
+          "text": "If a red instant or sorcery spell you control divides damage among multiple recipients (such as Fireball does), the damage is divided before Fire Servant's effect doubles it."
         },
         {
           "date": "2010-08-15",
@@ -1046,7 +1046,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who’s copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
+          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who's copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
         },
         {
           "date": "2016-06-08",
@@ -1054,11 +1054,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The copy of Chain Lightning is created on the stack, so it’s not cast. Abilities that trigger when a player casts a spell won’t trigger. Players may respond to that spell before it resolves."
+          "text": "The copy of Chain Lightning is created on the stack, so it's not cast. Abilities that trigger when a player casts a spell won't trigger. Players may respond to that spell before it resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can’t be copied."
+          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can't be copied."
         }
       ],
       "text": "Chain Lightning deals 3 damage to target creature or player. Then that player or that creature's controller may pay {R}{R}. If the player does, he or she may copy this spell and may choose a new target for that copy.",
@@ -1287,19 +1287,19 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Reverberate can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Reverberate can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2010-08-15",
-          "text": "When Reverberate resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When Reverberate resolves, it creates a copy of a spell. You control the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2010-08-15",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2010-08-15",
-          "text": "If the spell Reverberate copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Reverberate copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2010-08-15",
@@ -1307,11 +1307,11 @@
         },
         {
           "date": "2010-08-15",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Reverberate, the copy of Fling will also deal 3 damage to its target."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if a player sacrifices a 3/3 creature to cast Fling, and you copy it with Reverberate, the copy of Fling will also deal 3 damage to its target."
         },
         {
           "date": "2010-08-15",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
@@ -1431,7 +1431,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "The damage is unpreventable, and the targeted player’s life gain that turn is replaced with nothing."
+          "text": "The damage is unpreventable, and the targeted player's life gain that turn is replaced with nothing."
         },
         {
           "date": "2005-02-01",
@@ -1734,7 +1734,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The additional cost is paid when you pay the rest of Fireball’s costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn’t count toward Fireball’s converted mana cost."
+          "text": "The additional cost is paid when you pay the rest of Fireball's costs, even though that text appears second on the card (to make the card easier to read). The additional cost doesn't count toward Fireball's converted mana cost."
         },
         {
           "date": "2004-12-01",
@@ -1746,7 +1746,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Fireball’s damage is divided as Fireball resolves, not as it’s cast, because there are no choices involved. The division involves only targets that are still legal at that time."
+          "text": "Fireball's damage is divided as Fireball resolves, not as it's cast, because there are no choices involved. The division involves only targets that are still legal at that time."
         },
         {
           "date": "2009-10-01",
@@ -1848,11 +1848,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Ghitu Encampment enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\n{1}{R}: Ghitu Encampment becomes a 2/1 red Warrior creature with first strike until end of turn. It's still a land. (It deals combat damage before creatures without first strike.)",

--- a/json/PD3.json
+++ b/json/PD3.json
@@ -117,7 +117,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -263,7 +263,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2016-06-08",
@@ -408,7 +408,8 @@
         "ARC",
         "CMD",
         "PD3",
-        "CN2"
+        "CN2",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -486,7 +487,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If a targeted permanent has indestructible or regenerates, its controller won’t get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner’s graveyard, its controller won’t get an Elephant token for it."
+          "text": "If a targeted permanent has indestructible or regenerates, its controller won't get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner's graveyard, its controller won't get an Elephant token for it."
         }
       ],
       "subtypes": [
@@ -557,7 +558,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Verdant Force’s controller gets the tokens. That is the controller at the beginning of upkeep."
+          "text": "Verdant Force's controller gets the tokens. That is the controller at the beginning of upkeep."
         },
         {
           "date": "2005-08-01",
@@ -756,7 +757,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -998,7 +999,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You lose life equal to the converted mana cost of the card you’re bringing back, so if you Reanimate Volrath’s Shapeshifter, you lose three life, regardless of what the next card down is."
+          "text": "You lose life equal to the converted mana cost of the card you're bringing back, so if you Reanimate Volrath's Shapeshifter, you lose three life, regardless of what the next card down is."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
@@ -1062,7 +1063,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -1070,11 +1071,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -1396,7 +1397,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the creature is on the battlefield and is returned to its owner’s hand or is exiled, this card loses track of the creature and has no further effects in the future."
+          "text": "If the creature is on the battlefield and is returned to its owner's hand or is exiled, this card loses track of the creature and has no further effects in the future."
         }
       ],
       "text": "When Diabolic Servitude enters the battlefield, return target creature card from your graveyard to the battlefield.\nWhen the creature put onto the battlefield with Diabolic Servitude dies, exile it and return Diabolic Servitude to its owner's hand.\nWhen Diabolic Servitude leaves the battlefield, exile the creature put onto the battlefield with Diabolic Servitude.",

--- a/json/PLC.json
+++ b/json/PLC.json
@@ -235,43 +235,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -487,7 +487,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Dawn Charm’s third mode can target a spell that has multiple targets, as long as at least one of those targets is you."
+          "text": "Dawn Charm's third mode can target a spell that has multiple targets, as long as at least one of those targets is you."
         }
       ],
       "text": "Choose one —\n• Prevent all combat damage that would be dealt this turn.\n• Regenerate target creature.\n• Counter target spell that targets you.",
@@ -587,15 +587,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner’s hand."
+          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner's hand."
         },
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -798,39 +798,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1131,7 +1131,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Pallid Mycoderm gives a creature that’s both a Saproling and a Fungus (such as Mistform Ultimus) +1/+1, not +2/+2."
+          "text": "Pallid Mycoderm gives a creature that's both a Saproling and a Fungus (such as Mistform Ultimus) +1/+1, not +2/+2."
         }
       ],
       "subtypes": [
@@ -1236,11 +1236,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1444,11 +1444,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "All the Auras return to the battlefield simultaneously. Whether an Aura can be attached to a creature is checked before any of them are returned and doesn’t take into account any simultaneously returning Auras. For example, if Tattoo Ward (which gives enchanted creature protection from enchantments) and Holy Strength are in your graveyard and there’s only one creature on the battlefield, both Auras are returned to the battlefield attached to that creature, then Holy Strength is put into your graveyard the next time state-based actions are checked."
+          "text": "All the Auras return to the battlefield simultaneously. Whether an Aura can be attached to a creature is checked before any of them are returned and doesn't take into account any simultaneously returning Auras. For example, if Tattoo Ward (which gives enchanted creature protection from enchantments) and Holy Strength are in your graveyard and there's only one creature on the battlefield, both Auras are returned to the battlefield attached to that creature, then Holy Strength is put into your graveyard the next time state-based actions are checked."
         },
         {
           "date": "2007-02-01",
-          "text": "Auras don’t need to say “enchant creature” to return to the battlefield. For example, an Aura with “enchant land” will return to the battlefield if there’s an animated land for it to enchant."
+          "text": "Auras don't need to say \"enchant creature\" to return to the battlefield. For example, an Aura with \"enchant land\" will return to the battlefield if there's an animated land for it to enchant."
         }
       ],
       "text": "Return each Aura card from your graveyard to the battlefield. Only creatures can be enchanted this way. (Aura cards that can't enchant a creature on the battlefield remain in your graveyard.)",
@@ -1548,43 +1548,43 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If Riftmarked Knight is suspended, then when the last time counter is removed from it, both its own triggered ability and the “cast this card” part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If Riftmarked Knight is suspended, then when the last time counter is removed from it, both its own triggered ability and the \"cast this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1990,39 +1990,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -2137,11 +2137,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -2258,19 +2258,19 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner’s hand."
+          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner's hand."
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -2379,7 +2379,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can’t be cast. The other half is unaffected."
+          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can't be cast. The other half is unaffected."
         },
         {
           "date": "2007-02-01",
@@ -2391,7 +2391,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -2499,11 +2499,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You may return this creature itself to its owner’s hand as its triggered ability resolves. If you don’t control enough other creatures, you must return it."
+          "text": "You may return this creature itself to its owner's hand as its triggered ability resolves. If you don't control enough other creatures, you must return it."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability doesn’t target any creature. You don’t choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
+          "text": "The ability doesn't target any creature. You don't choose what to return until the ability resolves. Once the ability has started to resolve, no one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -2931,15 +2931,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Mesa Enchantress’s last ability will resolve before the spell that caused it to trigger."
+          "text": "Mesa Enchantress's last ability will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "If the enchantment spell is countered, Mesa Enchantress’s last ability still resolves and causes you to draw a card."
+          "text": "If the enchantment spell is countered, Mesa Enchantress's last ability still resolves and causes you to draw a card."
         },
         {
           "date": "2016-06-08",
-          "text": "Enchantments put onto the battlefield without being cast won’t cause Mesa Enchantress’s last ability to trigger."
+          "text": "Enchantments put onto the battlefield without being cast won't cause Mesa Enchantress's last ability to trigger."
         }
       ],
       "subtypes": [
@@ -3150,7 +3150,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "This card’s ability is not targeted, so even untargetable creatures or those with Protection can be chosen."
+          "text": "This card's ability is not targeted, so even untargetable creatures or those with Protection can be chosen."
         },
         {
           "date": "2007-02-01",
@@ -3162,7 +3162,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If there are multiple creatures tied for least power and some but not all of them have indestructible, the ones with indestructible can’t be chosen."
+          "text": "If there are multiple creatures tied for least power and some but not all of them have indestructible, the ones with indestructible can't be chosen."
         }
       ],
       "text": "At the beginning of your upkeep, destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them.\nWhen there are no creatures on the battlefield, sacrifice Porphyry Nodes.",
@@ -3379,11 +3379,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -3598,43 +3598,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -3743,7 +3743,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The first ability is a replacement effect. The choice is made as Aquamorph Entity is turned face up (or enters the battlefield); it turns face up (or enters the battlefield) as a creature of that size. It doesn’t become a 0/0 and then a creature of the chosen size."
+          "text": "The first ability is a replacement effect. The choice is made as Aquamorph Entity is turned face up (or enters the battlefield); it turns face up (or enters the battlefield) as a creature of that size. It doesn't become a 0/0 and then a creature of the chosen size."
         },
         {
           "date": "2007-02-01",
@@ -3751,7 +3751,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of a face-up Aquamorph Entity, its power and toughness become the power and toughness that were chosen for the Entity."
+          "text": "If a creature that's already on the battlefield becomes a copy of a face-up Aquamorph Entity, its power and toughness become the power and toughness that were chosen for the Entity."
         }
       ],
       "subtypes": [
@@ -3855,7 +3855,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Auramancer’s Guise counts itself when determining the power and toughness bonus."
+          "text": "Auramancer's Guise counts itself when determining the power and toughness bonus."
         }
       ],
       "subtypes": [
@@ -3960,11 +3960,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Treat Body Double as though it were the chosen card entering the battlefield. Any “As this card enters the battlefield,” “This card enters the battlefield with,” and “When this card enters the battlefield” abilities of the chosen card will work."
+          "text": "Treat Body Double as though it were the chosen card entering the battlefield. Any \"As this card enters the battlefield,\" \"This card enters the battlefield with,\" and \"When this card enters the battlefield\" abilities of the chosen card will work."
         },
         {
           "date": "2007-02-01",
-          "text": "You don’t have to choose a card to copy. If you don’t, Body Double enters the battlefield as a 0/0 creature and is probably put into your graveyard immediately, unless something is increasing its toughness to keep it alive."
+          "text": "You don't have to choose a card to copy. If you don't, Body Double enters the battlefield as a 0/0 creature and is probably put into your graveyard immediately, unless something is increasing its toughness to keep it alive."
         },
         {
           "date": "2007-02-01",
@@ -4175,11 +4175,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The ability checks to see if Chronozoa had no time counters on it at the time it was put into a graveyard from the battlefield. This doesn’t necessarily mean it must have been sacrificed due to vanishing; it could have been put into the graveyard some other way (say, while the sacrifice ability of vanishing is on the stack)."
+          "text": "The ability checks to see if Chronozoa had no time counters on it at the time it was put into a graveyard from the battlefield. This doesn't necessarily mean it must have been sacrificed due to vanishing; it could have been put into the graveyard some other way (say, while the sacrifice ability of vanishing is on the stack)."
         },
         {
           "date": "2007-02-01",
-          "text": "Chronozoa’s last ability creates two Chronozoa tokens that each enter the battlefield with three time counters and have all of Chronozoa’s abilities."
+          "text": "Chronozoa's last ability creates two Chronozoa tokens that each enter the battlefield with three time counters and have all of Chronozoa's abilities."
         },
         {
           "date": "2007-02-01",
@@ -4286,43 +4286,43 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The cards all enter the battlefield simultaneously. If one of the cards that’s entering the battlefield is an Aura, it must enter the battlefield attached to a permanent already on the battlefield. It can’t enter the battlefield attached to another permanent entering the battlefield via Dichotomancy. If an Aura can’t enter the battlefield this way, it remains in the opponent’s library."
+          "text": "The cards all enter the battlefield simultaneously. If one of the cards that's entering the battlefield is an Aura, it must enter the battlefield attached to a permanent already on the battlefield. It can't enter the battlefield attached to another permanent entering the battlefield via Dichotomancy. If an Aura can't enter the battlefield this way, it remains in the opponent's library."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -4620,7 +4620,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The target creature is chosen as the spell is cast. You don’t reveal cards until the spell resolves."
+          "text": "The target creature is chosen as the spell is cast. You don't reveal cards until the spell resolves."
         }
       ],
       "text": "Choose target creature. Reveal cards from the top of your library until you reveal a nonland card. That creature gets +X/-X until end of turn, where X is that card's converted mana cost. Put all cards revealed this way on the bottom of your library in any order.",
@@ -4919,7 +4919,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The creature’s controller gets the Ape token even if the creature isn’t actually destroyed."
+          "text": "The creature's controller gets the Ape token even if the creature isn't actually destroyed."
         }
       ],
       "text": "Destroy target creature. It can't be regenerated. Its controller creates a 3/3 green Ape creature token.",
@@ -5219,15 +5219,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If the targeted spell can’t be countered, it remains on the stack and the rest of Spellshift’s effect continues to happen."
+          "text": "If the targeted spell can't be countered, it remains on the stack and the rest of Spellshift's effect continues to happen."
         },
         {
           "date": "2007-02-01",
-          "text": "If the revealed instant or sorcery card isn’t cast, it gets shuffled back into the library."
+          "text": "If the revealed instant or sorcery card isn't cast, it gets shuffled back into the library."
         },
         {
           "date": "2007-02-01",
-          "text": "If there are no instant or sorcery cards in the player’s library, the entire library is revealed and then shuffled."
+          "text": "If there are no instant or sorcery cards in the player's library, the entire library is revealed and then shuffled."
         }
       ],
       "text": "Counter target instant or sorcery spell. Its controller reveals cards from the top of his or her library until he or she reveals an instant or sorcery card. That player may cast that card without paying its mana cost. Then he or she shuffles his or her library.",
@@ -5328,11 +5328,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -5436,11 +5436,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Unless something is boosting Tidewalker’s toughness, when the last time counter is removed, it will be put into the graveyard as a state-based action for having 0 toughness before it can be sacrificed as the result of vanishing."
+          "text": "Unless something is boosting Tidewalker's toughness, when the last time counter is removed, it will be put into the graveyard as a state-based action for having 0 toughness before it can be sacrificed as the result of vanishing."
         },
         {
           "date": "2007-02-01",
-          "text": "If you don’t control any Islands when Tidewalker enters the battlefield, its vanishing ability has no effect. (It enters the battlefield with no time counters on it, so neither of the vanishing triggers can trigger. See “Vanishing” in the General Notes section above.) On the other hand, it will be 0/0 and will be put into its owner’s graveyard unless something is boosting its toughness."
+          "text": "If you don't control any Islands when Tidewalker enters the battlefield, its vanishing ability has no effect. (It enters the battlefield with no time counters on it, so neither of the vanishing triggers can trigger. See \"Vanishing\" in the General Notes section above.) On the other hand, it will be 0/0 and will be put into its owner's graveyard unless something is boosting its toughness."
         }
       ],
       "subtypes": [
@@ -5544,7 +5544,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The mode and target of the triggered ability are chosen when it’s put on the stack."
+          "text": "The mode and target of the triggered ability are chosen when it's put on the stack."
         }
       ],
       "subtypes": [
@@ -5649,51 +5649,51 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If Veiling Oddity is suspended, then when the last time counter is removed from it, both its triggered ability and the “cast this card” part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If Veiling Oddity is suspended, then when the last time counter is removed from it, both its triggered ability and the \"cast this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2007-02-01",
-          "text": "Regardless of which order those abilities resolve in, Veiling Oddity can’t be blocked that turn. The ability affects all creatures, not just the creatures that were on the battlefield when it resolved."
+          "text": "Regardless of which order those abilities resolve in, Veiling Oddity can't be blocked that turn. The ability affects all creatures, not just the creatures that were on the battlefield when it resolved."
         },
         {
           "date": "2007-02-01",
-          "text": "If Veiling Oddity is suspended and the last time counter is removed during another player’s turn, that player’s creatures can’t be blocked that turn, too."
+          "text": "If Veiling Oddity is suspended and the last time counter is removed during another player's turn, that player's creatures can't be blocked that turn, too."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -6010,7 +6010,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "It applies to cards and tokens that are put onto the battlefield by an effect, as well as ones that are played from the player’s hand."
+          "text": "It applies to cards and tokens that are put onto the battlefield by an effect, as well as ones that are played from the player's hand."
         }
       ],
       "text": "Artifacts, creatures, and lands your opponents control enter the battlefield tapped.",
@@ -6116,7 +6116,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You’ll sacrifice Skulking Ghost even if you counter the spell or ability that targets it. If that spell has no other targets, it’ll be countered when it tries to resolve."
+          "text": "You'll sacrifice Skulking Ghost even if you counter the spell or ability that targets it. If that spell has no other targets, it'll be countered when it tries to resolve."
         }
       ],
       "subtypes": [
@@ -6230,7 +6230,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -6336,7 +6336,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Ovinize doesn’t counter abilities that have already triggered or been activated. In particular, you can’t cast this fast enough to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering, since they trigger before players get priority."
+          "text": "Ovinize doesn't counter abilities that have already triggered or been activated. In particular, you can't cast this fast enough to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering, since they trigger before players get priority."
         },
         {
           "date": "2007-02-01",
@@ -6344,15 +6344,15 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If a face-down creature is affected by Ovinize, it won’t be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/1 creature with no abilities until the turn ends. Its “When this creature turns face up” or “As this creature turns face up” abilities won’t work."
+          "text": "If a face-down creature is affected by Ovinize, it won't be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/1 creature with no abilities until the turn ends. Its \"When this creature turns face up\" or \"As this creature turns face up\" abilities won't work."
         },
         {
           "date": "2007-02-01",
-          "text": "Ovinize can be used to disable a creature’s vanishing ability permanently by casting it in response to the vanishing upkeep trigger when there’s one time counter left. The last time counter will be removed as that ability resolves, but since the creature no longer has vanishing, the “sacrifice” triggered ability won’t exist. When Ovinize’s effect ends and the creature regains vanishing, its triggered ability will no longer be able to trigger because it has no time counters."
+          "text": "Ovinize can be used to disable a creature's vanishing ability permanently by casting it in response to the vanishing upkeep trigger when there's one time counter left. The last time counter will be removed as that ability resolves, but since the creature no longer has vanishing, the \"sacrifice\" triggered ability won't exist. When Ovinize's effect ends and the creature regains vanishing, its triggered ability will no longer be able to trigger because it has no time counters."
         },
         {
           "date": "2007-02-01",
-          "text": "If Ovinize affects Mistform Ultimus, the Ultimus will lose its ability that says “Mistform Ultimus is every creature type,” but it will still *be* all creature types. The way continuous effects work, Mistform Ultimus’s type-changing ability is applied before Ovinize’s ability removes it."
+          "text": "If Ovinize affects Mistform Ultimus, the Ultimus will lose its ability that says \"Mistform Ultimus is every creature type,\" but it will still *be* all creature types. The way continuous effects work, Mistform Ultimus's type-changing ability is applied before Ovinize's ability removes it."
         },
         {
           "date": "2007-02-01",
@@ -6565,7 +6565,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
+          "text": "If a creature that's already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
         },
         {
           "date": "2007-02-01",
@@ -6577,7 +6577,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
         }
       ],
       "subtypes": [
@@ -7205,7 +7205,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When this spell is cast, its “when you cast” ability triggers and goes on the stack on top of it."
+          "text": "When this spell is cast, its \"when you cast\" ability triggers and goes on the stack on top of it."
         },
         {
           "date": "2007-02-01",
@@ -7213,7 +7213,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "A player can’t choose to sacrifice a creature unless he or she actually controls a creature that can be sacrificed. For example, if the action were “discard three cards,” a player with two or fewer cards in hand couldn’t take the option to counter the spell."
+          "text": "A player can't choose to sacrifice a creature unless he or she actually controls a creature that can be sacrificed. For example, if the action were \"discard three cards,\" a player with two or fewer cards in hand couldn't take the option to counter the spell."
         }
       ],
       "subtypes": [
@@ -7316,15 +7316,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The player you target doesn’t have to be the controller of the source that dealt damage to you."
+          "text": "The player you target doesn't have to be the controller of the source that dealt damage to you."
         },
         {
           "date": "2007-02-01",
-          "text": "If the damage reduces you to 0 or less life, you lose the game before Circle of Affliction’s ability has a chance to give you life."
+          "text": "If the damage reduces you to 0 or less life, you lose the game before Circle of Affliction's ability has a chance to give you life."
         },
         {
           "date": "2007-02-01",
-          "text": "Each time a source deals damage to you, you may pay {1}. You can’t pay more than {1}, even if more than 1 damage was dealt."
+          "text": "Each time a source deals damage to you, you may pay {1}. You can't pay more than {1}, even if more than 1 damage was dealt."
         },
         {
           "date": "2007-02-01",
@@ -7522,7 +7522,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When this spell is cast, its “when you cast” ability triggers and goes on the stack on top of it."
+          "text": "When this spell is cast, its \"when you cast\" ability triggers and goes on the stack on top of it."
         },
         {
           "date": "2007-02-01",
@@ -7530,7 +7530,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "A player can’t choose to pay 5 life unless he or she actually has 5 or more life to pay."
+          "text": "A player can't choose to pay 5 life unless he or she actually has 5 or more life to pay."
         }
       ],
       "text": "When you cast Dash Hopes, any player may pay 5 life. If a player does, counter Dash Hopes.\nCounter target spell.",
@@ -7630,7 +7630,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The ability checks to see if Deadly Grub had no time counters on it at the time it was put into a graveyard from the battlefield. This doesn’t necessarily mean it must have been sacrificed due to vanishing; it could have been put into the graveyard some other way (say, while the sacrifice ability of vanishing is on the stack)."
+          "text": "The ability checks to see if Deadly Grub had no time counters on it at the time it was put into a graveyard from the battlefield. This doesn't necessarily mean it must have been sacrificed due to vanishing; it could have been put into the graveyard some other way (say, while the sacrifice ability of vanishing is on the stack)."
         }
       ],
       "subtypes": [
@@ -7740,11 +7740,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn’t start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
+          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn't start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -7851,23 +7851,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
@@ -7979,7 +7979,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t make a spell which is on the stack target itself."
+          "text": "You can't make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -7999,15 +7999,15 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If there is no other legal target for the spell, the spell’s target isn’t changed. You still lose the life."
+          "text": "If there is no other legal target for the spell, the spell's target isn't changed. You still lose the life."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Imp’s Mischief, even if all but one of the targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Imp's Mischief, even if all but one of the targets has become illegal."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell has multiple targets but is targeting the same thing with all of them (such as Seeds of Strength targeting the same creature three times), you can’t target that spell with Imp’s Mischief."
+          "text": "If a spell has multiple targets but is targeting the same thing with all of them (such as Seeds of Strength targeting the same creature three times), you can't target that spell with Imp's Mischief."
         }
       ],
       "text": "Change the target of target spell with a single target. You lose life equal to that spell's converted mana cost.",
@@ -8302,7 +8302,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If Mirri the Cursed is in combat with a creature that doesn’t have first strike or double strike, Mirri will deal combat damage to that creature, then get a +1/+1 counter, then (if the other creature is still on the battlefield) Mirri will be dealt combat damage."
+          "text": "If Mirri the Cursed is in combat with a creature that doesn't have first strike or double strike, Mirri will deal combat damage to that creature, then get a +1/+1 counter, then (if the other creature is still on the battlefield) Mirri will be dealt combat damage."
         }
       ],
       "subtypes": [
@@ -8410,15 +8410,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The spell’s target is changed to Muck Drubb only if Muck Drubb is a legal target for that spell."
+          "text": "The spell's target is changed to Muck Drubb only if Muck Drubb is a legal target for that spell."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Muck Drubb’s ability, even if only one of those targets is a creature or all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Muck Drubb's ability, even if only one of those targets is a creature or all but one of those targets has become illegal."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell has multiple targets, but it’s targeting the same thing with all of them (such as Seeds of Strength targeting the same creature three times), you can target that spell with Muck Drubb’s ability. In that case, you change all of those targets to Muck Drubb."
+          "text": "If a spell has multiple targets, but it's targeting the same thing with all of them (such as Seeds of Strength targeting the same creature three times), you can target that spell with Muck Drubb's ability. In that case, you change all of those targets to Muck Drubb."
         }
       ],
       "subtypes": [
@@ -8522,7 +8522,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When this spell is cast, its “when you cast” ability triggers and goes on the stack on top of it."
+          "text": "When this spell is cast, its \"when you cast\" ability triggers and goes on the stack on top of it."
         },
         {
           "date": "2007-02-01",
@@ -8530,7 +8530,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "A player can’t choose to discard unless he or she actually has three cards in his or her hand."
+          "text": "A player can't choose to discard unless he or she actually has three cards in his or her hand."
         }
       ],
       "subtypes": [
@@ -8734,11 +8734,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If your life total is less than or equal to the life total of the opponent with the most life, Roiling Horror’s toughness is 0 or less. It will be put into its owner’s graveyard as a state-based action."
+          "text": "If your life total is less than or equal to the life total of the opponent with the most life, Roiling Horror's toughness is 0 or less. It will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2007-02-01",
-          "text": "You never choose an opponent, and the opponent that Roiling Horror looks at is never “locked in.” Roiling Horror continuously looks at the life totals of all opponents and uses whichever value is the largest."
+          "text": "You never choose an opponent, and the opponent that Roiling Horror looks at is never \"locked in.\" Roiling Horror continuously looks at the life totals of all opponents and uses whichever value is the largest."
         },
         {
           "date": "2007-02-01",
@@ -8746,43 +8746,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -8891,11 +8891,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -8999,7 +8999,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When this spell is cast, its “when you cast” ability triggers and goes on the stack on top of it."
+          "text": "When this spell is cast, its \"when you cast\" ability triggers and goes on the stack on top of it."
         },
         {
           "date": "2007-02-01",
@@ -9102,11 +9102,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If you don’t control the creature when the ability resolves, the creature won’t be sacrificed. It will have haste permanently."
+          "text": "If you don't control the creature when the ability resolves, the creature won't be sacrificed. It will have haste permanently."
         },
         {
           "date": "2007-02-01",
-          "text": "If you cast Treacherous Urge during the End step, you won’t sacrifice the creature until the end of the following turn."
+          "text": "If you cast Treacherous Urge during the End step, you won't sacrifice the creature until the end of the following turn."
         }
       ],
       "text": "Target opponent reveals his or her hand. You may put a creature card from it onto the battlefield under your control. That creature gains haste. Sacrifice it at the beginning of the next end step.",
@@ -9407,7 +9407,8 @@
         "pJGP",
         "pMPR",
         "PLC",
-        "MM3"
+        "MM3",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -9523,7 +9524,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "Dunerider Outlaw’s triggered ability checks to see if it dealt damage during the turn to an opponent of its current controller. If it dealt damage to player A, then player A takes control of it, the ability doesn’t trigger."
+          "text": "Dunerider Outlaw's triggered ability checks to see if it dealt damage during the turn to an opponent of its current controller. If it dealt damage to player A, then player A takes control of it, the ability doesn't trigger."
         },
         {
           "date": "2007-02-01",
@@ -9842,7 +9843,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The triggered ability will trigger when you play a land card or cast a nonland card as a spell. It won’t trigger when you play a copy of a card, such as with Isochron Scepter."
+          "text": "The triggered ability will trigger when you play a land card or cast a nonland card as a spell. It won't trigger when you play a copy of a card, such as with Isochron Scepter."
         },
         {
           "date": "2007-02-01",
@@ -10067,7 +10068,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "You target an opponent when you cast Shrouded Lore. The opponent chooses a card in your graveyard as Shrouded Lore resolves. After that choice is made, you’re given the option to pay {B}. If you do, the targeted opponent must choose a different card, if there is one. (If there isn’t one, this part is skipped.) Then you’re given the option to pay {B} again. As long as you keep paying {B}, the process continues. As soon as you decline to pay {B}, the last card that was chosen by the opponent is put into your hand."
+          "text": "You target an opponent when you cast Shrouded Lore. The opponent chooses a card in your graveyard as Shrouded Lore resolves. After that choice is made, you're given the option to pay {B}. If you do, the targeted opponent must choose a different card, if there is one. (If there isn't one, this part is skipped.) Then you're given the option to pay {B} again. As long as you keep paying {B}, the process continues. As soon as you decline to pay {B}, the last card that was chosen by the opponent is put into your hand."
         },
         {
           "date": "2007-02-01",
@@ -10288,7 +10289,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The blocked creature is returned to its owner’s hand at end of combat only if the blocked creature is still on the battlefield. It doesn’t matter whether Aether Membrane is on the battlefield."
+          "text": "The blocked creature is returned to its owner's hand at end of combat only if the blocked creature is still on the battlefield. It doesn't matter whether Aether Membrane is on the battlefield."
         }
       ],
       "subtypes": [
@@ -10511,11 +10512,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -10627,43 +10628,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -10771,7 +10772,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don’t actually have Flying."
+          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don't actually have Flying."
         }
       ],
       "subtypes": [
@@ -10874,7 +10875,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If you don’t control the affected creature at end of turn, it isn’t sacrificed."
+          "text": "If you don't control the affected creature at end of turn, it isn't sacrificed."
         }
       ],
       "text": "Until end of turn, target creature you control gains trample and gets +X/+0, where X is its power. Sacrifice it at the beginning of the next end step.",
@@ -11369,7 +11370,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If multiple creatures you control deal combat damage to a player, Lavacore Elemental’s ability triggers that many times."
+          "text": "If multiple creatures you control deal combat damage to a player, Lavacore Elemental's ability triggers that many times."
         },
         {
           "date": "2007-02-01",
@@ -11483,15 +11484,15 @@
         },
         {
           "date": "2007-02-01",
-          "text": "Magus of the Arena’s controller always chooses his or her creature first."
+          "text": "Magus of the Arena's controller always chooses his or her creature first."
         },
         {
           "date": "2007-02-01",
-          "text": "Tapped creatures can be targeted. Tapping them again will do nothing, but they’ll still deal damage."
+          "text": "Tapped creatures can be targeted. Tapping them again will do nothing, but they'll still deal damage."
         },
         {
           "date": "2007-02-01",
-          "text": "If an effect changes the targets of this ability, the second target can be changed to any creature the chosen opponent controls. The choice of opponent can’t be changed."
+          "text": "If an effect changes the targets of this ability, the second target can be changed to any creature the chosen opponent controls. The choice of opponent can't be changed."
         }
       ],
       "subtypes": [
@@ -11695,39 +11696,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -11936,23 +11937,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -12152,15 +12153,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When the third ability resolves, you must change the target if able. If you can’t choose a legal target for the spell when this ability resolves, that spell’s target doesn’t change."
+          "text": "When the third ability resolves, you must change the target if able. If you can't choose a legal target for the spell when this ability resolves, that spell's target doesn't change."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell targets multiple things, you can’t target it with Torchling’s third ability, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Torchling's third ability, even if all but one of those targets has become illegal."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell has multiple targets, but it’s targeting Torchling with all of them (such as Seeds of Strength targeting Torchling three times), you can target that spell with Torchling’s third ability. In that case, you change all of those targets to the same new target, as long as it meets each of the spell’s targeting conditions."
+          "text": "If a spell has multiple targets, but it's targeting Torchling with all of them (such as Seeds of Strength targeting Torchling three times), you can target that spell with Torchling's third ability. In that case, you change all of those targets to the same new target, as long as it meets each of the spell's targeting conditions."
         }
       ],
       "subtypes": [
@@ -12264,11 +12265,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "As Volcano Hellion’s enters-the-battlefield ability resolves, you choose a number. Volcano Hellion deals that amount of damage to you and to the targeted creature. You may choose 0."
+          "text": "As Volcano Hellion's enters-the-battlefield ability resolves, you choose a number. Volcano Hellion deals that amount of damage to you and to the targeted creature. You may choose 0."
         },
         {
           "date": "2007-02-01",
-          "text": "Volcano Hellion’s echo cost constantly changes; it’s not locked in when it enters the battlefield. The echo cost you pay is equal your life total as the echo triggered ability resolves."
+          "text": "Volcano Hellion's echo cost constantly changes; it's not locked in when it enters the battlefield. The echo cost you pay is equal your life total as the echo triggered ability resolves."
         }
       ],
       "subtypes": [
@@ -13167,7 +13168,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The player who controlled Molten Firebird when it was put into a graveyard will skip his or her next draw step even if Molten Firebird is returned to the battlefield under a different player’s control (because it’s owned by someone else) or isn’t returned to the battlefield at all (because it left the graveyard before the end of the turn, for example)."
+          "text": "The player who controlled Molten Firebird when it was put into a graveyard will skip his or her next draw step even if Molten Firebird is returned to the battlefield under a different player's control (because it's owned by someone else) or isn't returned to the battlefield at all (because it left the graveyard before the end of the turn, for example)."
         },
         {
           "date": "2007-02-01",
@@ -13400,7 +13401,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -13613,7 +13614,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When Shivan Wumpus enters the battlefield, first the active player gets the option to sacrifice a land. If he or she declines, the next player in turn order gets the option. If a player elects to sacrifice a land, Shivan Wumpus is put on top of its owner’s library, but then all remaining players still get the option. If all players decline, then nothing happens and Shivan Wumpus stays on the battlefield."
+          "text": "When Shivan Wumpus enters the battlefield, first the active player gets the option to sacrifice a land. If he or she declines, the next player in turn order gets the option. If a player elects to sacrifice a land, Shivan Wumpus is put on top of its owner's library, but then all remaining players still get the option. If all players decline, then nothing happens and Shivan Wumpus stays on the battlefield."
         },
         {
           "date": "2007-02-01",
@@ -14352,43 +14353,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -14497,39 +14498,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -14640,7 +14641,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         }
       ],
       "text": "Kicker {3}{G} (You may pay an additional {3}{G} as you cast this spell.)\nSearch your library for up to two Forest cards and put them onto the battlefield tapped. Then shuffle your library.\nIf Hunting Wilds was kicked, untap all Forests put onto the battlefield this way. They become 3/3 green creatures with haste that are still lands.",
@@ -14957,11 +14958,11 @@
         },
         {
           "date": "2007-02-01",
-          "text": "Forests that enter the battlefield while Life and Limb is on the battlefield will enter the battlefield as creatures. They’ll have summoning sickness."
+          "text": "Forests that enter the battlefield while Life and Limb is on the battlefield will enter the battlefield as creatures. They'll have summoning sickness."
         },
         {
           "date": "2007-02-01",
-          "text": "Saprolings that are on the battlefield while Life and Limb is on the battlefield have the ability “{T}: Add {G} to your mana pool.” Although they’re Forests, they are not basic lands."
+          "text": "Saprolings that are on the battlefield while Life and Limb is on the battlefield have the ability \"{T}: Add {G} to your mana pool.\" Although they're Forests, they are not basic lands."
         },
         {
           "date": "2007-02-01",
@@ -15473,11 +15474,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -16079,7 +16080,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "The game checks the power and toughness of the creature that just entered the battlefield as it exists on the battlefield. That might mean it’s impossible to get another copy of that same card. For example, a Triskelion on the battlefield is 4/4, but a Triskelion in your library is 1/1. The power and toughness might also have been affected while the triggered ability was on the stack (such as with Giant Growth, Sudden Death, or Ovinize)."
+          "text": "The game checks the power and toughness of the creature that just entered the battlefield as it exists on the battlefield. That might mean it's impossible to get another copy of that same card. For example, a Triskelion on the battlefield is 4/4, but a Triskelion in your library is 1/1. The power and toughness might also have been affected while the triggered ability was on the stack (such as with Giant Growth, Sudden Death, or Ovinize)."
         },
         {
           "date": "2007-02-01",
@@ -16306,7 +16307,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If the draw is replaced by another effect, none of the rest of Fa’adiyah Seer’s ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
+          "text": "If the draw is replaced by another effect, none of the rest of Fa'adiyah Seer's ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
         },
         {
           "date": "2007-02-01",
@@ -16963,7 +16964,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If put on your opponent’s creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
+          "text": "If put on your opponent's creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
         },
         {
           "date": "2007-02-01",
@@ -17080,7 +17081,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "You can activate Seal of Primordium’s ability targeting Seal of Primordium itself if you want it to leave the battlefield. This is because targets are chosen before costs are paid. The ability will be countered as it tries to resolve."
+          "text": "You can activate Seal of Primordium's ability targeting Seal of Primordium itself if you want it to leave the battlefield. This is because targets are chosen before costs are paid. The ability will be countered as it tries to resolve."
         }
       ],
       "text": "Sacrifice Seal of Primordium: Destroy target artifact or enchantment.",
@@ -17187,11 +17188,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -17298,15 +17299,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The player who controlled the Sliver that’s sacrificed gains the life, not the controller of Darkheart Sliver."
+          "text": "The player who controlled the Sliver that's sacrificed gains the life, not the controller of Darkheart Sliver."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -17421,11 +17422,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -17535,11 +17536,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -17648,11 +17649,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "After Intet leaves the battlefield, if a card exiled this way is still exiled, you may still look at it. You won’t be able to play it, though."
+          "text": "After Intet leaves the battlefield, if a card exiled this way is still exiled, you may still look at it. You won't be able to play it, though."
         },
         {
           "date": "2007-02-01",
-          "text": "Once you play a card this way, it leaves the Exile zone and goes to the stack. You won’t be able to play it again."
+          "text": "Once you play a card this way, it leaves the Exile zone and goes to the stack. You won't be able to play it again."
         }
       ],
       "subtypes": [
@@ -17763,11 +17764,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -18095,7 +18096,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Radha’s triggered ability is not a mana ability (because it doesn’t trigger from another mana ability). It goes on the stack and it can be countered."
+          "text": "Radha's triggered ability is not a mana ability (because it doesn't trigger from another mana ability). It goes on the stack and it can be countered."
         }
       ],
       "subtypes": [
@@ -18415,19 +18416,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If Urborg, Tomb of Yawgmoth and either Blood Moon or Magus of the Moon are on the battlefield, all nonbasic lands will be Mountains, not Swamps. Urborg, Tomb of Yawgmoth will be a Mountain as well. It will have “{T}: Add {R} to your mana pool” and no other abilities."
+          "text": "If Urborg, Tomb of Yawgmoth and either Blood Moon or Magus of the Moon are on the battlefield, all nonbasic lands will be Mountains, not Swamps. Urborg, Tomb of Yawgmoth will be a Mountain as well. It will have \"{T}: Add {R} to your mana pool\" and no other abilities."
         },
         {
           "date": "2014-07-18",
-          "text": "Urborg, Tomb of Yawgmoth isn’t a Swamp while it’s not on the battlefield."
+          "text": "Urborg, Tomb of Yawgmoth isn't a Swamp while it's not on the battlefield."
         },
         {
           "date": "2014-07-18",
-          "text": "Urborg’s ability causes each land on the battlefield to have the land type Swamp. Each land thus has the ability “{T}: Add {B} to your mana pool.” Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they’re legendary or basic."
+          "text": "Urborg's ability causes each land on the battlefield to have the land type Swamp. Each land thus has the ability \"{T}: Add {B} to your mana pool.\" Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they're legendary or basic."
         },
         {
           "date": "2014-07-18",
-          "text": "If Urborg loses its abilities (for example, if it becomes a creature and then Turn to Frog targets it), all lands on the battlefield, including Urborg, will still be Swamps, but Urborg won’t have the ability “Each land is a Swamp in addition to its other land types.” Urborg also won’t be able to tap to produce {B}, but other lands (including those that enter the battlefield later in the turn) will. The way continuous effects work, Urborg’s type-changing ability is applied before the effect that removes both the type-changing ability and its own mana ability."
+          "text": "If Urborg loses its abilities (for example, if it becomes a creature and then Turn to Frog targets it), all lands on the battlefield, including Urborg, will still be Swamps, but Urborg won't have the ability \"Each land is a Swamp in addition to its other land types.\" Urborg also won't be able to tap to produce {B}, but other lands (including those that enter the battlefield later in the turn) will. The way continuous effects work, Urborg's type-changing ability is applied before the effect that removes both the type-changing ability and its own mana ability."
         }
       ],
       "supertypes": [

--- a/json/PLS.json
+++ b/json/PLS.json
@@ -91,7 +91,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t draw a card if this spell is countered. This can happen if the target is illegal on resolution."
+          "text": "You don't draw a card if this spell is countered. This can happen if the target is illegal on resolution."
         },
         {
           "date": "2004-10-04",
@@ -179,7 +179,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "When no birds are available, Kangee's disciples fill the sky with anything that‘s willing to fight.",
+      "flavor": "When no birds are available, Kangee's disciples fill the sky with anything that's willing to fight.",
       "foreignNames": [
         {
           "language": "French",
@@ -751,7 +751,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "This can’t be used as a counterspell. It will have no effect on spells which were on the stack when it was cast, nor on those cast in response to it."
+          "text": "This can't be used as a counterspell. It will have no effect on spells which were on the stack when it was cast, nor on those cast in response to it."
         }
       ],
       "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nTarget player can't cast spells this turn.\nIf Orim's Chant was kicked, creatures can't attack this turn.",
@@ -882,7 +882,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose zero targets. You must choose between 1 and 3 (or 6) targets."
+          "text": "You can't choose zero targets. You must choose between 1 and 3 (or 6) targets."
         }
       ],
       "text": "Kicker—Sacrifice a land. (You may sacrifice a land in addition to any other costs as you cast this spell.)\nPrevent the next 3 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose. If Pollen Remedy was kicked, prevent the next 6 damage this way instead.",
@@ -1031,7 +1031,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -1175,7 +1175,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -1195,7 +1195,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -1414,7 +1414,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Target player draws a card for each basic land type among lands he or she controls.",
@@ -1547,7 +1547,7 @@
           "text": "Confound is countered on resolution if the targeted spell has been countered or does not still target one or more permanents that are still creatures and are still on the battlefield. Confound is different from other such spells in that it actually specifies that the spell must target a creature, not just be able to target a creature or that the spell has a certain number of targets."
         }
       ],
-      "text": "Counter target spell that targets a creature. \nDraw a card.",
+      "text": "Counter target spell that targets a creature.\nDraw a card.",
       "type": "Instant",
       "types": [
         "Instant"
@@ -1611,7 +1611,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the Dralnu’s Pet is kicked, Dralnu’s Pet will have flying from the moment it enters the battlefield. This will trigger abilities that look for a creature with flying entering the battlefield."
+          "text": "If the Dralnu's Pet is kicked, Dralnu's Pet will have flying from the moment it enters the battlefield. This will trigger abilities that look for a creature with flying entering the battlefield."
         }
       ],
       "subtypes": [
@@ -2016,11 +2016,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If Planeswalker’s Mischief leaves the battlefield, any cards it exiled are still under the effect of the ability and can be cast (and if they are not cast, they are returned to the owner’s hand)."
+          "text": "If Planeswalker's Mischief leaves the battlefield, any cards it exiled are still under the effect of the ability and can be cast (and if they are not cast, they are returned to the owner's hand)."
         },
         {
           "date": "2004-10-04",
-          "text": "When cast, the card goes to its owner’s graveyard after it resolves."
+          "text": "When cast, the card goes to its owner's graveyard after it resolves."
         }
       ],
       "text": "{3}{U}: Target opponent reveals a card at random from his or her hand. If it's an instant or sorcery card, exile it. You may cast it without paying its mana cost for as long as it remains exiled. (If it has X in its mana cost, X is 0.) At the beginning of the next end step, if you haven't cast it, return it to its owner's hand. Activate this ability only any time you could cast a sorcery.",
@@ -2491,7 +2491,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -2511,7 +2511,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -2648,7 +2648,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It affects your creatures as well as your opponent’s."
+          "text": "It affects your creatures as well as your opponent's."
         }
       ],
       "subtypes": [
@@ -2995,7 +2995,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Target player loses X life and you gain X life, where X is the number of basic land types among lands you control.",
@@ -3353,7 +3353,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -3373,7 +3373,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -3827,7 +3827,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t draw a card if this spell is countered."
+          "text": "You don't draw a card if this spell is countered."
         }
       ],
       "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
@@ -3964,7 +3964,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card can trigger on itself being returned to a player’s hand."
+          "text": "This card can trigger on itself being returned to a player's hand."
         }
       ],
       "text": "Whenever a permanent is returned to a player's hand, that player discards a card.",
@@ -4241,7 +4241,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When it comes to choice of items, use common sense. Items should be small enough to hide but large enough to count. Make it clear what kind of object you are hiding beforehand. For example, one player may choose coins and the other may choose dice. If you can’t find something convenient to hide, write numbers on a piece of paper and reveal the numbers. Make sure the numbers are unambiguous (for example, underline a 6 or 9 so it can’t be misread)."
+          "text": "When it comes to choice of items, use common sense. Items should be small enough to hide but large enough to count. Make it clear what kind of object you are hiding beforehand. For example, one player may choose coins and the other may choose dice. If you can't find something convenient to hide, write numbers on a piece of paper and reveal the numbers. Make sure the numbers are unambiguous (for example, underline a 6 or 9 so it can't be misread)."
         },
         {
           "date": "2007-02-01",
@@ -4986,7 +4986,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"All right, let's light ‘em up\"\n—Gerrard",
+      "flavor": "\"All right, let's light 'em up\"\n—Gerrard",
       "foreignNames": [
         {
           "language": "French",
@@ -5247,7 +5247,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -5267,7 +5267,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -5546,7 +5546,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability applies to your opponent’s spells as well as your own."
+          "text": "The ability applies to your opponent's spells as well as your own."
         }
       ],
       "subtypes": [
@@ -5624,7 +5624,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
@@ -5698,7 +5698,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -6046,7 +6046,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Kicker—Sacrifice a creature. (You may sacrifice a creature in addition to any other costs as you cast this spell.)\nSearch your library for a basic land card, put that card onto the battlefield, then shuffle your library. If Primal Growth was kicked, instead search your library for up to two basic land cards, put them onto the battlefield, then shuffle your library.",
@@ -6064,7 +6064,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"We could learn a lot by watching the little ones,\" said Agnate.\n\"Define ‘little,'\" replied Grizzlegom.",
+      "flavor": "\"We could learn a lot by watching the little ones,\" said Agnate.\n\"Define 'little,'\" replied Grizzlegom.",
       "foreignNames": [
         {
           "language": "French",
@@ -6184,11 +6184,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "Quirion Dryad’s ability will trigger only once per spell you cast, as long as that spell is at least one of the listed colors."
+          "text": "Quirion Dryad's ability will trigger only once per spell you cast, as long as that spell is at least one of the listed colors."
         },
         {
           "date": "2012-07-01",
-          "text": "Quirion Dryad’s ability will trigger if you cast a spell that’s green and at least one of the listed colors."
+          "text": "Quirion Dryad's ability will trigger if you cast a spell that's green and at least one of the listed colors."
         }
       ],
       "subtypes": [
@@ -6260,7 +6260,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If the opponent only has lands that produce colorless or no mana, this card’s ability can still be activated; it just won’t produce any mana."
+          "text": "If the opponent only has lands that produce colorless or no mana, this card's ability can still be activated; it just won't produce any mana."
         }
       ],
       "subtypes": [
@@ -6397,7 +6397,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This affects your lands and your opponent’s."
+          "text": "This affects your lands and your opponent's."
         }
       ],
       "text": "All lands gain shroud until end of turn. (They can't be the targets of spells or abilities.)\nDraw a card.",
@@ -6543,19 +6543,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You choose whether to kick a spell as you cast it, and you pay that much along with the spell’s mana cost at the same time. Kicking a spell is always optional."
+          "text": "You choose whether to kick a spell as you cast it, and you pay that much along with the spell's mana cost at the same time. Kicking a spell is always optional."
         },
         {
           "date": "2017-03-14",
-          "text": "You can pay any particular kicker cost only once. You can’t pay it multiple times to get multiples of either triggered ability."
+          "text": "You can pay any particular kicker cost only once. You can't pay it multiple times to get multiples of either triggered ability."
         },
         {
           "date": "2017-03-14",
-          "text": "If Thornscape Battlemage is put onto the battlefield as the result of a spell or ability, there’s no opportunity to kick it."
+          "text": "If Thornscape Battlemage is put onto the battlefield as the result of a spell or ability, there's no opportunity to kick it."
         },
         {
           "date": "2017-03-14",
-          "text": "Kicker costs don’t change a spell’s mana cost or converted mana cost."
+          "text": "Kicker costs don't change a spell's mana cost or converted mana cost."
         }
       ],
       "subtypes": [
@@ -6631,7 +6631,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -6651,7 +6651,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -7392,7 +7392,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -8117,19 +8117,19 @@
       "rulings": [
         {
           "date": "2009-05-01",
-          "text": "No one can cast spells or activate abilities between the time a card is named and the time that Meddling Mage’s ability starts to work."
+          "text": "No one can cast spells or activate abilities between the time a card is named and the time that Meddling Mage's ability starts to work."
         },
         {
           "date": "2009-05-01",
-          "text": "Spells with the chosen name that somehow happen to already be on the stack when Meddling Mage enters the battlefield are not affected by Meddling Mage’s ability."
+          "text": "Spells with the chosen name that somehow happen to already be on the stack when Meddling Mage enters the battlefield are not affected by Meddling Mage's ability."
         },
         {
           "date": "2009-05-01",
-          "text": "Although the named card can’t be cast, it can still be put onto the battlefield by a spell or ability (if it’s a permanent card)."
+          "text": "Although the named card can't be cast, it can still be put onto the battlefield by a spell or ability (if it's a permanent card)."
         },
         {
           "date": "2009-05-01",
-          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can’t be cast. The other half is unaffected."
+          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can't be cast. The other half is unaffected."
         },
         {
           "date": "2009-05-01",
@@ -8213,7 +8213,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         }
       ],
       "text": "When Natural Emergence enters the battlefield, return a red or green enchantment you control to its owner's hand.\nLands you control are 2/2 creatures with first strike. They're still lands.",
@@ -8489,7 +8489,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It probably won’t matter much, but you choose the order in which the two triggered abilities are placed on the stack."
+          "text": "It probably won't matter much, but you choose the order in which the two triggered abilities are placed on the stack."
         },
         {
           "date": "2004-10-04",
@@ -8852,7 +8852,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It probably won’t matter much, but you choose the order in which the two triggered abilities are placed on the stack."
+          "text": "It probably won't matter much, but you choose the order in which the two triggered abilities are placed on the stack."
         },
         {
           "date": "2004-10-04",
@@ -9207,7 +9207,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -9343,11 +9343,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If this card leaves the battlefield, the remaining cards that were exiled don’t come back."
+          "text": "If this card leaves the battlefield, the remaining cards that were exiled don't come back."
         },
         {
           "date": "2004-10-04",
-          "text": "The card goes to its owner’s hand as per the errata."
+          "text": "The card goes to its owner's hand as per the errata."
         },
         {
           "date": "2004-10-04",
@@ -9489,7 +9489,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "subtypes": [
@@ -9560,11 +9560,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you don’t want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
+          "text": "If you don't want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
         },
         {
           "date": "2005-08-01",
-          "text": "This land is of type “Lair” only; other subtypes have been removed. It is not a basic land."
+          "text": "This land is of type \"Lair\" only; other subtypes have been removed. It is not a basic land."
         }
       ],
       "subtypes": [
@@ -9629,11 +9629,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you don’t want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
+          "text": "If you don't want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
         },
         {
           "date": "2005-08-01",
-          "text": "This land is of type “Lair” only; other subtypes have been removed. It is not a basic land."
+          "text": "This land is of type \"Lair\" only; other subtypes have been removed. It is not a basic land."
         }
       ],
       "subtypes": [
@@ -9698,11 +9698,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you don’t want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
+          "text": "If you don't want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
         },
         {
           "date": "2005-08-01",
-          "text": "This land is of type “Lair” only; other subtypes have been removed. It is not a basic land."
+          "text": "This land is of type \"Lair\" only; other subtypes have been removed. It is not a basic land."
         }
       ],
       "subtypes": [
@@ -9820,7 +9820,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose “colorless”. You have to choose one of the five colors."
+          "text": "You can't choose \"colorless\". You have to choose one of the five colors."
         }
       ],
       "text": "{T}: Choose a color of a permanent you control. Add one mana of that color to your mana pool.",
@@ -9882,11 +9882,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you don’t want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
+          "text": "If you don't want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
         },
         {
           "date": "2005-08-01",
-          "text": "This land is of type “Lair” only; other subtypes have been removed. It is not a basic land."
+          "text": "This land is of type \"Lair\" only; other subtypes have been removed. It is not a basic land."
         }
       ],
       "subtypes": [
@@ -9946,7 +9946,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{2}, {T}, Sacrifice Terminal Moraine: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -10008,11 +10008,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you don’t want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
+          "text": "If you don't want to unsummon a land, you can play this card then tap it for mana before the enters the battlefield ability resolves. You may then choose to sacrifice it instead of unsummoning a land."
         },
         {
           "date": "2005-08-01",
-          "text": "This land is of type “Lair” only; other subtypes have been removed. It is not a basic land."
+          "text": "This land is of type \"Lair\" only; other subtypes have been removed. It is not a basic land."
         }
       ],
       "subtypes": [
@@ -10254,11 +10254,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If this card leaves the battlefield, the remaining cards that were exiled don’t come back."
+          "text": "If this card leaves the battlefield, the remaining cards that were exiled don't come back."
         },
         {
           "date": "2004-10-04",
-          "text": "The card goes to its owner’s hand as per the errata."
+          "text": "The card goes to its owner's hand as per the errata."
         },
         {
           "date": "2004-10-04",

--- a/json/PO2.json
+++ b/json/PO2.json
@@ -74,7 +74,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -593,11 +593,11 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If Angel of Fury is removed from the graveyard after the ability triggers but before it resolves, it will remain in its zone when its owner shuffles his or her library. Similarly, if a replacement effect has it move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If Angel of Fury is removed from the graveyard after the ability triggers but before it resolves, it will remain in its zone when its owner shuffles his or her library. Similarly, if a replacement effect has it move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         },
         {
           "date": "2008-10-01",
-          "text": "Angel of Fury’s second ability is a leaves-the-battlefield ability. Because it works only from on the battlefield, it behaves differently than the _Lorwyn_ Incarnations. When Angel of Fury is put into a graveyard from the battlefield, it will look back in time (to the point just before it left the battlefield) to see if its ability triggers. That means the following: — If Angel of Fury lost its triggered ability while on the battlefield (due to Snakeform, for example) and then was destroyed, the ability would not trigger. Angel of Fury would stay in its owner’s graveyard. — If Angel of Fury had its triggered ability when it left the battlefield, but lost it when it was put into the graveyard (due to Yixlid Jailer, for example), the ability would still trigger. Angel of Fury would be shuffled into its owner’s library."
+          "text": "Angel of Fury's second ability is a leaves-the-battlefield ability. Because it works only from on the battlefield, it behaves differently than the _Lorwyn_ Incarnations. When Angel of Fury is put into a graveyard from the battlefield, it will look back in time (to the point just before it left the battlefield) to see if its ability triggers. That means the following: — If Angel of Fury lost its triggered ability while on the battlefield (due to Snakeform, for example) and then was destroyed, the ability would not trigger. Angel of Fury would stay in its owner's graveyard. — If Angel of Fury had its triggered ability when it left the battlefield, but lost it when it was put into the graveyard (due to Yixlid Jailer, for example), the ability would still trigger. Angel of Fury would be shuffled into its owner's library."
         }
       ],
       "subtypes": [
@@ -964,7 +964,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -1263,7 +1264,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"This isn't what I meant by ‘facing the heat of battle!'\"\n—Jefan, Talas ship captain",
+      "flavor": "\"This isn't what I meant by 'facing the heat of battle!'\"\n—Jefan, Talas ship captain",
       "id": "03bd8bf8af08ae6e505de519fdf6fa8ecbf41cb1",
       "imageName": "blaze",
       "layout": "normal",
@@ -2031,11 +2032,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -2043,7 +2044,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -2316,7 +2317,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures and lands are only prevented from untapping during the targeted player’s next untap step. They can still can untap during other player’s untap steps."
+          "text": "The creatures and lands are only prevented from untapping during the targeted player's next untap step. They can still can untap during other player's untap steps."
         },
         {
           "date": "2009-10-01",
@@ -3620,11 +3621,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type “Summon Goblin” and “Summon Goblins” also count. You can’t search for cards that have Goblin in the name but don’t have the creature type Goblin."
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
         }
       ],
       "subtypes": [
@@ -4091,7 +4092,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -5232,11 +5233,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -5244,7 +5245,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -6560,7 +6561,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -6630,7 +6631,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"‘Air superiority?' Not while our archers scan the skies.\"\n—Elvish scout",
+      "flavor": "\"'Air superiority?' Not while our archers scan the skies.\"\n—Elvish scout",
       "id": "e13ef5868e2bd35b2fe43fb799d7521604d683fc",
       "imageName": "norwood archers",
       "layout": "normal",
@@ -7177,7 +7178,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the spell fails because the target is not there or isn’t legal, the owner does not gain any life."
+          "text": "If the spell fails because the target is not there or isn't legal, the owner does not gain any life."
         }
       ],
       "text": "Destroy target creature. Its owner gains 4 life.",
@@ -8362,7 +8363,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -8588,7 +8589,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -9027,7 +9028,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, if one of the lands has become an illegal target (because it’s no longer on the battlefield, for example), you return the other one to your hand. If both of the lands have become illegal targets, the ability is countered. This has no effect on Sea Drake."
+          "text": "When the ability resolves, if one of the lands has become an illegal target (because it's no longer on the battlefield, for example), you return the other one to your hand. If both of the lands have become illegal targets, the ability is countered. This has no effect on Sea Drake."
         }
       ],
       "subtypes": [
@@ -10718,7 +10719,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one.",
@@ -11185,7 +11186,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two creatures may have different owners and return to their respective owner’s hands."
+          "text": "The two creatures may have different owners and return to their respective owner's hands."
         }
       ],
       "text": "Return two target creatures to their owners' hands.",
@@ -11242,7 +11243,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2006-10-15",

--- a/json/POR.json
+++ b/json/POR.json
@@ -76,7 +76,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "This will always be shuffled into its owner’s library."
+          "text": "This will always be shuffled into its owner's library."
         }
       ],
       "subtypes": [
@@ -509,7 +509,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘O miserable of happy! Is this the end\nOf this new glorious world . . . ?'\"\n—John Milton, Paradise Lost",
+      "flavor": "\"'O miserable of happy! Is this the end\nOf this new glorious world . . . ?'\"\n—John Milton, Paradise Lost",
       "id": "43215b5242f3395a774e6c76f77e498bcf03b3f6",
       "imageName": "armageddon",
       "layout": "normal",
@@ -551,7 +551,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -3192,7 +3193,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures and lands are only prevented from untapping during the targeted player’s next untap step. They can still can untap during other player’s untap steps."
+          "text": "The creatures and lands are only prevented from untapping during the targeted player's next untap step. They can still can untap during other player's untap steps."
         },
         {
           "date": "2009-10-01",
@@ -4967,6 +4968,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -5211,6 +5216,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -5252,7 +5261,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -7373,7 +7382,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are no other creatures on the battlefield when Man-o’-War enters the battlefield, its ability must target itself."
+          "text": "If there are no other creatures on the battlefield when Man-o'-War enters the battlefield, its ability must target itself."
         }
       ],
       "subtypes": [
@@ -9091,11 +9100,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sacrificing a green creature is part of Natural Order’s cost. You can’t sacrifice more creatures to search for more creature cards, and you can’t cast Natural Order at all if you control no green creatures."
+          "text": "Sacrificing a green creature is part of Natural Order's cost. You can't sacrifice more creatures to search for more creature cards, and you can't cast Natural Order at all if you control no green creatures."
         },
         {
           "date": "2016-06-08",
-          "text": "Players can respond to this spell only after it’s been cast and all its costs have been paid. No one can try to destroy the creature you sacrificed to stop you from casting this spell or to make you sacrifice a different one."
+          "text": "Players can respond to this spell only after it's been cast and all its costs have been paid. No one can try to destroy the creature you sacrificed to stop you from casting this spell or to make you sacrifice a different one."
         }
       ],
       "text": "As an additional cost to cast Natural Order, sacrifice a green creature.\nSearch your library for a green creature card and put it onto the battlefield. Then shuffle your library.",
@@ -9256,7 +9265,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -9605,7 +9614,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the spell fails because the target is not there or isn’t legal, the owner does not gain any life."
+          "text": "If the spell fails because the target is not there or isn't legal, the owner does not gain any life."
         }
       ],
       "text": "Destroy target creature. Its owner gains 4 life.",
@@ -9654,7 +9663,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -11351,7 +11360,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You must target two different lands. You can’t choose to target just one."
+          "text": "You must target two different lands. You can't choose to target just one."
         }
       ],
       "text": "Destroy two target lands.",
@@ -11488,7 +11497,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -14048,7 +14057,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a creature card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -14679,7 +14688,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2006-10-15",
@@ -15729,7 +15738,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [

--- a/json/PTK.json
+++ b/json/PTK.json
@@ -116,11 +116,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If all the attacking creatures attack your planeswalkers, you can’t cast Eightfold Maze. To cast it, a creature needs to have attacked _you_."
+          "text": "If all the attacking creatures attack your planeswalkers, you can't cast Eightfold Maze. To cast it, a creature needs to have attacked _you_."
         },
         {
           "date": "2009-10-01",
-          "text": "If you’re able to cast Eightfold Maze, it can target any attacking creature (including one attacking a planeswalker)."
+          "text": "If you're able to cast Eightfold Maze, it can target any attacking creature (including one attacking a planeswalker)."
         }
       ],
       "text": "Cast Eightfold Maze only during the declare attackers step and only if you've been attacked this step.\nDestroy target attacking creature.",
@@ -310,15 +310,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "If Guan Yu, Sainted Warrior is removed from the graveyard after the ability triggers but before it resolves, it won’t get shuffled into your library."
+          "text": "If Guan Yu, Sainted Warrior is removed from the graveyard after the ability triggers but before it resolves, it won't get shuffled into your library."
         },
         {
           "date": "2009-10-01",
-          "text": "If a replacement effect has Guan Yu move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If a replacement effect has Guan Yu move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         }
       ],
       "subtypes": [
@@ -581,7 +581,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -698,11 +698,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The creature’s *owner* gains the life, regardless of who happens to control it."
+          "text": "The creature's *owner* gains the life, regardless of who happens to control it."
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         }
       ],
       "text": "Destroy target creature. Its owner gains 4 life.",
@@ -996,7 +996,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -1103,7 +1103,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -1310,7 +1310,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -1659,7 +1659,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -1719,7 +1719,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -2165,7 +2165,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures and lands are only prevented from untapping during the targeted player’s next untap step. They can still can untap during other player’s untap steps."
+          "text": "The creatures and lands are only prevented from untapping during the targeted player's next untap step. They can still can untap during other player's untap steps."
         },
         {
           "date": "2009-10-01",
@@ -2370,7 +2370,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -2490,11 +2490,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "Lu Xun’s second ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Lu Xun's second ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -2709,11 +2709,19 @@
       "layout": "normal",
       "legalities": [
         {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Commander",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
           "legality": "Legal"
         },
         {
@@ -2841,7 +2849,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -2902,11 +2910,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "Sun Quan’s ability affects Sun Quan itself."
+          "text": "Sun Quan's ability affects Sun Quan itself."
         }
       ],
       "subtypes": [
@@ -3016,7 +3024,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -3120,7 +3128,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -3232,7 +3240,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -3613,7 +3621,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -3887,7 +3895,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Desperate Charge affects only creatures you control at the time it resolves. A creature that enters the battlefield later in the turn won’t get +2/+0."
+          "text": "Desperate Charge affects only creatures you control at the time it resolves. A creature that enters the battlefield later in the turn won't get +2/+0."
         }
       ],
       "text": "Creatures you control get +2/+0 until end of turn.",
@@ -4306,7 +4314,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted opponent is an illegal target by the time Stolen Grain resolves, the ability is countered. You won’t gain life."
+          "text": "If the targeted opponent is an illegal target by the time Stolen Grain resolves, the ability is countered. You won't gain life."
         }
       ],
       "text": "Stolen Grain deals 5 damage to target opponent. You gain 5 life.",
@@ -4513,7 +4521,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -4618,11 +4626,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "Wei Night Raiders’s second ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Wei Night Raiders's second ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -4678,7 +4686,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -4736,7 +4744,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -4793,11 +4801,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t activate Xiahou Dun’s ability to return Xiahou Dun itself to your hand. You must choose a target before you sacrifice Xiahou Dun, so it’s not a black card in your graveyard yet."
+          "text": "You can't activate Xiahou Dun's ability to return Xiahou Dun itself to your hand. You must choose a target before you sacrifice Xiahou Dun, so it's not a black card in your graveyard yet."
         },
         {
           "date": "2013-09-20",
@@ -4969,7 +4977,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -5227,7 +5235,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -5439,11 +5447,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The lands that will be destroyed aren’t chosen until Burning of Xinye resolves."
+          "text": "The lands that will be destroyed aren't chosen until Burning of Xinye resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye’s destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
+          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye's destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
         },
         {
           "date": "2009-10-01",
@@ -5904,11 +5912,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-10-01",
-          "text": "If a creature card has “*” in its power, the ability that defines its power works in all zones."
+          "text": "If a creature card has \"*\" in its power, the ability that defines its power works in all zones."
         }
       ],
       "subtypes": [
@@ -6014,7 +6022,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -6073,7 +6081,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -6250,7 +6258,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -6585,7 +6593,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -6641,7 +6649,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -6746,7 +6754,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -6904,11 +6912,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If Zodiac Dragon is removed from the graveyard after the ability triggers but before it resolves, you can’t return it to your hand. Similarly, if a replacement effect has Zodiac Dragon move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+          "text": "If Zodiac Dragon is removed from the graveyard after the ability triggers but before it resolves, you can't return it to your hand. Similarly, if a replacement effect has Zodiac Dragon move to a different zone instead of being put into the graveyard, the ability won't trigger at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Even though Zodiac Dragon is a Dragon, it doesn’t have flying."
+          "text": "Even though Zodiac Dragon is a Dragon, it doesn't have flying."
         }
       ],
       "subtypes": [
@@ -7145,15 +7153,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If all the attacking creatures attack your planeswalkers, you can’t cast Heavy Fog. To cast it, a creature needs to have attacked _you_."
+          "text": "If all the attacking creatures attack your planeswalkers, you can't cast Heavy Fog. To cast it, a creature needs to have attacked _you_."
         },
         {
           "date": "2009-10-01",
-          "text": "Heavy Fog prevents only damage that would be dealt to you by attacking creatures. It won’t prevent damage attacking creatures would deal to creatures or planeswalkers you control."
+          "text": "Heavy Fog prevents only damage that would be dealt to you by attacking creatures. It won't prevent damage attacking creatures would deal to creatures or planeswalkers you control."
         },
         {
           "date": "2009-10-01",
-          "text": "Heavy Fog prevents all damage attacking creatures would deal to you this turn, not just combat damage. Noncombat damage from those creatures is prevented only if they’re still attacking at the time that damage would be dealt or, if the creature has left the battlefield by then, if it was an attacking creature at the time it left."
+          "text": "Heavy Fog prevents all damage attacking creatures would deal to you this turn, not just combat damage. Noncombat damage from those creatures is prevented only if they're still attacking at the time that damage would be dealt or, if the creature has left the battlefield by then, if it was an attacking creature at the time it left."
         }
       ],
       "text": "Cast Heavy Fog only during the declare attackers step and only if you've been attacked this step.\nPrevent all damage that would be dealt to you this turn by attacking creatures.",
@@ -7263,11 +7271,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2009-10-01",
-          "text": "Hunting Cheetah’s ability allows you to search your library for any card with the land type Forest, not just a card with the name Forest."
+          "text": "Hunting Cheetah's ability allows you to search your library for any card with the land type Forest, not just a card with the name Forest."
         }
       ],
       "subtypes": [
@@ -7322,7 +7330,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         }
       ],
       "subtypes": [
@@ -7394,11 +7402,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -7406,7 +7414,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -7608,7 +7616,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The spell’s effect has no duration. The targeted creature gets +2/+2 until the game ends or it leaves the battlefield. It has horsemanship until the game ends, it leaves the battlefield, or some other effect causes it to lose horsemanship."
+          "text": "The spell's effect has no duration. The targeted creature gets +2/+2 until the game ends or it leaves the battlefield. It has horsemanship until the game ends, it leaves the battlefield, or some other effect causes it to lose horsemanship."
         }
       ],
       "text": "Target creature gets +2/+2 and gains horsemanship. (It can't be blocked except by creatures with horsemanship. This effect lasts indefinitely.)",
@@ -7764,7 +7772,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2009-10-01",
@@ -8069,7 +8077,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2009-10-01",
@@ -8309,11 +8317,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -8321,7 +8329,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -8343,7 +8351,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\". . . ‘First take Jingzhou, next the Riverlands; / On that rich region, base your own royal stand.' . . .\"",
+      "flavor": "\". . . 'First take Jingzhou, next the Riverlands; / On that rich region, base your own royal stand.' . . .\"",
       "id": "5915d28584c46e08aefc660410e10a2b742d85d2",
       "imageName": "zodiac horse",
       "layout": "normal",

--- a/json/RAV.json
+++ b/json/RAV.json
@@ -129,7 +129,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Any Aura card you find must be able to enchant Auratouched Mage as it currently exists, or as it most recently existed on the battlefield if it’s no longer on the battlefield. If an effect has made the Mage an artifact, for example, you could search for an Aura with “enchant artifact.”"
+          "text": "Any Aura card you find must be able to enchant Auratouched Mage as it currently exists, or as it most recently existed on the battlefield if it's no longer on the battlefield. If an effect has made the Mage an artifact, for example, you could search for an Aura with \"enchant artifact.\""
         }
       ],
       "subtypes": [
@@ -244,11 +244,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
+          "text": "A creature \"shares a color\" with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
         },
         {
           "date": "2005-10-01",
-          "text": "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+          "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
         },
         {
           "date": "2005-10-01",
@@ -459,7 +459,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -563,7 +563,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If red mana was spent, Boros Fury-Shield, not the target creature, deals the damage to the creature’s controller."
+          "text": "If red mana was spent, Boros Fury-Shield, not the target creature, deals the damage to the creature's controller."
         }
       ],
       "text": "Prevent all combat damage that would be dealt by target attacking or blocking creature this turn. If {R} was spent to cast Boros Fury-Shield, it deals damage to that creature's controller equal to the creature's power.",
@@ -767,31 +767,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPrevent all damage that would be dealt by creatures this turn. You gain life equal to the damage prevented this way.",
@@ -891,7 +891,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "For example, a player controls three creatures when Concerted Effort’s ability resolves: one creature with flying and protection from red, one with islandwalk and protection from green; and one with vigilance. All three creatures will have flying, islandwalk, vigilance, protection from red, and protection from green until the end of the turn."
+          "text": "For example, a player controls three creatures when Concerted Effort's ability resolves: one creature with flying and protection from red, one with islandwalk and protection from green; and one with vigilance. All three creatures will have flying, islandwalk, vigilance, protection from red, and protection from green until the end of the turn."
         },
         {
           "date": "2005-10-01",
@@ -1001,31 +1001,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -1133,31 +1133,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -1262,31 +1262,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -1491,7 +1491,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "You can tap untapped attacking or blocking creatures you control to help cast Devouring Light. This doesn’t remove those creatures from combat."
+          "text": "You can tap untapped attacking or blocking creatures you control to help cast Devouring Light. This doesn't remove those creatures from combat."
         },
         {
           "date": "2014-07-18",
@@ -1499,31 +1499,31 @@
         },
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nExile target attacking or blocking creature.",
@@ -1724,7 +1724,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Each time Dromad Purebred is dealt damage, including from multiple sources at once, you gain 1 life. You don’t gain life equal to the damage dealt."
+          "text": "Each time Dromad Purebred is dealt damage, including from multiple sources at once, you gain 1 life. You don't gain life equal to the damage dealt."
         }
       ],
       "subtypes": [
@@ -1832,11 +1832,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Faith’s Fetters doesn’t stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
+          "text": "Faith's Fetters doesn't stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -2040,7 +2040,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The card that was enchanted comes back onto the battlefield first, regardless of whether it’s still a creature. Then any Auras exiled that can legally enchant that card come back. Any Auras that can’t enchant that permanent remain exiled."
+          "text": "The card that was enchanted comes back onto the battlefield first, regardless of whether it's still a creature. Then any Auras exiled that can legally enchant that card come back. Any Auras that can't enchant that permanent remain exiled."
         },
         {
           "date": "2005-10-01",
@@ -2048,7 +2048,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the enchanted creature was also enchanted by Copy Enchantment, Copy Enchantment will return to the battlefield attached to that permanent. As Copy Enchantment returns to the battlefield, its controller may choose any enchantment on the battlefield for it to copy. It can’t copy Flickerform or any other Aura returning to the battlefield at the same time. If it copies a non-Aura enchantment, it returns to the battlefield unattached instead."
+          "text": "If the enchanted creature was also enchanted by Copy Enchantment, Copy Enchantment will return to the battlefield attached to that permanent. As Copy Enchantment returns to the battlefield, its controller may choose any enchantment on the battlefield for it to copy. It can't copy Flickerform or any other Aura returning to the battlefield at the same time. If it copies a non-Aura enchantment, it returns to the battlefield unattached instead."
         },
         {
           "date": "2014-02-01",
@@ -2255,11 +2255,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If a damage prevention effect and Ghosts of the Innocent’s effect would apply to the same damage, the player or the controller of the creature being dealt damage may apply the effects in either order (most likely applying the halving effect first)."
+          "text": "If a damage prevention effect and Ghosts of the Innocent's effect would apply to the same damage, the player or the controller of the creature being dealt damage may apply the effects in either order (most likely applying the halving effect first)."
         },
         {
           "date": "2005-10-01",
-          "text": "Half of 1 rounded down is 0. A source that would deal 1 damage to a creature or player won’t deal damage to that creature or player at all."
+          "text": "Half of 1 rounded down is 0. A source that would deal 1 damage to a creature or player won't deal damage to that creature or player at all."
         },
         {
           "date": "2005-10-01",
@@ -2267,11 +2267,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "This isn’t a damage prevention effect. If Excruciator (“Damage that would be dealt by Excruciator can’t be prevented”) would deal 7 damage to a creature or player, it deals 3 damage instead."
+          "text": "This isn't a damage prevention effect. If Excruciator (\"Damage that would be dealt by Excruciator can't be prevented\") would deal 7 damage to a creature or player, it deals 3 damage instead."
         },
         {
           "date": "2005-10-01",
-          "text": "If damage is redirected, it’s only halved once."
+          "text": "If damage is redirected, it's only halved once."
         },
         {
           "date": "2005-10-01",
@@ -2380,31 +2380,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy all nontoken creatures.",
@@ -3095,7 +3095,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Because the cost of Sandsower’s ability doesn’t include the {T} symbol, you can tap any three untapped creatures you control (including Sandsower itself), even if those creatures haven’t been under your control continuously since the beginning of your most recent turn."
+          "text": "Because the cost of Sandsower's ability doesn't include the {T} symbol, you can tap any three untapped creatures you control (including Sandsower itself), even if those creatures haven't been under your control continuously since the beginning of your most recent turn."
         }
       ],
       "subtypes": [
@@ -3396,11 +3396,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Suppression Field’s ability doesn’t affect static abilities, triggered abilities, or mana abilities. (A “mana ability” is an ability that produces mana, not an ability that costs mana.)"
+          "text": "Suppression Field's ability doesn't affect static abilities, triggered abilities, or mana abilities. (A \"mana ability\" is an ability that produces mana, not an ability that costs mana.)"
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Activated abilities cost {2} more to activate unless they're mana abilities.",
@@ -3597,11 +3597,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The first ability only cares that creature tokens leave the battlefield. It doesn’t matter where they went."
+          "text": "The first ability only cares that creature tokens leave the battlefield. It doesn't matter where they went."
         },
         {
           "date": "2005-10-01",
-          "text": "If a player leaves a multiplayer game, all creature tokens that player owns also leave the game. Twilight Drover’s ability will trigger once per token."
+          "text": "If a player leaves a multiplayer game, all creature tokens that player owns also leave the game. Twilight Drover's ability will trigger once per token."
         },
         {
           "date": "2005-10-01",
@@ -3609,7 +3609,7 @@
         },
         {
           "date": "2005-10-01",
-          "text": "Note that Twilight Drover doesn’t have any way to sacrifice tokens or otherwise cause them to leave the battlefield."
+          "text": "Note that Twilight Drover doesn't have any way to sacrifice tokens or otherwise cause them to leave the battlefield."
         }
       ],
       "subtypes": [
@@ -4517,15 +4517,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If you choose an Aura, you also choose a legal permanent for the Copy Enchantment copy of it to enchant. Copy Enchantment doesn’t target that permanent, however, so it can enter the battlefield attached to an untargetable creature."
+          "text": "If you choose an Aura, you also choose a legal permanent for the Copy Enchantment copy of it to enchant. Copy Enchantment doesn't target that permanent, however, so it can enter the battlefield attached to an untargetable creature."
         },
         {
           "date": "2005-10-01",
-          "text": "If you choose an Aura and there isn’t a legal permanent for it to enchant, you put Copy Enchantment into your graveyard. It never enters the battlefield."
+          "text": "If you choose an Aura and there isn't a legal permanent for it to enchant, you put Copy Enchantment into your graveyard. It never enters the battlefield."
         },
         {
           "date": "2005-10-01",
-          "text": "If you don’t choose an enchantment, Copy Enchantment enters the battlefield without copying anything, and it sits there with a useless ability."
+          "text": "If you don't choose an enchantment, Copy Enchantment enters the battlefield without copying anything, and it sits there with a useless ability."
         },
         {
           "date": "2006-04-01",
@@ -4728,7 +4728,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The ability lets you return any enchantment on the battlefield, including an opponent’s enchantment. The ability isn’t targeted, so you can return an untargetable enchantment. If there are no enchantments on the battlefield, or you choose not to return one, you must sacrifice Drake Familiar."
+          "text": "The ability lets you return any enchantment on the battlefield, including an opponent's enchantment. The ability isn't targeted, so you can return an untargetable enchantment. If there are no enchantments on the battlefield, or you choose not to return one, you must sacrifice Drake Familiar."
         }
       ],
       "subtypes": [
@@ -4832,7 +4832,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The restriction that the permanent must be tapped is checked only if you cast Dream Leash as a spell. Once Dream Leash is on the battlefield, it doesn’t matter if the enchanted permanent becomes untapped."
+          "text": "The restriction that the permanent must be tapped is checked only if you cast Dream Leash as a spell. Once Dream Leash is on the battlefield, it doesn't matter if the enchanted permanent becomes untapped."
         },
         {
           "date": "2005-10-01",
@@ -5136,7 +5136,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The ability triggers when a player casts an instant or sorcery *card*. A copy of a card (such as those generated by Eye of the Storm itself) won’t trigger this ability. The card that was cast is exiled and won’t resolve, but the player will get a copy of the spell from Eye of the Storm."
+          "text": "The ability triggers when a player casts an instant or sorcery *card*. A copy of a card (such as those generated by Eye of the Storm itself) won't trigger this ability. The card that was cast is exiled and won't resolve, but the player will get a copy of the spell from Eye of the Storm."
         },
         {
           "date": "2005-10-01",
@@ -5144,11 +5144,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "The player chooses modes, pays additional costs, chooses targets, and so on for the copies when casting them. Any X in the mana cost of a copy cast this way will be 0. Alternative costs can’t be paid."
+          "text": "The player chooses modes, pays additional costs, chooses targets, and so on for the copies when casting them. Any X in the mana cost of a copy cast this way will be 0. Alternative costs can't be paid."
         },
         {
           "date": "2006-01-01",
-          "text": "You must still follow any restrictions on when you can cast the spell, such as “cast only during combat” or “cast only on your own turn.”"
+          "text": "You must still follow any restrictions on when you can cast the spell, such as \"cast only during combat\" or \"cast only on your own turn.\""
         },
         {
           "date": "2006-02-01",
@@ -5449,7 +5449,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Any enters-the-battlefield abilities of the copied creature trigger when the creature tokens enter the battlefield. The creature tokens also have any “this enters the battlefield with” or “as this enters the battlefield” abilities that the copied creature has."
+          "text": "Any enters-the-battlefield abilities of the copied creature trigger when the creature tokens enter the battlefield. The creature tokens also have any \"this enters the battlefield with\" or \"as this enters the battlefield\" abilities that the copied creature has."
         },
         {
           "date": "2007-02-01",
@@ -5457,7 +5457,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If Followed Footsteps and the enchanted creature leave the battlefield simultaneously (say via Upheaval or Akroma’s Vengence somehow cast in response to the triggered ability), then a token copy of the creature that was enchanted when it was last on the battlefield is created. If Followed Foosteps did not enchant a creature when last on the battlefield as it went to the graveyard as a state-based action when the enchanted creature left the battlefield in response to the trigger, then no copy will get created."
+          "text": "If Followed Footsteps and the enchanted creature leave the battlefield simultaneously (say via Upheaval or Akroma's Vengence somehow cast in response to the triggered ability), then a token copy of the creature that was enchanted when it was last on the battlefield is created. If Followed Foosteps did not enchant a creature when last on the battlefield as it went to the graveyard as a state-based action when the enchanted creature left the battlefield in response to the trigger, then no copy will get created."
         }
       ],
       "subtypes": [
@@ -5764,7 +5764,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Whenever you cast a creature spell, Halcyon Glaze becomes a 4/4 Illusion creature with flying in addition to its other types until end of turn.",
@@ -6254,7 +6254,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Each player shuffles his or her graveyard into his or her library.",
@@ -6549,11 +6549,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You can choose any single color or any combination of more than one color. You can’t choose colorless."
+          "text": "You can choose any single color or any combination of more than one color. You can't choose colorless."
         },
         {
           "date": "2005-10-01",
-          "text": "Quickchange won’t make an artifact stop being an artifact. It’ll just be a colorful artifact."
+          "text": "Quickchange won't make an artifact stop being an artifact. It'll just be a colorful artifact."
         }
       ],
       "text": "Target creature becomes the color or colors of your choice until end of turn.\nDraw a card.",
@@ -6656,7 +6656,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The countered spell goes to its owner’s hand from the stack. It never hits the graveyard."
+          "text": "The countered spell goes to its owner's hand from the stack. It never hits the graveyard."
         },
         {
           "date": "2007-02-01",
@@ -6867,7 +6867,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If either target becomes illegal (say, if a creature’s power has changed such that the creature you control now has less power than the other creature), then the exchange won’t happen."
+          "text": "If either target becomes illegal (say, if a creature's power has changed such that the creature you control now has less power than the other creature), then the exchange won't happen."
         }
       ],
       "subtypes": [
@@ -7376,11 +7376,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Terraformer’s effect overwrites the land type of all lands you control that had other types and gives a land type to all lands you control that don’t normally have one."
+          "text": "Terraformer's effect overwrites the land type of all lands you control that had other types and gives a land type to all lands you control that don't normally have one."
         },
         {
           "date": "2005-10-01",
-          "text": "Changing a land’s type doesn’t change its name or whether it’s legendary or basic."
+          "text": "Changing a land's type doesn't change its name or whether it's legendary or basic."
         },
         {
           "date": "2005-10-01",
@@ -7587,7 +7587,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If the named card is found, everything from the top of the library down to the named card is put into the graveyard and the library isn’t shuffled. If the named card isn’t in the library, no cards are put into the graveyard and the library is shuffled."
+          "text": "If the named card is found, everything from the top of the library down to the named card is put into the graveyard and the library isn't shuffled. If the named card isn't in the library, no cards are put into the graveyard and the library is shuffled."
         }
       ],
       "text": "Choose a card name. Target player reveals cards from the top of his or her library until a card with that name is revealed. If it is, that player puts the rest of the revealed cards into his or her graveyard and puts the card with the chosen name on top of his or her library. Otherwise, the player shuffles his or her library.",
@@ -7689,7 +7689,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If Vedalken Dismisser is the only creature on the battlefield when its ability triggers, you’ll have to choose it as the target."
+          "text": "If Vedalken Dismisser is the only creature on the battlefield when its ability triggers, you'll have to choose it as the target."
         }
       ],
       "subtypes": [
@@ -7896,11 +7896,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -8598,11 +8598,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "text": "Target creature gets -1/-1 until end of turn.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
@@ -9089,11 +9089,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -9301,7 +9301,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You must target six different creatures. If you can’t, you can’t cast Hex. If some of the creatures become illegal targets before the spell resolves, Hex will still destroy the rest of them."
+          "text": "You must target six different creatures. If you can't, you can't cast Hex. If some of the creatures become illegal targets before the spell resolves, Hex will still destroy the rest of them."
         }
       ],
       "text": "Destroy six target creatures.",
@@ -10197,11 +10197,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -10409,11 +10409,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         },
         {
           "date": "2014-02-01",
@@ -11008,11 +11008,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The instant or sorcery card is cast from your graveyard, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can’t be paid."
+          "text": "The instant or sorcery card is cast from your graveyard, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can't be paid."
         },
         {
           "date": "2005-10-01",
-          "text": "The instant or sorcery card never gets put back into your graveyard, even if it’s countered. You can’t cast it more than once."
+          "text": "The instant or sorcery card never gets put back into your graveyard, even if it's countered. You can't cast it more than once."
         }
       ],
       "text": "Until end of turn, you may cast target instant or sorcery card from your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, exile it instead. Exile Sins of the Past.",
@@ -11120,15 +11120,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         },
         {
           "date": "2013-06-07",
-          "text": "Notably, Stinkweed Imp’s ability isn’t deathtouch. It’s a triggered ability that triggers only on combat damage."
+          "text": "Notably, Stinkweed Imp's ability isn't deathtouch. It's a triggered ability that triggers only on combat damage."
         }
       ],
       "subtypes": [
@@ -12025,7 +12025,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If there isn’t a legal creature to attach Breath of Fury to after the enchanted creature is sacrificed, you don’t untap your creatures or get an additional combat phase, and Breath of Fury is put into its owner’s graveyard as a state-based action."
+          "text": "If there isn't a legal creature to attach Breath of Fury to after the enchanted creature is sacrificed, you don't untap your creatures or get an additional combat phase, and Breath of Fury is put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -12230,11 +12230,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
+          "text": "A creature \"shares a color\" with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
         },
         {
           "date": "2005-10-01",
-          "text": "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+          "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
         },
         {
           "date": "2005-10-01",
@@ -12538,15 +12538,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "An effect may redirect Excruciator’s damage."
+          "text": "An effect may redirect Excruciator's damage."
         },
         {
           "date": "2005-10-01",
-          "text": "Excruciator can deal damage to creatures with protection from red. (It can’t block creatures with protection from red, though.)"
+          "text": "Excruciator can deal damage to creatures with protection from red. (It can't block creatures with protection from red, though.)"
         },
         {
           "date": "2005-10-01",
-          "text": "Damage prevention shields that would prevent this damage aren’t used up and they stick around for the next time something would deal damage."
+          "text": "Damage prevention shields that would prevent this damage aren't used up and they stick around for the next time something would deal damage."
         },
         {
           "date": "2005-10-01",
@@ -12554,7 +12554,7 @@
         },
         {
           "date": "2005-10-01",
-          "text": "Replacement effects that don’t use the word “prevent” can replace Excruciator’s damage with something else. See Phytohydra and Szadek, Lord of Secrets, for example."
+          "text": "Replacement effects that don't use the word \"prevent\" can replace Excruciator's damage with something else. See Phytohydra and Szadek, Lord of Secrets, for example."
         }
       ],
       "subtypes": [
@@ -12765,11 +12765,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "“Summoning sickness” applies only to creatures, not to other permanents. You may tap a noncreature permanent to pay for an ability with {T} in its cost even if the permanent entered the battlefield that turn."
+          "text": "\"Summoning sickness\" applies only to creatures, not to other permanents. You may tap a noncreature permanent to pay for an ability with {T} in its cost even if the permanent entered the battlefield that turn."
         },
         {
           "date": "2005-10-01",
-          "text": "Tapping an Aura or Equipment doesn’t tap the creature it’s attached to and vice versa. Tapped enchantments work normally. Tapped artifacts work normally unless they say otherwise."
+          "text": "Tapping an Aura or Equipment doesn't tap the creature it's attached to and vice versa. Tapped enchantments work normally. Tapped artifacts work normally unless they say otherwise."
         }
       ],
       "text": "Until end of turn, permanents you control gain \"{T}: This permanent deals 1 damage to target creature or player.\"",
@@ -13690,11 +13690,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
+          "text": "A creature \"shares a color\" with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
         },
         {
           "date": "2005-10-01",
-          "text": "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+          "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
         },
         {
           "date": "2005-10-01",
@@ -13706,7 +13706,7 @@
         },
         {
           "date": "2005-11-01",
-          "text": "The targeted creature and the creatures that share a color with it at the time Incite Hysteria resolves gain an ability that says they can’t block this turn. It doesn’t matter if those creatures change colors before blockers are declared."
+          "text": "The targeted creature and the creatures that share a color with it at the time Incite Hysteria resolves gain an ability that says they can't block this turn. It doesn't matter if those creatures change colors before blockers are declared."
         }
       ],
       "text": "Radiance — Until end of turn, target creature and each other creature that shares a color with it gain \"This creature can't block.\"",
@@ -13907,7 +13907,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Instill Furor grants a triggered ability that triggers at the end of the creature’s controller’s turn."
+          "text": "Instill Furor grants a triggered ability that triggers at the end of the creature's controller's turn."
         },
         {
           "date": "2005-10-01",
@@ -14014,15 +14014,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Whenever you cast a spell, Mindmoil’s ability triggers. The ability will resolve before the spell does."
+          "text": "Whenever you cast a spell, Mindmoil's ability triggers. The ability will resolve before the spell does."
         },
         {
           "date": "2005-10-01",
-          "text": "After Mindmoil’s ability triggers, players may cast instants and activate activated abilities. Each time you cast an instant spell “in response,” Mindmoil’s ability triggers again."
+          "text": "After Mindmoil's ability triggers, players may cast instants and activate activated abilities. Each time you cast an instant spell \"in response,\" Mindmoil's ability triggers again."
         },
         {
           "date": "2005-10-01",
-          "text": "After Mindmoil’s ability resolves, but before the spell that triggered it does, you can cast instants from your new hand of cards. Each time you do, Mindmoil’s ability triggers again."
+          "text": "After Mindmoil's ability resolves, but before the spell that triggered it does, you can cast instants from your new hand of cards. Each time you do, Mindmoil's ability triggers again."
         }
       ],
       "text": "Whenever you cast a spell, put the cards in your hand on the bottom of your library in any order, then draw that many cards.",
@@ -14123,11 +14123,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If a creature enters the battlefield copying Molten Sentry, that creature’s controller flips a coin to see what the copy will be."
+          "text": "If a creature enters the battlefield copying Molten Sentry, that creature's controller flips a coin to see what the copy will be."
         },
         {
           "date": "2005-10-01",
-          "text": "If a creature that’s already on the battlefield copies Molten Sentry, it becomes a copy of whatever Molten Sentry already is (either a 5/2 creature with haste or a 2/5 creature with defender)."
+          "text": "If a creature that's already on the battlefield copies Molten Sentry, it becomes a copy of whatever Molten Sentry already is (either a 5/2 creature with haste or a 2/5 creature with defender)."
         }
       ],
       "subtypes": [
@@ -14427,7 +14427,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Change the target of target activated ability with a single target. (Mana abilities can't be targeted.)\nDraw a card.",
@@ -15023,7 +15023,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If the player doesn’t have an untapped land as Stoneshaker Shaman’s ability resolves, that player does nothing."
+          "text": "If the player doesn't have an untapped land as Stoneshaker Shaman's ability resolves, that player does nothing."
         }
       ],
       "subtypes": [
@@ -15531,7 +15531,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Tokens are permanents but not cards. They’ll count toward the number of permanents shuffled into your library, so you’ll get a card back for each token you owned. But the tokens themselves should be ignored while you’re revealing *cards* from your library. In practice, you shouldn’t actually shuffle them into your library since they’ll cease to exist as soon as Warp World finishes resolving. Note that a token’s owner is the player under whose control it first entered the battlefield."
+          "text": "Tokens are permanents but not cards. They'll count toward the number of permanents shuffled into your library, so you'll get a card back for each token you owned. But the tokens themselves should be ignored while you're revealing *cards* from your library. In practice, you shouldn't actually shuffle them into your library since they'll cease to exist as soon as Warp World finishes resolving. Note that a token's owner is the player under whose control it first entered the battlefield."
         }
       ],
       "text": "Each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, and land cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of his or her library.",
@@ -16148,31 +16148,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nSearch your library for a creature card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.",
@@ -16383,7 +16383,7 @@
         },
         {
           "date": "2005-10-01",
-          "text": "Doubling Season affects cards that “enter the battlefield with” a certain number of counters. Triskelion, for example, would enter the battlefield with six +1/+1 counters on it rather than three."
+          "text": "Doubling Season affects cards that \"enter the battlefield with\" a certain number of counters. Triskelion, for example, would enter the battlefield with six +1/+1 counters on it rather than three."
         },
         {
           "date": "2005-10-01",
@@ -16391,7 +16391,7 @@
         },
         {
           "date": "2005-10-01",
-          "text": "Planeswalkers will enter the battlefield with double the normal amount of loyalty counters. However, if you activate an ability whose cost has you put loyalty counters on a planeswalker, the number you put on isn’t doubled. This is because those counters are put on as a cost, not as an effect."
+          "text": "Planeswalkers will enter the battlefield with double the normal amount of loyalty counters. However, if you activate an ability whose cost has you put loyalty counters on a planeswalker, the number you put on isn't doubled. This is because those counters are put on as a cost, not as an effect."
         }
       ],
       "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
@@ -16594,7 +16594,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The spell checks on resolution to see if any mana of the stated color was spent to pay its cost. It doesn’t matter how much mana of that color was spent."
+          "text": "The spell checks on resolution to see if any mana of the stated color was spent to pay its cost. It doesn't matter how much mana of that color was spent."
         },
         {
           "date": "2005-10-01",
@@ -17013,15 +17013,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You create the Saproling tokens, even if Fists of Ironwood enters the battlefield attached to another player’s creature."
+          "text": "You create the Saproling tokens, even if Fists of Ironwood enters the battlefield attached to another player's creature."
         },
         {
           "date": "2017-03-14",
-          "text": "The Saproling tokens aren’t created until after Fists of Ironwood is on the battlefield, so you can’t cast Fists of Ironwood on one of those tokens."
+          "text": "The Saproling tokens aren't created until after Fists of Ironwood is on the battlefield, so you can't cast Fists of Ironwood on one of those tokens."
         },
         {
           "date": "2017-03-14",
-          "text": "If the target creature is an illegal target when Fists of Ironwood tries to resolve, Fists of Ironwood will be countered and won’t enter the battlefield. You won’t create Saproling tokens."
+          "text": "If the target creature is an illegal target when Fists of Ironwood tries to resolve, Fists of Ironwood will be countered and won't enter the battlefield. You won't create Saproling tokens."
         }
       ],
       "subtypes": [
@@ -17124,31 +17124,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +2/+2 until end of turn.",
@@ -17257,11 +17257,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -17375,11 +17375,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -17591,11 +17591,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -17906,11 +17906,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "text": "Return up to three target land cards from your graveyard to your hand.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
@@ -18015,11 +18015,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
+          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "subtypes": [
@@ -18225,31 +18225,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreatures you control get +3/+3 until end of turn.",
@@ -18350,7 +18350,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You may find any card with Plains, Island, Swamp, Mountain, or Forest on its type line. The land doesn’t need to be a basic land, so you can find a land such as Overgrown Tomb or Tropical Island."
+          "text": "You may find any card with Plains, Island, Swamp, Mountain, or Forest on its type line. The land doesn't need to be a basic land, so you can find a land such as Overgrown Tomb or Tropical Island."
         }
       ],
       "text": "{1}, Sacrifice a creature: Search your library for a land card with a basic land type and put it onto the battlefield tapped. Then shuffle your library.",
@@ -18744,31 +18744,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -18875,31 +18875,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate three 1/1 green Saproling creature tokens.",
@@ -19103,31 +19103,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -19333,31 +19333,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target artifact or enchantment.",
@@ -19460,7 +19460,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If you use this ability during a turn’s end phase, the chance to put “at end of turn”-triggered abilities on the stack has passed. You won’t get the Spirit creature token until the beginning of the next end step."
+          "text": "If you use this ability during a turn's end phase, the chance to put \"at end of turn\"-triggered abilities on the stack has passed. You won't get the Spirit creature token until the beginning of the next end step."
         }
       ],
       "subtypes": [
@@ -19566,7 +19566,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The second ability checks whether a creature being put into a graveyard (a) currently has flying and (b) was dealt damage earlier this turn by Trophy Hunter. It doesn’t matter whether Trophy Hunter dealt the damage that caused the creature to be destroyed, whether the damage from Trophy Hunter was dealt in combat or via its activated ability, or who controlled the creature."
+          "text": "The second ability checks whether a creature being put into a graveyard (a) currently has flying and (b) was dealt damage earlier this turn by Trophy Hunter. It doesn't matter whether Trophy Hunter dealt the damage that caused the creature to be destroyed, whether the damage from Trophy Hunter was dealt in combat or via its activated ability, or who controlled the creature."
         }
       ],
       "subtypes": [
@@ -19985,31 +19985,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -20318,7 +20318,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You gain life equal to the total damage dealt by Brightflame to all creatures. You don’t gain life for any damage that was prevented."
+          "text": "You gain life equal to the total damage dealt by Brightflame to all creatures. You don't gain life for any damage that was prevented."
         },
         {
           "date": "2005-10-01",
@@ -20326,11 +20326,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
+          "text": "A creature \"shares a color\" with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
         },
         {
           "date": "2005-10-01",
-          "text": "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+          "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
         },
         {
           "date": "2005-10-01",
@@ -20443,15 +20443,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Chorus of the Conclave’s ability works only while it’s on the battlefield, so you can’t use it to put +1/+1 counters on itself."
+          "text": "Chorus of the Conclave's ability works only while it's on the battlefield, so you can't use it to put +1/+1 counters on itself."
         },
         {
           "date": "2005-10-01",
-          "text": "Chorus of the Conclave’s ability applies to creature spells only as they’re being cast. You can’t pay mana to put counters on creatures being put onto the battlefield by an effect."
+          "text": "Chorus of the Conclave's ability applies to creature spells only as they're being cast. You can't pay mana to put counters on creatures being put onto the battlefield by an effect."
         },
         {
           "date": "2005-10-01",
-          "text": "Chorus of the Conclave’s ability combines well with the convoke mechanic, effectively letting you tap creatures to put +1/+1 counters on the creature with convoke that you’re casting, if you choose to do so."
+          "text": "Chorus of the Conclave's ability combines well with the convoke mechanic, effectively letting you tap creatures to put +1/+1 counters on the creature with convoke that you're casting, if you choose to do so."
         }
       ],
       "subtypes": [
@@ -20565,19 +20565,19 @@
         },
         {
           "date": "2005-10-01",
-          "text": "If you cast a blue and black spell, both of Circu’s triggered abilities trigger. You can target two different libraries or target the same library twice."
+          "text": "If you cast a blue and black spell, both of Circu's triggered abilities trigger. You can target two different libraries or target the same library twice."
         },
         {
           "date": "2005-10-01",
-          "text": "Circu’s last ability applies to all of its controller’s opponents, not just the owner of the exiled card."
+          "text": "Circu's last ability applies to all of its controller's opponents, not just the owner of the exiled card."
         },
         {
           "date": "2005-10-01",
-          "text": "Circu’s last ability doesn’t prevent copies of the exiled cards from being cast because copies aren’t cards."
+          "text": "Circu's last ability doesn't prevent copies of the exiled cards from being cast because copies aren't cards."
         },
         {
           "date": "2005-10-01",
-          "text": "If a split card is exiled this way, opponents can’t cast either half of the split card."
+          "text": "If a split card is exiled this way, opponents can't cast either half of the split card."
         }
       ],
       "subtypes": [
@@ -20784,7 +20784,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The order in which the cards are placed on top of the library isn’t revealed."
+          "text": "The order in which the cards are placed on top of the library isn't revealed."
         }
       ],
       "text": "Search your library for up to three creature cards and reveal them. Shuffle your library, then put those cards on top of it in any order.",
@@ -21187,11 +21187,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "This creature becomes an exact copy of a copied card, except that it also has Dimir Doppelganger’s activated ability. If it becomes a copy of a different creature card, the new copy will overwrite the old copy."
+          "text": "This creature becomes an exact copy of a copied card, except that it also has Dimir Doppelganger's activated ability. If it becomes a copy of a different creature card, the new copy will overwrite the old copy."
         },
         {
           "date": "2005-10-01",
-          "text": "A permanent’s ability that refers to cards the creature exiled (such as Sisters of Stone Death’s third ability) only affects cards exiled by other abilities intrinsic to that permanent (such as Sisters of Stone Death’s second ability). Suppose that (a) Dimir Doppelganger copies Arc-Slogger, (b) its “deal 2 damage” ability is activated, and then (c) it copies Sisters of Stone Death. Creatures exiled by Arc-Slogger’s ability can’t be returned with Sisters of Stone Death’s ability."
+          "text": "A permanent's ability that refers to cards the creature exiled (such as Sisters of Stone Death's third ability) only affects cards exiled by other abilities intrinsic to that permanent (such as Sisters of Stone Death's second ability). Suppose that (a) Dimir Doppelganger copies Arc-Slogger, (b) its \"deal 2 damage\" ability is activated, and then (c) it copies Sisters of Stone Death. Creatures exiled by Arc-Slogger's ability can't be returned with Sisters of Stone Death's ability."
         }
       ],
       "subtypes": [
@@ -21319,7 +21319,7 @@
         "Black",
         "Green"
       ],
-      "flavor": "\"The Golgari expand, yes, but I refuse to call their tainted creations ‘growth.'\"\n—Veszka, Selesnya evangel",
+      "flavor": "\"The Golgari expand, yes, but I refuse to call their tainted creations 'growth.'\"\n—Veszka, Selesnya evangel",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -21506,7 +21506,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If you return Firemane Angel from your graveyard to the battlefield during your upkeep before its life-gain ability resolves, you won’t gain 1 life. (Most of the time, players will let the triggered ability resolve before activating its activated ability.)"
+          "text": "If you return Firemane Angel from your graveyard to the battlefield during your upkeep before its life-gain ability resolves, you won't gain 1 life. (Most of the time, players will let the triggered ability resolve before activating its activated ability.)"
         },
         {
           "date": "2006-07-01",
@@ -21620,7 +21620,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All creatures under your control when Flame-Kin Zealot’s triggered ability resolves are affected, including Flame-Kin Zealot itself. Ones that come under your control or become creatures later in the turn are not."
+          "text": "All creatures under your control when Flame-Kin Zealot's triggered ability resolves are affected, including Flame-Kin Zealot itself. Ones that come under your control or become creatures later in the turn are not."
         }
       ],
       "subtypes": [
@@ -22127,7 +22127,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You may sacrifice Grave-Shell Scarab to pay for its first ability, then replace that draw using the Scarab’s dredge ability. The result is that the top card of your library is put into your graveyard and Grave-Shell Scarab returns to your hand (after a brief trip to the graveyard)."
+          "text": "You may sacrifice Grave-Shell Scarab to pay for its first ability, then replace that draw using the Scarab's dredge ability. The result is that the top card of your library is put into your graveyard and Grave-Shell Scarab returns to your hand (after a brief trip to the graveyard)."
         }
       ],
       "subtypes": [
@@ -22235,31 +22235,31 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell’s costs. Tapping a creature this way is simply another way to pay."
+          "text": "The rules for convoke have changed slightly since it last appeared in an expansion. Previously, convoke reduced the cost to cast a spell. Under current rules, you tap creatures at the same time you pay the spell's costs. Tapping a creature this way is simply another way to pay."
         },
         {
           "date": "2014-07-18",
-          "text": "Convoke doesn’t change a spell’s mana cost or converted mana cost."
+          "text": "Convoke doesn't change a spell's mana cost or converted mana cost."
         },
         {
           "date": "2014-07-18",
-          "text": "When calculating a spell’s total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
+          "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated."
         },
         {
           "date": "2014-07-18",
-          "text": "Because convoke isn’t an alternative cost, it can be used in conjunction with alternative costs."
+          "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
         },
         {
           "date": "2014-07-18",
-          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature’s colors."
+          "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
         },
         {
           "date": "2014-07-18",
-          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell’s total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you’ll have to pay {1}{G}."
+          "text": "When using convoke to cast a spell with {X} in its mana cost, first choose the value for X. That choice, plus any cost increases or decreases, will determine the spell's total cost. Then you can tap creatures you control to help pay that cost. For example, if you cast Chord of Calling (a spell with convoke and mana cost {X}{G}{G}{G}) and choose X to be 3, the total cost is {3}{G}{G}{G}. If you tap two green creatures and two red creatures, you'll have to pay {1}{G}."
         },
         {
           "date": "2014-07-18",
-          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell’s costs. You won’t be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won’t be on the battlefield when you pay the spell’s costs, so you won’t be able to tap it for convoke."
+          "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped when you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
         }
       ],
       "subtypes": [
@@ -22371,7 +22371,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won’t gain 3 life."
+          "text": "If the creature or player is an illegal target as Lightning Helix tries to resolve, it will be countered and none of its effects will happen. You won't gain 3 life."
         }
       ],
       "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
@@ -22584,19 +22584,19 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The spell is cast during the resolution of Mindleech Mass’s triggered ability. You may cast any nonland card in the player’s hand, not just an instant card. This doesn’t get around other prohibitions, such as “Cast this card only before attackers are declared.”"
+          "text": "The spell is cast during the resolution of Mindleech Mass's triggered ability. You may cast any nonland card in the player's hand, not just an instant card. This doesn't get around other prohibitions, such as \"Cast this card only before attackers are declared.\""
         },
         {
           "date": "2005-10-01",
-          "text": "You control the spell and, if it’s an artifact, creature, or enchantment spell, you control the resulting permanent."
+          "text": "You control the spell and, if it's an artifact, creature, or enchantment spell, you control the resulting permanent."
         },
         {
           "date": "2005-10-01",
-          "text": "The card is cast from your opponent’s hand, not yours."
+          "text": "The card is cast from your opponent's hand, not yours."
         },
         {
           "date": "2005-10-01",
-          "text": "You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can’t be paid."
+          "text": "You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can't be paid."
         }
       ],
       "subtypes": [
@@ -22806,7 +22806,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If the spell’s controller has no cards in his or her hand, that player can still choose to discard his or her hand and prevent the spell from being countered."
+          "text": "If the spell's controller has no cards in his or her hand, that player can still choose to discard his or her hand and prevent the spell from being countered."
         }
       ],
       "text": "Counter target spell unless its controller discards his or her hand.\nTransmute {1}{U}{B} ({1}{U}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Transmute only as a sorcery.)",
@@ -22910,7 +22910,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If another effect would prevent damage from being dealt to Phytohydra or replace it with something else, Phytohydra’s controller chooses which effect to apply first."
+          "text": "If another effect would prevent damage from being dealt to Phytohydra or replace it with something else, Phytohydra's controller chooses which effect to apply first."
         },
         {
           "date": "2005-10-01",
@@ -23231,7 +23231,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "This spell isn’t Modal. When it resolves, it will destroy the target if it’s a creature or an artifact, even if it changed from one to the other between targeting and resolution."
+          "text": "This spell isn't Modal. When it resolves, it will destroy the target if it's a creature or an artifact, even if it changed from one to the other between targeting and resolution."
         }
       ],
       "text": "Destroy target artifact or creature. It can't be regenerated.",
@@ -23433,11 +23433,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The 3 damage doesn’t have to be from the same source, and it doesn’t have to be all dealt at once. If only 2 damage is redirected, the next 1 damage will also be redirected."
+          "text": "The 3 damage doesn't have to be from the same source, and it doesn't have to be all dealt at once. If only 2 damage is redirected, the next 1 damage will also be redirected."
         },
         {
           "date": "2005-10-01",
-          "text": "If either target creature leaves the battlefield before damage is dealt, that damage won’t be redirected. It doesn’t matter if Razia leaves the battlefield."
+          "text": "If either target creature leaves the battlefield before damage is dealt, that damage won't be redirected. It doesn't matter if Razia leaves the battlefield."
         }
       ],
       "subtypes": [
@@ -23547,7 +23547,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If a player doesn’t control three permanents, that player chooses all the permanents he or she does control and doesn’t sacrifice anything."
+          "text": "If a player doesn't control three permanents, that player chooses all the permanents he or she does control and doesn't sacrifice anything."
         },
         {
           "date": "2005-10-01",
@@ -23655,15 +23655,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "These abilities trigger specifically when you “sacrifice” a creature. They won’t trigger when a creature is put into your graveyard for any other reason."
+          "text": "These abilities trigger specifically when you \"sacrifice\" a creature. They won't trigger when a creature is put into your graveyard for any other reason."
         },
         {
           "date": "2005-10-01",
-          "text": "Savra itself doesn’t let you sacrifice creatures, and you can’t sacrifice them spontaneously. You must have another spell or ability that lets you sacrifice creatures."
+          "text": "Savra itself doesn't let you sacrifice creatures, and you can't sacrifice them spontaneously. You must have another spell or ability that lets you sacrifice creatures."
         },
         {
           "date": "2005-10-01",
-          "text": "Sacrificing a creature that’s both black and green will make both abilities trigger. You may put them on the stack in whichever order you want."
+          "text": "Sacrificing a creature that's both black and green will make both abilities trigger. You may put them on the stack in whichever order you want."
         }
       ],
       "subtypes": [
@@ -23775,7 +23775,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Searing Meditation doesn’t care how much life you gain. It triggers just once for each life-gaining event, whether it’s 1 life from Firemane Angel or 15 life from Brightflame."
+          "text": "Searing Meditation doesn't care how much life you gain. It triggers just once for each life-gaining event, whether it's 1 life from Firemane Angel or 15 life from Brightflame."
         }
       ],
       "text": "Whenever you gain life, you may pay {2}. If you do, Searing Meditation deals 2 damage to target creature or player.",
@@ -23878,7 +23878,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You may choose the same creature as a target multiple times since the card says “target creature” multiple times. You may give three different creatures +1/+1 each, one creature +2/+2 and another creature +1/+1, or a single creature +3/+3."
+          "text": "You may choose the same creature as a target multiple times since the card says \"target creature\" multiple times. You may give three different creatures +1/+1 each, one creature +2/+2 and another creature +1/+1, or a single creature +3/+3."
         }
       ],
       "text": "Target creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.",
@@ -24291,11 +24291,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The second ability can only exile a creature that’s currently blocking or being blocked by Sisters of Stone Death. If Sisters of Stone Death isn’t on the battlefield or have been removed from combat, the ability will be countered."
+          "text": "The second ability can only exile a creature that's currently blocking or being blocked by Sisters of Stone Death. If Sisters of Stone Death isn't on the battlefield or have been removed from combat, the ability will be countered."
         },
         {
           "date": "2005-10-01",
-          "text": "The third ability can get back any creature card exiled by the second ability, no matter when it was exiled. If a card that’s not a creature card (such as Svogthos, the Restless Tomb) was exiled, the third ability can’t return it."
+          "text": "The third ability can get back any creature card exiled by the second ability, no matter when it was exiled. If a card that's not a creature card (such as Svogthos, the Restless Tomb) was exiled, the third ability can't return it."
         }
       ],
       "subtypes": [
@@ -24619,7 +24619,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If another effect would prevent Szadek’s combat damage from being dealt to the defending player or replace it with something else, that player chooses which effect applies first. For example, the player can choose to first have Mending Hands prevent 4 of the damage and then apply Szadek’s ability so that it gets only one counter."
+          "text": "If another effect would prevent Szadek's combat damage from being dealt to the defending player or replace it with something else, that player chooses which effect applies first. For example, the player can choose to first have Mending Hands prevent 4 of the damage and then apply Szadek's ability so that it gets only one counter."
         }
       ],
       "subtypes": [
@@ -24837,11 +24837,11 @@
         },
         {
           "date": "2005-10-01",
-          "text": "The token is named “Voja” and has creature type “Wolf.” This is different from most creature tokens, where the name and creature type are the same."
+          "text": "The token is named \"Voja\" and has creature type \"Wolf.\" This is different from most creature tokens, where the name and creature type are the same."
         },
         {
           "date": "2013-07-01",
-          "text": "The “legend rule” means that creating a second Voja while one is already under your control will result in one of them being put into its owner’s graveyard (where it promptly ceases to exist). You choose which of the two remains on the battlefield and which is put into the graveyard."
+          "text": "The \"legend rule\" means that creating a second Voja while one is already under your control will result in one of them being put into its owner's graveyard (where it promptly ceases to exist). You choose which of the two remains on the battlefield and which is put into the graveyard."
         }
       ],
       "subtypes": [
@@ -25054,11 +25054,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "The ability doesn’t care why a card goes to your opponent’s graveyard — only that it does. The ability triggers when a card is put into your opponent’s graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player’s hand (a card is discarded), from the player’s library (from a Millstone-like effect), or from any other zone."
+          "text": "The ability doesn't care why a card goes to your opponent's graveyard — only that it does. The ability triggers when a card is put into your opponent's graveyard from the stack (a spell resolves or is countered), from the battlefield (a permanent is destroyed or sacrificed), from the player's hand (a card is discarded), from the player's library (from a Millstone-like effect), or from any other zone."
         },
         {
           "date": "2005-10-01",
-          "text": "This ability triggers only on cards, so it won’t trigger when a token is put into your opponent’s graveyard."
+          "text": "This ability triggers only on cards, so it won't trigger when a token is put into your opponent's graveyard."
         }
       ],
       "subtypes": [
@@ -25273,7 +25273,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -25899,7 +25899,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "At the next end of combat step in the turn, all creatures that had blocked the targeted creature at any point during the turn will be destroyed. This includes creatures that blocked it before Gaze of the Gorgon was cast. It doesn’t matter whether the targeted creature is still on the battlefield at that point."
+          "text": "At the next end of combat step in the turn, all creatures that had blocked the targeted creature at any point during the turn will be destroyed. This includes creatures that blocked it before Gaze of the Gorgon was cast. It doesn't matter whether the targeted creature is still on the battlefield at that point."
         }
       ],
       "text": "({B/G} can be paid with either {B} or {G}.)\nRegenerate target creature. At this turn's next end of combat, destroy all creatures that blocked or were blocked by it this turn.",
@@ -26320,15 +26320,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You choose attackers and make blocking assignments regardless of whether it’s your turn and regardless of whether the creatures are attacking you. Your choices must be legal within the normal rules for attacking and blocking."
+          "text": "You choose attackers and make blocking assignments regardless of whether it's your turn and regardless of whether the creatures are attacking you. Your choices must be legal within the normal rules for attacking and blocking."
         },
         {
           "date": "2006-01-01",
-          "text": "You can decide that a creature won’t block."
+          "text": "You can decide that a creature won't block."
         },
         {
           "date": "2008-04-01",
-          "text": "If the defending player controls a planeswalker, the person who cast Master Warcraft first chooses the complete group of creatures that are going to attack. Then, for each of those creatures, the active player chooses who or what it’s going to attack."
+          "text": "If the defending player controls a planeswalker, the person who cast Master Warcraft first chooses the complete group of creatures that are going to attack. Then, for each of those creatures, the active player chooses who or what it's going to attack."
         },
         {
           "date": "2013-09-20",
@@ -26639,19 +26639,19 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If an effect says “You may search your library . . . If you do, shuffle your library,” you can’t choose to search since it’s impossible, and you won’t shuffle."
+          "text": "If an effect says \"You may search your library . . . If you do, shuffle your library,\" you can't choose to search since it's impossible, and you won't shuffle."
         },
         {
           "date": "2005-10-01",
-          "text": "If an effect says “Search your library . . . Then shuffle your library,” the search effect fails, but you will have to shuffle."
+          "text": "If an effect says \"Search your library . . . Then shuffle your library,\" the search effect fails, but you will have to shuffle."
         },
         {
           "date": "2005-10-01",
-          "text": "Since players can’t search, players won’t be able to find any cards in a library. The effect applies to all players and all libraries. If a spell or ability’s effect has other parts that don’t depend on searching for or finding cards, they will still work normally."
+          "text": "Since players can't search, players won't be able to find any cards in a library. The effect applies to all players and all libraries. If a spell or ability's effect has other parts that don't depend on searching for or finding cards, they will still work normally."
         },
         {
           "date": "2005-10-01",
-          "text": "Effects that tell a player to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word “search” will fail."
+          "text": "Effects that tell a player to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word \"search\" will fail."
         }
       ],
       "text": "({U/B} can be paid with either {U} or {B}.)\nPlayers can't search libraries this turn.\nDraw a card.",
@@ -26749,7 +26749,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You may activate the second ability in response to activating the first one. If you do, you’ll remove the blood counter that was just added before you lose the life."
+          "text": "You may activate the second ability in response to activating the first one. If you do, you'll remove the blood counter that was just added before you lose the life."
         }
       ],
       "text": "{2}, {T}, Put a blood counter on Bloodletter Quill: Draw a card, then you lose 1 life for each blood counter on Bloodletter Quill.\n{U}{B}: Remove a blood counter from Bloodletter Quill.",
@@ -26941,7 +26941,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Errata’d to make it clear that only the cards you own go into your hand, so if you somehow gain control of the Cloister, your opponent’s cards won’t go to your hand."
+          "text": "Errata'd to make it clear that only the cards you own go into your hand, so if you somehow gain control of the Cloister, your opponent's cards won't go to your hand."
         }
       ],
       "text": "At the beginning of each opponent's upkeep, exile all cards from your hand face down.\nAt the beginning of your upkeep, return all cards you own exiled with Bottled Cloister to your hand, then draw a card.",
@@ -27131,11 +27131,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -27608,11 +27608,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Grifter’s Blade must enter the battlefield attached to a creature you control, if possible."
+          "text": "Grifter's Blade must enter the battlefield attached to a creature you control, if possible."
         },
         {
           "date": "2005-10-01",
-          "text": "If you don’t control a creature Grifter’s Blade could be attached to, it simply enters the battlefield unattached."
+          "text": "If you don't control a creature Grifter's Blade could be attached to, it simply enters the battlefield unattached."
         }
       ],
       "subtypes": [
@@ -27898,11 +27898,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Nullstone Gargoyle cares about the first noncreature spell cast during a turn, not the first one it “sees.” If a noncreature spell was cast before Nullstone Gargoyle entered the battlefield, it won’t counter the next one."
+          "text": "Nullstone Gargoyle cares about the first noncreature spell cast during a turn, not the first one it \"sees.\" If a noncreature spell was cast before Nullstone Gargoyle entered the battlefield, it won't counter the next one."
         },
         {
           "date": "2005-10-01",
-          "text": "If another spell is cast in response to the first spell, Nullstone Gargoyle doesn’t affect that second spell."
+          "text": "If another spell is cast in response to the first spell, Nullstone Gargoyle doesn't affect that second spell."
         }
       ],
       "subtypes": [
@@ -28001,7 +28001,7 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "If Pariah’s Shield isn’t attached to a creature, all damage that would be dealt to you is dealt to you normally."
+          "text": "If Pariah's Shield isn't attached to a creature, all damage that would be dealt to you is dealt to you normally."
         }
       ],
       "subtypes": [
@@ -28193,11 +28193,11 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You choose whether to add or remove a counter when the second ability resolves. You can’t choose to remove a counter if there isn’t one there."
+          "text": "You choose whether to add or remove a counter when the second ability resolves. You can't choose to remove a counter if there isn't one there."
         },
         {
           "date": "2005-10-01",
-          "text": "If the third ability triggers, removing a counter in response won’t stop the effect. However, somehow removing Plague Boiler from the battlefield in response would stop the effect because then you wouldn’t be able to sacrifice Plague Boiler."
+          "text": "If the third ability triggers, removing a counter in response won't stop the effect. However, somehow removing Plague Boiler from the battlefield in response would stop the effect because then you wouldn't be able to sacrifice Plague Boiler."
         },
         {
           "date": "2005-10-01",
@@ -28493,15 +28493,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "You can’t pay the cost of the second ability unless Sunforger is attached to a creature."
+          "text": "You can't pay the cost of the second ability unless Sunforger is attached to a creature."
         },
         {
           "date": "2005-10-01",
-          "text": "Any card you find must be legally castable (for example, you have to be able to choose a legal target for it). If you can’t find a castable card (or choose not to), nothing happens and you shuffle your library."
+          "text": "Any card you find must be legally castable (for example, you have to be able to choose a legal target for it). If you can't find a castable card (or choose not to), nothing happens and you shuffle your library."
         },
         {
           "date": "2005-10-01",
-          "text": "The card is cast from your library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can’t be paid."
+          "text": "The card is cast from your library, not your hand. You choose modes, pay additional costs, choose targets, etc. for the spell as normal when casting it. Any X in the mana cost will be 0. Alternative costs can't be paid."
         }
       ],
       "subtypes": [
@@ -28623,7 +28623,7 @@
         },
         {
           "date": "2016-07-13",
-          "text": "Terrarion’s last ability triggers no matter how it’s put into a graveyard from the battlefield."
+          "text": "Terrarion's last ability triggers no matter how it's put into a graveyard from the battlefield."
         }
       ],
       "text": "Terrarion enters the battlefield tapped.\n{2}, {T}, Sacrifice Terrarion: Add two mana in any combination of colors to your mana pool.\nWhen Terrarion is put into a graveyard from the battlefield, draw a card.",
@@ -29210,15 +29210,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -29324,15 +29324,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -29542,7 +29542,7 @@
         },
         {
           "date": "2005-10-01",
-          "text": "If you give double strike to a creature after either first-strike or normal combat damage has been dealt, it won’t help that creature deal any additional combat damage."
+          "text": "If you give double strike to a creature after either first-strike or normal combat damage has been dealt, it won't help that creature deal any additional combat damage."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{2}{R}{W}, {T}: Target creature gains double strike until end of turn.",
@@ -29640,15 +29640,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "While animated, Svogthos’s power and toughness changes each time a creature card enters or leaves its controller’s graveyard."
+          "text": "While animated, Svogthos's power and toughness changes each time a creature card enters or leaves its controller's graveyard."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with \"This creature's power and toughness are each equal to the number of creature cards in your graveyard.\" It's still a land.",
@@ -29750,15 +29750,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -29960,15 +29960,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -35337,22 +35337,7 @@
         {
           "language": "Chinese Simplified",
           "name": "山脉",
-          "multiverseid": 111457
-        },
-        {
-          "language": "Chinese Simplified",
-          "name": "山脉",
-          "multiverseid": 111458
-        },
-        {
-          "language": "Chinese Simplified",
-          "name": "山脉",
           "multiverseid": 111459
-        },
-        {
-          "language": "Chinese Simplified",
-          "name": "山脉",
-          "multiverseid": 111460
         },
         {
           "language": "French",
@@ -35455,9 +35440,24 @@
           "multiverseid": 112990
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 114395
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 113293
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 113294
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 113295
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 113296
         }
       ],
       "id": "2cd5add2c887e996246f815c76db8bf44c3a91e1",

--- a/json/ROE.json
+++ b/json/ROE.json
@@ -131,7 +131,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Tokens may also be colored permanents. The effect that creates a token states what color it is or whether it’s colorless."
+          "text": "Tokens may also be colored permanents. The effect that creates a token states what color it is or whether it's colorless."
         },
         {
           "date": "2010-06-15",
@@ -143,7 +143,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "All Is Dust doesn’t destroy permanents. Rather, it causes them to be sacrificed. Regeneration, totem armor, and indestructibile can’t save permanents from All Is Dust."
+          "text": "All Is Dust doesn't destroy permanents. Rather, it causes them to be sacrificed. Regeneration, totem armor, and indestructibile can't save permanents from All Is Dust."
         }
       ],
       "subtypes": [
@@ -247,15 +247,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -353,19 +353,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "Eldrazi Conscription is an Eldrazi. However, it doesn’t turn the enchanted creature into an Eldrazi."
+          "text": "Eldrazi Conscription is an Eldrazi. However, it doesn't turn the enchanted creature into an Eldrazi."
         }
       ],
       "subtypes": [
@@ -466,31 +466,31 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "Emrakul can be targeted by spells that try to counter it (such as Lay Bare). Those spells will resolve, but the part of their effect that would counter Emrakul won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Emrakul can be targeted by spells that try to counter it (such as Lay Bare). Those spells will resolve, but the part of their effect that would counter Emrakul won't do anything. Any other effects those spells have will work as normal."
         },
         {
           "date": "2010-06-15",
-          "text": "“Protection from colored spells” means that Emrakul can’t be the target of colored spells (including colored Aura spells) or of abilities whose sources are colored spells (such as the “when you cast” ability of an Ulamog, the Infinite Gyre that’s been turned red by Painter’s Servant). It also means that all damage that would be dealt to Emrakul by colored spells is prevented. Like every protection ability, it works only while Emrakul is on the battlefield."
+          "text": "\"Protection from colored spells\" means that Emrakul can't be the target of colored spells (including colored Aura spells) or of abilities whose sources are colored spells (such as the \"when you cast\" ability of an Ulamog, the Infinite Gyre that's been turned red by Painter's Servant). It also means that all damage that would be dealt to Emrakul by colored spells is prevented. Like every protection ability, it works only while Emrakul is on the battlefield."
         },
         {
           "date": "2010-06-15",
-          "text": "“Colored spells” is not synonymous with “colored instants and sorceries.” For example, if a player cycles Choking Tethers, its triggered ability may target Emrakul because Choking Tethers wasn’t cast as a spell."
+          "text": "\"Colored spells\" is not synonymous with \"colored instants and sorceries.\" For example, if a player cycles Choking Tethers, its triggered ability may target Emrakul because Choking Tethers wasn't cast as a spell."
         },
         {
           "date": "2010-06-15",
-          "text": "Emrakul may be affected by colored spells that don’t target it or deal damage to it, including those that cause it to become blocked. Abilities of colored permanents (such as Journey to Nowhere) may target it. Auras may be moved onto it by abilities or by colored spells that don’t target it (such as Aura Graft)."
+          "text": "Emrakul may be affected by colored spells that don't target it or deal damage to it, including those that cause it to become blocked. Abilities of colored permanents (such as Journey to Nowhere) may target it. Auras may be moved onto it by abilities or by colored spells that don't target it (such as Aura Graft)."
         }
       ],
       "subtypes": [
@@ -592,23 +592,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "Casting Hand of Emrakul by paying its alternative cost doesn’t change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
+          "text": "Casting Hand of Emrakul by paying its alternative cost doesn't change when you can cast it. You can cast it only at the normal time you could cast a creature spell."
         },
         {
           "date": "2010-06-15",
-          "text": "Casting Hand of Emrakul by paying its alternative cost doesn’t change its mana cost or converted mana cost."
+          "text": "Casting Hand of Emrakul by paying its alternative cost doesn't change its mana cost or converted mana cost."
         },
         {
           "date": "2010-06-15",
@@ -711,15 +711,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -822,15 +822,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
@@ -838,7 +838,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "It doesn’t matter whose graveyard the permanent is put into, only that it was last controlled by, and sacrificed by, an opponent."
+          "text": "It doesn't matter whose graveyard the permanent is put into, only that it was last controlled by, and sacrificed by, an opponent."
         },
         {
           "date": "2010-06-15",
@@ -846,15 +846,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "When the second ability resolves, you must return the card to the battlefield, even if you don’t want to."
+          "text": "When the second ability resolves, you must return the card to the battlefield, even if you don't want to."
         },
         {
           "date": "2010-06-15",
-          "text": "If an opponent sacrifices an Aura, you’ll choose what it enchants as you return it to the battlefield. No player can respond to the choice. Since an Aura doesn’t target anything if it isn’t cast as a spell, you can enchant a permanent with shroud this way."
+          "text": "If an opponent sacrifices an Aura, you'll choose what it enchants as you return it to the battlefield. No player can respond to the choice. Since an Aura doesn't target anything if it isn't cast as a spell, you can enchant a permanent with shroud this way."
         },
         {
           "date": "2010-06-15",
-          "text": "If the sacrificed permanent that caused the second ability to trigger somehow leaves the graveyard before the ability resolves (possibly because it was returned to the battlefield by the ability of another It That Betrays), the ability simply won’t do anything when it resolves."
+          "text": "If the sacrificed permanent that caused the second ability to trigger somehow leaves the graveyard before the ability resolves (possibly because it was returned to the battlefield by the ability of another It That Betrays), the ability simply won't do anything when it resolves."
         }
       ],
       "subtypes": [
@@ -955,19 +955,19 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Not of This World’s first ability checks the current state of the targets of the spell or ability it’s targeting to determine whether one of them is a permanent you control. For example, say a player casts Forked Bolt targeting you and a creature you control. If, in response, another spell or ability causes that creature to no longer be under your control, then you can’t cast Not of This World targeting Forked Bolt. Alternately, if you cast Not of This World targeting Forked Bolt and, in response, another spell or ability causes that creature to no longer be under your control, Not of This World will be countered when it tries to resolve for having an illegal target."
+          "text": "Not of This World's first ability checks the current state of the targets of the spell or ability it's targeting to determine whether one of them is a permanent you control. For example, say a player casts Forked Bolt targeting you and a creature you control. If, in response, another spell or ability causes that creature to no longer be under your control, then you can't cast Not of This World targeting Forked Bolt. Alternately, if you cast Not of This World targeting Forked Bolt and, in response, another spell or ability causes that creature to no longer be under your control, Not of This World will be countered when it tries to resolve for having an illegal target."
         },
         {
           "date": "2010-06-15",
-          "text": "Not of This World’s second ability checks the current state of the targets of the spell or ability it’s targeting to determine whether one of them is a creature you control with power 7 or greater. This check is made as you cast Not of This World, before you activate mana abilities. It doesn’t matter what the power of the creature was at the time the targeted spell or ability was cast."
+          "text": "Not of This World's second ability checks the current state of the targets of the spell or ability it's targeting to determine whether one of them is a creature you control with power 7 or greater. This check is made as you cast Not of This World, before you activate mana abilities. It doesn't matter what the power of the creature was at the time the targeted spell or ability was cast."
         },
         {
           "date": "2010-06-15",
-          "text": "Not of This World doesn’t check whether the targets of the spell or ability it’s targeting are currently legal for that spell or ability, only who controls them and what their power is. For example, say a player casts Forked Bolt targeting you and a creature you control. If, in response, another spell or ability causes that creature to gain shroud, then you can still cast Not of This World targeting Forked Bolt."
+          "text": "Not of This World doesn't check whether the targets of the spell or ability it's targeting are currently legal for that spell or ability, only who controls them and what their power is. For example, say a player casts Forked Bolt targeting you and a creature you control. If, in response, another spell or ability causes that creature to gain shroud, then you can still cast Not of This World targeting Forked Bolt."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability targets you, but not a permanent you control, you can’t cast Not of This World targeting it. Keep in mind that if a player casts a spell or activates an ability with the intent of dealing damage to a planeswalker you control, that spell or ability is actually targeting you, not that planeswalker."
+          "text": "If a spell or ability targets you, but not a permanent you control, you can't cast Not of This World targeting it. Keep in mind that if a player casts a spell or activates an ability with the intent of dealing damage to a planeswalker you control, that spell or ability is actually targeting you, not that planeswalker."
         }
       ],
       "subtypes": [
@@ -1067,15 +1067,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -1265,27 +1265,27 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "You cast Eldrazi cards from outside the game as part of the resolution of Spawnsire of Ulamog’s last ability. You may cast those cards in any order. Timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law). You cast all of the cards you like, putting them onto the stack, then the ability finishes resolving. The spells you cast this way will then resolve as normal, one at a time, in the opposite order that they were put on the stack. They’ll remain in the game for the remainder of that game."
+          "text": "You cast Eldrazi cards from outside the game as part of the resolution of Spawnsire of Ulamog's last ability. You may cast those cards in any order. Timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law). You cast all of the cards you like, putting them onto the stack, then the ability finishes resolving. The spells you cast this way will then resolve as normal, one at a time, in the opposite order that they were put on the stack. They'll remain in the game for the remainder of that game."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. On the other hand, if the card has additional costs, you may pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. On the other hand, if the card has additional costs, you may pay those."
         },
         {
           "date": "2010-06-15",
-          "text": "In a casual game, the cards you cast from outside the game come from your personal collection. In a sanctioned event, those cards must come from your sideboard. Note that you can’t cast cards from exile this way; exile is a zone in the game."
+          "text": "In a casual game, the cards you cast from outside the game come from your personal collection. In a sanctioned event, those cards must come from your sideboard. Note that you can't cast cards from exile this way; exile is a zone in the game."
         }
       ],
       "subtypes": [
@@ -1385,19 +1385,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -1501,23 +1501,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "If, during your declare attackers step, Ulamog’s Crusher is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then it doesn’t attack. If there’s a cost associated with having Ulamog’s Crusher attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Ulamog's Crusher is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then it doesn't attack. If there's a cost associated with having Ulamog's Crusher attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If there are multiple combat phases in a turn, Ulamog’s Crusher must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Ulamog's Crusher must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -1724,23 +1724,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -1948,7 +1948,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -2154,11 +2154,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -2166,15 +2166,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -2182,15 +2182,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -2296,11 +2296,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -2308,27 +2308,27 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2010-06-15",
-          "text": "You choose the color as Emerge Unscathed resolves. Once you choose a color, it’s too late for players to respond."
+          "text": "You choose the color as Emerge Unscathed resolves. Once you choose a color, it's too late for players to respond."
         }
       ],
       "text": "Target creature you control gains protection from the color of your choice until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -2430,43 +2430,43 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s first ability doesn’t lock in what it applies to. That’s because the effect states a true thing about a set of creatures, but doesn’t actually change the characteristics of those creatures. As a result, whatever creatures the targeted opponent controls during the declare attackers step of his or her next turn must attack Gideon Jura if able. This includes creatures that come under that player’s control after the ability has resolved and creatures that have lost all abilities."
+          "text": "Gideon Jura's first ability doesn't lock in what it applies to. That's because the effect states a true thing about a set of creatures, but doesn't actually change the characteristics of those creatures. As a result, whatever creatures the targeted opponent controls during the declare attackers step of his or her next turn must attack Gideon Jura if able. This includes creatures that come under that player's control after the ability has resolved and creatures that have lost all abilities."
         },
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s first ability causes creatures to attack him if able. If, during the affected player’s declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then that creature doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so the creature doesn’t have to attack in that case either."
+          "text": "Gideon Jura's first ability causes creatures to attack him if able. If, during the affected player's declare attackers step, a creature he or she controls is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then that creature doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so the creature doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature controlled by the affected player can’t attack Gideon Jura (because he’s no longer on the battlefield, for example), that player may have it attack you, another one of your planeswalkers, or nothing at all."
+          "text": "If a creature controlled by the affected player can't attack Gideon Jura (because he's no longer on the battlefield, for example), that player may have it attack you, another one of your planeswalkers, or nothing at all."
         },
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s first ability applies during each combat phase of the affected player’s next turn (as opposed to applying during the affected player’s next combat phase). The distinction is relevant if there are no combat phases during that turn (due to Fatespinner’s effect, for example) or there are multiples (due to World at War, for example)."
+          "text": "Gideon Jura's first ability applies during each combat phase of the affected player's next turn (as opposed to applying during the affected player's next combat phase). The distinction is relevant if there are no combat phases during that turn (due to Fatespinner's effect, for example) or there are multiples (due to World at War, for example)."
         },
         {
           "date": "2010-06-15",
-          "text": "If Gideon Jura becomes a creature due to his third ability, that doesn’t count as having a creature enter the battlefield. Gideon Jura was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "If Gideon Jura becomes a creature due to his third ability, that doesn't count as having a creature enter the battlefield. Gideon Jura was already on the battlefield; he only changed his types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-06-15",
-          "text": "If Gideon Jura becomes a creature, he may be affected by “summoning sickness.” You can’t attack with him or use any of his {T} abilities (if he gains any) unless he began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when Gideon Jura came under your control, not when he became a creature."
+          "text": "If Gideon Jura becomes a creature, he may be affected by \"summoning sickness.\" You can't attack with him or use any of his {T} abilities (if he gains any) unless he began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when Gideon Jura came under your control, not when he became a creature."
         },
         {
           "date": "2010-06-15",
-          "text": "Gideon Jura’s third ability causes him to become a creature with the creature types Human Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
+          "text": "Gideon Jura's third ability causes him to become a creature with the creature types Human Soldier. He remains a planeswalker with the planeswalker type Gideon. (He also retains any other card types or subtypes he may have had.) Each subtype is correlated to the proper card type: Gideon is just a planeswalker type (not a creature type), and Human and Soldier are just creature types (not planeswalker types)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you activate Gideon Jura’s third ability and then unpreventable damage is dealt to him (due to Unstable Footing, for example), that damage has all applicable results: specifically, the damage is marked on Gideon Jura (since he’s a creature) and that damage causes that many loyalty counters to be removed from him (since he’s a planeswalker). If the total amount of damage marked on Gideon Jura is lethal damage, he’s destroyed as a state-based action. If Gideon Jura has no loyalty counters on him, he’s put into his owner’s graveyard as a state-based action."
+          "text": "If you activate Gideon Jura's third ability and then unpreventable damage is dealt to him (due to Unstable Footing, for example), that damage has all applicable results: specifically, the damage is marked on Gideon Jura (since he's a creature) and that damage causes that many loyalty counters to be removed from him (since he's a planeswalker). If the total amount of damage marked on Gideon Jura is lethal damage, he's destroyed as a state-based action. If Gideon Jura has no loyalty counters on him, he's put into his owner's graveyard as a state-based action."
         },
         {
           "date": "2010-06-15",
-          "text": "Say you activate Gideon Jura’s third ability, then an opponent gains control of him before combat. You may have any of your creatures attack Gideon Jura (since he’s still a planeswalker). Then Gideon Jura may block (since he’s a creature). He may block any eligible attacking creature, including one that’s attacking him! During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he’s blocking, but he doesn’t deal combat damage to any unblocked creatures that are attacking him."
+          "text": "Say you activate Gideon Jura's third ability, then an opponent gains control of him before combat. You may have any of your creatures attack Gideon Jura (since he's still a planeswalker). Then Gideon Jura may block (since he's a creature). He may block any eligible attacking creature, including one that's attacking him! During combat, he behaves as an attacked planeswalker and/or a blocking creature, as appropriate. For example, he deals combat damage to any creatures he's blocking, but he doesn't deal combat damage to any unblocked creatures that are attacking him."
         },
         {
           "date": "2011-01-22",
-          "text": "The first ability only affects the declaration of attackers. If a creature is put onto the battlefield attacking (thanks to Hero of Bladehold, Preeminent Captain, or the Ninjutsu ability, for example), that creature’s controller may choose the defending player or planeswalker that it will be attacking in the normal way."
+          "text": "The first ability only affects the declaration of attackers. If a creature is put onto the battlefield attacking (thanks to Hero of Bladehold, Preeminent Captain, or the Ninjutsu ability, for example), that creature's controller may choose the defending player or planeswalker that it will be attacking in the normal way."
         }
       ],
       "subtypes": [
@@ -2773,7 +2773,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Combat damage dealt by blocking creatures isn’t prevented."
+          "text": "Combat damage dealt by blocking creatures isn't prevented."
         }
       ],
       "text": "Prevent all combat damage that would be dealt this turn by attacking creatures.",
@@ -2873,23 +2873,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         },
         {
           "date": "2010-06-15",
@@ -2901,11 +2901,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a source would deal damage to multiple applicable recipients, the prevention effects apply to each of those recipients separately. For example, if Hedron-Field Purists is level 1 and you cast Earthquake (“Earthquake deals X damage to each creature without flying and each player”) with X equal to 3, that Earthquake will deal 2 damage to you, 2 damage to each creature without flying you control, 3 damage to each other player, and 3 damage to each creature without flying other players control."
+          "text": "If a source would deal damage to multiple applicable recipients, the prevention effects apply to each of those recipients separately. For example, if Hedron-Field Purists is level 1 and you cast Earthquake (\"Earthquake deals X damage to each creature without flying and each player\") with X equal to 3, that Earthquake will deal 2 damage to you, 2 damage to each creature without flying you control, 3 damage to each other player, and 3 damage to each creature without flying other players control."
         },
         {
           "date": "2010-06-15",
-          "text": "The prevention effects don’t affect damage dealt directly to a planeswalker you control (such as combat damage, or damage Sarkhan the Mad deals to himself due to his first ability). They can prevent noncombat damage that’s redirected from you to a planeswalker you control if you apply these effects first."
+          "text": "The prevention effects don't affect damage dealt directly to a planeswalker you control (such as combat damage, or damage Sarkhan the Mad deals to himself due to his first ability). They can prevent noncombat damage that's redirected from you to a planeswalker you control if you apply these effects first."
         },
         {
           "date": "2010-06-15",
@@ -3015,11 +3015,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -3027,15 +3027,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -3043,15 +3043,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -3158,23 +3158,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -3281,23 +3281,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -3404,23 +3404,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -3634,7 +3634,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an Aura spell, Kor Spiritdancer’s second ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an Aura spell, Kor Spiritdancer's second ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         },
         {
           "date": "2010-06-15",
@@ -3743,7 +3743,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Lightmine Field’s ability triggers when any creatures attack, including your own."
+          "text": "Lightmine Field's ability triggers when any creatures attack, including your own."
         },
         {
           "date": "2010-06-15",
@@ -3755,7 +3755,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "For example: If a creature attacks but is removed from combat before Lightmine Field’s ability resolves (because it would be destroyed and regenerates, perhaps), that creature is dealt damage by Lightmine Field but isn’t counted when determining the amount of damage. On the other hand, if a creature is put onto the battlefield attacking (due to Preeminent Captain’s ability, perhaps), it isn’t dealt damage by Lightmine Field, but it is counted when determining the amount of damage."
+          "text": "For example: If a creature attacks but is removed from combat before Lightmine Field's ability resolves (because it would be destroyed and regenerates, perhaps), that creature is dealt damage by Lightmine Field but isn't counted when determining the amount of damage. On the other hand, if a creature is put onto the battlefield attacking (due to Preeminent Captain's ability, perhaps), it isn't dealt damage by Lightmine Field, but it is counted when determining the amount of damage."
         }
       ],
       "text": "Whenever one or more creatures attack, Lightmine Field deals damage to each of those creatures equal to the number of attacking creatures.",
@@ -3857,7 +3857,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2017-03-14",
@@ -3865,7 +3865,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Linvala’s last ability affects only creatures on the battlefield. Activated abilities that work in other zones (such as bloodrush or unearth) can still be activated. Triggered abilities (starting with “when,” “whenever,” or “at”) are unaffected."
+          "text": "Linvala's last ability affects only creatures on the battlefield. Activated abilities that work in other zones (such as bloodrush or unearth) can still be activated. Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected."
         }
       ],
       "subtypes": [
@@ -4074,11 +4074,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The controller of Luminous Wake (who is not necessarily the controller of the enchanted creature) controls the triggered ability and gains life when it resolves. In other words, if you enchant your opponent’s creature with Luminous Wake, you — not your opponent — gain life whenever that creature attacks or blocks."
+          "text": "The controller of Luminous Wake (who is not necessarily the controller of the enchanted creature) controls the triggered ability and gains life when it resolves. In other words, if you enchant your opponent's creature with Luminous Wake, you — not your opponent — gain life whenever that creature attacks or blocks."
         },
         {
           "date": "2010-06-15",
-          "text": "When the enchanted creature blocks, Luminous Wake’s ability triggers just once, even if that creature somehow blocked multiple attacking creatures."
+          "text": "When the enchanted creature blocks, Luminous Wake's ability triggers just once, even if that creature somehow blocked multiple attacking creatures."
         }
       ],
       "subtypes": [
@@ -4282,11 +4282,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -4294,15 +4294,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -4310,15 +4310,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -4426,11 +4426,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "This ability has an “intervening ‘if’ clause.” That means (1) the ability triggers only if you have exactly 1 life as your upkeep begins, and (2) the ability does nothing if your life total is anything other than 1 by the time it resolves."
+          "text": "This ability has an \"intervening 'if' clause.\" That means (1) the ability triggers only if you have exactly 1 life as your upkeep begins, and (2) the ability does nothing if your life total is anything other than 1 by the time it resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, anything that cares about your life total checks your team’s life total. You’ll win the game if your team has exactly 1 life."
+          "text": "In a Two-Headed Giant game, anything that cares about your life total checks your team's life total. You'll win the game if your team has exactly 1 life."
         }
       ],
       "text": "At the beginning of your upkeep, if you have exactly 1 life, you win the game.",
@@ -4530,11 +4530,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -4542,23 +4542,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Create a 1/1 white Kor Soldier creature token for each creature you control.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -4576,7 +4576,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"‘Invincible' is just a word.\"\n—Gideon Jura",
+      "flavor": "\"'Invincible' is just a word.\"\n—Gideon Jura",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -4659,19 +4659,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature’s owner has one or more cards in his or her library, that creature is put into that library directly under the top card."
+          "text": "If the targeted creature's owner has one or more cards in his or her library, that creature is put into that library directly under the top card."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature’s owner has no cards left in his or her library, that creature is put into that library as the only card there."
+          "text": "If the targeted creature's owner has no cards left in his or her library, that creature is put into that library as the only card there."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is a token, it will cease to exist after it’s put into its owner’s library."
+          "text": "If the targeted creature is a token, it will cease to exist after it's put into its owner's library."
         },
         {
           "date": "2010-06-15",
-          "text": "Note that the creature’s controller, not its owner, is the one who gains life."
+          "text": "Note that the creature's controller, not its owner, is the one who gains life."
         },
         {
           "date": "2010-06-15",
@@ -4788,11 +4788,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step."
         },
         {
           "date": "2010-06-15",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
         }
       ],
       "text": "Destroy target attacking or blocking creature with power 3 or less.",
@@ -4893,19 +4893,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may target zero, one, or two creatures. The creatures don’t need to be untapped."
+          "text": "You may target zero, one, or two creatures. The creatures don't need to be untapped."
         },
         {
           "date": "2010-06-15",
-          "text": "If you target zero creatures, Repel the Darkness can’t be countered for having no legal targets. When it resolves, all that happens is that you draw a card."
+          "text": "If you target zero creatures, Repel the Darkness can't be countered for having no legal targets. When it resolves, all that happens is that you draw a card."
         },
         {
           "date": "2010-06-15",
-          "text": "If you target one creature and that target is illegal as Repel the Darkness resolves, the spell is countered. You don’t draw a card."
+          "text": "If you target one creature and that target is illegal as Repel the Darkness resolves, the spell is countered. You don't draw a card."
         },
         {
           "date": "2010-06-15",
-          "text": "If you target two creatures and they’re both illegal as Repel the Darkness resolves, the spell is countered; you don’t draw a card. If just one is illegal, the spell does resolve; the remaining legal target becomes tapped (if it’s untapped at that time) and you draw a card."
+          "text": "If you target two creatures and they're both illegal as Repel the Darkness resolves, the spell is countered; you don't draw a card. If just one is illegal, the spell does resolve; the remaining legal target becomes tapped (if it's untapped at that time) and you draw a card."
         }
       ],
       "text": "Tap up to two target creatures.\nDraw a card.",
@@ -5016,7 +5016,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "A “blocked creature” is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocked creature\" is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
         }
       ],
       "text": "Destroy target blocked creature.",
@@ -5117,7 +5117,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If Soul’s Attendant and another creature enter the battlefield at the same time, Soul’s Attendant’s ability will trigger."
+          "text": "If Soul's Attendant and another creature enter the battlefield at the same time, Soul's Attendant's ability will trigger."
         }
       ],
       "subtypes": [
@@ -5323,7 +5323,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Stalwart Shield-Bearers continually checks which creatures you control have defender and gives the bonus only to them. If an effect causes a creature with defender to lose defender (as Shoal Serpent does), Stalwart Shield-Bearers stops giving it the bonus for as long as it doesn’t have defender. On the other hand, if a spell or ability causes a creature to be able to attack as though it didn’t have defender (as Warmonger’s Chariot does), Stalwart Shield-Bearers continues to give it the bonus because it never actually loses the defender ability."
+          "text": "Stalwart Shield-Bearers continually checks which creatures you control have defender and gives the bonus only to them. If an effect causes a creature with defender to lose defender (as Shoal Serpent does), Stalwart Shield-Bearers stops giving it the bonus for as long as it doesn't have defender. On the other hand, if a spell or ability causes a creature to be able to attack as though it didn't have defender (as Warmonger's Chariot does), Stalwart Shield-Bearers continues to give it the bonus because it never actually loses the defender ability."
         }
       ],
       "subtypes": [
@@ -5428,23 +5428,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -5549,11 +5549,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -5561,27 +5561,27 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, anything that cares about your life total checks the life total of your team. For example, say that your team has 10 life and your opponent’s team has 11 life when you cast Survival Cache. You’ll gain 2 life, so your team’s life total becomes 12. Since your life total (12) is greater than an opponent’s life total (11), you’ll draw a card."
+          "text": "In a Two-Headed Giant game, anything that cares about your life total checks the life total of your team. For example, say that your team has 10 life and your opponent's team has 11 life when you cast Survival Cache. You'll gain 2 life, so your team's life total becomes 12. Since your life total (12) is greater than an opponent's life total (11), you'll draw a card."
         }
       ],
       "text": "You gain 2 life. Then if you have more life than an opponent, draw a card.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -5681,11 +5681,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Each creature you control with a level counter on it gets just +2/+2, regardless of how many level counters it has. It doesn’t get the bonus for each counter."
+          "text": "Each creature you control with a level counter on it gets just +2/+2, regardless of how many level counters it has. It doesn't get the bonus for each counter."
         },
         {
           "date": "2010-06-15",
-          "text": "Time of Heroes affects any creature you control with a level counter on it, not just levelers. (Of course, it’s pretty hard to get level counters onto a creature that’s not a leveler, but it can be done with copy effects, Fate Transfer, or Quicksilver Elemental, among other possibilities.)"
+          "text": "Time of Heroes affects any creature you control with a level counter on it, not just levelers. (Of course, it's pretty hard to get level counters onto a creature that's not a leveler, but it can be done with copy effects, Fate Transfer, or Quicksilver Elemental, among other possibilities.)"
         }
       ],
       "text": "Each creature you control with a level counter on it gets +2/+2.",
@@ -5885,27 +5885,27 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "subtypes": [
@@ -6012,11 +6012,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -6024,15 +6024,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -6040,23 +6040,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2010-06-15",
-          "text": "All _Rise of the Eldrazi_ cards printed with totem armor are Auras with “enchant creature.” But Umbra Mystic grants totem armor to Auras attached to any permanent you control, not just creatures. The ability works the same way even if the Aura is enchanting a land, an artifact, or any other permanent."
+          "text": "All _Rise of the Eldrazi_ cards printed with totem armor are Auras with \"enchant creature.\" But Umbra Mystic grants totem armor to Auras attached to any permanent you control, not just creatures. The ability works the same way even if the Aura is enchanting a land, an artifact, or any other permanent."
         },
         {
           "date": "2010-06-15",
-          "text": "Umbra Mystic grants totem armor to Auras attached to permanents you control, regardless of who controls those Auras. Conversely, it doesn’t grant totem armor to Auras you control that are attached to permanents controlled by other players."
+          "text": "Umbra Mystic grants totem armor to Auras attached to permanents you control, regardless of who controls those Auras. Conversely, it doesn't grant totem armor to Auras you control that are attached to permanents controlled by other players."
         },
         {
           "date": "2010-06-15",
-          "text": "If a permanent you control would be destroyed, and it’s enchanted by an Aura with totem armor, it doesn’t matter who controls that Aura. The totem armor effect is mandatory. If that permanent is enchanted by multiple Auras, you choose which one is destroyed, regardless of who controls them."
+          "text": "If a permanent you control would be destroyed, and it's enchanted by an Aura with totem armor, it doesn't matter who controls that Aura. The totem armor effect is mandatory. If that permanent is enchanted by multiple Auras, you choose which one is destroyed, regardless of who controls them."
         },
         {
           "date": "2010-06-15",
-          "text": "Say you control a permanent that’s enchanted by an Aura you control, and that Aura is itself enchanted by an Aura. If the permanent would be destroyed, instead the first Aura is destroyed... but since that Aura would be destroyed, instead the second Aura is destroyed."
+          "text": "Say you control a permanent that's enchanted by an Aura you control, and that Aura is itself enchanted by an Aura. If the permanent would be destroyed, instead the first Aura is destroyed... but since that Aura would be destroyed, instead the second Aura is destroyed."
         },
         {
           "date": "2010-06-15",
@@ -6064,11 +6064,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -6280,23 +6280,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may target any Aura you control, and you may target any creature (including one you don’t control). Whether the Aura could legally enchant the creature is irrelevant as you’re choosing the targets."
+          "text": "You may target any Aura you control, and you may target any creature (including one you don't control). Whether the Aura could legally enchant the creature is irrelevant as you're choosing the targets."
         },
         {
           "date": "2010-06-15",
-          "text": "If you target an Aura that’s attached to a creature, you may also target the creature it’s attached to. Aura Finesse won’t cause the Aura to move, but you’ll still draw a card when it resolves."
+          "text": "If you target an Aura that's attached to a creature, you may also target the creature it's attached to. Aura Finesse won't cause the Aura to move, but you'll still draw a card when it resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "As Aura Finesse resolves, if the targeted Aura can’t legally enchant the targeted creature (for example, because the Aura is red and the creature has protection from red, or because the Aura has “enchant creature you control” and an opponent controls the creature), the spell resolves but the Aura doesn’t move. You still draw a card."
+          "text": "As Aura Finesse resolves, if the targeted Aura can't legally enchant the targeted creature (for example, because the Aura is red and the creature has protection from red, or because the Aura has \"enchant creature you control\" and an opponent controls the creature), the spell resolves but the Aura doesn't move. You still draw a card."
         },
         {
           "date": "2010-06-15",
-          "text": "As Aura Finesse resolves, if either target is illegal, the spell resolves but the Aura doesn’t move. You still draw a card. If both targets are illegal, Aura Finesse is countered and you don’t draw a card."
+          "text": "As Aura Finesse resolves, if either target is illegal, the spell resolves but the Aura doesn't move. You still draw a card. If both targets are illegal, Aura Finesse is countered and you don't draw a card."
         },
         {
           "date": "2010-06-15",
-          "text": "You still control the Aura, even if you attach it to a creature you don’t control."
+          "text": "You still control the Aura, even if you attach it to a creature you don't control."
         }
       ],
       "text": "Attach target Aura you control to target creature.\nDraw a card.",
@@ -6395,11 +6395,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -6407,23 +6407,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2010-06-15",
@@ -6435,7 +6435,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell moves itself into another zone as part of its resolution (as Arc Blade, All Suns’ Dawn, and Beacon of Unrest do), rebound won’t get a chance to apply."
+          "text": "If a spell moves itself into another zone as part of its resolution (as Arc Blade, All Suns' Dawn, and Beacon of Unrest do), rebound won't get a chance to apply."
         },
         {
           "date": "2010-06-15",
@@ -6443,31 +6443,31 @@
         },
         {
           "date": "2010-06-15",
-          "text": "You’ll be able to cast a spell with flashback three times this way. First you can cast it from your hand. It will be exiled due to rebound as it resolves. Then you can cast it from exile due to rebound’s delayed triggered ability. It will be put into your graveyard as it resolves. Then you can cast it from your graveyard due to flashback. It will be exiled due to flashback as it resolves."
+          "text": "You'll be able to cast a spell with flashback three times this way. First you can cast it from your hand. It will be exiled due to rebound as it resolves. Then you can cast it from exile due to rebound's delayed triggered ability. It will be put into your graveyard as it resolves. Then you can cast it from your graveyard due to flashback. It will be exiled due to flashback as it resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "For the rebound effect to happen, Cast Through Time needs to be on the battlefield as the spell _finishes_ resolving. For example, if you cast Warp World from your hand, and as part of its resolution it puts Cast Through Time onto the battlefield, Warp World will rebound. Conversely, if Warp World shuffles your Cast Through Time into your library as part of its resolution, and doesn’t put another one onto the battlefield, it will not rebound."
+          "text": "For the rebound effect to happen, Cast Through Time needs to be on the battlefield as the spell _finishes_ resolving. For example, if you cast Warp World from your hand, and as part of its resolution it puts Cast Through Time onto the battlefield, Warp World will rebound. Conversely, if Warp World shuffles your Cast Through Time into your library as part of its resolution, and doesn't put another one onto the battlefield, it will not rebound."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast an instant or sorcery spell from your hand and it’s exiled due to rebound, the delayed triggered ability will allow you to cast it during your next upkeep even if Cast Through Time has left the battlefield by then."
+          "text": "If you cast an instant or sorcery spell from your hand and it's exiled due to rebound, the delayed triggered ability will allow you to cast it during your next upkeep even if Cast Through Time has left the battlefield by then."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile “without paying its mana cost,” you can’t pay any alternative costs. Any X in the mana cost will be 0. On the other hand, if the card has optional additional costs (such as kicker or multikicker), you may pay those when you cast the card. If the card has mandatory additional costs (such as Momentous Fall does), you must pay those if you choose to cast the card."
+          "text": "If you cast a card from exile \"without paying its mana cost,\" you can't pay any alternative costs. Any X in the mana cost will be 0. On the other hand, if the card has optional additional costs (such as kicker or multikicker), you may pay those when you cast the card. If the card has mandatory additional costs (such as Momentous Fall does), you must pay those if you choose to cast the card."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell has restrictions on when it can be cast (for example, “Cast [this spell] only during the declare blockers step”), those restrictions may prevent you from casting it from exile during your upkeep."
+          "text": "If a spell has restrictions on when it can be cast (for example, \"Cast [this spell] only during the declare blockers step\"), those restrictions may prevent you from casting it from exile during your upkeep."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell using the madness or suspend abilities, you’re casting it from exile, not from your hand. Although those spells will have rebound, the ability won’t have any effect."
+          "text": "If you cast a spell using the madness or suspend abilities, you're casting it from exile, not from your hand. Although those spells will have rebound, the ability won't have any effect."
         },
         {
           "date": "2010-06-15",
-          "text": "Similarly, if you gain control of an instant or sorcery spell with Commandeer, it will have rebound, but the ability won’t do anything because that spell wasn’t cast from your hand."
+          "text": "Similarly, if you gain control of an instant or sorcery spell with Commandeer, it will have rebound, but the ability won't do anything because that spell wasn't cast from your hand."
         }
       ],
       "text": "Instant and sorcery spells you control have rebound. (Exile the spell as it resolves if you cast it from your hand. At the beginning of your next upkeep, you may cast that card from exile without paying its mana cost.)",
@@ -6666,23 +6666,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -6786,11 +6786,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -6798,15 +6798,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -6814,23 +6814,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2010-06-15",
-          "text": "Only Crab Umbra’s controller (who is not necessarily the enchanted creature’s controller) can activate its activated ability."
+          "text": "Only Crab Umbra's controller (who is not necessarily the enchanted creature's controller) can activate its activated ability."
         },
         {
           "date": "2010-06-15",
-          "text": "When Crab Umbra’s activated ability resolves, it will untap the creature Crab Umbra is enchanting at that time (regardless of what creature Crab Umbra was enchanting when the ability was activated). If Crab Umbra has left the battlefield by then, the ability will untap the creature it was enchanting at the time it left the battlefield."
+          "text": "When Crab Umbra's activated ability resolves, it will untap the creature Crab Umbra is enchanting at that time (regardless of what creature Crab Umbra was enchanting when the ability was activated). If Crab Umbra has left the battlefield by then, the ability will untap the creature it was enchanting at the time it left the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -7030,11 +7030,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -7042,27 +7042,27 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2010-06-15",
-          "text": "Distortion Strike doesn’t grant an ability to the targeted creature. Rather, it affects the game rules and states something that’s now true about that creature. The creature can’t be blocked even if it loses all abilities."
+          "text": "Distortion Strike doesn't grant an ability to the targeted creature. Rather, it affects the game rules and states something that's now true about that creature. The creature can't be blocked even if it loses all abilities."
         }
       ],
       "text": "Target creature gets +1/+0 until end of turn and can't be blocked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -7162,15 +7162,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Domestication’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability triggers only if the enchanted creature’s power is 4 or greater as your end step begins, and (2) the ability does nothing if the enchanted creature’s power is 3 or less by the time it resolves."
+          "text": "Domestication's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability triggers only if the enchanted creature's power is 4 or greater as your end step begins, and (2) the ability does nothing if the enchanted creature's power is 3 or less by the time it resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "Domestication can target, and can enchant, a creature with power 4 or greater. The enchanted creature’s power is checked only when the triggered ability triggers and resolves."
+          "text": "Domestication can target, and can enchant, a creature with power 4 or greater. The enchanted creature's power is checked only when the triggered ability triggers and resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "If an effect changes the enchanted creature’s power until end of turn, it will still have the modified power during your end step."
+          "text": "If an effect changes the enchanted creature's power until end of turn, it will still have the modified power during your end step."
         }
       ],
       "subtypes": [
@@ -7273,23 +7273,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Dormant Gomazoa’s last ability triggers when you become the target of any spell, including one you control. It doesn’t matter who else or what else the spell targets."
+          "text": "Dormant Gomazoa's last ability triggers when you become the target of any spell, including one you control. It doesn't matter who else or what else the spell targets."
         },
         {
           "date": "2010-06-15",
-          "text": "A spell can target you only if it specifically says the word “target.” One that says “You draw two cards,” for example, doesn’t target you."
+          "text": "A spell can target you only if it specifically says the word \"target.\" One that says \"You draw two cards,\" for example, doesn't target you."
         },
         {
           "date": "2010-06-15",
-          "text": "You become the target of a spell when a spell is cast targeting you, when a spell has one of its targets changed to you due to a spell or ability like Deflection, when a spell that’s targeting you is copied and that target isn’t changed, or when a spell is copied and one of its targets is changed to you."
+          "text": "You become the target of a spell when a spell is cast targeting you, when a spell has one of its targets changed to you due to a spell or ability like Deflection, when a spell that's targeting you is copied and that target isn't changed, or when a spell is copied and one of its targets is changed to you."
         },
         {
           "date": "2010-06-15",
-          "text": "Dormant Gomazoa’s last ability won’t trigger when you become the target of an ability."
+          "text": "Dormant Gomazoa's last ability won't trigger when you become the target of an ability."
         },
         {
           "date": "2010-06-15",
-          "text": "If you become the target of a spell, Dormant Gomazoa’s last ability triggers and is put on the stack on top of that spell. Dormant Gomazoa’s last ability will resolve (allowing you to untap it) first."
+          "text": "If you become the target of a spell, Dormant Gomazoa's last ability triggers and is put on the stack on top of that spell. Dormant Gomazoa's last ability will resolve (allowing you to untap it) first."
         }
       ],
       "subtypes": [
@@ -7392,11 +7392,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -7404,15 +7404,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -7420,15 +7420,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -7536,43 +7536,43 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         },
         {
           "date": "2010-06-15",
-          "text": "Echo Mage’s last two activated abilities can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Echo Mage's last two activated abilities can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2010-06-15",
-          "text": "When either ability resolves, it creates a copy (or two) of a spell. The copies are created on the stack, so they’re not “cast.” Abilities that trigger when a player casts a spell won’t trigger. Each copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. Each copy resolves before the original spell does."
+          "text": "When either ability resolves, it creates a copy (or two) of a spell. The copies are created on the stack, so they're not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. Each copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities. Each copy resolves before the original spell does."
         },
         {
           "date": "2010-06-15",
-          "text": "Each copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "Each copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you activate Echo Mage’s last ability to copy a spell twice, you may choose new targets for each copy independently. They don’t have to have the same targets as one another. Be sure to specify which of the copies will resolve first."
+          "text": "If you activate Echo Mage's last ability to copy a spell twice, you may choose new targets for each copy independently. They don't have to have the same targets as one another. Be sure to specify which of the copies will resolve first."
         },
         {
           "date": "2010-06-15",
-          "text": "If the spell the ability copies is modal (that is, it says “Choose one —” or the like), each copy will have the same mode as the original spell. You can’t choose a different one."
+          "text": "If the spell the ability copies is modal (that is, it says \"Choose one —\" or the like), each copy will have the same mode as the original spell. You can't choose a different one."
         },
         {
           "date": "2010-06-15",
@@ -7580,11 +7580,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "You can’t choose to pay any additional costs for a copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for each copy too."
+          "text": "You can't choose to pay any additional costs for a copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for each copy too."
         },
         {
           "date": "2010-06-15",
-          "text": "If a copy says that it affects “you,” it affects the controller of that copy, not the controller of the original spell. Similarly, if a copy says that it affects an “opponent,” it affects an opponent of that copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If a copy says that it affects \"you,\" it affects the controller of that copy, not the controller of the original spell. Similarly, if a copy says that it affects an \"opponent,\" it affects an opponent of that copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "subtypes": [
@@ -7688,11 +7688,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -7700,15 +7700,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -7716,15 +7716,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -7831,23 +7831,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -7959,11 +7959,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Fleeting Distraction resolves, the spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target by the time Fleeting Distraction resolves, the spell is countered. You won't draw a card."
         },
         {
           "date": "2012-05-01",
-          "text": "If the targeted creature is an illegal target when Fleeting Distraction tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target when Fleeting Distraction tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
@@ -8368,23 +8368,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -8489,23 +8489,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -8707,7 +8707,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted spell is an illegal target by the time Lay Bare resolves, Lay Bare is countered. You won’t look at its controller’s hand."
+          "text": "If the targeted spell is an illegal target by the time Lay Bare resolves, Lay Bare is countered. You won't look at its controller's hand."
         }
       ],
       "text": "Counter target spell. Look at its controller's hand.",
@@ -8807,43 +8807,43 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         },
         {
           "date": "2010-06-15",
-          "text": "In a two-player game, if you have a level 7 Lighthouse Chronologist and there are no other extra-turn effects, the game will proceed like this (with extra turns in brackets): your turn, your opponent’s turn, [your turn], your turn, your opponent’s turn, [your turn], your turn, your opponent’s turn, and so on."
+          "text": "In a two-player game, if you have a level 7 Lighthouse Chronologist and there are no other extra-turn effects, the game will proceed like this (with extra turns in brackets): your turn, your opponent's turn, [your turn], your turn, your opponent's turn, [your turn], your turn, your opponent's turn, and so on."
         },
         {
           "date": "2010-06-15",
-          "text": "In a four-player game, if you have a level 7 Lighthouse Chronologist and there are no other extra-turn effects, the game will proceed like this (with extra turns in brackets): your turn, opponent A’s turn, [your turn], opponent B’s turn, [your turn], opponent C’s turn, [your turn], your turn, opponent A’s turn, and so on. The same principle applies to a multiplayer game with a different number of players."
+          "text": "In a four-player game, if you have a level 7 Lighthouse Chronologist and there are no other extra-turn effects, the game will proceed like this (with extra turns in brackets): your turn, opponent A's turn, [your turn], opponent B's turn, [your turn], opponent C's turn, [your turn], your turn, opponent A's turn, and so on. The same principle applies to a multiplayer game with a different number of players."
         },
         {
           "date": "2010-06-15",
-          "text": "The effects of multiple level 7 Lighthouse Chronologists are cumulative. If you control two of them in a two-player game, you’ll take three turns for each turn your opponent takes."
+          "text": "The effects of multiple level 7 Lighthouse Chronologists are cumulative. If you control two of them in a two-player game, you'll take three turns for each turn your opponent takes."
         },
         {
           "date": "2010-06-15",
-          "text": "In a two-player game, if you and your opponent each control a level 7 Lighthouse Chronologist, they’ll essentially cancel each other out and you’ll alternate turns. Since all the turns you’d be taking are extra turns created by these abilities, make sure you know whose normal turn is supposed to be next in case one or both of the Lighthouse Chronologists leaves the battlefield."
+          "text": "In a two-player game, if you and your opponent each control a level 7 Lighthouse Chronologist, they'll essentially cancel each other out and you'll alternate turns. Since all the turns you'd be taking are extra turns created by these abilities, make sure you know whose normal turn is supposed to be next in case one or both of the Lighthouse Chronologists leaves the battlefield."
         },
         {
           "date": "2010-06-15",
-          "text": "In a multiplayer game, if multiple players each control a level 7 Lighthouse Chronologist, extra turns may sometimes be created faster than they can be taken. Keep track of them carefully. If multiple Chronologist’s abilities trigger during the same turn, the player whose turn would show up sooner in the natural turn order will get the first extra turn. For example, say Players B and C each control a level 7 Lighthouse Chronologist. Player A takes a turn. The game will proceed like this (with extra turns in brackets): Player A’s current turn, [Player B’s turn], [Player C’s turn], [Player B’s turn], [Player C’s turn], and so on. Because Players B and C will each add another extra turn after the other player’s extra turn, Player A will not take another turn as long as both level 7 Lighthouse Chronologists remain on the battlefield."
+          "text": "In a multiplayer game, if multiple players each control a level 7 Lighthouse Chronologist, extra turns may sometimes be created faster than they can be taken. Keep track of them carefully. If multiple Chronologist's abilities trigger during the same turn, the player whose turn would show up sooner in the natural turn order will get the first extra turn. For example, say Players B and C each control a level 7 Lighthouse Chronologist. Player A takes a turn. The game will proceed like this (with extra turns in brackets): Player A's current turn, [Player B's turn], [Player C's turn], [Player B's turn], [Player C's turn], and so on. Because Players B and C will each add another extra turn after the other player's extra turn, Player A will not take another turn as long as both level 7 Lighthouse Chronologists remain on the battlefield."
         }
       ],
       "subtypes": [
@@ -9054,7 +9054,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "You may target any permanent with the ability, including Merfolk Skyscout itself or a permanent that’s already untapped."
+          "text": "You may target any permanent with the ability, including Merfolk Skyscout itself or a permanent that's already untapped."
         }
       ],
       "subtypes": [
@@ -9266,11 +9266,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Narcolepsy’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability triggers only if the enchanted creature is untapped as any player’s upkeep begins, and (2) the ability does nothing if the enchanted creature is already tapped by the time it resolves."
+          "text": "Narcolepsy's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability triggers only if the enchanted creature is untapped as any player's upkeep begins, and (2) the ability does nothing if the enchanted creature is already tapped by the time it resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "Narcolepsy doesn’t keep the enchanted creature continually tapped. The creature untaps during its controller’s untap step as normal, then is tapped when Narcolepsy’s ability resolves during that upkeep. The creature may be tapped in response (for example, if it has an activated ability with {T} in its cost)."
+          "text": "Narcolepsy doesn't keep the enchanted creature continually tapped. The creature untaps during its controller's untap step as normal, then is tapped when Narcolepsy's ability resolves during that upkeep. The creature may be tapped in response (for example, if it has an activated ability with {T} in its cost)."
         }
       ],
       "subtypes": [
@@ -9374,7 +9374,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If Phantasmal Abomination becomes the target of a spell or ability, Phantasmal Abomination’s ability triggers and goes on the stack on top of that spell or ability. Phantasmal Abomination’s ability will resolve (causing it to be sacrificed) first. Unless the spell or ability has another target, it will then be countered when it tries to resolve for having no legal targets."
+          "text": "If Phantasmal Abomination becomes the target of a spell or ability, Phantasmal Abomination's ability triggers and goes on the stack on top of that spell or ability. Phantasmal Abomination's ability will resolve (causing it to be sacrificed) first. Unless the spell or ability has another target, it will then be countered when it tries to resolve for having no legal targets."
         }
       ],
       "subtypes": [
@@ -9478,11 +9478,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You choose Reality Spasm’s mode as you cast it."
+          "text": "You choose Reality Spasm's mode as you cast it."
         },
         {
           "date": "2010-06-15",
-          "text": "You may target any permanents with Reality Spasm, regardless of whether they’re tapped or untapped."
+          "text": "You may target any permanents with Reality Spasm, regardless of whether they're tapped or untapped."
         }
       ],
       "text": "Choose one —\n• Tap X target permanents.\n• Untap X target permanents.",
@@ -9581,11 +9581,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -9593,23 +9593,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Draw cards equal to the number of cards in target opponent's hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -9813,11 +9813,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If Renegade Doppelganger becomes a copy of another creature, that doesn’t count as having a creature enter the battlefield. Renegade Doppelganger was already on the battlefield; it only changed its characteristics. If Renegade Doppelganger gains any enters-the-battlefield triggered abilities, they won’t do anything. The same is true of any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities."
+          "text": "If Renegade Doppelganger becomes a copy of another creature, that doesn't count as having a creature enter the battlefield. Renegade Doppelganger was already on the battlefield; it only changed its characteristics. If Renegade Doppelganger gains any enters-the-battlefield triggered abilities, they won't do anything. The same is true of any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities."
         },
         {
           "date": "2010-06-15",
-          "text": "If Renegade Doppelganger becomes a copy of another creature, it copies exactly what was printed on that card and nothing more (unless that card is copying something else or it’s a token; see below). It doesn’t copy whether the original creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or whether it’s been affected by any noncopy effects that changed its power, toughness, types, color, or so on."
+          "text": "If Renegade Doppelganger becomes a copy of another creature, it copies exactly what was printed on that card and nothing more (unless that card is copying something else or it's a token; see below). It doesn't copy whether the original creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or whether it's been affected by any noncopy effects that changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2010-06-15",
@@ -9825,7 +9825,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If Renegade Doppelganger becomes a copy of a token, Renegade Doppelganger copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Renegade Doppelganger doesn’t become a token."
+          "text": "If Renegade Doppelganger becomes a copy of a token, Renegade Doppelganger copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Renegade Doppelganger doesn't become a token."
         },
         {
           "date": "2010-06-15",
@@ -9833,31 +9833,31 @@
         },
         {
           "date": "2010-06-15",
-          "text": "During the cleanup step, Renegade Doppelganger’s copy effect wears off. It will go back to being a 0/1 blue creature named Renegade Doppelganger, and will have its original ability again. Note that this happens at the same time that damage marked on the Renegade Doppelganger is removed. If it was dealt damage earlier in the turn, this damage will not cause Renegade Doppelganger to be destroyed when its copy effect wears off."
+          "text": "During the cleanup step, Renegade Doppelganger's copy effect wears off. It will go back to being a 0/1 blue creature named Renegade Doppelganger, and will have its original ability again. Note that this happens at the same time that damage marked on the Renegade Doppelganger is removed. If it was dealt damage earlier in the turn, this damage will not cause Renegade Doppelganger to be destroyed when its copy effect wears off."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enters the battlefield under your control and Renegade Doppelganger’s ability triggers, it can become a copy of that creature when the ability resolves even if that creature has left the battlefield by then. If it has, its last existence on the battlefield is checked to see what it was (specifically, if it was itself or if it was copying something else)."
+          "text": "If a creature enters the battlefield under your control and Renegade Doppelganger's ability triggers, it can become a copy of that creature when the ability resolves even if that creature has left the battlefield by then. If it has, its last existence on the battlefield is checked to see what it was (specifically, if it was itself or if it was copying something else)."
         },
         {
           "date": "2010-06-15",
-          "text": "Renegade Doppelganger’s ability isn’t targeted. It can copy a creature with shroud or protection."
+          "text": "Renegade Doppelganger's ability isn't targeted. It can copy a creature with shroud or protection."
         },
         {
           "date": "2010-06-15",
-          "text": "If the creature Renegade Doppelganger copies has an ability that triggers at the beginning of the end step, that ability will trigger and resolve before Renegade Doppelganger’s copy effect wears off."
+          "text": "If the creature Renegade Doppelganger copies has an ability that triggers at the beginning of the end step, that ability will trigger and resolve before Renegade Doppelganger's copy effect wears off."
         },
         {
           "date": "2010-06-15",
-          "text": "If Renegade Doppelganger becomes a copy of a creature with an ability that causes you to make a choice (such as naming a card or choosing a color) as it enters the battlefield, and another ability that refers to that choice, those abilities of the Doppelganger won’t do anything. You won’t have the chance to make a choice since the Doppelganger is already on the battlefield, so the value of that choice is undefined."
+          "text": "If Renegade Doppelganger becomes a copy of a creature with an ability that causes you to make a choice (such as naming a card or choosing a color) as it enters the battlefield, and another ability that refers to that choice, those abilities of the Doppelganger won't do anything. You won't have the chance to make a choice since the Doppelganger is already on the battlefield, so the value of that choice is undefined."
         },
         {
           "date": "2010-06-15",
-          "text": "If Renegade Doppelganger and another creature enter the battlefield under your control at the same time, Renegade Doppelganger’s ability will trigger. When the ability resolves, Renegade Doppelganger can become a copy of that creature."
+          "text": "If Renegade Doppelganger and another creature enter the battlefield under your control at the same time, Renegade Doppelganger's ability will trigger. When the ability resolves, Renegade Doppelganger can become a copy of that creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If multiple creatures enter the battlefield under your control at the same time, Renegade Doppelganger’s ability will trigger once for each of them. You choose the order that those abilities will resolve. It’s possible to have Renegade Doppelganger become a copy of something, activate an activated ability of that creature, then have it become a copy of something else under this scenario. The last ability that resolves that you choose to use determines what it ends up a copy of."
+          "text": "If multiple creatures enter the battlefield under your control at the same time, Renegade Doppelganger's ability will trigger once for each of them. You choose the order that those abilities will resolve. It's possible to have Renegade Doppelganger become a copy of something, activate an activated ability of that creature, then have it become a copy of something else under this scenario. The last ability that resolves that you choose to use determines what it ends up a copy of."
         },
         {
           "date": "2013-07-01",
@@ -9969,7 +9969,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If there’s only one card in your library as Sea Gate Oracle’s ability resolves, you’ll put it into your hand."
+          "text": "If there's only one card in your library as Sea Gate Oracle's ability resolves, you'll put it into your hand."
         }
       ],
       "subtypes": [
@@ -10076,11 +10076,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The card you shuffle into your library may be any card from your hand. It doesn’t have to be one of the cards you drew with the spell."
+          "text": "The card you shuffle into your library may be any card from your hand. It doesn't have to be one of the cards you drew with the spell."
         },
         {
           "date": "2010-06-15",
-          "text": "You have to shuffle a card from your hand into your library even if you don’t draw any cards (due to replacement effects or Maralen of the Mornsong’s ability, for example). If your hand is empty, you don’t shuffle your library."
+          "text": "You have to shuffle a card from your hand into your library even if you don't draw any cards (due to replacement effects or Maralen of the Mornsong's ability, for example). If your hand is empty, you don't shuffle your library."
         }
       ],
       "text": "Draw two cards, then shuffle a card from your hand into your library.",
@@ -10274,23 +10274,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -10503,11 +10503,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an instant or sorcery spell, Surrakar Spellblade’s first ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an instant or sorcery spell, Surrakar Spellblade's first ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         },
         {
           "date": "2010-06-15",
-          "text": "When Surrakar Spellblade’s second ability resolves, you either draw a card for each charge counter on it or you draw no cards at all."
+          "text": "When Surrakar Spellblade's second ability resolves, you either draw a card for each charge counter on it or you draw no cards at all."
         },
         {
           "date": "2010-06-15",
@@ -10615,35 +10615,35 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Training Grounds won’t affect a cost that isn’t the cost to activate a creature’s activated ability. For example, it won’t affect Flameblast Dragon’s {X}{R} cost, since that’s a cost paid when a triggered ability resolves, and it won’t affect a kicker cost, since that’s an additional cost to cast a spell. Activated ability costs appear before a colon (:) in a card’s rules text, or, in the case of some keywords, before a colon in reminder text."
+          "text": "Training Grounds won't affect a cost that isn't the cost to activate a creature's activated ability. For example, it won't affect Flameblast Dragon's {X}{R} cost, since that's a cost paid when a triggered ability resolves, and it won't affect a kicker cost, since that's an additional cost to cast a spell. Activated ability costs appear before a colon (:) in a card's rules text, or, in the case of some keywords, before a colon in reminder text."
         },
         {
           "date": "2010-06-15",
-          "text": "Training Grounds affects only creatures you control on the battlefield. The costs of activated abilities that work in other zones (such as cycling or unearth) won’t be reduced."
+          "text": "Training Grounds affects only creatures you control on the battlefield. The costs of activated abilities that work in other zones (such as cycling or unearth) won't be reduced."
         },
         {
           "date": "2010-06-15",
-          "text": "Training Grounds won’t affect the part of an activation cost represented by colored mana symbols or snow mana symbols. It also won’t affect nonmana parts of an activation cost, if there are any."
+          "text": "Training Grounds won't affect the part of an activation cost represented by colored mana symbols or snow mana symbols. It also won't affect nonmana parts of an activation cost, if there are any."
         },
         {
           "date": "2010-06-15",
-          "text": "Training Grounds can reduce the part of an activation cost represented by generic mana symbols down to nothing, as long as it still costs at least one mana. For example, if an activation cost is {2}{G}, you’d have to pay only {G}. If an activation cost is {2}, though, you’d still have to pay {1}."
+          "text": "Training Grounds can reduce the part of an activation cost represented by generic mana symbols down to nothing, as long as it still costs at least one mana. For example, if an activation cost is {2}{G}, you'd have to pay only {G}. If an activation cost is {2}, though, you'd still have to pay {1}."
         },
         {
           "date": "2010-06-15",
-          "text": "Training Grounds can reduce the amount you pay for a creature’s activated ability cost that includes {X}. For example, Drana, Kalastria Bloodchief has an activated ability that costs {X}{B}{B}. If you control Training Grounds and you activate the ability with X equal to 5, you’ll have to pay only {3}{B}{B}. This is true even if the ability states that {X} must be paid with a certain color of mana, as Crimson Hellkite’s ability does."
+          "text": "Training Grounds can reduce the amount you pay for a creature's activated ability cost that includes {X}. For example, Drana, Kalastria Bloodchief has an activated ability that costs {X}{B}{B}. If you control Training Grounds and you activate the ability with X equal to 5, you'll have to pay only {3}{B}{B}. This is true even if the ability states that {X} must be paid with a certain color of mana, as Crimson Hellkite's ability does."
         },
         {
           "date": "2010-06-15",
-          "text": "If an activated ability of a creature you control costs no generic mana to activate (for example, if it costs {R}{R}, it costs {0}, or it costs only nonmana actions such as {T} or “Sacrifice a creature”), Training Grounds simply won’t affect it. In particular, it won’t increase the cost to include a mana payment of {1}."
+          "text": "If an activated ability of a creature you control costs no generic mana to activate (for example, if it costs {R}{R}, it costs {0}, or it costs only nonmana actions such as {T} or \"Sacrifice a creature\"), Training Grounds simply won't affect it. In particular, it won't increase the cost to include a mana payment of {1}."
         },
         {
           "date": "2010-06-15",
-          "text": "Training Grounds takes the total cost to activate a creature’s activated ability into account, not just the cost printed on it. For example, Furnace Spirit has an activated ability that costs {R}, and Suppression Field says “Activated abilities cost {2} more to activate unless they’re mana abilities.” Since activating Furnace Spirit’s activated ability would now cost {2}{R}, Training Grounds reduces that cost back to {R}."
+          "text": "Training Grounds takes the total cost to activate a creature's activated ability into account, not just the cost printed on it. For example, Furnace Spirit has an activated ability that costs {R}, and Suppression Field says \"Activated abilities cost {2} more to activate unless they're mana abilities.\" Since activating Furnace Spirit's activated ability would now cost {2}{R}, Training Grounds reduces that cost back to {R}."
         },
         {
           "date": "2010-06-15",
-          "text": "You may choose not to apply Training Ground’s cost reduction effect. You may also choose to apply only part of it (causing an activated ability of a creature you control to cost just {1} less to activate)."
+          "text": "You may choose not to apply Training Ground's cost reduction effect. You may also choose to apply only part of it (causing an activated ability of a creature you control to cost just {1} less to activate)."
         }
       ],
       "text": "Activated abilities of creatures you control cost up to {2} less to activate. This effect can't reduce the amount of mana an ability costs to activate to less than one mana.",
@@ -10743,7 +10743,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Whether you control more creatures than the targeted spell’s controller is checked only as Unified Will resolves. If that player controls more creatures than you at this time, or you each control the same amount, Unified Will simply doesn’t do anything."
+          "text": "Whether you control more creatures than the targeted spell's controller is checked only as Unified Will resolves. If that player controls more creatures than you at this time, or you each control the same amount, Unified Will simply doesn't do anything."
         }
       ],
       "text": "Counter target spell if you control more creatures than that spell's controller.",
@@ -10844,23 +10844,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -10966,15 +10966,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The power of the other creature is checked only when it blocks or becomes blocked by Arrogant Bloodlord. Once the Bloodlord’s ability triggers, it will be destroyed at end of combat (after combat damage has been dealt) even if the other creature’s power changes before then."
+          "text": "The power of the other creature is checked only when it blocks or becomes blocked by Arrogant Bloodlord. Once the Bloodlord's ability triggers, it will be destroyed at end of combat (after combat damage has been dealt) even if the other creature's power changes before then."
         },
         {
           "date": "2010-06-15",
-          "text": "If Arrogant Bloodlord blocks or becomes blocked by a creature whose power is 2 or greater, Arrogant Bloodlord’s ability won’t trigger. It still won’t trigger if the other creature’s power changes to 1 or less later in combat."
+          "text": "If Arrogant Bloodlord blocks or becomes blocked by a creature whose power is 2 or greater, Arrogant Bloodlord's ability won't trigger. It still won't trigger if the other creature's power changes to 1 or less later in combat."
         },
         {
           "date": "2010-06-15",
-          "text": "If Arrogant Bloodlord becomes blocked by multiple creatures with power 1 or less, its ability triggers that many times. Each of those abilities will cause it to be destroyed separately (in case Arrogant Bloodlord isn’t destroyed the first time due to an Aura with totem armor, for example). The same is true if it somehow blocks multiple creatures with power 1 or less."
+          "text": "If Arrogant Bloodlord becomes blocked by multiple creatures with power 1 or less, its ability triggers that many times. Each of those abilities will cause it to be destroyed separately (in case Arrogant Bloodlord isn't destroyed the first time due to an Aura with totem armor, for example). The same is true if it somehow blocks multiple creatures with power 1 or less."
         }
       ],
       "subtypes": [
@@ -11386,11 +11386,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won’t be on the battlefield to get the bonus."
+          "text": "You can sacrifice Bloodthrone Vampire to activate its own ability, but it won't be on the battlefield to get the bonus."
         },
         {
           "date": "2010-06-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but the creature you wish to sacrifice is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -11691,11 +11691,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -11703,31 +11703,31 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2010-06-15",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its toughness."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted player doesn’t sacrifice a creature (because the player didn’t control any creatures or due to Tajuru Preserver, perhaps), you gain no life."
+          "text": "If the targeted player doesn't sacrifice a creature (because the player didn't control any creatures or due to Tajuru Preserver, perhaps), you gain no life."
         }
       ],
       "text": "Target player sacrifices a creature. You gain life equal to that creature's toughness.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -11832,19 +11832,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability to tap to add {B} to its controller’s mana pool. Contaminated Ground doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Swamp and has the ability to tap to add {B} to its controller's mana pool. Contaminated Ground doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         },
         {
           "date": "2010-06-15",
-          "text": "Contaminated Ground’s last ability triggers whenever the enchanted land becomes tapped for any reason, not just when it’s tapped for mana."
+          "text": "Contaminated Ground's last ability triggers whenever the enchanted land becomes tapped for any reason, not just when it's tapped for mana."
         },
         {
           "date": "2010-06-15",
-          "text": "If, while casting a spell or activating an ability, the enchanted land’s controller taps the land for mana to pay for it, Contaminated Ground’s ability triggers and goes on the stack on top of that spell or ability. Contaminated Ground’s ability will resolve first."
+          "text": "If, while casting a spell or activating an ability, the enchanted land's controller taps the land for mana to pay for it, Contaminated Ground's ability triggers and goes on the stack on top of that spell or ability. Contaminated Ground's ability will resolve first."
         },
         {
           "date": "2010-06-15",
-          "text": "On the other hand, the enchanted land’s controller may tap the land for mana, let Contaminated Ground’s ability trigger and go on the stack, then spend that mana to cast an instant or activate an ability in response. In that case, that instant or ability will resolve first."
+          "text": "On the other hand, the enchanted land's controller may tap the land for mana, let Contaminated Ground's ability trigger and go on the stack, then spend that mana to cast an instant or activate an ability in response. In that case, that instant or ability will resolve first."
         }
       ],
       "subtypes": [
@@ -12046,7 +12046,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a player casts a spell of the chosen color, Curse of Wizardry’s second ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If a player casts a spell of the chosen color, Curse of Wizardry's second ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         }
       ],
       "text": "As Curse of Wizardry enters the battlefield, choose a color.\nWhenever a player casts a spell of the chosen color, that player loses 1 life.",
@@ -12246,11 +12246,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "When Demonic Appetite’s triggered ability resolves, you may sacrifice the creature enchanted by Demonic Appetite. If you control no other creatures, you’ll have to sacrifice that one."
+          "text": "When Demonic Appetite's triggered ability resolves, you may sacrifice the creature enchanted by Demonic Appetite. If you control no other creatures, you'll have to sacrifice that one."
         },
         {
           "date": "2010-06-15",
-          "text": "If another player gains control of either Demonic Appetite or the enchanted creature (but not both), Demonic Appetite will be enchanting an illegal permanent. The Aura will be put into its owner’s graveyard as a state-based action."
+          "text": "If another player gains control of either Demonic Appetite or the enchanted creature (but not both), Demonic Appetite will be enchanting an illegal permanent. The Aura will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -12355,11 +12355,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The value of X may exceed the targeted creature’s toughness. Drana’s bonus is based on the value of X, regardless of what the targeted creature’s toughness was."
+          "text": "The value of X may exceed the targeted creature's toughness. Drana's bonus is based on the value of X, regardless of what the targeted creature's toughness was."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time the ability resolves, the ability is countered. Drana won’t get the bonus."
+          "text": "If the targeted creature is an illegal target by the time the ability resolves, the ability is countered. Drana won't get the bonus."
         },
         {
           "date": "2010-06-15",
@@ -12872,23 +12872,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -13001,19 +13001,19 @@
         },
         {
           "date": "2010-06-15",
-          "text": "You cast nonland cards from exile as part of the resolution of Hellcarver Demon’s ability. You may cast those cards in any order. Timing restrictions based on the card’s type (such as creature or sorcery) are ignored. Other restrictions are not (such as “Cast [this card] only before the combat damage step”). You cast all of the cards you like, putting them onto the stack, then Hellcarver Demon’s ability finishes resolving. The spells you cast this way will then resolve as normal, one at a time, in the opposite order that they were put on the stack."
+          "text": "You cast nonland cards from exile as part of the resolution of Hellcarver Demon's ability. You may cast those cards in any order. Timing restrictions based on the card's type (such as creature or sorcery) are ignored. Other restrictions are not (such as \"Cast [this card] only before the combat damage step\"). You cast all of the cards you like, putting them onto the stack, then Hellcarver Demon's ability finishes resolving. The spells you cast this way will then resolve as normal, one at a time, in the opposite order that they were put on the stack."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. On the other hand, if the card has optional additional costs (such as kicker or multikicker), you may pay those when you cast the card. If the card has mandatory additional costs (such as Momentous Fall does), you must pay those when you cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. On the other hand, if the card has optional additional costs (such as kicker or multikicker), you may pay those when you cast the card. If the card has mandatory additional costs (such as Momentous Fall does), you must pay those when you cast the card."
         },
         {
           "date": "2010-06-15",
-          "text": "Any cards you can’t cast (because they’re lands or they have no legal targets, perhaps) or choose not to cast simply remain exiled."
+          "text": "Any cards you can't cast (because they're lands or they have no legal targets, perhaps) or choose not to cast simply remain exiled."
         },
         {
           "date": "2010-06-15",
-          "text": "If you control two Hellcarver Demons that deal combat damage to a player at the same time, each Demon’s ability triggers. When the first one resolves, you’ll sacrifice all permanents except that Hellcarver Demon (meaning you’ll sacrifice the other one). Then you’ll exile six cards from your library and may cast nonland cards exiled that way. After those spells resolve, the other Demon’s ability resolves. You’ll sacrifice all permanents you now control (including the first Demon and any permanents put on the battlefield as a result of the spells you just cast), exile six more cards from your library, and cast any number of them."
+          "text": "If you control two Hellcarver Demons that deal combat damage to a player at the same time, each Demon's ability triggers. When the first one resolves, you'll sacrifice all permanents except that Hellcarver Demon (meaning you'll sacrifice the other one). Then you'll exile six cards from your library and may cast nonland cards exiled that way. After those spells resolve, the other Demon's ability resolves. You'll sacrifice all permanents you now control (including the first Demon and any permanents put on the battlefield as a result of the spells you just cast), exile six more cards from your library, and cast any number of them."
         }
       ],
       "subtypes": [
@@ -13320,7 +13320,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Last Kiss resolves, the spell is countered. You won’t gain life."
+          "text": "If the targeted creature is an illegal target by the time Last Kiss resolves, the spell is countered. You won't gain life."
         }
       ],
       "text": "Last Kiss deals 2 damage to target creature and you gain 2 life.",
@@ -13422,11 +13422,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Mortician Beetle’s ability triggers whenever any player, including you, sacrifices a creature because some other spell, ability, or cost instructed the player to do so. Mortician Beetle itself doesn’t allow you to sacrifice any creatures."
+          "text": "Mortician Beetle's ability triggers whenever any player, including you, sacrifices a creature because some other spell, ability, or cost instructed the player to do so. Mortician Beetle itself doesn't allow you to sacrifice any creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "If a creature is sacrificed as a cost to cast a spell or activate an ability, Mortician Beetle’s ability resolves before that spell or ability."
+          "text": "If a creature is sacrificed as a cost to cast a spell or activate an ability, Mortician Beetle's ability resolves before that spell or ability."
         }
       ],
       "subtypes": [
@@ -13530,7 +13530,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time the ability resolves, the ability is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target by the time the ability resolves, the ability is countered. You won't draw a card."
         }
       ],
       "text": "Target creature gains swampwalk until end of turn. (It can't be blocked as long as defending player controls a Swamp.)\nDraw a card.",
@@ -13630,23 +13630,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -13851,23 +13851,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -13973,11 +13973,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If multiple nontoken creatures you control (possibly including Pawn of Ulamog itself) are put into their owners’ graveyards at the same time, Pawn of Ulamog’s triggered ability will trigger that many times."
+          "text": "If multiple nontoken creatures you control (possibly including Pawn of Ulamog itself) are put into their owners' graveyards at the same time, Pawn of Ulamog's triggered ability will trigger that many times."
         },
         {
           "date": "2010-06-15",
-          "text": "If you control more than one Pawn of Ulamog and a nontoken creature you control is put into a graveyard, each of those Pawns’ abilities will trigger. You may put up to that many Eldrazi Spawn tokens onto the battlefield."
+          "text": "If you control more than one Pawn of Ulamog and a nontoken creature you control is put into a graveyard, each of those Pawns' abilities will trigger. You may put up to that many Eldrazi Spawn tokens onto the battlefield."
         }
       ],
       "subtypes": [
@@ -14082,7 +14082,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted player’s hand is empty, you can’t choose a card for that player to shuffle into his or her library. No shuffle occurs."
+          "text": "If the targeted player's hand is empty, you can't choose a card for that player to shuffle into his or her library. No shuffle occurs."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose a card from it. That player shuffles that card into his or her library.",
@@ -14289,11 +14289,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "For a player’s life total to become a certain number that’s lower than his or her current life total, what actually happens is that the player loses the appropriate amount of life. For example, if the lowest life total in the game is 5 and another player has 12 life, Repay in Kind will cause that player to lose 7 life. Abilities that interact with life loss will interact with this effect accordingly."
+          "text": "For a player's life total to become a certain number that's lower than his or her current life total, what actually happens is that the player loses the appropriate amount of life. For example, if the lowest life total in the game is 5 and another player has 12 life, Repay in Kind will cause that player to lose 7 life. Abilities that interact with life loss will interact with this effect accordingly."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, anything that cares about a player’s life total checks the life total of that player’s team. In addition, if an effect would cause the life total of each member of a team to become a certain number, that team chooses one of its members. On that team, only that player is affected, then the life total change is applied to the entire team. For example, if one team has 13 life and another team has 21 life, the team with the higher life total chooses one of its members and Repay in Kind causes that player to lose 8 life, thus causing that team’s life total to also be 13."
+          "text": "In a Two-Headed Giant game, anything that cares about a player's life total checks the life total of that player's team. In addition, if an effect would cause the life total of each member of a team to become a certain number, that team chooses one of its members. On that team, only that player is affected, then the life total change is applied to the entire team. For example, if one team has 13 life and another team has 21 life, the team with the higher life total chooses one of its members and Repay in Kind causes that player to lose 8 life, thus causing that team's life total to also be 13."
         }
       ],
       "text": "Each player's life total becomes the lowest life total among all players.",
@@ -14595,15 +14595,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The life that’s lost and the life that’s gained are based on the number of cards that are actually exiled, not on the value of X (in case any of the targeted cards somehow leave the graveyard in response and thus can’t be exiled this way)."
+          "text": "The life that's lost and the life that's gained are based on the number of cards that are actually exiled, not on the value of X (in case any of the targeted cards somehow leave the graveyard in response and thus can't be exiled this way)."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted player becomes an illegal target by the time Suffer the Past resolves but the targeted cards don’t, you still exile the cards and gain life. The player won’t be lose any life, though."
+          "text": "If the targeted player becomes an illegal target by the time Suffer the Past resolves but the targeted cards don't, you still exile the cards and gain life. The player won't be lose any life, though."
         },
         {
           "date": "2010-06-15",
-          "text": "Suffer the Past’s effect causes a single life-gain event, not a number of separate ones. This matters for cards such as Cradle of Vitality."
+          "text": "Suffer the Past's effect causes a single life-gain event, not a number of separate ones. This matters for cards such as Cradle of Vitality."
         }
       ],
       "text": "Exile X target cards from target player's graveyard. For each card exiled this way, that player loses 1 life and you gain 1 life.",
@@ -14703,15 +14703,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "As Thought Gorger’s first ability resolves, putting a +1/+1 counter on it for each card in your hand is mandatory. The effect says “if you do” because performing that action might be impossible. If Thought Gorger has left the battlefield by the time the ability resolves, you can’t put any +1/+1 counters on it, so you won’t discard your hand."
+          "text": "As Thought Gorger's first ability resolves, putting a +1/+1 counter on it for each card in your hand is mandatory. The effect says \"if you do\" because performing that action might be impossible. If Thought Gorger has left the battlefield by the time the ability resolves, you can't put any +1/+1 counters on it, so you won't discard your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "When Thought Gorger’s second ability resolves, its last existence on the battlefield is checked to see how many +1/+1 counters it had on it. All of them are counted, not just the ones put on it by its enters-the-battlefield ability."
+          "text": "When Thought Gorger's second ability resolves, its last existence on the battlefield is checked to see how many +1/+1 counters it had on it. All of them are counted, not just the ones put on it by its enters-the-battlefield ability."
         },
         {
           "date": "2010-06-15",
-          "text": "Once an ability starts to resolve, it’s too late to respond to it. For example, you can’t count a card in your hand while determining how many +1/+1 counters Thought Gorger gets and then cast it in response. If a card is counted, it’ll be discarded."
+          "text": "Once an ability starts to resolve, it's too late to respond to it. For example, you can't count a card in your hand while determining how many +1/+1 counters Thought Gorger gets and then cast it in response. If a card is counted, it'll be discarded."
         }
       ],
       "subtypes": [
@@ -14820,15 +14820,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Vendetta resolves, the spell is countered. You won’t lose life."
+          "text": "If the targeted creature is an illegal target by the time Vendetta resolves, the spell is countered. You won't lose life."
         },
         {
           "date": "2010-06-15",
-          "text": "The destroyed creature’s last existence on the battlefield is checked to determine its toughness."
+          "text": "The destroyed creature's last existence on the battlefield is checked to determine its toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature isn’t destroyed due to totem armor’s effect, Vendetta continues to resolve. You lose life equal to the creature’s current toughness (after the Aura with totem armor has been destroyed)."
+          "text": "If the targeted creature isn't destroyed due to totem armor's effect, Vendetta continues to resolve. You lose life equal to the creature's current toughness (after the Aura with totem armor has been destroyed)."
         }
       ],
       "text": "Destroy target nonblack creature. It can't be regenerated. You lose life equal to that creature's toughness.",
@@ -14927,11 +14927,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -14939,23 +14939,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Target creature gets +2/+0 and gains deathtouch until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -15155,23 +15155,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -15483,11 +15483,11 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Battle-Rattle Shaman’s ability triggers when the beginning of combat step starts during each of your turns. It resolves before you declare attackers."
+          "text": "Battle-Rattle Shaman's ability triggers when the beginning of combat step starts during each of your turns. It resolves before you declare attackers."
         },
         {
           "date": "2017-03-14",
-          "text": "If a spell or ability causes your turn to have multiple combat phases, Battle Rattle Shaman’s ability triggers during each of them."
+          "text": "If a spell or ability causes your turn to have multiple combat phases, Battle Rattle Shaman's ability triggers during each of them."
         }
       ],
       "subtypes": [
@@ -15592,23 +15592,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -15716,7 +15716,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If you put a single token onto the battlefield this way, it’s exactly like the ones specified earlier: it’s a 0/1 colorless Eldrazi Spawn creature token that has “Sacrifice this creature: Add {C} to your mana pool.”"
+          "text": "If you put a single token onto the battlefield this way, it's exactly like the ones specified earlier: it's a 0/1 colorless Eldrazi Spawn creature token that has \"Sacrifice this creature: Add {C} to your mana pool.\""
         }
       ],
       "text": "If you control an Eldrazi Spawn, create three 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C} to your mana pool.\" Otherwise, create one of those tokens.",
@@ -15818,7 +15818,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may target a creature that’s already untapped."
+          "text": "You may target a creature that's already untapped."
         },
         {
           "date": "2010-06-15",
@@ -15926,7 +15926,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may sacrifice zero lands as you cast Devastating Summons. If you do, you’ll put two 0/0 creature tokens onto the battlefield as the spell resolves. Unless some effect (such as the one from Glorious Anthem) is boosting their toughness, they’ll be put into the graveyard as a state-based action. Abilities that trigger when a creature enters the battlefield will trigger, as will those that trigger when a creature leaves the battlefield."
+          "text": "You may sacrifice zero lands as you cast Devastating Summons. If you do, you'll put two 0/0 creature tokens onto the battlefield as the spell resolves. Unless some effect (such as the one from Glorious Anthem) is boosting their toughness, they'll be put into the graveyard as a state-based action. Abilities that trigger when a creature enters the battlefield will trigger, as will those that trigger when a creature leaves the battlefield."
         }
       ],
       "text": "As an additional cost to cast Devastating Summons, sacrifice X lands.\nCreate two X/X red Elemental creature tokens.",
@@ -16221,15 +16221,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature or player is an illegal target by the time Explosive Revelation resolves, the spell is countered. You won’t reveal any cards from your library."
+          "text": "If the targeted creature or player is an illegal target by the time Explosive Revelation resolves, the spell is countered. You won't reveal any cards from your library."
         },
         {
           "date": "2010-06-15",
-          "text": "Once you start revealing cards from your library, it’s too late for players to respond. If you target a creature, for example, its controller can’t wait to see how much damage will be dealt to it before casting a damage prevention spell, activating a regeneration ability, sacrificing it for some benefit, or anything else. Any such actions must be done before Explosive Revelation starts to resolve."
+          "text": "Once you start revealing cards from your library, it's too late for players to respond. If you target a creature, for example, its controller can't wait to see how much damage will be dealt to it before casting a damage prevention spell, activating a regeneration ability, sacrificing it for some benefit, or anything else. Any such actions must be done before Explosive Revelation starts to resolve."
         },
         {
           "date": "2010-06-15",
-          "text": "If all the cards in your library are land cards, you’ll reveal all of them, then arrange them in your library in whatever order you like. No damage is dealt."
+          "text": "If all the cards in your library are land cards, you'll reveal all of them, then arrange them in your library in whatever order you like. No damage is dealt."
         }
       ],
       "text": "Choose target creature or player. Reveal cards from the top of your library until you reveal a nonland card. Explosive Revelation deals damage equal to that card's converted mana cost to that creature or player. Put the nonland card into your hand and the rest on the bottom of your library in any order.",
@@ -16330,7 +16330,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may choose just the first mode (targeting an artifact), just the second mode (targeting a nonbasic land), or both modes (targeting an artifact and a nonbasic land). You can’t choose a mode unless there’s a legal target for it."
+          "text": "You may choose just the first mode (targeting an artifact), just the second mode (targeting a nonbasic land), or both modes (targeting an artifact and a nonbasic land). You can't choose a mode unless there's a legal target for it."
         }
       ],
       "text": "Choose one or both —\n• Destroy target artifact.\n• Destroy target nonbasic land.",
@@ -16734,11 +16734,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The power of the targeted creature is checked both as you target it and as the ability resolves. After the ability resolves, the creature can’t be blocked that turn even if its power becomes greater than 2."
+          "text": "The power of the targeted creature is checked both as you target it and as the ability resolves. After the ability resolves, the creature can't be blocked that turn even if its power becomes greater than 2."
         },
         {
           "date": "2010-06-15",
-          "text": "The ability doesn’t grant an ability to the targeted creature. Rather, it affects the game rules and states something that’s now true about that creature. After the ability resolves, the creature can’t be blocked that turn even if it loses all abilities."
+          "text": "The ability doesn't grant an ability to the targeted creature. Rather, it affects the game rules and states something that's now true about that creature. After the ability resolves, the creature can't be blocked that turn even if it loses all abilities."
         }
       ],
       "subtypes": [
@@ -16844,7 +16844,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time the ability resolves, the ability is countered. Its controller won’t be dealt damage."
+          "text": "If the targeted creature is an illegal target by the time the ability resolves, the ability is countered. Its controller won't be dealt damage."
         }
       ],
       "subtypes": [
@@ -17147,23 +17147,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -17271,7 +17271,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an instant or sorcery spell, Kiln Fiend’s ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an instant or sorcery spell, Kiln Fiend's ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         }
       ],
       "subtypes": [
@@ -17580,23 +17580,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         },
         {
           "date": "2010-06-15",
@@ -17712,15 +17712,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Lust for War’s triggered ability triggers when the enchanted creature becomes tapped for any reason, not just when it attacks."
+          "text": "Lust for War's triggered ability triggers when the enchanted creature becomes tapped for any reason, not just when it attacks."
         },
         {
           "date": "2010-06-15",
-          "text": "If, during its controller’s declare attackers step, the enchanted creature is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then that creature doesn’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost, so the creature doesn’t have to attack in that case either."
+          "text": "If, during its controller's declare attackers step, the enchanted creature is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then that creature doesn't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost, so the creature doesn't have to attack in that case either."
         },
         {
           "date": "2010-06-15",
-          "text": "If there are multiple combat phases in a turn, the enchanted creature must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, the enchanted creature must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -18031,7 +18031,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If, during its controller’s declare attackers step, a creature affected by Rage Nimbus’s activated ability is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then that creature doesn’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost, so the creature doesn’t have to attack in that case either."
+          "text": "If, during its controller's declare attackers step, a creature affected by Rage Nimbus's activated ability is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then that creature doesn't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost, so the creature doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -18135,11 +18135,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The power of the attacking creature is checked only when the ability triggers. Once it triggers, Raid Bombardment will deal 1 damage to the defending player even if the creature’s power changes before the ability resolves."
+          "text": "The power of the attacking creature is checked only when the ability triggers. Once it triggers, Raid Bombardment will deal 1 damage to the defending player even if the creature's power changes before the ability resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "If you attack with multiple creatures with power 2 or less, Raid Bombardment’s ability triggers that many times."
+          "text": "If you attack with multiple creatures with power 2 or less, Raid Bombardment's ability triggers that many times."
         },
         {
           "date": "2010-06-15",
@@ -18147,7 +18147,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If Raid Bombardment’s ability triggers in a Two-Headed Giant game, the ability’s controller chooses which one of the defending players is dealt damage. The choice is made as the ability resolves. A different choice may be made for each ability."
+          "text": "If Raid Bombardment's ability triggers in a Two-Headed Giant game, the ability's controller chooses which one of the defending players is dealt damage. The choice is made as the ability resolves. A different choice may be made for each ability."
         }
       ],
       "text": "Whenever a creature you control with power 2 or less attacks, Raid Bombardment deals 1 damage to defending player.",
@@ -18348,7 +18348,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Soulsurge Elemental’s power is continuously calculated, regardless of where it is. If it’s on the battlefield, it counts itself."
+          "text": "Soulsurge Elemental's power is continuously calculated, regardless of where it is. If it's on the battlefield, it counts itself."
         }
       ],
       "subtypes": [
@@ -18547,15 +18547,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Splinter Twin grants an activated ability to the enchanted creature. That creature’s controller (who is not necessarily the Aura’s controller) can activate it. The creature’s controller is the player who gets the token."
+          "text": "Splinter Twin grants an activated ability to the enchanted creature. That creature's controller (who is not necessarily the Aura's controller) can activate it. The creature's controller is the player who gets the token."
         },
         {
           "date": "2010-06-15",
-          "text": "The token that’s put onto the battlefield copies exactly what’s printed on the enchanted creature (unless that creature is copying something else or it’s a token; see below), plus it has haste. It doesn’t copy whether the enchanted creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or whether it’s been affected by any noncopy effects that changed its power, toughness, types, color, or so on. In particular, it doesn’t copy the ability granted to the enchanted creature by Splinter Twin."
+          "text": "The token that's put onto the battlefield copies exactly what's printed on the enchanted creature (unless that creature is copying something else or it's a token; see below), plus it has haste. It doesn't copy whether the enchanted creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or whether it's been affected by any noncopy effects that changed its power, toughness, types, color, or so on. In particular, it doesn't copy the ability granted to the enchanted creature by Splinter Twin."
         },
         {
           "date": "2010-06-15",
-          "text": "If the enchanted creature is copying something else when the ability resolves (for example, if it’s a Renegade Doppelganger), then the token enters the battlefield as a copy of whatever the enchanted creature is copying, plus it has haste."
+          "text": "If the enchanted creature is copying something else when the ability resolves (for example, if it's a Renegade Doppelganger), then the token enters the battlefield as a copy of whatever the enchanted creature is copying, plus it has haste."
         },
         {
           "date": "2010-06-15",
@@ -18567,15 +18567,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Any enters-the-battlefield abilities of the enchanted creature will trigger when the token is put onto the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the enchanted creature will also work."
+          "text": "Any enters-the-battlefield abilities of the enchanted creature will trigger when the token is put onto the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the enchanted creature will also work."
         },
         {
           "date": "2010-06-15",
-          "text": "The token will not be kicked, even if the creature it’s copying was."
+          "text": "The token will not be kicked, even if the creature it's copying was."
         },
         {
           "date": "2010-06-15",
-          "text": "If you activate the ability and the enchanted creature leaves the battlefield before the ability resolves, you still get a token. The enchanted creature’s last existence on the battlefield is checked to see what it was (specifically, if it was itself or if it was copying something else)."
+          "text": "If you activate the ability and the enchanted creature leaves the battlefield before the ability resolves, you still get a token. The enchanted creature's last existence on the battlefield is checked to see what it was (specifically, if it was itself or if it was copying something else)."
         },
         {
           "date": "2010-06-15",
@@ -18583,11 +18583,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If the ability is activated during a turn’s end step, the token will be exiled at the beginning of the following turn’s end step."
+          "text": "If the ability is activated during a turn's end step, the token will be exiled at the beginning of the following turn's end step."
         },
         {
           "date": "2010-06-15",
-          "text": "If the token isn’t exiled when the delayed triggered ability resolves (due to Stifle, perhaps), it remains on the battlefield indefinitely. It continues to have haste."
+          "text": "If the token isn't exiled when the delayed triggered ability resolves (due to Stifle, perhaps), it remains on the battlefield indefinitely. It continues to have haste."
         },
         {
           "date": "2013-07-01",
@@ -18694,11 +18694,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -18706,23 +18706,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Staggershock deals 2 damage to target creature or player.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -18821,11 +18821,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -18833,39 +18833,39 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2010-06-15",
-          "text": "Surreal Memoir isn’t targeted. You don’t choose an instant card at random from your graveyard until it resolves. Once you randomly select a card, it’s too late for players to respond."
+          "text": "Surreal Memoir isn't targeted. You don't choose an instant card at random from your graveyard until it resolves. Once you randomly select a card, it's too late for players to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "If you have only one instant card in your graveyard as Surreal Memoir resolves, that’s the one you’ll return to your hand."
+          "text": "If you have only one instant card in your graveyard as Surreal Memoir resolves, that's the one you'll return to your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you’re playing a format involving only cards from the _Urza’s Saga_(TM) set and later, you may change the order of your graveyard at any time. That means the easiest way to choose an instant card at random from your graveyard is to take all the instant cards in your graveyard, turn them face down, shuffle them, and pick a card. Then you just put the rest back."
+          "text": "If you're playing a format involving only cards from the _Urza's Saga_(TM) set and later, you may change the order of your graveyard at any time. That means the easiest way to choose an instant card at random from your graveyard is to take all the instant cards in your graveyard, turn them face down, shuffle them, and pick a card. Then you just put the rest back."
         },
         {
           "date": "2010-06-15",
-          "text": "If you’re playing a format involving cards printed earlier than the _Urza’s Saga_ set, you may not reorder your graveyard. In this case, you need to be more careful when selecting an instant card at random, perhaps by using dice, writing the names of the instant cards on slips of paper and choosing one of them randomly, or carefully noting the existing graveyard order so you can reestablish it after performing the method suggested above, for example."
+          "text": "If you're playing a format involving cards printed earlier than the _Urza's Saga_ set, you may not reorder your graveyard. In this case, you need to be more careful when selecting an instant card at random, perhaps by using dice, writing the names of the instant cards on slips of paper and choosing one of them randomly, or carefully noting the existing graveyard order so you can reestablish it after performing the method suggested above, for example."
         },
         {
           "date": "2010-06-15",
@@ -18979,7 +18979,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may target a creature you already control. You may target a creature that’s already untapped."
+          "text": "You may target a creature you already control. You may target a creature that's already untapped."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gets +2/+0 and gains haste.",
@@ -19081,7 +19081,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Both Tuktuk the Explorer and Tuktuk the Returned are legendary creatures. However, since they have different names, one of each may coexist without being affected by the “legend rule.”"
+          "text": "Both Tuktuk the Explorer and Tuktuk the Returned are legendary creatures. However, since they have different names, one of each may coexist without being affected by the \"legend rule.\""
         }
       ],
       "subtypes": [
@@ -19193,7 +19193,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -19397,11 +19397,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -19409,39 +19409,39 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         },
         {
           "date": "2010-06-15",
-          "text": "As long as World at War resolves before the first postcombat main phase of a turn ends, it will have its full effect. That will happen in most cases, since it’s a sorcery (meaning it’s probably cast during the first or second main phase of a turn), and it has rebound (meaning it’ll be cast during your upkeep). If, however, it’s cast later than that, it won’t create any new phases. For example, if one World at War creates a second combat phase and a third main phase in a turn, then a second World at War is cast during that third main phase, no additional phases are created. The rebound effect still works, though."
+          "text": "As long as World at War resolves before the first postcombat main phase of a turn ends, it will have its full effect. That will happen in most cases, since it's a sorcery (meaning it's probably cast during the first or second main phase of a turn), and it has rebound (meaning it'll be cast during your upkeep). If, however, it's cast later than that, it won't create any new phases. For example, if one World at War creates a second combat phase and a third main phase in a turn, then a second World at War is cast during that third main phase, no additional phases are created. The rebound effect still works, though."
         },
         {
           "date": "2010-06-15",
-          "text": "Multiple World at War effects are cumulative, as long as they’re cast early enough. The first one modifies the turn structure to this: beginning phase, precombat main phase, combat phase, postcombat main phase, [new combat phase], [new postcombat main phase], ending phase. Each subsequent one inserts another combat phase and main phase into the turn after the original postcombat main phase and before the newest combat phase."
+          "text": "Multiple World at War effects are cumulative, as long as they're cast early enough. The first one modifies the turn structure to this: beginning phase, precombat main phase, combat phase, postcombat main phase, [new combat phase], [new postcombat main phase], ending phase. Each subsequent one inserts another combat phase and main phase into the turn after the original postcombat main phase and before the newest combat phase."
         },
         {
           "date": "2010-06-15",
-          "text": "Unlike other similar cards (such as Relentless Assault), World at War doesn’t untap the creatures that have attacked this turn when it resolves. Rather, those creatures untap when the new combat phase created by the spell begins. All creatures that attacked this turn untap, regardless of which combat phase they attacked in (if there have been more than one) or who controls them (if you’re playing a Two-Headed Giant game, for example)."
+          "text": "Unlike other similar cards (such as Relentless Assault), World at War doesn't untap the creatures that have attacked this turn when it resolves. Rather, those creatures untap when the new combat phase created by the spell begins. All creatures that attacked this turn untap, regardless of which combat phase they attacked in (if there have been more than one) or who controls them (if you're playing a Two-Headed Giant game, for example)."
         },
         {
           "date": "2010-06-15",
-          "text": "You don’t have to attack with any creatures during the new combat phase."
+          "text": "You don't have to attack with any creatures during the new combat phase."
         }
       ],
       "text": "After the first postcombat main phase this turn, there's an additional combat phase followed by an additional main phase. At the beginning of that combat, untap all creatures that attacked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -19547,11 +19547,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "The “can’t block” effect applies to each of the targeted creatures — and only those creatures — even if Wrap in Flames deals no damage to one or more of them (due to a prevention effect, for example) or Wrap in Flames deals damage to a different creature (due to a redirection effect)."
+          "text": "The \"can't block\" effect applies to each of the targeted creatures — and only those creatures — even if Wrap in Flames deals no damage to one or more of them (due to a prevention effect, for example) or Wrap in Flames deals damage to a different creature (due to a redirection effect)."
         },
         {
           "date": "2010-06-15",
-          "text": "If any of the targeted creatures is an illegal target by the time Wrap in Flames resolves, it won’t be dealt damage and will be able to block. The other targeted creatures will still be affected."
+          "text": "If any of the targeted creatures is an illegal target by the time Wrap in Flames resolves, it won't be dealt damage and will be able to block. The other targeted creatures will still be affected."
         }
       ],
       "text": "Wrap in Flames deals 1 damage to each of up to three target creatures. Those creatures can't block this turn.",
@@ -19747,11 +19747,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The power of each potential blocking creature is checked against Aura Gnarlid’s power only as blockers are declared. Once a creature blocks Aura Gnarlid, increasing the Gnarlid’s power or decreasing the blocking creature’s power won’t undo that block."
+          "text": "The power of each potential blocking creature is checked against Aura Gnarlid's power only as blockers are declared. Once a creature blocks Aura Gnarlid, increasing the Gnarlid's power or decreasing the blocking creature's power won't undo that block."
         },
         {
           "date": "2010-06-15",
-          "text": "Aura Gnarlid’s second ability counts each Aura regardless of who controls it."
+          "text": "Aura Gnarlid's second ability counts each Aura regardless of who controls it."
         }
       ],
       "subtypes": [
@@ -19951,11 +19951,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -19963,15 +19963,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -19979,19 +19979,19 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2010-06-15",
-          "text": "When the enchanted creature attacks, all lands controlled by that creature’s controller (who is not necessarily the Aura’s controller) untap."
+          "text": "When the enchanted creature attacks, all lands controlled by that creature's controller (who is not necessarily the Aura's controller) untap."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -20099,23 +20099,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -20222,11 +20222,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -20234,15 +20234,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -20250,15 +20250,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -20366,7 +20366,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Since Bramblesnap’s activated ability doesn’t have a tap symbol in its cost, you can tap a creature (including Bramblesnap itself) that hasn’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since Bramblesnap's activated ability doesn't have a tap symbol in its cost, you can tap a creature (including Bramblesnap itself) that hasn't been under your control since your most recent turn began to pay the cost."
         }
       ],
       "subtypes": [
@@ -20771,15 +20771,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "This ability overwrites all previous effects that set the targeted creature’s power and toughness to specific values. Other effects that set its power or toughness to specific values that start to apply after this ability resolves will overwrite this effect."
+          "text": "This ability overwrites all previous effects that set the targeted creature's power and toughness to specific values. Other effects that set its power or toughness to specific values that start to apply after this ability resolves will overwrite this effect."
         },
         {
           "date": "2010-06-15",
-          "text": "If a leveler is affected by Gigantomancer’s ability, then enough level counters are put on it to reach a level indicated by a new level symbol, it will still be 7/7, not the power and toughness indicated by that level symbol."
+          "text": "If a leveler is affected by Gigantomancer's ability, then enough level counters are put on it to reach a level indicated by a new level symbol, it will still be 7/7, not the power and toughness indicated by that level symbol."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify the targeted creature’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify the targeted creature's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         }
       ],
       "subtypes": [
@@ -20888,7 +20888,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "After attackers are declared and any Gravity Well abilities have resolved, a spell or ability that grants flying to a creature will work normally. This includes other abilities that trigger “whenever [a creature] attacks” (such as the one Order of the Golden Cricket has)."
+          "text": "After attackers are declared and any Gravity Well abilities have resolved, a spell or ability that grants flying to a creature will work normally. This includes other abilities that trigger \"whenever [a creature] attacks\" (such as the one Order of the Golden Cricket has)."
         }
       ],
       "text": "Whenever a creature with flying attacks, it loses flying until end of turn.",
@@ -21088,11 +21088,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Combat damage dealt by Haze Frog itself during the turn it enters the battlefield isn’t prevented. Combat damage that would be dealt by all other creatures is prevented, including creatures that weren’t on the battlefield at the time the ability resolved."
+          "text": "Combat damage dealt by Haze Frog itself during the turn it enters the battlefield isn't prevented. Combat damage that would be dealt by all other creatures is prevented, including creatures that weren't on the battlefield at the time the ability resolved."
         },
         {
           "date": "2010-06-15",
-          "text": "If two Haze Frogs enter the battlefield during the same turn, each one’s ability will prevent the other one’s combat damage."
+          "text": "If two Haze Frogs enter the battlefield during the same turn, each one's ability will prevent the other one's combat damage."
         }
       ],
       "subtypes": [
@@ -21197,15 +21197,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You can target a creature you don’t control or that otherwise couldn’t attack that turn."
+          "text": "You can target a creature you don't control or that otherwise couldn't attack that turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time Irresistible Prey resolves, the spell is countered. You won’t draw a card."
+          "text": "If the targeted creature is an illegal target by the time Irresistible Prey resolves, the spell is countered. You won't draw a card."
         },
         {
           "date": "2010-06-15",
-          "text": "The creature affected by Irresistible Prey doesn’t have to attack that turn."
+          "text": "The creature affected by Irresistible Prey doesn't have to attack that turn."
         },
         {
           "date": "2010-06-15",
@@ -21213,7 +21213,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If there are multiple combat phases in a turn, the affected creature must be blocked only in the first one in which it’s able to be blocked."
+          "text": "If there are multiple combat phases in a turn, the affected creature must be blocked only in the first one in which it's able to be blocked."
         }
       ],
       "text": "Target creature must be blocked this turn if able.\nDraw a card.",
@@ -21315,7 +21315,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You don’t choose which creatures to tap until the ability resolves. You may tap Jaddi Lifestrider itself this way, assuming it’s still on the battlefield untapped by this time."
+          "text": "You don't choose which creatures to tap until the ability resolves. You may tap Jaddi Lifestrider itself this way, assuming it's still on the battlefield untapped by this time."
         }
       ],
       "subtypes": [
@@ -21419,23 +21419,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         },
         {
           "date": "2010-06-15",
@@ -21546,23 +21546,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The abilities a leveler grants to itself don’t overwrite any other abilities it may have. In particular, they don’t overwrite the creature’s level up ability; it always has that."
+          "text": "The abilities a leveler grants to itself don't overwrite any other abilities it may have. In particular, they don't overwrite the creature's level up ability; it always has that."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that set a leveler’s power or toughness to a specific value, including the effects from a level symbol’s ability, apply in timestamp order. The timestamp of each level symbol’s ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
+          "text": "Effects that set a leveler's power or toughness to a specific value, including the effects from a level symbol's ability, apply in timestamp order. The timestamp of each level symbol's ability is the same as the timestamp of the leveler itself, regardless of when the most recent level counter was put on it."
         },
         {
           "date": "2010-06-15",
-          "text": "Effects that modify a leveler’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify a leveler's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-06-15",
-          "text": "If another creature becomes a copy of a leveler, all of the leveler’s printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
+          "text": "If another creature becomes a copy of a leveler, all of the leveler's printed abilities — including those represented by level symbols — are copied. The current characteristics of the leveler, and the number of level counters on it, are not. The abilities, power, and toughness of the copy will be determined based on how many level counters are on the copy."
         },
         {
           "date": "2010-06-15",
-          "text": "A creature’s level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
+          "text": "A creature's level is based on how many level counters it has on it, not how many times its level up ability has been activated or has resolved. If a leveler gets level counters due to some other effect (such as Clockspinning) or loses level counters for some reason (such as Vampire Hexmage), its level is changed accordingly."
         }
       ],
       "subtypes": [
@@ -21668,15 +21668,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "For the purpose of determining the cost reduction, the number of green creatures you control is checked as you cast Khalni Hydra, before your last chance to activate mana abilities to pay for it. For example, if you control Wild Cantor (a red and green creature with the ability “Sacrifice Wild Cantor: Add one mana of any color to your mana pool”) as you cast Khalni Hydra, first the cost to cast Khalni Hydra is reduced by {G}, then you could sacrifice Wild Cantor for mana to help pay for it."
+          "text": "For the purpose of determining the cost reduction, the number of green creatures you control is checked as you cast Khalni Hydra, before your last chance to activate mana abilities to pay for it. For example, if you control Wild Cantor (a red and green creature with the ability \"Sacrifice Wild Cantor: Add one mana of any color to your mana pool\") as you cast Khalni Hydra, first the cost to cast Khalni Hydra is reduced by {G}, then you could sacrifice Wild Cantor for mana to help pay for it."
         },
         {
           "date": "2010-06-15",
-          "text": "Khalni Hydra’s cost reduction effect doesn’t change its mana cost or converted mana cost."
+          "text": "Khalni Hydra's cost reduction effect doesn't change its mana cost or converted mana cost."
         },
         {
           "date": "2010-06-15",
-          "text": "If an effect (such as the one from Lodestone Golem) imposes an additional generic mana cost to casting Khalni Hydra, the Hydra’s ability will reduce it too. It’ll reduce the amount of green mana you need to spend first, though."
+          "text": "If an effect (such as the one from Lodestone Golem) imposes an additional generic mana cost to casting Khalni Hydra, the Hydra's ability will reduce it too. It'll reduce the amount of green mana you need to spend first, though."
         }
       ],
       "subtypes": [
@@ -22070,7 +22070,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The bonus is determined as Might of the Masses resolves. It won’t change if the number of creatures you control changes later in the turn."
+          "text": "The bonus is determined as Might of the Masses resolves. It won't change if the number of creatures you control changes later in the turn."
         },
         {
           "date": "2015-06-22",
@@ -22174,7 +22174,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its power and its toughness."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its power and its toughness."
         },
         {
           "date": "2013-04-15",
@@ -22286,11 +22286,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -22834,7 +22834,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Overgrown Battlement’s activated ability is a mana ability. No player can respond to it (such as by destroying a creature with defender)."
+          "text": "Overgrown Battlement's activated ability is a mana ability. No player can respond to it (such as by destroying a creature with defender)."
         }
       ],
       "subtypes": [
@@ -23038,11 +23038,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn’t resolve and rebound has no effect. The spell is simply put into your graveyard. You won’t get to cast it again next turn."
+          "text": "If a spell with rebound that you cast from your hand is countered for any reason (due to a spell like Cancel, or because all of its targets are illegal), the spell doesn't resolve and rebound has no effect. The spell is simply put into your graveyard. You won't get to cast it again next turn."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent’s hand due to Sen Triplets), rebound won’t have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
+          "text": "If you cast a spell with rebound from anywhere other than your hand (such as from your graveyard due to Sins of the Past, from your library due to cascade, or from your opponent's hand due to Sen Triplets), rebound won't have any effect. If you do cast it from your hand, rebound will work regardless of whether you paid its mana cost (for example, if you cast it from your hand due to Maelstrom Archangel)."
         },
         {
           "date": "2010-06-15",
@@ -23050,23 +23050,23 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Rebound will have no effect on copies of spells because you don’t cast them from your hand."
+          "text": "Rebound will have no effect on copies of spells because you don't cast them from your hand."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a spell with rebound from your hand and it resolves, it isn’t put into your graveyard. Rather, it’s exiled directly from the stack. Effects that care about cards being put into your graveyard won’t do anything."
+          "text": "If you cast a spell with rebound from your hand and it resolves, it isn't put into your graveyard. Rather, it's exiled directly from the stack. Effects that care about cards being put into your graveyard won't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
+          "text": "At the beginning of your upkeep, all delayed triggered abilities created by rebound effects trigger. You may handle them in any order. If you want to cast a card this way, you do so as part of the resolution of its delayed triggered ability. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as the one from Rule of Law)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won’t get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
+          "text": "If you are unable to cast a card from exile this way, or you choose not to, nothing happens when the delayed triggered ability resolves. The card remains exiled for the rest of the game, and you won't get another chance to cast the card. The same is true if the ability is countered (due to Stifle, perhaps)."
         },
         {
           "date": "2010-06-15",
-          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won’t go back to exile."
+          "text": "If you cast a card from exile this way, it will go to your graveyard when it resolves or is countered. It won't go back to exile."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
@@ -23165,7 +23165,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may reveal fewer than four land cards if you like. If you reveal one or two cards, those cards are put into your graveyard. If you reveal three cards, an opponent will choose two of those cards and you’ll put them into your graveyard; the remaining revealed card is put into your hand."
+          "text": "You may reveal fewer than four land cards if you like. If you reveal one or two cards, those cards are put into your graveyard. If you reveal three cards, an opponent will choose two of those cards and you'll put them into your graveyard; the remaining revealed card is put into your hand."
         }
       ],
       "text": "Search your library for up to four land cards with different names and reveal them. An opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
@@ -23266,11 +23266,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -23278,15 +23278,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -23294,11 +23294,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2010-06-15",
-          "text": "Snake Umbra grants the triggered ability to the creature. It triggers whenever the enchanted creature deals damage to an opponent of its controller (who is not necessarily an opponent of the Aura’s controller). In other words, if your Snake Umbra winds up enchanting your opponent’s creature, that opponent will draw a card whenever that creature damages you."
+          "text": "Snake Umbra grants the triggered ability to the creature. It triggers whenever the enchanted creature deals damage to an opponent of its controller (who is not necessarily an opponent of the Aura's controller). In other words, if your Snake Umbra winds up enchanting your opponent's creature, that opponent will draw a card whenever that creature damages you."
         },
         {
           "date": "2010-06-15",
@@ -23306,11 +23306,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -23417,11 +23417,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
+          "text": "Totem armor's effect is mandatory. If the enchanted permanent would be destroyed, you must remove all damage from it and destroy the Aura that has totem armor instead."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is applied no matter why the enchanted permanent would be destroyed: because it’s been dealt lethal damage, or because it’s being affected by an effect that says to “destroy” it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
+          "text": "Totem armor's effect is applied no matter why the enchanted permanent would be destroyed: because it's been dealt lethal damage, or because it's being affected by an effect that says to \"destroy\" it (such as Doom Blade). In either case, all damage is removed from the permanent and the Aura is destroyed instead."
         },
         {
           "date": "2010-06-15",
@@ -23429,15 +23429,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor’s effect will replace all of them and save the creature."
+          "text": "If a creature enchanted with an Aura that has totem armor would be destroyed by multiple state-based actions at the same time the totem armor's effect will replace all of them and save the creature."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it’s enchanting at the same time, totem armor’s effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
+          "text": "If a spell or ability (such as Planar Cleansing) would destroy both an Aura with totem armor and the permanent it's enchanting at the same time, totem armor's effect will save the enchanted permanent from being destroyed. Instead, the spell or ability will destroy the Aura in two different ways at the same time, but the result is the same as destroying it once."
         },
         {
           "date": "2010-06-15",
-          "text": "Totem armor’s effect is not regeneration. Specifically, if totem armor’s effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can’t be regenerated (as Vendetta does) won’t prevent totem armor’s effect from being applied."
+          "text": "Totem armor's effect is not regeneration. Specifically, if totem armor's effect is applied, the enchanted permanent does not become tapped and is not removed from combat as a result. Effects that say the enchanted permanent can't be regenerated (as Vendetta does) won't prevent totem armor's effect from being applied."
         },
         {
           "date": "2010-06-15",
@@ -23445,15 +23445,15 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability says that it would “destroy” a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn’t destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
+          "text": "If a spell or ability says that it would \"destroy\" a permanent enchanted with an Aura that has totem armor, that spell or ability causes the Aura to be destroyed instead. (This matters for cards such as Karmic Justice.) Totem armor doesn't destroy the Aura; rather, it changes the effects of the spell or ability. On the other hand, if a spell or ability deals lethal damage to a creature enchanted with an Aura that has totem armor, the game rules regarding lethal damage cause the Aura to be destroyed, not that spell or ability."
         },
         {
           "date": "2013-07-01",
-          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it’s sacrificed, if it’s legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Totem armor has no effect if the enchanted permanent is put into a graveyard for any other reason, such as if it's sacrificed, if it's legendary and another legendary permanent with the same name is controlled by the same player, or if its toughness is 0 or less."
         },
         {
           "date": "2013-07-01",
-          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won’t do anything because it won’t have to."
+          "text": "If a creature enchanted with an Aura that has totem armor has indestructible, lethal damage and effects that try to destroy it simply have no effect. Totem armor won't do anything because it won't have to."
         },
         {
           "date": "2013-07-01",
@@ -23760,11 +23760,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "As a spell or ability an opponent controls resolves, if it would force you to sacrifice a permanent (as the annihilator ability does), you just don’t. That part of the effect does nothing. If that spell or ability gives you the option to sacrifice a permanent (as Prowling Pangolin’s ability does), you can’t take that option."
+          "text": "As a spell or ability an opponent controls resolves, if it would force you to sacrifice a permanent (as the annihilator ability does), you just don't. That part of the effect does nothing. If that spell or ability gives you the option to sacrifice a permanent (as Prowling Pangolin's ability does), you can't take that option."
         },
         {
           "date": "2010-06-15",
-          "text": "If a spell or ability an opponent controls instructs you to perform an action unless you sacrifice a permanent (as Ogre Marauder does), you can’t choose to sacrifice a permanent. You must perform the action. On the other hand, if a spell or ability an opponent controls instructs you to sacrifice a permanent unless you perform an action (as Rishadan Brigand does), you can choose whether or not to perform the action. If you don’t perform the action, nothing happens, since you can’t sacrifice any permanents."
+          "text": "If a spell or ability an opponent controls instructs you to perform an action unless you sacrifice a permanent (as Ogre Marauder does), you can't choose to sacrifice a permanent. You must perform the action. On the other hand, if a spell or ability an opponent controls instructs you to sacrifice a permanent unless you perform an action (as Rishadan Brigand does), you can choose whether or not to perform the action. If you don't perform the action, nothing happens, since you can't sacrifice any permanents."
         },
         {
           "date": "2010-06-15",
@@ -23776,11 +23776,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "You may sacrifice a permanent as a special action, even if the effect that allows you to do so comes from an opponent’s permanent (such as Damping Engine or Volrath’s Curse). No one controls special actions."
+          "text": "You may sacrifice a permanent as a special action, even if the effect that allows you to do so comes from an opponent's permanent (such as Damping Engine or Volrath's Curse). No one controls special actions."
         },
         {
           "date": "2010-06-15",
-          "text": "This ability affects only sacrifices. It won’t stop a creature from being put into the graveyard due to lethal damage or having 0 toughness, and it won’t stop a permanent from being put into the graveyard due to the “legend rule” or the “planeswalker uniqueness rule.” None of these are sacrifices; they’re the result of game rules."
+          "text": "This ability affects only sacrifices. It won't stop a creature from being put into the graveyard due to lethal damage or having 0 toughness, and it won't stop a permanent from being put into the graveyard due to the \"legend rule\" or the \"planeswalker uniqueness rule.\" None of these are sacrifices; they're the result of game rules."
         }
       ],
       "subtypes": [
@@ -23887,23 +23887,23 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast your second creature spell in a turn and Vengevine is in your graveyard, Vengevine’s second ability triggers and goes on the stack on top of it. The ability will resolve, allowing you to return Vengevine to the battlefield, before the creature spell does."
+          "text": "If you cast your second creature spell in a turn and Vengevine is in your graveyard, Vengevine's second ability triggers and goes on the stack on top of it. The ability will resolve, allowing you to return Vengevine to the battlefield, before the creature spell does."
         },
         {
           "date": "2010-06-15",
-          "text": "Vengevine’s triggered ability works only if Vengevine is already in your graveyard as you finish casting your second creature spell in a turn, and it remains there continuously until the ability resolves."
+          "text": "Vengevine's triggered ability works only if Vengevine is already in your graveyard as you finish casting your second creature spell in a turn, and it remains there continuously until the ability resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "Vengevine doesn’t need to be in your graveyard as you start casting your second creature spell in a turn, only as you finish. This matters if you sacrifice a Vengevine on the battlefield while casting that creature spell, perhaps to pay a cost of that spell or a cost of a mana ability."
+          "text": "Vengevine doesn't need to be in your graveyard as you start casting your second creature spell in a turn, only as you finish. This matters if you sacrifice a Vengevine on the battlefield while casting that creature spell, perhaps to pay a cost of that spell or a cost of a mana ability."
         },
         {
           "date": "2010-06-15",
-          "text": "Vengevine’s triggered ability checks the card types of the spells you cast over the course of the entire turn, not just the ones you cast while Vengevine is in your graveyard. For example, if you cast a creature spell, then Vengevine is put into your graveyard, then you cast another creature spell, Vengevine’s ability triggers."
+          "text": "Vengevine's triggered ability checks the card types of the spells you cast over the course of the entire turn, not just the ones you cast while Vengevine is in your graveyard. For example, if you cast a creature spell, then Vengevine is put into your graveyard, then you cast another creature spell, Vengevine's ability triggers."
         },
         {
           "date": "2010-06-15",
-          "text": "Vengevine’s ability triggers only for the second creature spell you cast in a turn. It won’t trigger for the third, fourth, or so on. It also doesn’t matter how many noncreature spells you cast in a turn; the ability counts just the creature spells."
+          "text": "Vengevine's ability triggers only for the second creature spell you cast in a turn. It won't trigger for the third, fourth, or so on. It also doesn't matter how many noncreature spells you cast in a turn; the ability counts just the creature spells."
         }
       ],
       "subtypes": [
@@ -24114,19 +24114,19 @@
         },
         {
           "date": "2010-06-15",
-          "text": "Once the first ability starts to resolve and you reveal the top card of your library (and see how much damage Sarkhan the Mad deals to himself), it’s too late to respond."
+          "text": "Once the first ability starts to resolve and you reveal the top card of your library (and see how much damage Sarkhan the Mad deals to himself), it's too late to respond."
         },
         {
           "date": "2010-06-15",
-          "text": "The first ability causes Sarkhan to deal damage directly to himself, resulting in that many loyalty counters being removed from him. The damage would never have been dealt to you, so prevention effects that would prevent damage from being dealt to you won’t affect it."
+          "text": "The first ability causes Sarkhan to deal damage directly to himself, resulting in that many loyalty counters being removed from him. The damage would never have been dealt to you, so prevention effects that would prevent damage from being dealt to you won't affect it."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is an illegal target by the time the second ability resolves, the ability is countered. The player won’t get a Dragon token."
+          "text": "If the targeted creature is an illegal target by the time the second ability resolves, the ability is countered. The player won't get a Dragon token."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature is a legal target by the time the second ability resolves but its controller can’t sacrifice it (due to Tajuru Preserver, perhaps), the ability continues to resolve. That player gets a Dragon token."
+          "text": "If the targeted creature is a legal target by the time the second ability resolves but its controller can't sacrifice it (due to Tajuru Preserver, perhaps), the ability continues to resolve. That player gets a Dragon token."
         },
         {
           "date": "2010-06-15",
@@ -24231,7 +24231,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you’re dealt enough damage to reduce your life total to 0 or less, you’ll lose the game before you can put charge counters on Angelheart Vial."
+          "text": "If you're dealt enough damage to reduce your life total to 0 or less, you'll lose the game before you can put charge counters on Angelheart Vial."
         }
       ],
       "text": "Whenever you're dealt damage, you may put that many charge counters on Angelheart Vial.\n{2}, {T}, Remove four charge counters from Angelheart Vial: You gain 2 life and draw a card.",
@@ -24604,7 +24604,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The value of X is determined as the ability starts to resolve. If the targeted player has five cards in his or her graveyard at that time, for example, this ability will put five more cards into that graveyard from the top of that player’s library."
+          "text": "The value of X is determined as the ability starts to resolve. If the targeted player has five cards in his or her graveyard at that time, for example, this ability will put five more cards into that graveyard from the top of that player's library."
         }
       ],
       "text": "{5}, {T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of cards in that player's graveyard.",
@@ -24789,7 +24789,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "As long as you control Pennon Blade, its ability constantly counts the number of creatures you control. It doesn’t matter who controls the creature it’s equipping (in case an opponent somehow manages to take control of that creature). If you control the creature it’s equipping, the bonus will include that creature too."
+          "text": "As long as you control Pennon Blade, its ability constantly counts the number of creatures you control. It doesn't matter who controls the creature it's equipping (in case an opponent somehow manages to take control of that creature). If you control the creature it's equipping, the bonus will include that creature too."
         }
       ],
       "subtypes": [
@@ -25184,15 +25184,15 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "If you cast an instant or sorcery spell, Sphinx-Bone Wand’s ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast an instant or sorcery spell, Sphinx-Bone Wand's ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         },
         {
           "date": "2010-06-15",
-          "text": "If the targeted creature or player is an illegal target by the time the ability resolves, the ability is countered. You won’t put a charge counter on Sphinx-Bone Wand and it won’t deal damage."
+          "text": "If the targeted creature or player is an illegal target by the time the ability resolves, the ability is countered. You won't put a charge counter on Sphinx-Bone Wand and it won't deal damage."
         },
         {
           "date": "2010-06-15",
-          "text": "If Sphinx-Bone Wand leaves the battlefield before its ability resolves, you won’t be able to put a charge counter on it. As a result, it won’t deal damage."
+          "text": "If Sphinx-Bone Wand leaves the battlefield before its ability resolves, you won't be able to put a charge counter on it. As a result, it won't deal damage."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell, you may put a charge counter on Sphinx-Bone Wand. If you do, Sphinx-Bone Wand deals damage equal to the number of charge counters on it to target creature or player.",
@@ -25287,11 +25287,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "The second ability doesn’t cause the equipped creature to lose defender. It just lets it attack."
+          "text": "The second ability doesn't cause the equipped creature to lose defender. It just lets it attack."
         },
         {
           "date": "2010-06-15",
-          "text": "If the equipped creature doesn’t have defender, the second ability simply doesn’t affect it."
+          "text": "If the equipped creature doesn't have defender, the second ability simply doesn't affect it."
         }
       ],
       "subtypes": [
@@ -25388,7 +25388,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The mana generated by the last ability can’t be spent to activate abilities of Eldrazi sources that aren’t on the battlefield."
+          "text": "The mana generated by the last ability can't be spent to activate abilities of Eldrazi sources that aren't on the battlefield."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{T}: Add {C}{C} to your mana pool. Spend this mana only to cast colorless Eldrazi spells or activate abilities of colorless Eldrazi.",
@@ -30210,27 +30210,27 @@
         {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
+          "multiverseid": 217028
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha",
+          "multiverseid": 217030
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha",
+          "multiverseid": 217039
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha",
           "multiverseid": 217047
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217276
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217278
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217287
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217295
+          "language": "Russian",
+          "name": "Гора",
+          "multiverseid": 216055
         }
       ],
       "id": "d8472808af109fc24dcf70435eb8b450cf7a6c4b",
@@ -30595,27 +30595,27 @@
         {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
+          "multiverseid": 217028
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha",
+          "multiverseid": 217030
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha",
+          "multiverseid": 217039
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha",
           "multiverseid": 217047
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217276
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217278
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217287
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217295
+          "language": "Russian",
+          "name": "Гора",
+          "multiverseid": 216055
         }
       ],
       "id": "75d73d17a0b48e02c1424e9027218bda9e41d11a",
@@ -31365,27 +31365,27 @@
         {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
+          "multiverseid": 217028
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha",
+          "multiverseid": 217030
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha",
+          "multiverseid": 217039
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha",
           "multiverseid": 217047
         },
         {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217276
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217278
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217287
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 217295
+          "language": "Russian",
+          "name": "Гора",
+          "multiverseid": 216055
         }
       ],
       "id": "31d9182cbee3328454b5af7cc4b7617e8e00644e",

--- a/json/RTR.json
+++ b/json/RTR.json
@@ -152,11 +152,11 @@
         },
         {
           "date": "2013-01-24",
-          "text": "You choose the targets as part of putting the enters-the-battlefield trigger on the stack. Because that ability includes “you may,” you choose whether to exile the targets when the ability resolves."
+          "text": "You choose the targets as part of putting the enters-the-battlefield trigger on the stack. Because that ability includes \"you may,\" you choose whether to exile the targets when the ability resolves."
         },
         {
           "date": "2013-01-24",
-          "text": "If a creature targeted by the enters-the-battlefield ability dies before that ability resolves, it will become an illegal target even though it may be a creature card in a graveyard when the ability resolves. It won’t be exiled."
+          "text": "If a creature targeted by the enters-the-battlefield ability dies before that ability resolves, it will become an illegal target even though it may be a creature card in a graveyard when the ability resolves. It won't be exiled."
         }
       ],
       "subtypes": [
@@ -272,7 +272,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Vigilance only matters when Armory Guard is being declared as an attacking creature. If Armory Guard is already attacking, losing control of your only Gate won’t cause Armory Guard to become tapped or to leave combat."
+          "text": "Vigilance only matters when Armory Guard is being declared as an attacking creature. If Armory Guard is already attacking, losing control of your only Gate won't cause Armory Guard to become tapped or to leave combat."
         }
       ],
       "subtypes": [
@@ -404,7 +404,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -517,11 +517,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "It doesn’t matter what the creature dealt damage to. If the creature dealt damage to another creature or a planeswalker, it doesn’t matter whether that creature or planeswalker is still on the battlefield."
+          "text": "It doesn't matter what the creature dealt damage to. If the creature dealt damage to another creature or a planeswalker, it doesn't matter whether that creature or planeswalker is still on the battlefield."
         },
         {
           "date": "2012-10-01",
-          "text": "Avenging Arrow doesn’t affect the damage the creature dealt. It isn’t retroactively prevented."
+          "text": "Avenging Arrow doesn't affect the damage the creature dealt. It isn't retroactively prevented."
         }
       ],
       "text": "Destroy target creature that dealt damage this turn.",
@@ -632,7 +632,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -640,19 +640,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "subtypes": [
@@ -773,7 +773,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -781,19 +781,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "subtypes": [
@@ -910,11 +910,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Bazaar Krovod’s ability can target an attacking creature that’s untapped (such as one with vigilance)."
+          "text": "Bazaar Krovod's ability can target an attacking creature that's untapped (such as one with vigilance)."
         },
         {
           "date": "2012-10-01",
-          "text": "Untapping an attacking creature doesn’t cause it to stop attacking or remove it from combat."
+          "text": "Untapping an attacking creature doesn't cause it to stop attacking or remove it from combat."
         }
       ],
       "subtypes": [
@@ -1251,11 +1251,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -1263,11 +1263,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -1603,7 +1603,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "You must target a creature to cast Knightly Valor. If that creature is an illegal target when Knightly Valor tries to resolve, it will be countered and won’t enter the battlefield. You won’t get the Knight token."
+          "text": "You must target a creature to cast Knightly Valor. If that creature is an illegal target when Knightly Valor tries to resolve, it will be countered and won't enter the battlefield. You won't get the Knight token."
         }
       ],
       "subtypes": [
@@ -1716,7 +1716,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -1724,19 +1724,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "text": "At the beginning of your upkeep, detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
@@ -1848,15 +1848,15 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Applying this redirection effect doesn’t change whether the damage is combat damage."
+          "text": "Applying this redirection effect doesn't change whether the damage is combat damage."
         },
         {
           "date": "2012-10-01",
-          "text": "If noncombat damage would be dealt to a planeswalker you control, the planeswalker redirection effect and Palisade Giant’s redirection effect apply in whichever order you choose. No matter which order you choose to apply them in, that damage will be dealt to Palisade Giant instead."
+          "text": "If noncombat damage would be dealt to a planeswalker you control, the planeswalker redirection effect and Palisade Giant's redirection effect apply in whichever order you choose. No matter which order you choose to apply them in, that damage will be dealt to Palisade Giant instead."
         },
         {
           "date": "2012-10-01",
-          "text": "If you control more than one Palisade Giant, you choose which redirection effect to apply. You can’t divide damage dealt by one source. For example, if an attacking creature would deal 8 damage to you and you control two Palisade Giants, you may have that damage dealt to either of the Palisade Giants. You can’t have 4 damage dealt to each Giant or choose to have the 8 damage dealt to you."
+          "text": "If you control more than one Palisade Giant, you choose which redirection effect to apply. You can't divide damage dealt by one source. For example, if an attacking creature would deal 8 damage to you and you control two Palisade Giants, you may have that damage dealt to either of the Palisade Giants. You can't have 4 damage dealt to each Giant or choose to have the 8 damage dealt to you."
         }
       ],
       "subtypes": [
@@ -1973,7 +1973,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "A creature token that’s a copy of a nontoken creature is still a token. It will get +1/+1, but the original nontoken creature will not."
+          "text": "A creature token that's a copy of a nontoken creature is still a token. It will get +1/+1, but the original nontoken creature will not."
         }
       ],
       "subtypes": [
@@ -2200,15 +2200,15 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "While Rest in Peace is on the battlefield, abilities that trigger whenever a creature dies won’t trigger because cards and tokens never reach a player’s graveyard."
+          "text": "While Rest in Peace is on the battlefield, abilities that trigger whenever a creature dies won't trigger because cards and tokens never reach a player's graveyard."
         },
         {
           "date": "2012-10-01",
-          "text": "If Rest in Peace is destroyed by a spell, Rest in Peace will be exiled and then the spell will be put into its owner’s graveyard."
+          "text": "If Rest in Peace is destroyed by a spell, Rest in Peace will be exiled and then the spell will be put into its owner's graveyard."
         },
         {
           "date": "2012-10-01",
-          "text": "If a card is discarded while Rest in Peace is on the battlefield, abilities that function when a card is discarded (such as madness) still work, even though that card never reaches a graveyard. In addition, spells or abilities that check the characteristics of a discarded card (such as Chandra Ablaze’s first ability) can find that card in exile."
+          "text": "If a card is discarded while Rest in Peace is on the battlefield, abilities that function when a card is discarded (such as madness) still work, even though that card never reaches a graveyard. In addition, spells or abilities that check the characteristics of a discarded card (such as Chandra Ablaze's first ability) can find that card in exile."
         }
       ],
       "text": "When Rest in Peace enters the battlefield, exile all cards from all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
@@ -2318,11 +2318,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -2330,11 +2330,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -2452,7 +2452,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You must target a land to cast Security Blockade. If that land is an illegal target when Security Blockade tries to resolve, it will be countered and won’t enter the battlefield. You won’t get the Knight token."
+          "text": "You must target a land to cast Security Blockade. If that land is an illegal target when Security Blockade tries to resolve, it will be countered and won't enter the battlefield. You won't get the Knight token."
         }
       ],
       "subtypes": [
@@ -2785,7 +2785,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "The converted mana cost of a creature token is 0, unless that token is a copy of another creature, in which case it copies that creature’s mana cost."
+          "text": "The converted mana cost of a creature token is 0, unless that token is a copy of another creature, in which case it copies that creature's mana cost."
         },
         {
           "date": "2012-10-01",
@@ -2907,7 +2907,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "In a Two-Headed Giant game, if one player controls Sphere of Safety, creatures can’t attack that player’s team or a planeswalker that player controls unless their controller pays {X} for each of those creatures he or she controls. Creatures can attack planeswalkers controlled by that player’s teammate without having to pay this cost."
+          "text": "In a Two-Headed Giant game, if one player controls Sphere of Safety, creatures can't attack that player's team or a planeswalker that player controls unless their controller pays {X} for each of those creatures he or she controls. Creatures can attack planeswalkers controlled by that player's teammate without having to pay this cost."
         }
       ],
       "text": "Creatures can't attack you or a planeswalker you control unless their controller pays {X} for each of those creatures, where X is the number of enchantments you control.",
@@ -3340,19 +3340,19 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You must target a creature to cast Trostani’s Judgment. If that creature is an illegal target when Trostani’s Judgment tries to resolve, it will be countered and none of its effects will happen. You won’t populate."
+          "text": "You must target a creature to cast Trostani's Judgment. If that creature is an illegal target when Trostani's Judgment tries to resolve, it will be countered and none of its effects will happen. You won't populate."
         },
         {
           "date": "2012-10-01",
-          "text": "If you choose a creature token you control as the target, it will be exiled before you populate and you won’t be able to choose that creature to copy."
+          "text": "If you choose a creature token you control as the target, it will be exiled before you populate and you won't be able to choose that creature to copy."
         },
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -3360,11 +3360,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -3589,23 +3589,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -3613,7 +3613,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Tap target creature you don't control.\nOverload {3}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -3715,6 +3715,10 @@
         },
         {
           "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -3863,11 +3867,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Chronic Flooding’s ability will trigger whenever the enchanted land becomes tapped for any reason, not just because its controller taps it for mana."
+          "text": "Chronic Flooding's ability will trigger whenever the enchanted land becomes tapped for any reason, not just because its controller taps it for mana."
         },
         {
           "date": "2012-10-01",
-          "text": "Chronic Flooding becoming attached to a tapped land won’t cause its ability to immediately trigger. That land must go from untapped to tapped."
+          "text": "Chronic Flooding becoming attached to a tapped land won't cause its ability to immediately trigger. That land must go from untapped to tapped."
         }
       ],
       "subtypes": [
@@ -3980,15 +3984,15 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "The only legal target for Conjured Currency’s ability is a permanent both owned and controlled by another player, although it doesn’t have to be the same player. For example, a permanent owned by an opponent but controlled by your teammate (or another opponent) could be chosen as the target."
+          "text": "The only legal target for Conjured Currency's ability is a permanent both owned and controlled by another player, although it doesn't have to be the same player. For example, a permanent owned by an opponent but controlled by your teammate (or another opponent) could be chosen as the target."
         },
         {
           "date": "2012-10-01",
-          "text": "The exchange occurs only if Conjured Currency and the target permanent are both on the battlefield and controlled by different players when the ability resolves. In addition, the target permanent must be one you neither own nor control. If any of these things aren’t true when the ability tries to resolve, the exchange won’t happen and neither permanent will change controllers."
+          "text": "The exchange occurs only if Conjured Currency and the target permanent are both on the battlefield and controlled by different players when the ability resolves. In addition, the target permanent must be one you neither own nor control. If any of these things aren't true when the ability tries to resolve, the exchange won't happen and neither permanent will change controllers."
         },
         {
           "date": "2012-10-01",
-          "text": "You don’t necessarily have to control Conjured Currency when its ability resolves in order for the exchange to happen. If another player has gained control of Conjured Currency while the ability is on the stack, and a third player controls the target (and you don’t own it), you may choose to have those two players exchange control of the relevant permanents."
+          "text": "You don't necessarily have to control Conjured Currency when its ability resolves in order for the exchange to happen. If another player has gained control of Conjured Currency while the ability is on the stack, and a third player controls the target (and you don't own it), you may choose to have those two players exchange control of the relevant permanents."
         }
       ],
       "text": "At the beginning of your upkeep, you may exchange control of Conjured Currency and target permanent you neither own nor control.",
@@ -4210,23 +4214,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -4234,7 +4238,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -4577,23 +4581,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -4601,7 +4605,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Target creature you don't control gets -4/-0 until end of turn.\nOverload {2}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -4714,7 +4718,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Returning another creature you control to its owner’s hand is optional. You may choose to sacrifice Faerie Impostor, even if you could return a creature."
+          "text": "Returning another creature you control to its owner's hand is optional. You may choose to sacrifice Faerie Impostor, even if you could return a creature."
         }
       ],
       "subtypes": [
@@ -4939,7 +4943,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -4947,19 +4951,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "text": "Detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)\nDraw a card.",
@@ -5184,7 +5188,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -5192,19 +5196,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "subtypes": [
@@ -5321,11 +5325,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Jace’s first ability creates a delayed triggered ability that triggers whenever a creature an opponent controls attacks. It doesn’t matter which player or planeswalker that creature is attacking."
+          "text": "Jace's first ability creates a delayed triggered ability that triggers whenever a creature an opponent controls attacks. It doesn't matter which player or planeswalker that creature is attacking."
         },
         {
           "date": "2012-10-01",
-          "text": "You pick one of your opponents when Jace’s second ability resolves. The ability doesn’t target that opponent. All players may see the revealed cards and offer opinions. You (not your opponent) choose which pile is put into your hand and which pile is put on the bottom of your library."
+          "text": "You pick one of your opponents when Jace's second ability resolves. The ability doesn't target that opponent. All players may see the revealed cards and offer opinions. You (not your opponent) choose which pile is put into your hand and which pile is put on the bottom of your library."
         },
         {
           "date": "2012-10-01",
@@ -5333,11 +5337,11 @@
         },
         {
           "date": "2012-10-01",
-          "text": "When resolving Jace’s third ability, you search each player’s library (including yours) and exile the nonland cards before casting any of them."
+          "text": "When resolving Jace's third ability, you search each player's library (including yours) and exile the nonland cards before casting any of them."
         },
         {
           "date": "2012-10-01",
-          "text": "For each library, the search is complete only when you explicitly say it is. For example, you can look through one player’s library, set that library down, look at another player’s library, choose a nonland card in the first library, then choose a nonland card in the second library. Don’t reveal any cards from those libraries to any other player until you exile them."
+          "text": "For each library, the search is complete only when you explicitly say it is. For example, you can look through one player's library, set that library down, look at another player's library, choose a nonland card in the first library, then choose a nonland card in the second library. Don't reveal any cards from those libraries to any other player until you exile them."
         },
         {
           "date": "2012-10-01",
@@ -5345,15 +5349,15 @@
         },
         {
           "date": "2012-10-01",
-          "text": "When casting a card this way, ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "When casting a card this way, ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2012-10-01",
-          "text": "If you can’t cast a card, perhaps because there are no legal targets available, or if you choose not to cast one, it will remain exiled. Jace’s ability won’t allow you to cast it later."
+          "text": "If you can't cast a card, perhaps because there are no legal targets available, or if you choose not to cast one, it will remain exiled. Jace's ability won't allow you to cast it later."
         },
         {
           "date": "2012-10-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-10-01",
@@ -5469,23 +5473,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -5493,7 +5497,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Target creature you control gets +0/+1 and gains hexproof until end of turn.\nOverload {1}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -5726,11 +5730,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Psychic Spiral won’t be shuffled into your library, and it won’t be counted when determining how many cards the target player puts into his or her graveyard. It will be put into your graveyard after you follow its instructions."
+          "text": "Psychic Spiral won't be shuffled into your library, and it won't be counted when determining how many cards the target player puts into his or her graveyard. It will be put into your graveyard after you follow its instructions."
         },
         {
           "date": "2012-10-01",
-          "text": "If you cast Psychic Spiral when there are no cards in your graveyard, you’ll still shuffle your library."
+          "text": "If you cast Psychic Spiral when there are no cards in your graveyard, you'll still shuffle your library."
         }
       ],
       "text": "Shuffle all cards from your graveyard into your library. Target player puts that many cards from the top of his or her library into his or her graveyard.",
@@ -5948,15 +5952,15 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "To “play a card” is to play that card as a land or cast that card as a spell, whichever is appropriate."
+          "text": "To \"play a card\" is to play that card as a land or cast that card as a spell, whichever is appropriate."
         },
         {
           "date": "2012-10-01",
-          "text": "You can put only one card into its owner’s hand for each card you play."
+          "text": "You can put only one card into its owner's hand for each card you play."
         },
         {
           "date": "2012-10-01",
-          "text": "If you don’t sacrifice Search the City, perhaps because it was destroyed in response to its ability triggering, you won’t take an extra turn."
+          "text": "If you don't sacrifice Search the City, perhaps because it was destroyed in response to its ability triggering, you won't take an extra turn."
         }
       ],
       "text": "When Search the City enters the battlefield, exile the top five cards of your library.\nWhenever you play a card with the same name as one of the exiled cards, you may put one of those cards with that name into its owner's hand. Then if there are no cards exiled with Search the City, sacrifice it. If you do, take an extra turn after this one.",
@@ -6175,7 +6179,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -6183,19 +6187,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "subtypes": [
@@ -6758,7 +6762,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "If Voidwielder is the only creature on the battlefield, you’ll have to choose it as the target of its ability, although you may choose to not return it to its owner’s hand."
+          "text": "If Voidwielder is the only creature on the battlefield, you'll have to choose it as the target of its ability, although you may choose to not return it to its owner's hand."
         }
       ],
       "subtypes": [
@@ -6873,15 +6877,15 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You must be able to target a creature to cast Assassin’s Strike."
+          "text": "You must be able to target a creature to cast Assassin's Strike."
         },
         {
           "date": "2012-10-01",
-          "text": "If the creature is an illegal target when Assassin’s Strike tries to resolve, it will be countered and none of its effects will happen. Its controller won’t discard a card."
+          "text": "If the creature is an illegal target when Assassin's Strike tries to resolve, it will be countered and none of its effects will happen. Its controller won't discard a card."
         },
         {
           "date": "2013-07-01",
-          "text": "If Assassin’s Strike resolves but the creature isn’t destroyed (perhaps because it regenerated or has indestructible), its controller will discard a card."
+          "text": "If Assassin's Strike resolves but the creature isn't destroyed (perhaps because it regenerated or has indestructible), its controller will discard a card."
         }
       ],
       "text": "Destroy target creature. Its controller discards a card.",
@@ -7113,7 +7117,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If the target card is no longer in the graveyard when Cremate tries to resolve, it will be countered and none of its effects will happen. You won’t draw a card."
+          "text": "If the target card is no longer in the graveyard when Cremate tries to resolve, it will be countered and none of its effects will happen. You won't draw a card."
         }
       ],
       "text": "Exile target card from a graveyard.\nDraw a card.",
@@ -7333,7 +7337,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Dark Revenant’s ability isn’t optional. However, if Dark Revenant leaves the graveyard before its ability resolves, it won’t be put on top of its owner’s library."
+          "text": "Dark Revenant's ability isn't optional. However, if Dark Revenant leaves the graveyard before its ability resolves, it won't be put on top of its owner's library."
         }
       ],
       "subtypes": [
@@ -7448,7 +7452,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -7456,11 +7460,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -7577,7 +7581,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Players won’t know which player or planeswalker Desecration Demon will attack, if any, when deciding whether to sacrifice a creature."
+          "text": "Players won't know which player or planeswalker Desecration Demon will attack, if any, when deciding whether to sacrifice a creature."
         },
         {
           "date": "2017-03-14",
@@ -7921,7 +7925,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You may pay {B} only once. The target player will discard a maximum of one card because of Drainpipe Vermin’s ability."
+          "text": "You may pay {B} only once. The target player will discard a maximum of one card because of Drainpipe Vermin's ability."
         }
       ],
       "subtypes": [
@@ -8034,27 +8038,27 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Grave Betrayal doesn’t overwrite any previous colors or types. Rather, it adds another color and another creature type."
+          "text": "Grave Betrayal doesn't overwrite any previous colors or types. Rather, it adds another color and another creature type."
         },
         {
           "date": "2012-10-01",
-          "text": "If the creature is normally colorless, it will simply be black. It won’t be both black and colorless."
+          "text": "If the creature is normally colorless, it will simply be black. It won't be both black and colorless."
         },
         {
           "date": "2012-10-01",
-          "text": "If a creature you don’t control dies during the end step, that creature won’t return to the battlefield until the beginning of the next end step."
+          "text": "If a creature you don't control dies during the end step, that creature won't return to the battlefield until the beginning of the next end step."
         },
         {
           "date": "2012-10-01",
-          "text": "Each creature you don’t control that dies causes a delayed triggered ability to trigger at the beginning of the next end step. If there are multiple such abilities, you can put them on the stack in any order. The creatures will return to the battlefield one at a time as each ability resolves. The last ability you put on the stack will be the first one to resolve."
+          "text": "Each creature you don't control that dies causes a delayed triggered ability to trigger at the beginning of the next end step. If there are multiple such abilities, you can put them on the stack in any order. The creatures will return to the battlefield one at a time as each ability resolves. The last ability you put on the stack will be the first one to resolve."
         },
         {
           "date": "2012-10-01",
-          "text": "If the creature card leaves the graveyard before the delayed triggered ability resolves, it won’t return to the battlefield. This is also true if the card leaves the graveyard and returns to the graveyard before that ability resolves."
+          "text": "If the creature card leaves the graveyard before the delayed triggered ability resolves, it won't return to the battlefield. This is also true if the card leaves the graveyard and returns to the graveyard before that ability resolves."
         },
         {
           "date": "2012-10-01",
-          "text": "The phrase “with an additional +1/+1 counter on it” means that the creature enters the battlefield with one more +1/+1 counter than it would normally enter the battlefield with. It doesn’t keep any counters it had on it when it died."
+          "text": "The phrase \"with an additional +1/+1 counter on it\" means that the creature enters the battlefield with one more +1/+1 counter than it would normally enter the battlefield with. It doesn't keep any counters it had on it when it died."
         },
         {
           "date": "2012-10-01",
@@ -8169,7 +8173,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -8177,11 +8181,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -8297,7 +8301,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         },
         {
           "date": "2012-10-01",
@@ -8554,7 +8558,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "If that creature deals combat damage to a player at the same time it’s dealt lethal damage (perhaps because it has trample and was blocked), it will die before the triggered ability resolves and puts +1/+1 counters on it."
+          "text": "If that creature deals combat damage to a player at the same time it's dealt lethal damage (perhaps because it has trample and was blocked), it will die before the triggered ability resolves and puts +1/+1 counters on it."
         }
       ],
       "subtypes": [
@@ -8670,7 +8674,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Defender only matters when Ogre Jailbreaker could be declared as an attacking creature. If Ogre Jailbreaker is already attacking, losing control of your only Gate won’t cause Ogre Jailbreaker to leave combat."
+          "text": "Defender only matters when Ogre Jailbreaker could be declared as an attacking creature. If Ogre Jailbreaker is already attacking, losing control of your only Gate won't cause Ogre Jailbreaker to leave combat."
         }
       ],
       "subtypes": [
@@ -8785,19 +8789,19 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Pack Rat’s first ability counts any creature you control with the creature type Rat, not just Pack Rats."
+          "text": "Pack Rat's first ability counts any creature you control with the creature type Rat, not just Pack Rats."
         },
         {
           "date": "2012-10-01",
-          "text": "The token will copy Pack Rat’s two abilities. Its power and toughness will be equal to the number of Rats you control (not the number of Rats you controlled when the token entered the battlefield). It will also be able to create copies of itself."
+          "text": "The token will copy Pack Rat's two abilities. Its power and toughness will be equal to the number of Rats you control (not the number of Rats you controlled when the token entered the battlefield). It will also be able to create copies of itself."
         },
         {
           "date": "2012-10-01",
-          "text": "The token won’t copy counters on Pack Rat, nor will it copy other effects that have changed Pack Rat’s power, toughness, types, color, or so on. Normally, this means the token will simply be a Pack Rat. But if any copy effects have affected that Pack Rat, they’re taken into account."
+          "text": "The token won't copy counters on Pack Rat, nor will it copy other effects that have changed Pack Rat's power, toughness, types, color, or so on. Normally, this means the token will simply be a Pack Rat. But if any copy effects have affected that Pack Rat, they're taken into account."
         },
         {
           "date": "2012-10-01",
-          "text": "If Pack Rat leaves the battlefield before its activated ability resolves, the token will still enter the battlefield as a copy of Pack Rat, using Pack Rat’s copiable values from when it was last on the battlefield."
+          "text": "If Pack Rat leaves the battlefield before its activated ability resolves, the token will still enter the battlefield as a copy of Pack Rat, using Pack Rat's copiable values from when it was last on the battlefield."
         }
       ],
       "subtypes": [
@@ -9021,7 +9025,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -9136,7 +9140,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Shrieking Affliction’s ability will trigger only if an opponent begins his or her upkeep with one or fewer cards in hand. The ability will check the number of cards in that player’s hand again when it tries to resolve. If that player has two or more cards in hand at that time, that player won’t lose life."
+          "text": "Shrieking Affliction's ability will trigger only if an opponent begins his or her upkeep with one or fewer cards in hand. The ability will check the number of cards in that player's hand again when it tries to resolve. If that player has two or more cards in hand at that time, that player won't lose life."
         }
       ],
       "text": "At the beginning of each opponent's upkeep, if that player has one or fewer cards in hand, he or she loses 3 life.",
@@ -9247,7 +9251,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "When the ability resolves, you may sacrifice Slum Reaper itself. If you control no other creatures, you’ll have to sacrifice Slum Reaper."
+          "text": "When the ability resolves, you may sacrifice Slum Reaper itself. If you control no other creatures, you'll have to sacrifice Slum Reaper."
         }
       ],
       "subtypes": [
@@ -9471,11 +9475,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You can’t activate the ability if your life total is less than 3."
+          "text": "You can't activate the ability if your life total is less than 3."
         },
         {
           "date": "2012-10-01",
-          "text": "You can activate the ability if your life total is 3, but it’s probably a bad idea. You’ll lose the game before the ability resolves."
+          "text": "You can activate the ability if your life total is 3, but it's probably a bad idea. You'll lose the game before the ability resolves."
         }
       ],
       "subtypes": [
@@ -9591,7 +9595,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -9708,7 +9712,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -9716,11 +9720,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -10065,7 +10069,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -10184,7 +10188,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "A creature dealt damage by Annihilating Fire that dies this turn will be exiled even if it wasn’t the target of Annihilating Fire (say, because the damage was redirected somehow)."
+          "text": "A creature dealt damage by Annihilating Fire that dies this turn will be exiled even if it wasn't the target of Annihilating Fire (say, because the damage was redirected somehow)."
         },
         {
           "date": "2012-10-01",
@@ -10299,15 +10303,15 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Ash Zealot’s ability doesn’t allow any player to cast cards from a graveyard. Such cards need another way to be cast, such as the flashback ability."
+          "text": "Ash Zealot's ability doesn't allow any player to cast cards from a graveyard. Such cards need another way to be cast, such as the flashback ability."
         },
         {
           "date": "2012-10-01",
-          "text": "Ash Zealot’s triggered ability will resolve before that spell resolves."
+          "text": "Ash Zealot's triggered ability will resolve before that spell resolves."
         },
         {
           "date": "2012-10-01",
-          "text": "Ash Zealot’s ability doesn’t trigger if you put a card onto the battlefield from a graveyard (using Grave Betrayal’s ability, for example)."
+          "text": "Ash Zealot's ability doesn't trigger if you put a card onto the battlefield from a graveyard (using Grave Betrayal's ability, for example)."
         }
       ],
       "subtypes": [
@@ -10642,7 +10646,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -10650,11 +10654,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -10773,7 +10777,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -10781,11 +10785,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -11009,23 +11013,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -11033,11 +11037,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         },
         {
           "date": "2017-03-14",
-          "text": "An overloaded Dynacharge affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn won’t get +2/+0."
+          "text": "An overloaded Dynacharge affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn won't get +2/+0."
         }
       ],
       "text": "Target creature you control gets +2/+0 until end of turn.\nOverload {2}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -11147,23 +11151,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -11171,7 +11175,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Electrickery deals 1 damage to target creature you don't control.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -11491,7 +11495,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -11499,11 +11503,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -11618,7 +11622,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Guild Feud has one target: the opponent. You’ll see what creature that player puts onto the battlefield before revealing the top three cards of your library and deciding whether to put a creature onto the battlefield yourself."
+          "text": "Guild Feud has one target: the opponent. You'll see what creature that player puts onto the battlefield before revealing the top three cards of your library and deciding whether to put a creature onto the battlefield yourself."
         },
         {
           "date": "2012-10-01",
@@ -11626,7 +11630,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Players can’t cast spells or activate abilities between the creatures being put onto the battlefield and them fighting each other. Notably, you can’t respond with a spell like Giant Growth."
+          "text": "Players can't cast spells or activate abilities between the creatures being put onto the battlefield and them fighting each other. Notably, you can't respond with a spell like Giant Growth."
         },
         {
           "date": "2012-10-01",
@@ -11744,7 +11748,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Guttersnipe’s ability resolves and Guttersnipe deals damage before the instant or sorcery spell resolves."
+          "text": "Guttersnipe's ability resolves and Guttersnipe deals damage before the instant or sorcery spell resolves."
         }
       ],
       "subtypes": [
@@ -11864,7 +11868,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "You’ll untap Lobber Crew before that spell resolves."
+          "text": "You'll untap Lobber Crew before that spell resolves."
         }
       ],
       "subtypes": [
@@ -12090,23 +12094,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -12114,7 +12118,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -12562,7 +12566,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -12570,11 +12574,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -12691,23 +12695,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -12715,7 +12719,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Street Spasm deals X damage to target creature without flying you don't control.\nOverload {X}{X}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -12826,7 +12830,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "If the target land is an illegal target when Survey the Wreckage tries to resolve, it will be countered and none of its effects will happen. You won’t get the creature token."
+          "text": "If the target land is an illegal target when Survey the Wreckage tries to resolve, it will be countered and none of its effects will happen. You won't get the creature token."
         }
       ],
       "text": "Destroy target land. Create a 1/1 red Goblin creature token.",
@@ -13051,7 +13055,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "You may target a creature you already control. You may target a creature that’s already untapped."
+          "text": "You may target a creature you already control. You may target a creature that's already untapped."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gets +2/+0 and gains haste.",
@@ -13271,23 +13275,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -13295,7 +13299,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -13520,7 +13524,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If the creature with flying is an illegal target when Aerial Predation tries to resolve, it will be countered and none of its effects will happen. You won’t gain 2 life."
+          "text": "If the creature with flying is an illegal target when Aerial Predation tries to resolve, it will be countered and none of its effects will happen. You won't gain 2 life."
         }
       ],
       "text": "Destroy target creature with flying. You gain 2 life.",
@@ -13740,7 +13744,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Axebane Guardian’s activated ability is a mana ability. It doesn’t use the stack and can’t be responded to. The number of creatures with defender you control is counted, and the color(s) of mana produced chosen, immediately after the ability is activated when the ability resolves."
+          "text": "Axebane Guardian's activated ability is a mana ability. It doesn't use the stack and can't be responded to. The number of creatures with defender you control is counted, and the color(s) of mana produced chosen, immediately after the ability is activated when the ability resolves."
         }
       ],
       "subtypes": [
@@ -14073,11 +14077,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Once you activate the ability of Centaur’s Herald, it’s too late for a player to respond by trying to destroy it or otherwise stop you from sacrificing it."
+          "text": "Once you activate the ability of Centaur's Herald, it's too late for a player to respond by trying to destroy it or otherwise stop you from sacrificing it."
         },
         {
           "date": "2012-10-01",
-          "text": "You can only sacrifice Centaur’s Herald once, so it’s not possible to activate its ability more than once."
+          "text": "You can only sacrifice Centaur's Herald once, so it's not possible to activate its ability more than once."
         }
       ],
       "subtypes": [
@@ -14304,7 +14308,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -14530,7 +14534,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -14646,11 +14650,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -14658,11 +14662,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -14670,15 +14674,15 @@
         },
         {
           "date": "2017-03-14",
-          "text": "You can cast Druid’s Deliverance even if you don’t control any creature tokens."
+          "text": "You can cast Druid's Deliverance even if you don't control any creature tokens."
         },
         {
           "date": "2017-03-14",
-          "text": "Combat damage dealt to creatures or planeswalkers you control won’t be prevented."
+          "text": "Combat damage dealt to creatures or planeswalkers you control won't be prevented."
         },
         {
           "date": "2017-03-14",
-          "text": "In a Two-Headed Giant game, combat damage dealt to your teammate won’t be prevented."
+          "text": "In a Two-Headed Giant game, combat damage dealt to your teammate won't be prevented."
         }
       ],
       "text": "Prevent all combat damage that would be dealt to you this turn. Populate. (Create a token that's a copy of a creature token you control.)",
@@ -15149,7 +15153,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -15265,11 +15269,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -15277,11 +15281,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -15396,7 +15400,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -15510,7 +15514,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Mana Bloom’s last ability will trigger only if it has no charge counters on it at the beginning of your upkeep. If it has one charge counter on it as your turn begins, you won’t have priority to remove the counter until after this check."
+          "text": "Mana Bloom's last ability will trigger only if it has no charge counters on it at the beginning of your upkeep. If it has one charge counter on it as your turn begins, you won't have priority to remove the counter until after this check."
         }
       ],
       "text": "Mana Bloom enters the battlefield with X charge counters on it.\nRemove a charge counter from Mana Bloom: Add one mana of any color to your mana pool. Activate this ability only once each turn.\nAt the beginning of your upkeep, if Mana Bloom has no charge counters on it, return it to its owner's hand.",
@@ -16176,7 +16180,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Multiple instances of lifelink are redundant. Activating Stonefare Crocodile’s ability more than once during a single turn won’t cause you to gain more life."
+          "text": "multiple instances of lifelink on the same creature are redundant. Activating Stonefare Crocodile's ability more than once during a single turn won't cause you to gain more life."
         }
       ],
       "subtypes": [
@@ -16400,11 +16404,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "The enchanted land untaps at the same time as the active player’s permanents. You can’t choose to not untap it at that time."
+          "text": "The enchanted land untaps at the same time as the active player's permanents. You can't choose to not untap it at that time."
         },
         {
           "date": "2012-10-01",
-          "text": "Effects that state that the enchanted land doesn’t untap during your untap step won’t apply during another player’s untap step."
+          "text": "Effects that state that the enchanted land doesn't untap during your untap step won't apply during another player's untap step."
         }
       ],
       "subtypes": [
@@ -16519,7 +16523,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "The value of X is determined when the triggered ability resolves. If Wild Beastmaster is no longer on the battlefield at that time, use its last known power to determine the value of X. This could be bad for you if Wild Beastmaster’s power was negative. For example, if Wild Beastmaster’s power is -4, each other creature you control will get -4/-4 until end of turn."
+          "text": "The value of X is determined when the triggered ability resolves. If Wild Beastmaster is no longer on the battlefield at that time, use its last known power to determine the value of X."
+        },
+        {
+          "date": "2017-06-27",
+          "text": "If this creature's power is negative as its ability resolves, X is considered to be 0. (This is a change from previous rulings.)"
         }
       ],
       "subtypes": [
@@ -16634,7 +16642,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Worldspine Wurm’s last ability is a triggered ability, not a replacement ability. Players can respond to this ability, for example, by trying to exile Worldspine Wurm from the graveyard before it’s shuffled into a library."
+          "text": "Worldspine Wurm's last ability is a triggered ability, not a replacement ability. Players can respond to this ability, for example, by trying to exile Worldspine Wurm from the graveyard before it's shuffled into a library."
         }
       ],
       "subtypes": [
@@ -16751,7 +16759,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The converted mana cost of a creature token is 0, unless that token is a copy of another creature, in which case it copies that creature’s mana cost."
+          "text": "The converted mana cost of a creature token is 0, unless that token is a copy of another creature, in which case it copies that creature's mana cost."
         },
         {
           "date": "2017-03-14",
@@ -16873,11 +16881,11 @@
         },
         {
           "date": "2012-10-01",
-          "text": "The nonland permanents will be detained before blockers are chosen. Notably, a creature detained this way can’t block before it is detained."
+          "text": "The nonland permanents will be detained before blockers are chosen. Notably, a creature detained this way can't block before it is detained."
         },
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -16885,19 +16893,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "subtypes": [
@@ -17458,7 +17466,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -17466,11 +17474,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -17701,7 +17709,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "If you cast Chemister’s Trick with overload, only creatures you don’t control that are on the battlefield when Chemister’s Trick resolves are affected. Creatures that come under another player’s control later in the turn are not."
+          "text": "If you cast Chemister's Trick with overload, only creatures you don't control that are on the battlefield when Chemister's Trick resolves are affected. Creatures that come under another player's control later in the turn are not."
         },
         {
           "date": "2012-10-01",
@@ -17709,27 +17717,27 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If, during a player’s declare attacker’s step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attacker's step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -17737,7 +17745,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Target creature you don't control gets -2/-0 until end of turn and attacks this turn if able.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -17957,7 +17965,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You may choose the same creature for both targets. You may also choose two different creatures. This is because the word “target” is used twice."
+          "text": "You may choose the same creature for both targets. You may also choose two different creatures. This is because the word \"target\" is used twice."
         }
       ],
       "text": "Put a +1/+1 counter on target creature.\nPut a +1/+1 counter on target creature.",
@@ -18194,23 +18202,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -18218,7 +18226,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         }
       ],
       "text": "Counterflux can't be countered by spells or abilities.\nCounter target spell you don't control.\nOverload {1}{U}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -18331,11 +18339,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -18343,11 +18351,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -18467,7 +18475,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "The enters-the-battlefield ability has only one target. The other permanents with that name aren’t targeted. For example, a permanent with protection from white will be exiled if it has the same name as the target nonland permanent."
+          "text": "The enters-the-battlefield ability has only one target. The other permanents with that name aren't targeted. For example, a permanent with protection from white will be exiled if it has the same name as the target nonland permanent."
         },
         {
           "date": "2012-10-01",
@@ -18592,7 +18600,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If the target creature is an illegal target when Dramatic Rescue tries to resolve, it will be countered and none of its effects will happen. You won’t gain 2 life."
+          "text": "If the target creature is an illegal target when Dramatic Rescue tries to resolve, it will be countered and none of its effects will happen. You won't gain 2 life."
         }
       ],
       "text": "Return target creature to its owner's hand. You gain 2 life.",
@@ -18815,7 +18823,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -18937,15 +18945,15 @@
         },
         {
           "date": "2012-10-01",
-          "text": "When casting an instant or sorcery card this way, ignore timing restrictions based on the card’s type. Other timing restrictions, such as “Cast [this card] only during combat,” must be followed."
+          "text": "When casting an instant or sorcery card this way, ignore timing restrictions based on the card's type. Other timing restrictions, such as \"Cast [this card] only during combat,\" must be followed."
         },
         {
           "date": "2012-10-01",
-          "text": "If you can’t cast an instant or sorcery card, perhaps because there are no legal targets available, or if you choose not to cast one, it will be put into your graveyard."
+          "text": "If you can't cast an instant or sorcery card, perhaps because there are no legal targets available, or if you choose not to cast one, it will be put into your graveyard."
         },
         {
           "date": "2012-10-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay alternative costs such as overload costs. You can pay additional costs such as kicker costs. If the card has mandatory additional costs, you must pay those."
         },
         {
           "date": "2012-10-01",
@@ -19062,15 +19070,15 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Essence Backlash can target a creature spell that can’t be countered. If Essence Backlash resolves, it won’t counter the spell but it will still deal damage."
+          "text": "Essence Backlash can target a creature spell that can't be countered. If Essence Backlash resolves, it won't counter the spell but it will still deal damage."
         },
         {
           "date": "2012-10-01",
-          "text": "If the creature’s power is * and it has an ability defining its power, use that ability to determine its power."
+          "text": "If the creature's power is * and it has an ability defining its power, use that ability to determine its power."
         },
         {
           "date": "2012-10-01",
-          "text": "Abilities that change the power of a creature (such as the one of Collective Blessing) affect only creatures on the battlefield. They won’t change a creature spell’s power on the stack."
+          "text": "Abilities that change the power of a creature (such as the one of Collective Blessing) affect only creatures on the battlefield. They won't change a creature spell's power on the stack."
         }
       ],
       "text": "Counter target creature spell. Essence Backlash deals damage equal to that spell's power to its controller.",
@@ -19187,7 +19195,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If the target spell is an illegal target when Fall of the Gavel tries to resolve (perhaps because it’s been countered by another spell), Fall of the Gavel will be countered and none of its effects will happen. You won’t gain 5 life."
+          "text": "If the target spell is an illegal target when Fall of the Gavel tries to resolve (perhaps because it's been countered by another spell), Fall of the Gavel will be countered and none of its effects will happen. You won't gain 5 life."
         }
       ],
       "text": "Counter target spell. You gain 5 life.",
@@ -19301,7 +19309,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You don’t have to find any instant cards in your library, even if they are there."
+          "text": "You don't have to find any instant cards in your library, even if they are there."
         },
         {
           "date": "2012-10-01",
@@ -19427,11 +19435,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Goblin Electromancer can’t reduce colored mana costs or {C} in the cost of instant or sorcery spells."
+          "text": "Goblin Electromancer can't reduce colored mana costs or {C} in the cost of instant or sorcery spells."
         },
         {
           "date": "2017-03-14",
-          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben’s ability), apply those increases before applying cost reductions."
+          "text": "If there are additional costs to cast a spell, such as a kicker cost or a cost imposed by another effect (such as the one imposed by Thalia, Guardian of Thraben's ability), apply those increases before applying cost reductions."
         },
         {
           "date": "2017-03-14",
@@ -19776,11 +19784,11 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Effects that would replace gaining life with another effect won’t apply because it’s impossible for players to gain life."
+          "text": "Effects that would replace gaining life with another effect won't apply because it's impossible for players to gain life."
         },
         {
           "date": "2012-10-01",
-          "text": "If an effect says to set a player’s life total to a certain number and that number is higher than the player’s current life total, that part of the effect won’t do anything. (If the number is lower than the player’s current life total, the effect will work as normal.)"
+          "text": "If an effect says to set a player's life total to a certain number and that number is higher than the player's current life total, that part of the effect won't do anything. (If the number is lower than the player's current life total, the effect will work as normal.)"
         },
         {
           "date": "2012-10-01",
@@ -19788,7 +19796,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "In a Two-Headed Giant game, the last ability triggers for each player. Any life loss is applied to the team’s life total. For example, if the team has 30 life, the first ability will cause the player (and thus the team) to lose 15 life and then the second ability will cause the other player (and thus the team) to lose 8 life. The team will end up having 7 life."
+          "text": "In a Two-Headed Giant game, the last ability triggers for each player. Any life loss is applied to the team's life total. For example, if the team has 30 life, the first ability will cause the player (and thus the team) to lose 15 life and then the second ability will cause the other player (and thus the team) to lose 8 life. The team will end up having 7 life."
         }
       ],
       "text": "Players can't gain life.\nAt the beginning of each player's upkeep, that player loses half his or her life, rounded up.",
@@ -19901,11 +19909,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "The damage dealt by the last ability is equal to Hellhole Flailer’s power when it was last on the battlefield. For example, if it had a +1/+1 counter on it, it will deal 4 damage."
+          "text": "The damage dealt by the last ability is equal to Hellhole Flailer's power when it was last on the battlefield. For example, if it had a +1/+1 counter on it, it will deal 4 damage."
         },
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -19913,11 +19921,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -20269,7 +20277,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "The last ability has no effect on abilities that you can activate “any time you could cast a sorcery.”"
+          "text": "The last ability has no effect on abilities that you can activate \"any time you could cast a sorcery.\""
         }
       ],
       "subtypes": [
@@ -20387,7 +20395,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "In a Two-Headed Giant game, Isperia’s ability will trigger whenever a creature attacks your team or a planeswalker you control. It won’t trigger when a creature attacks a planeswalker controlled by your teammate."
+          "text": "In a Two-Headed Giant game, Isperia's ability will trigger whenever a creature attacks your team or a planeswalker you control. It won't trigger when a creature attacks a planeswalker controlled by your teammate."
         }
       ],
       "subtypes": [
@@ -20616,11 +20624,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Izzet Staticaster’s activated ability has only one target. Other creatures with that name are not targeted. For example, a creature with hexproof will be dealt damage if it has the same name as the target creature."
+          "text": "Izzet Staticaster's activated ability has only one target. Other creatures with that name are not targeted. For example, a creature with hexproof will be dealt damage if it has the same name as the target creature."
         },
         {
           "date": "2012-10-01",
-          "text": "The name of a creature token is the same as its creature types unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 3/3 Centaur creature token is named “Centaur.”"
+          "text": "The name of a creature token is the same as its creature types unless the token is a copy of another creature or the effect that created the token specifically gives it a different name. For example, a 3/3 Centaur creature token is named \"Centaur.\""
         }
       ],
       "subtypes": [
@@ -20741,7 +20749,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Jarad’s first ability applies only when Jarad is on the battlefield."
+          "text": "Jarad's first ability applies only when Jarad is on the battlefield."
         },
         {
           "date": "2012-10-01",
@@ -20749,7 +20757,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "To activate Jarad’s last ability, you must sacrifice two lands. It doesn’t matter what other land types the two lands have, as long as one is a Swamp and one is a Forest. Even if one of the lands you sacrifice is both a Swamp and a Forest, you have to sacrifice another land that is a Swamp or a Forest."
+          "text": "To activate Jarad's last ability, you must sacrifice two lands. It doesn't matter what other land types the two lands have, as long as one is a Swamp and one is a Forest. Even if one of the lands you sacrifice is both a Swamp and a Forest, you have to sacrifice another land that is a Swamp or a Forest."
         },
         {
           "date": "2012-10-01",
@@ -20874,7 +20882,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You can choose to find just one creature card. If you do, you’ll put that card into your hand."
+          "text": "You can choose to find just one creature card. If you do, you'll put that card into your hand."
         }
       ],
       "text": "Search your library for up to two creature cards and reveal them. Put one into your hand and the other into your graveyard. Then shuffle your library.",
@@ -20991,7 +20999,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Use the sacrificed creature’s toughness when it was last on the battlefield to determine the value of X."
+          "text": "Use the sacrificed creature's toughness when it was last on the battlefield to determine the value of X."
         }
       ],
       "subtypes": [
@@ -21224,7 +21232,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "If you discard Loxodon Smiter and put it onto the battlefield, you’ve still discarded a card. Abilities that trigger when you discard a card (such as the one from Liliana’s Caress) will still trigger."
+          "text": "If you discard Loxodon Smiter and put it onto the battlefield, you've still discarded a card. Abilities that trigger when you discard a card (such as the one from Liliana's Caress) will still trigger."
         }
       ],
       "subtypes": [
@@ -21342,7 +21350,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -21350,19 +21358,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "subtypes": [
@@ -21485,7 +21493,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If the discarded card has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If the discarded card has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         }
       ],
       "subtypes": [
@@ -21603,7 +21611,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” No one can activate any activated abilities, including mana abilities, of a detained permanent."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" No one can activate any activated abilities, including mana abilities, of a detained permanent."
         },
         {
           "date": "2013-04-15",
@@ -21611,19 +21619,19 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If a creature is already attacking or blocking when it’s detained, it won’t be removed from combat. It will continue to attack or block."
+          "text": "If a creature is already attacking or blocking when it's detained, it won't be removed from combat. It will continue to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "If a permanent’s activated ability is on the stack when that permanent is detained, the ability will be unaffected."
+          "text": "If a permanent's activated ability is on the stack when that permanent is detained, the ability will be unaffected."
         },
         {
           "date": "2013-04-15",
-          "text": "If a noncreature permanent is detained and later turns into a creature, it won’t be able to attack or block."
+          "text": "If a noncreature permanent is detained and later turns into a creature, it won't be able to attack or block."
         },
         {
           "date": "2013-04-15",
-          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player’s next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
+          "text": "When a player leaves a multiplayer game, any continuous effects with durations that last until that player's next turn or until a specific point in that turn will last until that turn would have begun. They neither expire immediately nor last indefinitely."
         }
       ],
       "subtypes": [
@@ -21743,27 +21751,27 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Nivix Guildmage’s second ability can target (and copy) any instant or sorcery spell you control, not just one with targets."
+          "text": "Nivix Guildmage's second ability can target (and copy) any instant or sorcery spell you control, not just one with targets."
         },
         {
           "date": "2012-10-01",
-          "text": "When the second ability resolves, it creates a copy of a spell. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When the second ability resolves, it creates a copy of a spell. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2012-10-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2012-10-01",
-          "text": "If the copied spell is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the copied spell is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2012-10-01",
-          "text": "If the copied spell has an X whose value was determined as it was cast (like Sphinx’s Revelation does), the copy has the same value of X."
+          "text": "If the copied spell has an X whose value was determined as it was cast (like Sphinx's Revelation does), the copy has the same value of X."
         },
         {
           "date": "2012-10-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you copy a spell that you cast by paying its overload cost, the copy will resolve as though its overload cost had been paid as well."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional or alternative costs that were paid for the original spell are copied as though those same costs were paid for the copy too. For example, if you copy a spell that you cast by paying its overload cost, the copy will resolve as though its overload cost had been paid as well."
         }
       ],
       "subtypes": [
@@ -21999,7 +22007,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Damage dealt by creatures because of the third mode can’t be redirected to a planeswalker."
+          "text": "Damage dealt by creatures because of the third mode can't be redirected to a planeswalker."
         }
       ],
       "text": "Choose one —\n• Exile all cards from target player's graveyard.\n• Destroy target artifact.\n• Each creature deals 1 damage to its controller.",
@@ -22345,11 +22353,11 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Rakdos’s last ability cares about the total life lost, not necessarily what an opponent’s life total is compared to what it was at the beginning of the turn. For example, if an opponent loses 5 life and then gains 10 life in a turn, creature spells you cast will cost {5} less to cast."
+          "text": "Rakdos's last ability cares about the total life lost, not necessarily what an opponent's life total is compared to what it was at the beginning of the turn. For example, if an opponent loses 5 life and then gains 10 life in a turn, creature spells you cast will cost {5} less to cast."
         },
         {
           "date": "2012-10-01",
-          "text": "Rakdos’s last ability can’t reduce the colored mana requirement of a creature spell you cast."
+          "text": "Rakdos's last ability can't reduce the colored mana requirement of a creature spell you cast."
         },
         {
           "date": "2012-10-01",
@@ -22357,7 +22365,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Rakdos’s last ability won’t reduce the cost to cast Rakdos itself. It applies only to creature spells you cast once Rakdos is on the battlefield."
+          "text": "Rakdos's last ability won't reduce the cost to cast Rakdos itself. It applies only to creature spells you cast once Rakdos is on the battlefield."
         }
       ],
       "subtypes": [
@@ -22477,7 +22485,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "The target opponent will discard X cards even if some or all of the damage dealt by Rakdos’s Return is prevented or redirected."
+          "text": "The target opponent will discard X cards even if some or all of the damage dealt by Rakdos's Return is prevented or redirected."
         }
       ],
       "text": "Rakdos's Return deals X damage to target opponent. That player discards X cards.",
@@ -23264,7 +23272,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Skull Rend doesn’t require any targets."
+          "text": "Skull Rend doesn't require any targets."
         },
         {
           "date": "2012-10-01",
@@ -23492,7 +23500,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You can leave any cards with that name in the zone they are in. You don’t have to exile them."
+          "text": "You can leave any cards with that name in the zone they are in. You don't have to exile them."
         }
       ],
       "text": "Slaughter Games can't be countered by spells or abilities.\nChoose a nonland card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
@@ -23605,7 +23613,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -23723,7 +23731,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -23731,11 +23739,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -23853,7 +23861,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "If the value chosen for X is larger than the number of cards left in your library, you’ll lose the game the next time state-based actions are performed."
+          "text": "If the value chosen for X is larger than the number of cards left in your library, you'll lose the game the next time state-based actions are performed."
         }
       ],
       "text": "You gain X life and draw X cards.",
@@ -24074,23 +24082,23 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you don’t pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won’t have any targets."
+          "text": "If you don't pay the overload cost of a spell, that spell will have a single target. If you pay the overload cost, the spell won't have any targets."
         },
         {
           "date": "2013-04-15",
-          "text": "Because a spell with overload doesn’t target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
+          "text": "Because a spell with overload doesn't target when its overload cost is paid, it may affect permanents with hexproof or with protection from the appropriate color."
         },
         {
           "date": "2013-04-15",
-          "text": "Note that if the spell with overload is dealing damage, protection from that spell’s color will still prevent that damage."
+          "text": "Note that if the spell with overload is dealing damage, protection from that spell's color will still prevent that damage."
         },
         {
           "date": "2013-04-15",
-          "text": "Overload doesn’t change when you can cast the spell."
+          "text": "Overload doesn't change when you can cast the spell."
         },
         {
           "date": "2013-04-15",
-          "text": "Casting a spell with overload doesn’t change that spell’s mana cost. You just pay the overload cost instead."
+          "text": "Casting a spell with overload doesn't change that spell's mana cost. You just pay the overload cost instead."
         },
         {
           "date": "2013-04-15",
@@ -24098,11 +24106,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "If you are instructed to cast a spell with overload “without paying its mana cost,” you can’t choose to pay its overload cost instead."
+          "text": "If you are instructed to cast a spell with overload \"without paying its mana cost,\" you can't choose to pay its overload cost instead."
         },
         {
           "date": "2017-03-14",
-          "text": "The set of creatures that gets +1/+0 from an overloaded Teleportal is determined as the spell resolves. Creatures you begin to control later in the turn won’t get +1/+0. However, because the second part of Teleportal’s effect doesn’t change the characteristics of any permanents, the set of creatures that can’t be blocked is constantly updated. Any creature you control at the moment blockers are chosen can’t be blocked."
+          "text": "The set of creatures that gets +1/+0 from an overloaded Teleportal is determined as the spell resolves. Creatures you begin to control later in the turn won't get +1/+0. However, because the second part of Teleportal's effect doesn't change the characteristics of any permanents, the set of creatures that can't be blocked is constantly updated. Any creature you control at the moment blockers are chosen can't be blocked."
         }
       ],
       "text": "Target creature you control gets +1/+0 until end of turn and can't be blocked this turn.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
@@ -24542,15 +24550,15 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Trostani’s first ability checks the creature’s toughness as it resolves. If that creature has left the battlefield, use its toughness from when it was last on the battlefield. You can’t lose life this way if that creature’s toughness was less than 0."
+          "text": "Trostani's first ability checks the creature's toughness as it resolves. If that creature has left the battlefield, use its toughness from when it was last on the battlefield. You can't lose life this way if that creature's toughness was less than 0."
         },
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -24558,11 +24566,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -24687,11 +24695,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -24699,11 +24707,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -24830,7 +24838,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Each Assassin token’s triggered ability will trigger whenever it deals combat damage to any player, including you."
+          "text": "Each Assassin token's triggered ability will trigger whenever it deals combat damage to any player, including you."
         }
       ],
       "subtypes": [
@@ -24946,11 +24954,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -24958,11 +24966,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -24970,11 +24978,11 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The ability that defines Wayfaring Temple’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Wayfaring Temple's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2017-03-14",
-          "text": "As long as Wayfaring Temple is on the battlefield, its first ability will count itself, so it’ll be at least 1/1."
+          "text": "As long as Wayfaring Temple is on the battlefield, its first ability will count itself, so it'll be at least 1/1."
         }
       ],
       "subtypes": [
@@ -25091,11 +25099,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You’ll only win the game if Azor’s Elocutors has five or more filibuster counters on it when the first ability resolves. For example, if Azor’s Elocutors has four filibuster counters on it and you somehow add another during your main phase, you won’t win the game immediately."
+          "text": "You'll only win the game if Azor's Elocutors has five or more filibuster counters on it when the first ability resolves. For example, if Azor's Elocutors has four filibuster counters on it and you somehow add another during your main phase, you won't win the game immediately."
         },
         {
           "date": "2012-10-01",
-          "text": "The second ability of Azor’s Elocutors removes one filibuster counter per source, no matter how much damage that source dealt. For example, if two attacking creatures deal damage to you at the same time, two filibuster counters will be removed."
+          "text": "The second ability of Azor's Elocutors removes one filibuster counter per source, no matter how much damage that source dealt. For example, if two attacking creatures deal damage to you at the same time, two filibuster counters will be removed."
         }
       ],
       "subtypes": [
@@ -25222,7 +25230,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If you copy an instant or sorcery spell on the stack (using Nivix Guildmage’s second ability, for example), the copy isn’t cast. Blistercoil Weird’s ability won’t trigger."
+          "text": "If you copy an instant or sorcery spell on the stack (using Nivix Guildmage's second ability, for example), the copy isn't cast. Blistercoil Weird's ability won't trigger."
         }
       ],
       "subtypes": [
@@ -25345,11 +25353,11 @@
         },
         {
           "date": "2012-10-01",
-          "text": "If no opponent has lost life on the turn Cryptborn Horror enters the battlefield, it will enter with no +1/+1 counters on it and be put into its owner’s graveyard (unless something else is raising its toughness)."
+          "text": "If no opponent has lost life on the turn Cryptborn Horror enters the battlefield, it will enter with no +1/+1 counters on it and be put into its owner's graveyard (unless something else is raising its toughness)."
         },
         {
           "date": "2012-10-01",
-          "text": "Cryptborn Horror cares about the total life lost, not necessarily what an opponent’s life total is compared to what it was at the beginning of the turn. For example, if an opponent loses 5 life and then gains 10 life on the turn Cryptborn Horror enters the battlefield, it will enter with five +1/+1 counters on it."
+          "text": "Cryptborn Horror cares about the total life lost, not necessarily what an opponent's life total is compared to what it was at the beginning of the turn. For example, if an opponent loses 5 life and then gains 10 life on the turn Cryptborn Horror enters the battlefield, it will enter with five +1/+1 counters on it."
         },
         {
           "date": "2012-10-01",
@@ -25475,7 +25483,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the target of any of Deathrite Shaman’s three abilities is an illegal target when that ability tries to resolve, it will be countered and none of its effects will happen. You won’t add mana to your mana pool, no opponent will lose life, or you won’t gain life, as appropriate."
+          "text": "If the target of any of Deathrite Shaman's three abilities is an illegal target when that ability tries to resolve, it will be countered and none of its effects will happen. You won't add mana to your mana pool, no opponent will lose life, or you won't gain life, as appropriate."
         }
       ],
       "subtypes": [
@@ -25501,7 +25509,7 @@
         "White",
         "Green"
       ],
-      "flavor": "\"We will defend the Worldsoul from Izzet ‘progress' at any cost.\"",
+      "flavor": "\"We will defend the Worldsoul from Izzet 'progress' at any cost.\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -25595,11 +25603,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "If an instant or sorcery spell destroys Dryad Militant directly (like Murder does), that instant or sorcery card will be put into its owner’s graveyard. However, if an instant or sorcery card deals lethal damage to Dryad Militant, Dryad Militant will remain on the battlefield until the next time state-based actions are checked, which is after the instant or sorcery finishes resolving. The instant or sorcery will be exiled."
+          "text": "If an instant or sorcery spell destroys Dryad Militant directly (like Murder does), that instant or sorcery card will be put into its owner's graveyard. However, if an instant or sorcery card deals lethal damage to Dryad Militant, Dryad Militant will remain on the battlefield until the next time state-based actions are checked, which is after the instant or sorcery finishes resolving. The instant or sorcery will be exiled."
         },
         {
           "date": "2012-10-01",
-          "text": "If an instant or sorcery card is discarded while Dryad Militant is on the battlefield, abilities that function when a card is discarded (such as madness) still work, even though that card never reaches a graveyard. In addition, spells or abilities that check the characteristics of a discarded card (such as Chandra Ablaze’s first ability) can find that card in exile."
+          "text": "If an instant or sorcery card is discarded while Dryad Militant is on the battlefield, abilities that function when a card is discarded (such as madness) still work, even though that card never reaches a graveyard. In addition, spells or abilities that check the characteristics of a discarded card (such as Chandra Ablaze's first ability) can find that card in exile."
         }
       ],
       "subtypes": [
@@ -25939,11 +25947,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -25951,11 +25959,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -26190,11 +26198,11 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Exiling a spell is not the same as countering it, although the spell won’t resolve in both cases. You may exile a spell that can’t be countered."
+          "text": "Exiling a spell is not the same as countering it, although the spell won't resolve in both cases. You may exile a spell that can't be countered."
         },
         {
           "date": "2012-10-01",
-          "text": "You can exile a copy of an instant or sorcery spell to activate Nivmagus Elemental’s ability if you control the copy."
+          "text": "You can exile a copy of an instant or sorcery spell to activate Nivmagus Elemental's ability if you control the copy."
         }
       ],
       "subtypes": [
@@ -26313,7 +26321,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it’s entering the battlefield. At that point, it’s too late for a player to respond to the creature spell by trying to counter it, for example."
+          "text": "You make the choice to have the creature with unleash enter the battlefield with a +1/+1 counter or not as it's entering the battlefield. At that point, it's too late for a player to respond to the creature spell by trying to counter it, for example."
         },
         {
           "date": "2013-04-15",
@@ -26321,11 +26329,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "A creature with unleash can’t block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
+          "text": "A creature with unleash can't block if it has any +1/+1 counter on it, not just one put on it by the unleash ability."
         },
         {
           "date": "2013-04-15",
-          "text": "Putting a +1/+1 counter on a creature with unleash that’s already blocking won’t remove it from combat. It will continue to block."
+          "text": "Putting a +1/+1 counter on a creature with unleash that's already blocking won't remove it from combat. It will continue to block."
         }
       ],
       "subtypes": [
@@ -26556,7 +26564,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it’s too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
+          "text": "Exiling the creature card with scavenge is part of the cost of activating the scavenge ability. Once the ability is activated and the cost is paid, it's too late to stop the ability from being activated by trying to remove the creature card from the graveyard."
         }
       ],
       "subtypes": [
@@ -26675,11 +26683,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers’ Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
+          "text": "You can choose any creature token you control for populate. If a spell or ability puts a token onto the battlefield under your control and then instructs you to populate (as Coursers' Accord does), you may choose to copy the token you just created, or you may choose to copy another creature token you control."
         },
         {
           "date": "2013-04-15",
-          "text": "If you choose to copy a creature token that’s a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
+          "text": "If you choose to copy a creature token that's a copy of another creature, the new creature token will copy the characteristics of whatever the original token is copying."
         },
         {
           "date": "2013-04-15",
@@ -26687,11 +26695,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The new token doesn’t copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
+          "text": "The new token doesn't copy whether the original token is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any noncopy effects that have changed its power, toughness, color, and so on."
         },
         {
           "date": "2013-04-15",
-          "text": "Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the new token will work."
+          "text": "Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the new token will work."
         },
         {
           "date": "2013-04-15",
@@ -26699,7 +26707,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "You must target an artifact or enchantment to cast Sundering Growth. If that artifact or enchantment is an illegal target when Sundering Growth tries to resolve, it will be countered and none of its effects will happen. You won’t populate."
+          "text": "You must target an artifact or enchantment to cast Sundering Growth. If that artifact or enchantment is an illegal target when Sundering Growth tries to resolve, it will be countered and none of its effects will happen. You won't populate."
         }
       ],
       "text": "Destroy target artifact or enchantment, then populate. (Create a token that's a copy of a creature token you control.)",
@@ -26926,7 +26934,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {W} or {U} to your mana pool.\n{W}{U}: Azorius Keyrune becomes a 2/2 white and blue Bird artifact creature with flying until end of turn.",
@@ -27033,7 +27041,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Lands you control won’t lose any other abilities they had. They also won’t gain or lose any land types."
+          "text": "Lands you control won't lose any other abilities they had. They also won't gain or lose any land types."
         }
       ],
       "text": "Lands you control have \"{T}: Add one mana of any color to your mana pool.\"\n{T}: Add one mana of any color to your mana pool.",
@@ -27137,7 +27145,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Civic Saber’s bonus can range from +0/+0 (for a colorless creature) to +5/+0 (for a creature that’s all five colors)."
+          "text": "Civic Saber's bonus can range from +0/+0 (for a colorless creature) to +5/+0 (for a creature that's all five colors)."
         },
         {
           "date": "2012-10-01",
@@ -27247,7 +27255,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "You choose the target of Codex Shredder’s last ability before paying its costs, so you can’t return Codex Shredder to your hand this way."
+          "text": "You choose the target of Codex Shredder's last ability before paying its costs, so you can't return Codex Shredder to your hand this way."
         }
       ],
       "text": "{T}: Target player puts the top card of his or her library into his or her graveyard.\n{5}, {T}, Sacrifice Codex Shredder: Return target card from your graveyard to your hand.",
@@ -27359,7 +27367,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {B} or {G} to your mana pool.\n{B}{G}: Golgari Keyrune becomes a 2/2 black and green Insect artifact creature with deathtouch until end of turn.",
@@ -27475,7 +27483,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {U} or {R} to your mana pool.\n{U}{R}: Until end of turn, Izzet Keyrune becomes a 2/1 blue and red Elemental artifact creature.\nWhenever Izzet Keyrune deals combat damage to a player, you may draw a card. If you do, discard a card.",
@@ -27588,15 +27596,15 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Pithing Needle affects cards regardless of what zone they’re in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can’t cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
+          "text": "Pithing Needle affects cards regardless of what zone they're in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can't cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
         },
         {
           "date": "2005-06-01",
-          "text": "You can name any card, even if that card doesn’t normally have an activated ability. You can’t name a token unless that token has the same name as a card."
+          "text": "You can name any card, even if that card doesn't normally have an activated ability. You can't name a token unless that token has the same name as a card."
         },
         {
           "date": "2005-06-01",
-          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can’t be activated."
+          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -27604,7 +27612,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” Triggered abilities and static abilities of the named card work normally."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" Triggered abilities and static abilities of the named card work normally."
         }
       ],
       "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
@@ -27716,7 +27724,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {B} or {R} to your mana pool.\n{B}{R}: Rakdos Keyrune becomes a 3/1 black and red Devil artifact creature with first strike until end of turn.",
@@ -27829,7 +27837,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Activating the ability that turns the Keyrune into a creature while it’s already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "Activating the ability that turns the Keyrune into a creature while it's already a creature will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         }
       ],
       "text": "{T}: Add {G} or {W} to your mana pool.\n{G}{W}: Selesnya Keyrune becomes a 3/3 green and white Wolf artifact creature until end of turn.",
@@ -27935,7 +27943,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Street Sweeper’s ability is mandatory, but you can choose a land with no Auras attached to it as the target."
+          "text": "Street Sweeper's ability is mandatory, but you can choose a land with no Auras attached to it as the target."
         }
       ],
       "subtypes": [
@@ -28383,15 +28391,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -28622,11 +28630,11 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "To activate Grove of the Guardian’s second ability you can tap any two untapped creatures you control, including ones you haven’t controlled continuously since the beginning of your most recent turn."
+          "text": "To activate Grove of the Guardian's second ability you can tap any two untapped creatures you control, including ones you haven't controlled continuously since the beginning of your most recent turn."
         },
         {
           "date": "2012-10-01",
-          "text": "You can’t tap Grove of the Guardian to activate both abilities at the same time."
+          "text": "You can't tap Grove of the Guardian to activate both abilities at the same time."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{3}{G}{W}, {T}, Tap two untapped creatures you control, Sacrifice Grove of the Guardian: Create an 8/8 green and white Elemental creature token with vigilance.",
@@ -28739,15 +28747,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -28982,15 +28990,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -29218,7 +29226,7 @@
       "rulings": [
         {
           "date": "2012-10-01",
-          "text": "Activating the second ability of Rogue’s Passage after a creature has become blocked won’t cause it to become unblocked."
+          "text": "Activating the second ability of Rogue's Passage after a creature has become blocked won't cause it to become unblocked."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}, {T}: Target creature can't be blocked this turn.",
@@ -29448,15 +29456,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -29573,15 +29581,15 @@
       "rulings": [
         {
           "date": "2005-10-01",
-          "text": "Has basic land types, but isn’t a basic land. Things that affect basic lands don’t affect it. For example, you can’t find it with Civic Wayfinder."
+          "text": "Has basic land types, but isn't a basic land. Things that affect basic lands don't affect it. For example, you can't find it with Civic Wayfinder."
         },
         {
           "date": "2005-10-01",
-          "text": "If another effect (such as Loxodon Gatekeeper’s ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
+          "text": "If another effect (such as Loxodon Gatekeeper's ability) tells you to put lands onto the battlefield tapped, it enters the battlefield tapped whether you pay 2 life or not."
         },
         {
           "date": "2005-10-01",
-          "text": "If multiple permanents with “as enters the battlefield” effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you’re at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
+          "text": "If multiple permanents with \"as enters the battlefield\" effects are entering the battlefield at the same time, process those effects one at a time, then put the permanents onto the battlefield all at once. For example, if you're at 3 life and an effect puts two of these onto the battlefield, you can pay 2 life for only one of them, not both."
         }
       ],
       "subtypes": [
@@ -29750,6 +29758,31 @@
           "multiverseid": 355716
         },
         {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355986
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355987
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355988
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355989
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355990
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Planície",
           "multiverseid": 357082
@@ -29798,31 +29831,6 @@
           "language": "Russian",
           "name": "Равнина",
           "multiverseid": 355442
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365708
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365709
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365710
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365711
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365712
         }
       ],
       "id": "0059a970501efcd76c299fe1451514e1be60ecc4",
@@ -30132,6 +30140,31 @@
           "multiverseid": 355716
         },
         {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355986
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355987
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355988
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355989
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355990
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Planície",
           "multiverseid": 357082
@@ -30180,31 +30213,6 @@
           "language": "Russian",
           "name": "Равнина",
           "multiverseid": 355442
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365708
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365709
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365710
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365711
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365712
         }
       ],
       "id": "1aaa27cfeddbbb0a0bdfdc428814275f92046f93",
@@ -30514,6 +30522,31 @@
           "multiverseid": 355716
         },
         {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355986
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355987
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355988
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355989
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355990
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Planície",
           "multiverseid": 357082
@@ -30562,31 +30595,6 @@
           "language": "Russian",
           "name": "Равнина",
           "multiverseid": 355442
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365708
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365709
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365710
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365711
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365712
         }
       ],
       "id": "59727577bf350de81d06c8a2a2a062b837afef75",
@@ -31278,6 +31286,31 @@
           "multiverseid": 355716
         },
         {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355986
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355987
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355988
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355989
+        },
+        {
+          "language": "German",
+          "name": "Ebene",
+          "multiverseid": 355990
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Planície",
           "multiverseid": 357082
@@ -31326,31 +31359,6 @@
           "language": "Russian",
           "name": "Равнина",
           "multiverseid": 355442
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365708
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365709
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365710
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365711
-        },
-        {
-          "language": "Spanish",
-          "name": "Llanura",
-          "multiverseid": 365712
         }
       ],
       "id": "f0e15190a1d97c7fa1ba3cfa8e9c9ce25376d72e",
@@ -35485,6 +35493,31 @@
           "multiverseid": 355731
         },
         {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356001
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356002
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356003
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356004
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356005
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
           "multiverseid": 357097
@@ -35533,31 +35566,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 355457
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365723
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365724
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365725
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365726
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365727
         }
       ],
       "id": "2ad6caca9b15dd99cfadfb7bb2974f83a3d7aec7",
@@ -36257,6 +36265,31 @@
           "multiverseid": 355731
         },
         {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356001
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356002
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356003
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356004
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356005
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
           "multiverseid": 357097
@@ -36305,31 +36338,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 355457
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365723
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365724
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365725
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365726
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365727
         }
       ],
       "id": "08431a91393ef1f347f32866177addf5233552f1",
@@ -36643,6 +36651,31 @@
           "multiverseid": 355731
         },
         {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356001
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356002
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356003
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356004
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 356005
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
           "multiverseid": 357097
@@ -36691,31 +36724,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 355457
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365723
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365724
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365725
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365726
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 365727
         }
       ],
       "id": "f22fcc8cc6eb73548ea1b2fed6eff10102f9d0b0",
@@ -37415,6 +37423,31 @@
           "multiverseid": 355736
         },
         {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356006
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356007
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356008
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356009
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356010
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Floresta",
           "multiverseid": 357102
@@ -37463,31 +37496,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 355462
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365728
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365729
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365730
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365731
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365732
         }
       ],
       "id": "ffe76a0e5455d10b6afbe28286c0d236be380258",
@@ -38183,6 +38191,31 @@
           "multiverseid": 355736
         },
         {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356006
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356007
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356008
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356009
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356010
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Floresta",
           "multiverseid": 357102
@@ -38231,31 +38264,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 355462
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365728
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365729
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365730
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365731
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365732
         }
       ],
       "id": "95c86c3d44265ab42d17091e7bc466afced3be1e",
@@ -38951,6 +38959,31 @@
           "multiverseid": 355736
         },
         {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356006
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356007
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356008
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356009
+        },
+        {
+          "language": "German",
+          "name": "Wald",
+          "multiverseid": 356010
+        },
+        {
           "language": "Portuguese (Brazil)",
           "name": "Floresta",
           "multiverseid": 357102
@@ -38999,31 +39032,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 355462
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365728
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365729
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365730
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365731
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 365732
         }
       ],
       "id": "21506fe751acfa94ae093498961ead470d53590e",

--- a/json/S00.json
+++ b/json/S00.json
@@ -3930,11 +3930,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -3942,7 +3942,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -4381,7 +4381,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"As it moved, the wurm's spines gathered up bits of flowstone, which took the shapes of dead villagers' heads. Each head spoke a single sound, but if taken together, they said, ‘Alas for the living.'\"\n—Dal myth of the wurm",
+      "flavor": "\"As it moved, the wurm's spines gathered up bits of flowstone, which took the shapes of dead villagers' heads. Each head spoke a single sound, but if taken together, they said, 'Alas for the living.'\"\n—Dal myth of the wurm",
       "id": "37a6349eeefb60ac12edf2f229e12fe8c935694b",
       "imageName": "spined wurm",
       "layout": "normal",

--- a/json/S99.json
+++ b/json/S99.json
@@ -377,7 +377,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Destroy all lands.",
@@ -1158,7 +1159,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the spell fails because the target is not there or isn’t legal, the owner does not gain any life."
+          "text": "If the spell fails because the target is not there or isn't legal, the owner does not gain any life."
         }
       ],
       "text": "Destroy target creature. Its owner gains 4 life.",
@@ -2027,7 +2028,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures and lands are only prevented from untapping during the targeted player’s next untap step. They can still can untap during other player’s untap steps."
+          "text": "The creatures and lands are only prevented from untapping during the targeted player's next untap step. They can still can untap during other player's untap steps."
         },
         {
           "date": "2009-10-01",
@@ -2290,7 +2291,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are no other creatures on the battlefield when Man-o’-War enters the battlefield, its ability must target itself."
+          "text": "If there are no other creatures on the battlefield when Man-o'-War enters the battlefield, its ability must target itself."
         }
       ],
       "subtypes": [
@@ -2583,7 +2584,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says that a player can’t lose life, that player can’t exchange life totals with a player who has a lower life total; in that case, the exchange won’t happen."
+          "text": "If an effect says that a player can't lose life, that player can't exchange life totals with a player who has a lower life total; in that case, the exchange won't happen."
         }
       ],
       "text": "If the difference between your life total and target player's life total is 5 or less, exchange life totals with that player.",
@@ -2745,7 +2746,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "text": "Counter target creature spell.",
@@ -3157,7 +3158,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Target player takes an extra turn after this one.",
@@ -3258,7 +3259,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two creatures may have different owners and return to their respective owner’s hands."
+          "text": "The two creatures may have different owners and return to their respective owner's hands."
         }
       ],
       "text": "Return two target creatures to their owners' hands.",
@@ -4342,6 +4343,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -4384,7 +4389,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -4803,7 +4808,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -6450,7 +6455,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -7324,11 +7329,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -7336,7 +7341,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -7658,7 +7663,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -7680,7 +7685,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"‘Air superiority?' Not while our archers scan the skies.\"\n—Elvish scout",
+      "flavor": "\"'Air superiority?' Not while our archers scan the skies.\"\n—Elvish scout",
       "id": "da135cf86defb29ade2213e6dd7e93b9b0576c9d",
       "imageName": "norwood archers",
       "layout": "normal",
@@ -7820,11 +7825,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -7832,7 +7837,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -8260,11 +8265,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -8272,7 +8277,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -8334,7 +8339,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2006-10-15",
@@ -8606,7 +8611,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [

--- a/json/SCG.json
+++ b/json/SCG.json
@@ -193,15 +193,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -702,7 +702,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two X’s in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
+          "text": "The two X's in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
         },
         {
           "date": "2004-10-04",
@@ -722,7 +722,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
@@ -806,11 +806,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Remember that the returned creature just came under your control, so it can’t attack until you start a turn with it under your control."
+          "text": "Remember that the returned creature just came under your control, so it can't attack until you start a turn with it under your control."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t pick a card that can’t legally be returned to the battlefield. If there are no cards that can be legally returned, then you can’t pick one."
+          "text": "You can't pick a card that can't legally be returned to the battlefield. If there are no cards that can be legally returned, then you can't pick one."
         }
       ],
       "text": "Exile all permanents. For as long as any of those cards remain exiled, at the beginning of each player's upkeep, that player returns one of the exiled cards he or she owns to the battlefield.",
@@ -1052,7 +1052,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Plainscycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Plains card. After you find a Plains card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Plainscycling doesn't allow you to draw a card. Instead, it lets you search your library for a Plains card. After you find a Plains card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -1230,7 +1230,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you control more than one, each time you take damage you can decide which one replaces the damage, and that one replaces all of the damage. You can’t split the damage between them. You decide each time you take damage. Note that damage from multiple sources that happens at one time (such as combat damage) gives one choice, not one per source."
+          "text": "If you control more than one, each time you take damage you can decide which one replaces the damage, and that one replaces all of the damage. You can't split the damage between them. You decide each time you take damage. Note that damage from multiple sources that happens at one time (such as combat damage) gives one choice, not one per source."
         },
         {
           "date": "2004-10-04",
@@ -1319,7 +1319,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creature type is checked for “non-Soldier” at the time the damage would be dealt. If the creature that is dealing the damage is not on the battlefield, use its creature type right before it left the battlefield."
+          "text": "The creature type is checked for \"non-Soldier\" at the time the damage would be dealt. If the creature that is dealing the damage is not on the battlefield, use its creature type right before it left the battlefield."
         }
       ],
       "subtypes": [
@@ -2130,15 +2130,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -2481,15 +2481,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -2751,11 +2751,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Whenever an opponent casts a spell, counter that spell and put a depletion counter on Decree of Silence. If there are three or more depletion counters on Decree of Silence, sacrifice it.\nCycling {4}{U}{U} ({4}{U}{U}, Discard this card: Draw a card.)\nWhen you cycle Decree of Silence, you may counter target spell.",
@@ -2998,7 +2998,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You either tap all of them or untap all of them. You can’t tap some and untap others."
+          "text": "You either tap all of them or untap all of them. You can't tap some and untap others."
         }
       ],
       "text": "Whenever a creature dies, tap all untapped creatures that share a creature type with it or untap all tapped creatures that share a creature type with it.",
@@ -3164,15 +3164,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -3507,15 +3507,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -3771,7 +3771,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t look at the face down cards."
+          "text": "You can't look at the face down cards."
         }
       ],
       "text": "When Parallel Thoughts enters the battlefield, search your library for seven cards, exile them in a face-down pile, and shuffle that pile. Then shuffle your library.\nIf you would draw a card, you may instead put the top card of the pile you exiled into your hand.",
@@ -4420,15 +4420,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "An activated ability has a “Cost: Effect” format. Look for the colon. A triggered ability starts with “when”, “whenever”, or “at”."
+          "text": "An activated ability has a \"Cost: Effect\" format. Look for the colon. A triggered ability starts with \"when\", \"whenever\", or \"at\"."
         },
         {
           "date": "2004-10-04",
-          "text": "Turn-based actions and special actions like the normal card draw, combat damage, or turning a face-down creature face up can’t be targeted."
+          "text": "Turn-based actions and special actions like the normal card draw, combat damage, or turning a face-down creature face up can't be targeted."
         },
         {
           "date": "2004-10-04",
-          "text": "It can target delayed triggered abilities. For example, a card that says “Whenever a player cycles a card, you may exile target creature. If you do, return that creature to the battlefield at the beginning of the end step.” triggers when a player cycles a card and creates a delayed trigger that happens at the beginning of the end step. You can choose to target the “at the beginning of the end step” trigger when it is placed on the stack at end of turn."
+          "text": "It can target delayed triggered abilities. For example, a card that says \"Whenever a player cycles a card, you may exile target creature. If you do, return that creature to the battlefield at the beginning of the end step.\" triggers when a player cycles a card and creates a delayed trigger that happens at the beginning of the end step. You can choose to target the \"at the beginning of the end step\" trigger when it is placed on the stack at end of turn."
         }
       ],
       "text": "Counter target activated or triggered ability. (Mana abilities can't be targeted.)",
@@ -4510,15 +4510,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -4929,11 +4929,11 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If there is at least one creature on the battlefield at the beginning of the end step, the last ability won’t trigger. If it does trigger, but a creature enters the battlefield before it resolves, the ability won’t do anything when it resolves. Call to the Grave’s controller won’t sacrifice it."
+          "text": "If there is at least one creature on the battlefield at the beginning of the end step, the last ability won't trigger. If it does trigger, but a creature enters the battlefield before it resolves, the ability won't do anything when it resolves. Call to the Grave's controller won't sacrifice it."
         },
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, Call to the Grave will trigger twice during each team’s upkeep, once for each player. Each of the two players will sacrifice a non-Zombie creature when the ability referring to that player resolves."
+          "text": "In a Two-Headed Giant game, Call to the Grave will trigger twice during each team's upkeep, once for each player. Each of the two players will sacrifice a non-Zombie creature when the ability referring to that player resolves."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player sacrifices a non-Zombie creature.\nAt the beginning of the end step, if no creatures are on the battlefield, sacrifice Call to the Grave.",
@@ -5431,7 +5431,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way.\nCycling {3}{B}{B} ({3}{B}{B}, Discard this card: Draw a card.)\nWhen you cycle Decree of Pain, all creatures get -2/-2 until end of turn.",
@@ -6075,15 +6075,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -6353,15 +6353,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -6465,7 +6465,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2016-06-08",
@@ -6550,6 +6550,10 @@
         },
         {
           "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -7064,7 +7068,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The targeted creature can’t be regenerated and is exiled if it would die no matter why it would die this turn. It doesn’t have to be destroyed because of the damage Carbonize deals to it."
+          "text": "The targeted creature can't be regenerated and is exiled if it would die no matter why it would die this turn. It doesn't have to be destroyed because of the damage Carbonize deals to it."
         }
       ],
       "text": "Carbonize deals 3 damage to target creature or player. That creature can't be regenerated this turn. If the creature would die this turn, exile it instead.",
@@ -7151,7 +7155,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Mountaincycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Mountaincycling doesn't allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -7257,7 +7261,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Exile all artifacts, creatures, and lands from the battlefield, all cards from all graveyards, and all cards from all hands.\nCycling {5}{R}{R} ({5}{R}{R}, Discard this card: Draw a card.)\nWhen you cycle Decree of Annihilation, destroy all lands.",
@@ -7678,15 +7682,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -7940,11 +7944,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It sets your life total at the beginning of the end step of every player’s turn, not just your own."
+          "text": "It sets your life total at the beginning of the end step of every player's turn, not just your own."
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "At the beginning of your upkeep, Form of the Dragon deals 5 damage to target creature or player.\nAt the beginning of each end step, your life total becomes 5.\nCreatures without flying can't attack you.",
@@ -8687,15 +8691,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -8793,11 +8797,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander’s activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
+          "text": "You can sacrifice any Goblin you control to activate Siege-Gang Commander's activated ability, not just the ones its triggered ability puts onto the battlefield. You can even sacrifice Siege-Gang Commander itself."
         },
         {
           "date": "2016-06-08",
-          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking Goblin during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that Goblin has been dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "subtypes": [
@@ -9441,7 +9445,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -9782,11 +9786,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Put four +1/+1 counters on each creature you control.\nCycling {4}{G}{G} ({4}{G}{G}, Discard this card: Draw a card.)\nWhen you cycle Decree of Savagery, you may put four +1/+1 counters on target creature.",
@@ -10023,7 +10027,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Forestcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Forestcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -10306,15 +10310,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -10878,15 +10882,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -11052,7 +11056,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -11225,7 +11229,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Forestcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Forestcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -11487,7 +11491,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The defending player may cast spells before Xantid Swarm’s triggered ability resolves."
+          "text": "The defending player may cast spells before Xantid Swarm's triggered ability resolves."
         },
         {
           "date": "2016-06-08",

--- a/json/SHM.json
+++ b/json/SHM.json
@@ -240,7 +240,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "This ability counts the number of Plains controlled by Armored Ascension’s controller, not the enchanted creature’s controller (in case they’re different players)."
+          "text": "This ability counts the number of Plains controlled by Armored Ascension's controller, not the enchanted creature's controller (in case they're different players)."
         },
         {
           "date": "2009-10-01",
@@ -463,7 +463,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You put the -1/-1 counter on Barrenton Medic as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the creature to have 0 toughness, it’s put into the graveyard before you can untap it and before you can even pay the cost again."
+          "text": "You put the -1/-1 counter on Barrenton Medic as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the creature to have 0 toughness, it's put into the graveyard before you can untap it and before you can even pay the cost again."
         }
       ],
       "subtypes": [
@@ -573,11 +573,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Boon Reflection doesn’t cause you to gain life. Rather, it causes life-gaining effects to have you gain more life."
+          "text": "Boon Reflection doesn't cause you to gain life. Rather, it causes life-gaining effects to have you gain more life."
         },
         {
           "date": "2008-05-01",
-          "text": "The effects of multiple Boon Reflections are cumulative. For example, if you have three Boon Reflections on the battlefield, you’ll gain eight times the original amount of life."
+          "text": "The effects of multiple Boon Reflections are cumulative. For example, if you have three Boon Reflections on the battlefield, you'll gain eight times the original amount of life."
         },
         {
           "date": "2008-05-01",
@@ -585,7 +585,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "In a Two-Headed Giant game, only Boon Reflection’s controller is affected by it. If that player’s teammate gains life, Boon Reflection will have no effect, even when that life gain is applied to the shared team life total."
+          "text": "In a Two-Headed Giant game, only Boon Reflection's controller is affected by it. If that player's teammate gains life, Boon Reflection will have no effect, even when that life gain is applied to the shared team life total."
         }
       ],
       "text": "If you would gain life, you gain twice that much life instead.",
@@ -795,7 +795,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you have two on the battlefield, they’ll each grant the other one shroud."
+          "text": "If you have two on the battlefield, they'll each grant the other one shroud."
         }
       ],
       "text": "Other enchantments you control have shroud. (A permanent with shroud can't be the target of spells or abilities.)\nEnchanted creatures you control have shroud.",
@@ -1224,7 +1224,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the creature is an illegal target when Last Breath tries to resolve, it will be countered and none of its effects will happen. Its controller won’t gain 4 life."
+          "text": "If the creature is an illegal target when Last Breath tries to resolve, it will be countered and none of its effects will happen. Its controller won't gain 4 life."
         }
       ],
       "text": "Exile target creature with power 2 or less. Its controller gains 4 life.",
@@ -1533,15 +1533,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "While a spell with X in its cost is on the stack, its converted mana cost takes the chosen value of X into account. Mistmeadow Skulk can be chosen as a target for a Blaze (which has mana cost {X}{R}) if X is 0 or 1, for example, but it can’t be chosen as a target for a Blaze if X is 2 or more."
+          "text": "While a spell with X in its cost is on the stack, its converted mana cost takes the chosen value of X into account. Mistmeadow Skulk can be chosen as a target for a Blaze (which has mana cost {X}{R}) if X is 0 or 1, for example, but it can't be chosen as a target for a Blaze if X is 2 or more."
         },
         {
           "date": "2007-05-01",
-          "text": "A face-down creature has a converted mana cost of 0, so Mistmeadow Skulk doesn’t have protection from it ."
+          "text": "A face-down creature has a converted mana cost of 0, so Mistmeadow Skulk doesn't have protection from it ."
         },
         {
           "date": "2008-05-01",
-          "text": "The protection ability means the following: - Mistmeadow Skulk can’t be blocked by creatures with converted mana cost 3 or greater. - Mistmeadow Skulk can’t be enchanted by Auras with converted mana cost 3 or greater. It also can’t be equipped by Equipment with converted mana cost 3 or greater. - Mistmeadow Skulk can’t be targeted by spells with converted mana cost 3 or greater. It also can’t be targeted by abilities from sources with converted mana cost 3 or greater. - All damage that would be dealt to Mistmeadow Skulk by sources with converted mana cost 3 or greater is prevented."
+          "text": "The protection ability means the following: - Mistmeadow Skulk can't be blocked by creatures with converted mana cost 3 or greater. - Mistmeadow Skulk can't be enchanted by Auras with converted mana cost 3 or greater. It also can't be equipped by Equipment with converted mana cost 3 or greater. - Mistmeadow Skulk can't be targeted by spells with converted mana cost 3 or greater. It also can't be targeted by abilities from sources with converted mana cost 3 or greater. - All damage that would be dealt to Mistmeadow Skulk by sources with converted mana cost 3 or greater is prevented."
         }
       ],
       "subtypes": [
@@ -1751,15 +1751,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         }
       ],
       "subtypes": [
@@ -1870,15 +1870,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         }
       ],
       "subtypes": [
@@ -1990,11 +1990,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The last ability works only if Prison Term is already on the battlefield. You may move it from the creature it’s currently enchanting onto the new creature."
+          "text": "The last ability works only if Prison Term is already on the battlefield. You may move it from the creature it's currently enchanting onto the new creature."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -2312,7 +2312,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Runed Halo gives you protection from each object with the chosen name, whether it’s a card, a token, or a copy of a spell. It doesn’t matter what game zone that object is in."
+          "text": "Runed Halo gives you protection from each object with the chosen name, whether it's a card, a token, or a copy of a spell. It doesn't matter what game zone that object is in."
         },
         {
           "date": "2008-05-01",
@@ -2320,23 +2320,23 @@
         },
         {
           "date": "2008-05-01",
-          "text": "You’ll have protection from the name, not from the word. For example, if you choose the name Forest, you’ll have protection from anything named “Forest” — but you won’t have protection from Forests. An animated Sapseep Forest, for example, could deal damage to you even though its subtype is Forest."
+          "text": "You'll have protection from the name, not from the word. For example, if you choose the name Forest, you'll have protection from anything named \"Forest\" — but you won't have protection from Forests. An animated Sapseep Forest, for example, could deal damage to you even though its subtype is Forest."
         },
         {
           "date": "2008-05-01",
-          "text": "You can name either half of a split card, but not both. You’ll have protection from the half you named (and from a fused split spell with that name), but not the other half."
+          "text": "You can name either half of a split card, but not both. You'll have protection from the half you named (and from a fused split spell with that name), but not the other half."
         },
         {
           "date": "2008-05-01",
-          "text": "You can’t choose [nothing] as a name. Face-down creatures have no name, so Runed Halo can’t give you protection from them."
+          "text": "You can't choose [nothing] as a name. Face-down creatures have no name, so Runed Halo can't give you protection from them."
         },
         {
           "date": "2008-05-01",
-          "text": "You must choose the name of a card, not the name of a token. For example, you can’t choose “Saproling” or “Voja.” However, if a token happens to have the same name as a card (such as “Shapeshifter” or “Goldmeadow Harrier”), you can choose it."
+          "text": "You must choose the name of a card, not the name of a token. For example, you can't choose \"Saproling\" or \"Voja.\" However, if a token happens to have the same name as a card (such as \"Shapeshifter\" or \"Goldmeadow Harrier\"), you can choose it."
         },
         {
           "date": "2008-05-01",
-          "text": "You may choose either one of a flip card’s names. You’ll have protection only from the appropriate version. For example, if you choose Nighteyes the Desecrator, you won’t have protection from Nezumi Graverobber."
+          "text": "You may choose either one of a flip card's names. You'll have protection only from the appropriate version. For example, if you choose Nighteyes the Desecrator, you won't have protection from Nezumi Graverobber."
         }
       ],
       "text": "As Runed Halo enters the battlefield, choose a card name.\nYou have protection from the chosen name. (You can't be targeted, dealt damage, or enchanted by anything with that name.)",
@@ -2442,15 +2442,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         }
       ],
       "subtypes": [
@@ -2564,7 +2564,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -2791,23 +2791,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -2917,7 +2917,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "This is a static ability. Your creatures will have lifelink from the moment they’re declared as attackers until the moment the combat phase ends, they’re removed from combat, or Windbrisk Raptor leaves the battlefield, whichever comes first."
+          "text": "This is a static ability. Your creatures will have lifelink from the moment they're declared as attackers until the moment the combat phase ends, they're removed from combat, or Windbrisk Raptor leaves the battlefield, whichever comes first."
         }
       ],
       "subtypes": [
@@ -3129,7 +3129,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -3457,11 +3457,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An effect that changes a permanent’s colors overwrites all its old colors unless it specifically says “in addition to its other colors.” For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn’t matter what colors it used to be (even if, for example, it used to be blue and black)."
+          "text": "An effect that changes a permanent's colors overwrites all its old colors unless it specifically says \"in addition to its other colors.\" For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn't matter what colors it used to be (even if, for example, it used to be blue and black)."
         },
         {
           "date": "2008-05-01",
-          "text": "Changing a permanent’s color won’t change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
+          "text": "Changing a permanent's color won't change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
         },
         {
           "date": "2008-05-01",
@@ -3673,19 +3673,19 @@
         },
         {
           "date": "2008-05-01",
-          "text": "The cards you’re searching for must be found if they’re in the graveyard, because that’s a zone everyone can see. Finding those cards in the hand and library is optional, though."
+          "text": "The cards you're searching for must be found if they're in the graveyard, because that's a zone everyone can see. Finding those cards in the hand and library is optional, though."
         },
         {
           "date": "2008-05-01",
-          "text": "In most cases, Counterbore will exile the targeted spell. Its first sentence counters the spell, which puts it into its owner’s graveyard. Its second sentence then removes it from the graveyard. However, there are some exceptions to this, as listed below."
+          "text": "In most cases, Counterbore will exile the targeted spell. Its first sentence counters the spell, which puts it into its owner's graveyard. Its second sentence then removes it from the graveyard. However, there are some exceptions to this, as listed below."
         },
         {
           "date": "2008-05-01",
-          "text": "If the spell’s controller isn’t the same as its owner (due to Commandeer, for example), it won’t be exiled. The spell is countered and put into its owner’s graveyard. Then the spell’s controller’s graveyard, hand, and library are searched."
+          "text": "If the spell's controller isn't the same as its owner (due to Commandeer, for example), it won't be exiled. The spell is countered and put into its owner's graveyard. Then the spell's controller's graveyard, hand, and library are searched."
         },
         {
           "date": "2008-05-01",
-          "text": "If the targeted spell can’t be countered (it’s Vexing Shusher, for example), that spell will remain on the stack. Counterbore will continue to resolve. You still get to search for and exile all other cards with that name."
+          "text": "If the targeted spell can't be countered (it's Vexing Shusher, for example), that spell will remain on the stack. Counterbore will continue to resolve. You still get to search for and exile all other cards with that name."
         }
       ],
       "text": "Counter target spell. Search its controller's graveyard, hand, and library for all cards with the same name as that spell and exile them. Then that player shuffles his or her library.",
@@ -4413,7 +4413,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "It doesn’t matter which library has twenty or fewer cards in it, and you don’t have to specify a library. If multiple libraries have twenty or fewer cards in them, Isleback Spawn will still get its bonus only once."
+          "text": "It doesn't matter which library has twenty or fewer cards in it, and you don't have to specify a library. If multiple libraries have twenty or fewer cards in them, Isleback Spawn will still get its bonus only once."
         }
       ],
       "subtypes": [
@@ -4523,7 +4523,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You may target a creature that doesn’t have flying."
+          "text": "You may target a creature that doesn't have flying."
         }
       ],
       "subtypes": [
@@ -4634,23 +4634,23 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         },
         {
           "date": "2008-05-01",
-          "text": "The exiled card is played using the normal timing rules for its card type, as well as any other applicable restrictions such as “Cast [this card] only during combat.” For example, you can’t play the card during an opponent’s turn unless it’s an instant or has flash. Similarly, if the exiled card is a land, you can’t play it if you’ve already played a land that turn. If it’s a nonland card, you’ll have to pay its mana cost. The only thing that’s different is you’re playing it from the Exile zone."
+          "text": "The exiled card is played using the normal timing rules for its card type, as well as any other applicable restrictions such as \"Cast [this card] only during combat.\" For example, you can't play the card during an opponent's turn unless it's an instant or has flash. Similarly, if the exiled card is a land, you can't play it if you've already played a land that turn. If it's a nonland card, you'll have to pay its mana cost. The only thing that's different is you're playing it from the Exile zone."
         },
         {
           "date": "2008-05-01",
-          "text": "If you don’t play the exiled card that turn, it remains exiled but you can’t play it."
+          "text": "If you don't play the exiled card that turn, it remains exiled but you can't play it."
         }
       ],
       "subtypes": [
@@ -4761,19 +4761,19 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         },
         {
           "date": "2008-05-01",
-          "text": "Leech Bonder’s activated ability can move any kind of counter, not just a -1/-1 counter. It can target any two creatures, whether they have counters on them or not."
+          "text": "Leech Bonder's activated ability can move any kind of counter, not just a -1/-1 counter. It can target any two creatures, whether they have counters on them or not."
         },
         {
           "date": "2008-05-01",
@@ -4781,7 +4781,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If either one of the target creatures becomes an illegal target (because it left the battlefield or for any other reason), the counter doesn’t move. If both targets become illegal, the ability is countered."
+          "text": "If either one of the target creatures becomes an illegal target (because it left the battlefield or for any other reason), the counter doesn't move. If both targets become illegal, the ability is countered."
         }
       ],
       "subtypes": [
@@ -4892,15 +4892,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         }
       ],
       "subtypes": [
@@ -5117,11 +5117,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An effect that changes a permanent’s colors overwrites all its old colors unless it specifically says “in addition to its other colors.” For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn’t matter what colors it used to be (even if, for example, it used to be blue and black)."
+          "text": "An effect that changes a permanent's colors overwrites all its old colors unless it specifically says \"in addition to its other colors.\" For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn't matter what colors it used to be (even if, for example, it used to be blue and black)."
         },
         {
           "date": "2008-05-01",
-          "text": "Changing a permanent’s color won’t change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
+          "text": "Changing a permanent's color won't change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
         },
         {
           "date": "2008-05-01",
@@ -5129,11 +5129,11 @@
         },
         {
           "date": "2008-05-01",
-          "text": "You can choose any single color or any combination of more than one color. You can’t choose colorless."
+          "text": "You can choose any single color or any combination of more than one color. You can't choose colorless."
         },
         {
           "date": "2008-05-01",
-          "text": "This ability won’t make an artifact stop being an artifact. It’ll just be a colorful artifact."
+          "text": "This ability won't make an artifact stop being an artifact. It'll just be a colorful artifact."
         }
       ],
       "subtypes": [
@@ -5242,15 +5242,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You choose two targets such that as a set, all of the targeting conditions are met. That means, for example, that if you control a nonland permanent whose converted mana cost is lower than any of your opponents’ nonland permanents, you can’t choose it as a target. (If you did, you’d be unable to choose a second target.)"
+          "text": "You choose two targets such that as a set, all of the targeting conditions are met. That means, for example, that if you control a nonland permanent whose converted mana cost is lower than any of your opponents' nonland permanents, you can't choose it as a target. (If you did, you'd be unable to choose a second target.)"
         },
         {
           "date": "2008-05-01",
-          "text": "Even if you don’t plan on exchanging control of any permanents, if you can choose two legal targets when the ability triggers, you must do so. If you can’t, then you don’t choose any targets."
+          "text": "Even if you don't plan on exchanging control of any permanents, if you can choose two legal targets when the ability triggers, you must do so. If you can't, then you don't choose any targets."
         },
         {
           "date": "2008-05-01",
-          "text": "If either one of the targets becomes illegal (because it leaves the battlefield or for any other reason) by the time the ability resolves, the exchange won’t happen. If both targets become illegal, the ability is countered."
+          "text": "If either one of the targets becomes illegal (because it leaves the battlefield or for any other reason) by the time the ability resolves, the exchange won't happen. If both targets become illegal, the ability is countered."
         }
       ],
       "text": "At the beginning of your upkeep, you may exchange control of target nonland permanent you control and target nonland permanent an opponent controls with an equal or lesser converted mana cost.",
@@ -5359,11 +5359,11 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If the targeted spell can’t be countered, that spell will remain on the stack. Put Away will continue to resolve. If you targeted a card in your graveyard, you still get to shuffle it into your library."
+          "text": "If the targeted spell can't be countered, that spell will remain on the stack. Put Away will continue to resolve. If you targeted a card in your graveyard, you still get to shuffle it into your library."
         },
         {
           "date": "2008-05-01",
-          "text": "You must choose all the targets at the time you cast Put Away. You can’t use it to counter your own spell and then shuffle that card into your library because at the time you choose targets, the spell isn’t in your graveyard yet."
+          "text": "You must choose all the targets at the time you cast Put Away. You can't use it to counter your own spell and then shuffle that card into your library because at the time you choose targets, the spell isn't in your graveyard yet."
         }
       ],
       "text": "Counter target spell. You may shuffle up to one target card from your graveyard into your library.",
@@ -5468,23 +5468,23 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "River Kelpie doesn’t give you the ability to cast spells from graveyards. Its second ability merely triggers whenever a spell is cast this way (by using Memory Plunder, for example)."
+          "text": "River Kelpie doesn't give you the ability to cast spells from graveyards. Its second ability merely triggers whenever a spell is cast this way (by using Memory Plunder, for example)."
         },
         {
           "date": "2008-05-01",
-          "text": "If River Kelpie and another permanent are each put onto the battlefield from a graveyard at the same time, River Kelpie’s first ability will trigger twice. (It will see the other permanent entering the battlefield.)"
+          "text": "If River Kelpie and another permanent are each put onto the battlefield from a graveyard at the same time, River Kelpie's first ability will trigger twice. (It will see the other permanent entering the battlefield.)"
         },
         {
           "date": "2008-05-01",
-          "text": "If you cast another artifact, creature, enchantment, or planeswalker spell from a graveyard, only the second ability triggers. That’s because the card is put onto the stack, not onto the battlefield."
+          "text": "If you cast another artifact, creature, enchantment, or planeswalker spell from a graveyard, only the second ability triggers. That's because the card is put onto the stack, not onto the battlefield."
         },
         {
           "date": "2008-05-01",
-          "text": "If you cast River Kelpie itself from your graveyard (by using Yawgmoth’s Will, for example), neither ability triggers. The first ability doesn’t trigger because River Kelpie is put onto the stack; the second ability doesn’t trigger because it works only while River Kelpie is already on the battlefield."
+          "text": "If you cast River Kelpie itself from your graveyard (by using Yawgmoth's Will, for example), neither ability triggers. The first ability doesn't trigger because River Kelpie is put onto the stack; the second ability doesn't trigger because it works only while River Kelpie is already on the battlefield."
         },
         {
           "date": "2008-05-01",
-          "text": "If you play a land card from a graveyard (by using Crucible of Worlds, for example), only the first ability triggers. That’s because the land (which isn’t a spell) is put directly onto the battlefield from the graveyard."
+          "text": "If you play a land card from a graveyard (by using Crucible of Worlds, for example), only the first ability triggers. That's because the land (which isn't a spell) is put directly onto the battlefield from the graveyard."
         },
         {
           "date": "2013-06-07",
@@ -5496,23 +5496,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -5719,7 +5719,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Sinking Feeling grants the untap ability to the creature it’s enchanting. Only the creature’s controller can activate that ability, not Sinking Feeling’s controller."
+          "text": "Sinking Feeling grants the untap ability to the creature it's enchanting. Only the creature's controller can activate that ability, not Sinking Feeling's controller."
         }
       ],
       "subtypes": [
@@ -5927,19 +5927,19 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Thought Reflection doesn’t cause you to draw cards. Rather, it causes card-drawing effects to have you draw more cards. It also causes the draw action during your draw step to have you draw two cards."
+          "text": "Thought Reflection doesn't cause you to draw cards. Rather, it causes card-drawing effects to have you draw more cards. It also causes the draw action during your draw step to have you draw two cards."
         },
         {
           "date": "2008-05-01",
-          "text": "If a spell or ability causes you to draw multiple cards, Thought Reflection’s effect doubles the total number you would draw. For example, if you cast Concentrate (“Draw three cards”), you’ll draw six cards."
+          "text": "If a spell or ability causes you to draw multiple cards, Thought Reflection's effect doubles the total number you would draw. For example, if you cast Concentrate (\"Draw three cards\"), you'll draw six cards."
         },
         {
           "date": "2008-05-01",
-          "text": "The effects of multiple Thought Reflections are cumulative. For example, if you have three Thought Reflections on the battlefield, you’ll draw eight times the original number of cards."
+          "text": "The effects of multiple Thought Reflections are cumulative. For example, if you have three Thought Reflections on the battlefield, you'll draw eight times the original number of cards."
         },
         {
           "date": "2008-05-01",
-          "text": "If two or more replacement effects would apply to a card-drawing event, the player who’s drawing the card chooses what order to apply them."
+          "text": "If two or more replacement effects would apply to a card-drawing event, the player who's drawing the card chooses what order to apply them."
         }
       ],
       "text": "If you would draw a card, draw two cards instead.",
@@ -6148,11 +6148,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An effect that changes a permanent’s colors overwrites all its old colors unless it specifically says “in addition to its other colors.” For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn’t matter what colors it used to be (even if, for example, it used to be blue and black)."
+          "text": "An effect that changes a permanent's colors overwrites all its old colors unless it specifically says \"in addition to its other colors.\" For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn't matter what colors it used to be (even if, for example, it used to be blue and black)."
         },
         {
           "date": "2008-05-01",
-          "text": "Changing a permanent’s color won’t change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
+          "text": "Changing a permanent's color won't change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
         },
         {
           "date": "2008-05-01",
@@ -6368,7 +6368,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -6485,11 +6485,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "When Blowfly Infestation’s ability resolves, it will put a single -1/-1 counter on the targeted creature. It doesn’t matter how many -1/-1 counters were on the creature that went to a graveyard as long as it had at least one on it."
+          "text": "When Blowfly Infestation's ability resolves, it will put a single -1/-1 counter on the targeted creature. It doesn't matter how many -1/-1 counters were on the creature that went to a graveyard as long as it had at least one on it."
         },
         {
           "date": "2008-05-01",
-          "text": "This ability is mandatory. If you’re the only player who controls any creatures when this ability triggers, you must target one of them."
+          "text": "This ability is mandatory. If you're the only player who controls any creatures when this ability triggers, you must target one of them."
         }
       ],
       "text": "Whenever a creature dies, if it had a -1/-1 counter on it, put a -1/-1 counter on target creature.",
@@ -6700,7 +6700,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You put the -1/-1 counter on Cinderhaze Wretch as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the creature to have 0 toughness, it’s put into the graveyard before you can untap it and before you can even pay the cost again."
+          "text": "You put the -1/-1 counter on Cinderhaze Wretch as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the creature to have 0 toughness, it's put into the graveyard before you can untap it and before you can even pay the cost again."
         }
       ],
       "subtypes": [
@@ -6937,7 +6937,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -7367,7 +7367,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Faerie Macabre’s second ability can be activated only while it’s in your hand. You can do this any time you could cast an instant."
+          "text": "Faerie Macabre's second ability can be activated only while it's in your hand. You can do this any time you could cast an instant."
         },
         {
           "date": "2008-05-01",
@@ -7581,11 +7581,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The first ability checks whether you have no cards in hand both when it triggers and when it resolves. If you have any cards in your hand at the beginning of your upkeep, it won’t trigger at all. If you have any cards in your hand when the ability resolves, it does nothing."
+          "text": "The first ability checks whether you have no cards in hand both when it triggers and when it resolves. If you have any cards in your hand at the beginning of your upkeep, it won't trigger at all. If you have any cards in your hand when the ability resolves, it does nothing."
         },
         {
           "date": "2008-05-01",
-          "text": "The second ability behaves the same way, except that it’s checking your opponent instead of you."
+          "text": "The second ability behaves the same way, except that it's checking your opponent instead of you."
         }
       ],
       "subtypes": [
@@ -7696,7 +7696,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If Hollowsage becomes untapped during your untap step, the ability will trigger. However, since no player gets priority during the untap step, it waits to be put on the stack until your upkeep starts. At that time, all your “beginning of upkeep” triggers will also trigger. You can put them and Hollowsage’s trigger on the stack in any order."
+          "text": "If Hollowsage becomes untapped during your untap step, the ability will trigger. However, since no player gets priority during the untap step, it waits to be put on the stack until your upkeep starts. At that time, all your \"beginning of upkeep\" triggers will also trigger. You can put them and Hollowsage's trigger on the stack in any order."
         }
       ],
       "subtypes": [
@@ -7808,7 +7808,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You must target three different creatures. If you can’t, you can’t cast Incremental Blight."
+          "text": "You must target three different creatures. If you can't, you can't cast Incremental Blight."
         }
       ],
       "text": "Put a -1/-1 counter on target creature, two -1/-1 counters on another target creature, and three -1/-1 counters on a third target creature.",
@@ -8122,11 +8122,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to pay life. It doesn’t end the first time a player chooses not to pay life. If a player chooses not to pay life but the process continues, that player may pay life the next time the process gets around to him or her."
+          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to pay life. It doesn't end the first time a player chooses not to pay life. If a player chooses not to pay life but the process continues, that player may pay life the next time the process gets around to him or her."
         },
         {
           "date": "2008-05-01",
-          "text": "The amount of life a player may spend must be equal to or less than that player’s life total; you can’t spend life you haven’t got."
+          "text": "The amount of life a player may spend must be equal to or less than that player's life total; you can't spend life you haven't got."
         },
         {
           "date": "2008-05-01",
@@ -8134,11 +8134,11 @@
         },
         {
           "date": "2008-05-01",
-          "text": "After the process stops, the total amount of life each player paid this way is calculated. That’s how many tokens each player gets. All the tokens enter the battlefield at the same time."
+          "text": "After the process stops, the total amount of life each player paid this way is calculated. That's how many tokens each player gets. All the tokens enter the battlefield at the same time."
         },
         {
           "date": "2008-05-01",
-          "text": "In a Two-Headed Giant game, each player on a team gets a chance to pay life. The team’s life total is adjusted in between."
+          "text": "In a Two-Headed Giant game, each player on a team gets a chance to pay life. The team's life total is adjusted in between."
         }
       ],
       "text": "Starting with you, each player may pay any amount of life. Repeat this process until no one pays life. Each player creates a 1/1 black Rat creature token for each 1 life he or she paid this way.",
@@ -8351,23 +8351,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -9005,23 +9005,23 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "When Wound Reflection’s ability resolves, it checks how much life each opponent lost over the course of the turn, then it causes that opponent to lose that much life. It doesn’t matter how the opponent lost life or who caused it. It also doesn’t matter if Wound Reflection wasn’t on the battlefield at the time some or all of the life was lost."
+          "text": "When Wound Reflection's ability resolves, it checks how much life each opponent lost over the course of the turn, then it causes that opponent to lose that much life. It doesn't matter how the opponent lost life or who caused it. It also doesn't matter if Wound Reflection wasn't on the battlefield at the time some or all of the life was lost."
         },
         {
           "date": "2008-05-01",
-          "text": "Wound Reflection’s ability checks only whether life was lost. It doesn’t care whether life was also gained. For example, if an opponent lost 4 life and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Wound Reflection’s ability will still cause that player to lose 4 life."
+          "text": "Wound Reflection's ability checks only whether life was lost. It doesn't care whether life was also gained. For example, if an opponent lost 4 life and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Wound Reflection's ability will still cause that player to lose 4 life."
         },
         {
           "date": "2008-05-01",
-          "text": "Wound Reflection’s ability triggers at the end of every turn. It doesn’t have to be your turn, and it doesn’t have to be the turn of an opponent that lost life."
+          "text": "Wound Reflection's ability triggers at the end of every turn. It doesn't have to be your turn, and it doesn't have to be the turn of an opponent that lost life."
         },
         {
           "date": "2008-05-01",
-          "text": "If Wound Reflection’s ability resolves, then an opponent loses life later in the same turn, that life loss is never counted by Wound Reflection."
+          "text": "If Wound Reflection's ability resolves, then an opponent loses life later in the same turn, that life loss is never counted by Wound Reflection."
         },
         {
           "date": "2008-05-01",
-          "text": "Multiple Wound Reflections are cumulative. They’ll both trigger at the same time. One will resolve first. When the second one resolves, it will see the same life loss that the first Wound Reflection saw, as well as the life loss caused by the first Wound Reflection. For example, if an opponent lost 3 life during the turn, the first Wound Reflection will cause that opponent to lose 3 more life, then the second Wound Reflection will cause that opponent to lose 6 life."
+          "text": "Multiple Wound Reflections are cumulative. They'll both trigger at the same time. One will resolve first. When the second one resolves, it will see the same life loss that the first Wound Reflection saw, as well as the life loss caused by the first Wound Reflection. For example, if an opponent lost 3 life during the turn, the first Wound Reflection will cause that opponent to lose 3 more life, then the second Wound Reflection will cause that opponent to lose 6 life."
         }
       ],
       "text": "At the beginning of each end step, each opponent loses life equal to the life he or she lost this turn. (Damage causes loss of life.)",
@@ -9644,15 +9644,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You target the player when the ability triggers. You won’t know which card is discarded until the ability resolves."
+          "text": "You target the player when the ability triggers. You won't know which card is discarded until the ability resolves."
         },
         {
           "date": "2008-05-01",
-          "text": "Cragganwick Cremator deals damage equal to the discarded creature’s power as it exists in the graveyard. (This can matter for certain creatures with variable power, such as Maro or Tarmogoyf.)"
+          "text": "Cragganwick Cremator deals damage equal to the discarded creature's power as it exists in the graveyard. (This can matter for certain creatures with variable power, such as Maro or Tarmogoyf.)"
         },
         {
           "date": "2008-05-01",
-          "text": "If you have no cards in hand when Cragganwick Cremator’s ability resolves, you don’t discard anything."
+          "text": "If you have no cards in hand when Cragganwick Cremator's ability resolves, you don't discard anything."
         }
       ],
       "subtypes": [
@@ -9762,11 +9762,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An effect that changes a permanent’s colors overwrites all its old colors unless it specifically says “in addition to its other colors.” For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn’t matter what colors it used to be (even if, for example, it used to be blue and black)."
+          "text": "An effect that changes a permanent's colors overwrites all its old colors unless it specifically says \"in addition to its other colors.\" For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn't matter what colors it used to be (even if, for example, it used to be blue and black)."
         },
         {
           "date": "2008-05-01",
-          "text": "Changing a permanent’s color won’t change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
+          "text": "Changing a permanent's color won't change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
         },
         {
           "date": "2008-05-01",
@@ -9979,7 +9979,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The enchanted creature’s power is checked at the time the ability resolves. If the enchanted creature has left the battlefield by then, its last known information is used."
+          "text": "The enchanted creature's power is checked at the time the ability resolves. If the enchanted creature has left the battlefield by then, its last known information is used."
         },
         {
           "date": "2008-05-01",
@@ -9987,7 +9987,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If the ability is activated after the current turn’s End step has begun, the tokens won’t be exiled until the next turn’s End step."
+          "text": "If the ability is activated after the current turn's End step has begun, the tokens won't be exiled until the next turn's End step."
         }
       ],
       "subtypes": [
@@ -10204,7 +10204,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -10329,23 +10329,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -10777,7 +10777,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The amount of damage is locked in as you cast Jaws of Stone. It won’t change, even if the number of Mountains you control changes."
+          "text": "The amount of damage is locked in as you cast Jaws of Stone. It won't change, even if the number of Mountains you control changes."
         },
         {
           "date": "2008-05-01",
@@ -10891,15 +10891,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You target an opponent when the ability triggers. You don’t decide whether you want to discard and draw until the ability resolves."
+          "text": "You target an opponent when the ability triggers. You don't decide whether you want to discard and draw until the ability resolves."
         },
         {
           "date": "2008-05-01",
-          "text": "This ability counts the total amount of damage (both combat and noncombat) dealt to the targeted opponent by all sources (including ones you controlled and ones you didn’t) over the course of the turn. Damage that was prevented or replaced doesn’t count. Damage that resolved but didn’t cause loss of life (due to Worship, for example) will count."
+          "text": "This ability counts the total amount of damage (both combat and noncombat) dealt to the targeted opponent by all sources (including ones you controlled and ones you didn't) over the course of the turn. Damage that was prevented or replaced doesn't count. Damage that resolved but didn't cause loss of life (due to Worship, for example) will count."
         },
         {
           "date": "2008-05-01",
-          "text": "Knollspine Dragon’s ability checks only whether damage was dealt. It doesn’t care whether the player’s life total also changed for other reasons (such as if the player paid life or gained life). For example, if an opponent was dealt 4 damage and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Knollspine Dragon’s ability will let you discard your hand and draw four cards."
+          "text": "Knollspine Dragon's ability checks only whether damage was dealt. It doesn't care whether the player's life total also changed for other reasons (such as if the player paid life or gained life). For example, if an opponent was dealt 4 damage and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Knollspine Dragon's ability will let you discard your hand and draw four cards."
         }
       ],
       "subtypes": [
@@ -11323,7 +11323,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If you target a creature with 1 toughness, Puncture Bolt deals 1 damage to it, then puts a -1/-1 counter on it, which reduces it to 0 toughness. The creature will be put into its owner’s graveyard as a result of having 0 toughness. Regeneration can’t save it."
+          "text": "If you target a creature with 1 toughness, Puncture Bolt deals 1 damage to it, then puts a -1/-1 counter on it, which reduces it to 0 toughness. The creature will be put into its owner's graveyard as a result of having 0 toughness. Regeneration can't save it."
         }
       ],
       "text": "Puncture Bolt deals 1 damage to target creature. Put a -1/-1 counter on that creature.",
@@ -11536,7 +11536,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If a creature loses double strike after assigning damage in the “first strike” combat damage step (due to Rage Reflection leaving the battlefield, for example), that creature won’t assign damage in the “normal” combat damage step."
+          "text": "If a creature loses double strike after assigning damage in the \"first strike\" combat damage step (due to Rage Reflection leaving the battlefield, for example), that creature won't assign damage in the \"normal\" combat damage step."
         }
       ],
       "text": "Creatures you control have double strike.",
@@ -11959,11 +11959,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You target three permanents as you cast Wild Swing. You don’t randomly choose which one will be destroyed until Wild Swing resolves. If one of those permanents has become an illegal target by then, you randomly choose between the other two. If two of those permanents have become illegal targets by then, there is no random choice — the remaining permanent is destroyed."
+          "text": "You target three permanents as you cast Wild Swing. You don't randomly choose which one will be destroyed until Wild Swing resolves. If one of those permanents has become an illegal target by then, you randomly choose between the other two. If two of those permanents have become illegal targets by then, there is no random choice — the remaining permanent is destroyed."
         },
         {
           "date": "2008-05-01",
-          "text": "As Wild Swing resolves, there is no time to react between the time a permanent is chosen at random and the time it’s destroyed. If you want to put a regeneration shield on one of those permanents, or sacrifice it for some effect, or anything else, you must do so before Wild Swing resolves (and before you know which one of the permanents will be chosen at random)."
+          "text": "As Wild Swing resolves, there is no time to react between the time a permanent is chosen at random and the time it's destroyed. If you want to put a regeneration shield on one of those permanents, or sacrifice it for some effect, or anything else, you must do so before Wild Swing resolves (and before you know which one of the permanents will be chosen at random)."
         },
         {
           "date": "2013-07-01",
@@ -12178,7 +12178,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You put the -1/-1 counter on Devoted Druid as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the creature to have 0 toughness, it’s put into the graveyard before you can untap it and before you can even pay the cost again."
+          "text": "You put the -1/-1 counter on Devoted Druid as a cost. That means it happens when you activate the ability, not when it resolves. If paying the cost causes the creature to have 0 toughness, it's put into the graveyard before you can untap it and before you can even pay the cost again."
         }
       ],
       "subtypes": [
@@ -12606,7 +12606,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "This ability triggers once for each -1/-1 counter. For example, if Leech Bonder (a creature that enters the battlefield with two -1/-1 counters on it) entered the battlefield, Flourishing Defenses’s ability would trigger twice."
+          "text": "This ability triggers once for each -1/-1 counter. For example, if Leech Bonder (a creature that enters the battlefield with two -1/-1 counters on it) entered the battlefield, Flourishing Defenses's ability would trigger twice."
         }
       ],
       "text": "Whenever a -1/-1 counter is put on a creature, you may create a 1/1 green Elf Warrior creature token.",
@@ -13455,7 +13455,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You’re “tapping a permanent for mana” only if you’re activating an activated ability of that permanent that includes the {T} symbol in its cost and produces mana as part of its effect."
+          "text": "You're \"tapping a permanent for mana\" only if you're activating an activated ability of that permanent that includes the {T} symbol in its cost and produces mana as part of its effect."
         },
         {
           "date": "2008-05-01",
@@ -13463,19 +13463,19 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Mana Reflection doesn’t produce any mana itself. Rather, it causes permanents you tap for mana to produce more mana. (This is different than seemingly similar cards like Heartbeat of Spring and Gauntlet of Power.) If the permanent puts any restrictions or riders on the mana it produces, as Pillar of the Paruns and Hall of the Bandit Lord do, that will apply to all the mana it produces this way."
+          "text": "Mana Reflection doesn't produce any mana itself. Rather, it causes permanents you tap for mana to produce more mana. (This is different than seemingly similar cards like Heartbeat of Spring and Gauntlet of Power.) If the permanent puts any restrictions or riders on the mana it produces, as Pillar of the Paruns and Hall of the Bandit Lord do, that will apply to all the mana it produces this way."
         },
         {
           "date": "2008-05-01",
-          "text": "Mana Reflection doesn’t cause permanents you tap for mana to produce one extra mana — rather, it doubles the type and amount of mana that permanent would produce. For example, if you tap Mystic Gate for {W}{U}, it will produce {W}{W}{U}{U} instead."
+          "text": "Mana Reflection doesn't cause permanents you tap for mana to produce one extra mana — rather, it doubles the type and amount of mana that permanent would produce. For example, if you tap Mystic Gate for {W}{U}, it will produce {W}{W}{U}{U} instead."
         },
         {
           "date": "2008-05-01",
-          "text": "The effects of multiple Mana Reflections are cumulative. For example, if you have three Mana Reflections on the battlefield, you’ll get eight times the original amount and type of mana."
+          "text": "The effects of multiple Mana Reflections are cumulative. For example, if you have three Mana Reflections on the battlefield, you'll get eight times the original amount and type of mana."
         },
         {
           "date": "2008-05-01",
-          "text": "If you have Mana Reflection on the battlefield and tap a permanent for mana, but another replacement effect would change the type and/or amount of mana it would produce (such as Contamination, which says “If a land is tapped for mana, it produces {B} instead of any other type and amount”), you decide what order to apply those effects in. In this example, applying Mana Reflection first and Contamination second would result in {B}; applying Contamination first and Mana Reflection second would result in {B}{B}."
+          "text": "If you have Mana Reflection on the battlefield and tap a permanent for mana, but another replacement effect would change the type and/or amount of mana it would produce (such as Contamination, which says \"If a land is tapped for mana, it produces {B} instead of any other type and amount\"), you decide what order to apply those effects in. In this example, applying Mana Reflection first and Contamination second would result in {B}; applying Contamination first and Mana Reflection second would result in {B}{B}."
         }
       ],
       "text": "If you tap a permanent for mana, it produces twice as much of that mana instead.",
@@ -13580,11 +13580,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The first ability essentially means that Mossbridge Troll always has a regeneration shield. It retains that shield even if it’s used."
+          "text": "The first ability essentially means that Mossbridge Troll always has a regeneration shield. It retains that shield even if it's used."
         },
         {
           "date": "2008-05-01",
-          "text": "The total power of the creatures you tap is checked only when you pay the cost. It doesn’t matter if their power decreases, or if any of them have left the battlefield, by the time the ability resolves. Note that you may tap a Mossbridge Troll to help pay the cost of a different Mossbridge Troll’s ability."
+          "text": "The total power of the creatures you tap is checked only when you pay the cost. It doesn't matter if their power decreases, or if any of them have left the battlefield, by the time the ability resolves. Note that you may tap a Mossbridge Troll to help pay the cost of a different Mossbridge Troll's ability."
         }
       ],
       "subtypes": [
@@ -13800,7 +13800,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The creature’s controller, not Presence of Gond’s controller, is the one who can activate the ability, so that’s the player who will get the token."
+          "text": "The creature's controller, not Presence of Gond's controller, is the one who can activate the ability, so that's the player who will get the token."
         }
       ],
       "subtypes": [
@@ -13908,11 +13908,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Each land you control will have the land types Plains, Island, Swamp, Mountain, and Forest. They’ll also have the mana ability of each basic land type (for example, Forests can tap to produce {G}). They’ll still have their other subtypes and abilities."
+          "text": "Each land you control will have the land types Plains, Island, Swamp, Mountain, and Forest. They'll also have the mana ability of each basic land type (for example, Forests can tap to produce {G}). They'll still have their other subtypes and abilities."
         },
         {
           "date": "2008-05-01",
-          "text": "Giving a land extra basic land types doesn’t change its name or whether it’s legendary or basic."
+          "text": "Giving a land extra basic land types doesn't change its name or whether it's legendary or basic."
         }
       ],
       "text": "Lands you control are every basic land type in addition to their other types.",
@@ -14225,19 +14225,19 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "As the token is created, it checks the printed values of the Spawnwrithe it’s copying — or, if the Spawnwrithe whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the Spawnwrithe, nor will it copy other effects that have changed Spawnwrithe’s power, toughness, types, color, or so on. Normally, this means the token will simply be a Spawnwrithe. But if any copy effects have affected that Spawnwrithe, they’re taken into account."
+          "text": "As the token is created, it checks the printed values of the Spawnwrithe it's copying — or, if the Spawnwrithe whose ability triggered was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the Spawnwrithe, nor will it copy other effects that have changed Spawnwrithe's power, toughness, types, color, or so on. Normally, this means the token will simply be a Spawnwrithe. But if any copy effects have affected that Spawnwrithe, they're taken into account."
         },
         {
           "date": "2008-05-01",
-          "text": "If Spawnwrithe’s ability triggers, then Spawnwrithe becomes a copy of another creature before its ability resolves (due to Mirrorweave, perhaps), the token will be a copy of whatever creature the Spawnwrithe is currently a copy of. At the end of the turn, Spawnwrithe will revert back to what it was, but the token will stay as it is."
+          "text": "If Spawnwrithe's ability triggers, then Spawnwrithe becomes a copy of another creature before its ability resolves (due to Mirrorweave, perhaps), the token will be a copy of whatever creature the Spawnwrithe is currently a copy of. At the end of the turn, Spawnwrithe will revert back to what it was, but the token will stay as it is."
         },
         {
           "date": "2008-05-01",
-          "text": "If a copy effect such as Mirrorweave causes some other creature to become a copy of Spawnwrithe, then that creature deals combat damage to a player, the token that’s put onto the battlefield is simply a copy of Spawnwrithe."
+          "text": "If a copy effect such as Mirrorweave causes some other creature to become a copy of Spawnwrithe, then that creature deals combat damage to a player, the token that's put onto the battlefield is simply a copy of Spawnwrithe."
         },
         {
           "date": "2008-05-01",
-          "text": "A token created by a Cemetery Puca that’s copying a Spawnwrithe will be a Spawnwrithe with the Cemetery Puca ability."
+          "text": "A token created by a Cemetery Puca that's copying a Spawnwrithe will be a Spawnwrithe with the Cemetery Puca ability."
         }
       ],
       "subtypes": [
@@ -14444,7 +14444,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -14460,7 +14460,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "When the creature affected by Tower Above attacks, you can target any creature on the battlefield with the triggered ability. However, if the creature you target can’t block the creature affected by Tower Above (for example, because the attacking creature has flying and the other one doesn’t, or because both creatures are controlled by the same player), the triggered ability does nothing. In that case, the creature you targeted is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "When the creature affected by Tower Above attacks, you can target any creature on the battlefield with the triggered ability. However, if the creature you target can't block the creature affected by Tower Above (for example, because the attacking creature has flying and the other one doesn't, or because both creatures are controlled by the same player), the triggered ability does nothing. In that case, the creature you targeted is free to block whichever creature its controller chooses, or block no creatures at all."
         }
       ],
       "text": "({2/G} can be paid with any two mana or with {G}. This card's converted mana cost is 6.)\nUntil end of turn, target creature gets +4/+4 and gains trample, wither, and \"When this creature attacks, target creature blocks it this turn if able.\" (It deals damage to creatures in the form of -1/-1 counters.)",
@@ -14565,11 +14565,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An effect that changes a permanent’s colors overwrites all its old colors unless it specifically says “in addition to its other colors.” For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn’t matter what colors it used to be (even if, for example, it used to be blue and black)."
+          "text": "An effect that changes a permanent's colors overwrites all its old colors unless it specifically says \"in addition to its other colors.\" For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn't matter what colors it used to be (even if, for example, it used to be blue and black)."
         },
         {
           "date": "2008-05-01",
-          "text": "Changing a permanent’s color won’t change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
+          "text": "Changing a permanent's color won't change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
         },
         {
           "date": "2008-05-01",
@@ -14783,11 +14783,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Witherscale Wurm’s second ability triggers when it deals any damage to an opponent, not just combat damage."
+          "text": "Witherscale Wurm's second ability triggers when it deals any damage to an opponent, not just combat damage."
         },
         {
           "date": "2008-05-01",
-          "text": "Witherscale Wurm’s first ability does *not* give Witherscale Wurm wither."
+          "text": "Witherscale Wurm's first ability does *not* give Witherscale Wurm wither."
         }
       ],
       "subtypes": [
@@ -14905,23 +14905,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -15559,7 +15559,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "When Glamer Spinners enters the battlefield, you target only one permanent: the one that will be losing its Auras. You don’t choose the permanent that will be receiving the Auras until the ability resolves."
+          "text": "When Glamer Spinners enters the battlefield, you target only one permanent: the one that will be losing its Auras. You don't choose the permanent that will be receiving the Auras until the ability resolves."
         },
         {
           "date": "2008-05-01",
@@ -15567,7 +15567,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "When the ability resolves, you choose the permanent that will be receiving the Auras. It can’t be the targeted permanent, it must have the same controller as the targeted permanent, and it must be able to be enchanted by all the Auras attached to the targeted permanent. If you can’t choose a permanent that meets all those criteria, the Auras won’t move."
+          "text": "When the ability resolves, you choose the permanent that will be receiving the Auras. It can't be the targeted permanent, it must have the same controller as the targeted permanent, and it must be able to be enchanted by all the Auras attached to the targeted permanent. If you can't choose a permanent that meets all those criteria, the Auras won't move."
         }
       ],
       "subtypes": [
@@ -15680,15 +15680,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "This doesn’t cause creatures to lose their abilities."
+          "text": "This doesn't cause creatures to lose their abilities."
         },
         {
           "date": "2008-05-01",
-          "text": "If two Godheads of Awe are on the battlefield, they’ll each make the other one 1/1."
+          "text": "If two Godheads of Awe are on the battlefield, they'll each make the other one 1/1."
         },
         {
           "date": "2009-10-01",
-          "text": "Godhead of Awe’s ability overwrites other effects that set a creature’s power and toughness to specific values only if those effects existed before the Godhead entered the battlefield. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the Godhead enters the battlefield. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including that of the Godhead."
+          "text": "Godhead of Awe's ability overwrites other effects that set a creature's power and toughness to specific values only if those effects existed before the Godhead entered the battlefield. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the Godhead enters the battlefield. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including that of the Godhead."
         }
       ],
       "subtypes": [
@@ -15801,15 +15801,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Each other creature copies the printed values of the targeted creature, plus any copy effects that have been applied to that creature. They won’t copy other effects that have changed the targeted creature’s power, toughness, types, color, or so on. They also won’t copy counters on the targeted creature (they’ll each just retain the counters they already have)."
+          "text": "Each other creature copies the printed values of the targeted creature, plus any copy effects that have been applied to that creature. They won't copy other effects that have changed the targeted creature's power, toughness, types, color, or so on. They also won't copy counters on the targeted creature (they'll each just retain the counters they already have)."
         },
         {
           "date": "2008-05-01",
-          "text": "If the targeted creature is itself copying a creature, each other creature will become whatever it’s copying, as modified by that copy effect. For example, if you target a Cemetery Puca that’s copying a Grizzly Bears (a 2/2 creature with no abilities), each other creature will become a Grizzly Bears with the Cemetery Puca ability."
+          "text": "If the targeted creature is itself copying a creature, each other creature will become whatever it's copying, as modified by that copy effect. For example, if you target a Cemetery Puca that's copying a Grizzly Bears (a 2/2 creature with no abilities), each other creature will become a Grizzly Bears with the Cemetery Puca ability."
         },
         {
           "date": "2008-05-01",
-          "text": "This effect can cause each other creature to stop being a creature. For example, if you target an animated Mutavault (a land with an activated ability that turns it into a creature), only the printed wording will be copied — the “becomes a creature” effect won’t. Each other creature will become an unanimated Mutavault."
+          "text": "This effect can cause each other creature to stop being a creature. For example, if you target an animated Mutavault (a land with an activated ability that turns it into a creature), only the printed wording will be copied — the \"becomes a creature\" effect won't. Each other creature will become an unanimated Mutavault."
         },
         {
           "date": "2008-05-01",
@@ -15817,11 +15817,11 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If the targeted creature is a token, each other creature copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Those creatures don’t become tokens."
+          "text": "If the targeted creature is a token, each other creature copies the original characteristics of that token as stated by the effect that put it onto the battlefield. Those creatures don't become tokens."
         },
         {
           "date": "2008-05-01",
-          "text": "As the turn ends, the other creatures revert to what they were before. If two Mirrorweaves are cast on the same turn, they’ll both wear off at the same time."
+          "text": "As the turn ends, the other creatures revert to what they were before. If two Mirrorweaves are cast on the same turn, they'll both wear off at the same time."
         }
       ],
       "text": "Each other creature becomes a copy of target nonlegendary creature until end of turn.",
@@ -16148,15 +16148,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         }
       ],
       "subtypes": [
@@ -16267,11 +16267,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You choose whether or not to target a creature spell before you decide whether or not to spend {U} on Repel Intruders. You may target a creature spell and then not spend {U} to cast Repel Intruders; if you do, Repel Intruders simply won’t affect that creature spell. Similarly, if you don’t target a creature spell but then you spend {U} to cast Repel Intruders, that part of Repel Intruders has no effect."
+          "text": "You choose whether or not to target a creature spell before you decide whether or not to spend {U} on Repel Intruders. You may target a creature spell and then not spend {U} to cast Repel Intruders; if you do, Repel Intruders simply won't affect that creature spell. Similarly, if you don't target a creature spell but then you spend {U} to cast Repel Intruders, that part of Repel Intruders has no effect."
         },
         {
           "date": "2008-05-01",
-          "text": "If you choose to target a creature spell, Repel Intruders has a target. If that target becomes illegal by the time Repel Intruders resolves, the entire spell will be countered. You won’t get any tokens."
+          "text": "If you choose to target a creature spell, Repel Intruders has a target. If that target becomes illegal by the time Repel Intruders resolves, the entire spell will be countered. You won't get any tokens."
         },
         {
           "date": "2016-06-08",
@@ -16279,7 +16279,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -16391,15 +16391,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         }
       ],
       "subtypes": [
@@ -16734,19 +16734,19 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If a spell is causing damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Burn Trail says “Burn Trail deals 3 damage to target creature or player.”"
+          "text": "If a spell is causing damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Burn Trail says \"Burn Trail deals 3 damage to target creature or player.\""
         },
         {
           "date": "2008-05-01",
-          "text": "If an ability is causing damage to be dealt, that ability will always identify the source of the damage. The ability itself is never the source. However, the source of the ability is often the source of the damage. For example, Knollspine Invocation’s ability says “Knollspine Invocation deals X damage to target creature or player.”"
+          "text": "If an ability is causing damage to be dealt, that ability will always identify the source of the damage. The ability itself is never the source. However, the source of the ability is often the source of the damage. For example, Knollspine Invocation's ability says \"Knollspine Invocation deals X damage to target creature or player.\""
         },
         {
           "date": "2008-05-01",
-          "text": "If the source of the damage is a permanent, Swans of Bryn Argoll checks who that permanent’s controller is at the time that damage is prevented. If the permanent has left the battlefield by then, its last known information is used. If the source of the damage is a spell, its controller is obvious. If the source of the damage is a card from some other zone (such as a cycled Gempalm Incinerator), Swans of Bryn Argoll checks its owner rather than its controller."
+          "text": "If the source of the damage is a permanent, Swans of Bryn Argoll checks who that permanent's controller is at the time that damage is prevented. If the permanent has left the battlefield by then, its last known information is used. If the source of the damage is a spell, its controller is obvious. If the source of the damage is a card from some other zone (such as a cycled Gempalm Incinerator), Swans of Bryn Argoll checks its owner rather than its controller."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with wither would deal damage to Swans of Bryn Argoll, that damage is treated just like any other damage. It’s prevented, and the creature’s controller draws cards. Swans of Bryn Argoll doesn’t get any -1/-1 counters."
+          "text": "If a creature with wither would deal damage to Swans of Bryn Argoll, that damage is treated just like any other damage. It's prevented, and the creature's controller draws cards. Swans of Bryn Argoll doesn't get any -1/-1 counters."
         }
       ],
       "subtypes": [
@@ -16858,7 +16858,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An object that’s both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
+          "text": "An object that's both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
         }
       ],
       "subtypes": [
@@ -17499,7 +17499,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Cemetery Puca copies the printed values of the creature, plus any copy effects that have been applied to it. It won’t copy other effects that have changed the creature’s power, toughness, types, color, or so on. It also won’t copy counters on the creature (it’ll just retain the counters it already has)."
+          "text": "Cemetery Puca copies the printed values of the creature, plus any copy effects that have been applied to it. It won't copy other effects that have changed the creature's power, toughness, types, color, or so on. It also won't copy counters on the creature (it'll just retain the counters it already has)."
         },
         {
           "date": "2008-05-01",
@@ -17507,11 +17507,11 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Cemetery Puca’s ability isn’t targeted. It can copy a creature with shroud or protection."
+          "text": "Cemetery Puca's ability isn't targeted. It can copy a creature with shroud or protection."
         },
         {
           "date": "2008-05-01",
-          "text": "If multiple creatures are put into their owners’ graveyards at the same time, Cemetery Puca’s ability will trigger once for each of those creatures. You choose the order that those abilities will resolve. It’s possible to pay {1}, have Cemetery Puca become a copy of something, activate an activated ability of that creature, then pay {1} again, for example. It will end up a copy of the last creature card paid for."
+          "text": "If multiple creatures are put into their owners' graveyards at the same time, Cemetery Puca's ability will trigger once for each of those creatures. You choose the order that those abilities will resolve. It's possible to pay {1}, have Cemetery Puca become a copy of something, activate an activated ability of that creature, then pay {1} again, for example. It will end up a copy of the last creature card paid for."
         }
       ],
       "subtypes": [
@@ -17621,7 +17621,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An object that’s both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
+          "text": "An object that's both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
         }
       ],
       "text": "Whenever a blue creature enters the battlefield under your control, you may have target player draw a card.\nWhenever a black creature enters the battlefield under your control, you may have target player discard a card.",
@@ -17837,7 +17837,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If either one of the targets becomes illegal (because it leaves the battlefield or for any other reason) by the time Fate Transfer resolves, the counters don’t move. If both targets become illegal, Fate Transfer is countered."
+          "text": "If either one of the targets becomes illegal (because it leaves the battlefield or for any other reason) by the time Fate Transfer resolves, the counters don't move. If both targets become illegal, Fate Transfer is countered."
         }
       ],
       "text": "Move all counters from target creature onto another target creature.",
@@ -18175,23 +18175,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -18413,11 +18413,11 @@
         },
         {
           "date": "2008-05-01",
-          "text": "With regards to the two triggered abilities that Helm of the Ghastlord grants to the enchanted creature, the point when damage is actually dealt is the only time it matters what color the creature is. If the creature is blue or black at that time, the appropriate ability or abilities will trigger. They’ll resolve even if the creature changes color or loses its Aura."
+          "text": "With regards to the two triggered abilities that Helm of the Ghastlord grants to the enchanted creature, the point when damage is actually dealt is the only time it matters what color the creature is. If the creature is blue or black at that time, the appropriate ability or abilities will trigger. They'll resolve even if the creature changes color or loses its Aura."
         },
         {
           "date": "2008-05-01",
-          "text": "The two abilities trigger when the enchanted creature deals damage to an opponent of the creature’s controller, not when it deals damage to an opponent of the Helm’s controller. They trigger from any damage, not just combat damage."
+          "text": "The two abilities trigger when the enchanted creature deals damage to an opponent of the creature's controller, not when it deals damage to an opponent of the Helm's controller. They trigger from any damage, not just combat damage."
         }
       ],
       "subtypes": [
@@ -18637,15 +18637,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An “unblocked creature” is a creature that attacked and wasn’t blocked. Creatures aren’t “blocked” or “unblocked” until the declare blockers step, so activating this ability before then (or after combat ends) will have no effect."
+          "text": "An \"unblocked creature\" is a creature that attacked and wasn't blocked. Creatures aren't \"blocked\" or \"unblocked\" until the declare blockers step, so activating this ability before then (or after combat ends) will have no effect."
         },
         {
           "date": "2008-05-01",
-          "text": "Creatures stop being unblocked as the combat phase ends. However, they’ll stay 4/1 until turn ends."
+          "text": "Creatures stop being unblocked as the combat phase ends. However, they'll stay 4/1 until turn ends."
         },
         {
           "date": "2008-05-01",
-          "text": "Inkfathom Witch doesn’t cause creatures to lose their abilities."
+          "text": "Inkfathom Witch doesn't cause creatures to lose their abilities."
         },
         {
           "date": "2008-05-01",
@@ -18653,7 +18653,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature’s power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
+          "text": "The effect from the ability overwrites other effects that set power and/or toughness if and only if those effects existed before the ability resolved. It will not overwrite effects that modify power or toughness (whether from a static ability, counters, or a resolved spell or ability), nor will it overwrite effects that set power and toughness which come into existence after the ability resolves. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including this one, regardless of the order in which they are created."
         }
       ],
       "subtypes": [
@@ -18765,15 +18765,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you want to cast the card, you cast it as part of the resolution of Memory Plunder. Timing restrictions based on the card’s type are ignored if it’s a sorcery. Other casting restrictions are not (such as “Cast [this card] only during combat”)."
+          "text": "If you want to cast the card, you cast it as part of the resolution of Memory Plunder. Timing restrictions based on the card's type are ignored if it's a sorcery. Other casting restrictions are not (such as \"Cast [this card] only during combat\")."
         },
         {
           "date": "2008-05-01",
-          "text": "If you are unable to cast the card (there are no legal targets for the spell, for example), nothing happens when Memory Plunder resolves, and the card remains in its owner’s graveyard."
+          "text": "If you are unable to cast the card (there are no legal targets for the spell, for example), nothing happens when Memory Plunder resolves, and the card remains in its owner's graveyard."
         },
         {
           "date": "2008-05-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. On the other hand, if the card has additional costs (such as conspire), you may pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. On the other hand, if the card has additional costs (such as conspire), you may pay those."
         }
       ],
       "text": "You may cast target instant or sorcery card from an opponent's graveyard without paying its mana cost.",
@@ -18981,15 +18981,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         }
       ],
       "subtypes": [
@@ -19103,7 +19103,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You target the opponent when you activate Oona’s ability. You don’t choose the color until the ability resolves."
+          "text": "You target the opponent when you activate Oona's ability. You don't choose the color until the ability resolves."
         },
         {
           "date": "2008-05-01",
@@ -19332,7 +19332,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -19443,7 +19443,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you don’t control any creatures, you can’t cast Scarscale Ritual."
+          "text": "If you don't control any creatures, you can't cast Scarscale Ritual."
         }
       ],
       "text": "As an additional cost to cast Scarscale Ritual, put a -1/-1 counter on a creature you control.\nDraw two cards.",
@@ -19551,27 +19551,27 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "As the end step begins, Sygg’s ability checks whether a player who is currently your opponent, or a player who was your opponent at the time he or she left the game, has lost 3 or more life over the course of the turn. If so, the ability will trigger. If not, it won’t."
+          "text": "As the end step begins, Sygg's ability checks whether a player who is currently your opponent, or a player who was your opponent at the time he or she left the game, has lost 3 or more life over the course of the turn. If so, the ability will trigger. If not, it won't."
         },
         {
           "date": "2008-05-01",
-          "text": "It doesn’t matter how the opponent lost life or who caused it, as long as the total loss of life is 3 or more."
+          "text": "It doesn't matter how the opponent lost life or who caused it, as long as the total loss of life is 3 or more."
         },
         {
           "date": "2008-05-01",
-          "text": "Sygg’s ability checks only whether life was lost. It doesn’t care whether life was also gained. For example, if an opponent lost 4 life and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Sygg’s ability will trigger anyway."
+          "text": "Sygg's ability checks only whether life was lost. It doesn't care whether life was also gained. For example, if an opponent lost 4 life and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Sygg's ability will trigger anyway."
         },
         {
           "date": "2008-05-01",
-          "text": "You don’t specify an opponent when the ability triggers. If multiple opponents have lost 3 or more life over the course of the turn, the ability will trigger only once."
+          "text": "You don't specify an opponent when the ability triggers. If multiple opponents have lost 3 or more life over the course of the turn, the ability will trigger only once."
         },
         {
           "date": "2008-05-01",
-          "text": "Sygg’s ability will trigger even if Sygg wasn’t on the battlefield at the time some or all of the life was lost."
+          "text": "Sygg's ability will trigger even if Sygg wasn't on the battlefield at the time some or all of the life was lost."
         },
         {
           "date": "2008-05-01",
-          "text": "Sygg’s ability checks to see if it triggers at the end of every turn. It doesn’t have to be your turn, and it doesn’t have to be the turn of the opponent that lost life."
+          "text": "Sygg's ability checks to see if it triggers at the end of every turn. It doesn't have to be your turn, and it doesn't have to be the turn of the opponent that lost life."
         }
       ],
       "subtypes": [
@@ -20341,7 +20341,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "This ability triggers when you cast Demigod of Revenge as a spell. It won’t trigger if Demigod of Revenge is put directly onto the battlefield."
+          "text": "This ability triggers when you cast Demigod of Revenge as a spell. It won't trigger if Demigod of Revenge is put directly onto the battlefield."
         },
         {
           "date": "2008-05-01",
@@ -20349,7 +20349,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If Demigod of Revenge is countered *before* its triggered ability resolves, the ability will still resolve. It will return that Demigod of Revenge from your graveyard to the battlefield, as well as any others. If you’re casting a spell to counter Demigod of Revenge, it’s important to clarify you’re casting it *after* the triggered ability resolves if you don’t want that Demigod of Revenge to be put onto the battlefield."
+          "text": "If Demigod of Revenge is countered *before* its triggered ability resolves, the ability will still resolve. It will return that Demigod of Revenge from your graveyard to the battlefield, as well as any others. If you're casting a spell to counter Demigod of Revenge, it's important to clarify you're casting it *after* the triggered ability resolves if you don't want that Demigod of Revenge to be put onto the battlefield."
         }
       ],
       "subtypes": [
@@ -20461,11 +20461,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The parts of the spell happen in order. When determining how many black creatures and how many red creatures you control, keep in mind that you just put a creature onto the battlefield that’s black and red."
+          "text": "The parts of the spell happen in order. When determining how many black creatures and how many red creatures you control, keep in mind that you just put a creature onto the battlefield that's black and red."
         },
         {
           "date": "2008-05-01",
-          "text": "If the targeted opponent becomes an illegal target, the entire spell is countered. You won’t get a token."
+          "text": "If the targeted opponent becomes an illegal target, the entire spell is countered. You won't get a token."
         }
       ],
       "text": "Create a 5/5 black and red Elemental creature token. Target opponent sacrifices a creature for each black creature you control, then sacrifices a land for each red creature you control.",
@@ -20572,7 +20572,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An object that’s both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
+          "text": "An object that's both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
         }
       ],
       "subtypes": [
@@ -20690,31 +20690,31 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If a cost includes life gain (like Invigorate’s alternative cost does), that cost can’t be paid."
+          "text": "If a cost includes life gain (like Invigorate's alternative cost does), that cost can't be paid."
         },
         {
           "date": "2008-05-01",
-          "text": "Effects that would replace gaining life with some other effect won’t be able to do anything because it’s impossible for players to gain life."
+          "text": "Effects that would replace gaining life with some other effect won't be able to do anything because it's impossible for players to gain life."
         },
         {
           "date": "2008-05-01",
-          "text": "Effects that replace an event with gaining life (like Words of Worship’s effect does) will end up replacing the event with nothing."
+          "text": "Effects that replace an event with gaining life (like Words of Worship's effect does) will end up replacing the event with nothing."
         },
         {
           "date": "2008-05-01",
-          "text": "If an effect says to set your life total to a certain number, and that number is higher than your current life total, that effect will normally cause you to gain life equal to the difference. With Everlasting Torment on the battlefield, that part of the effect won’t do anything. (If the number is lower than your current life total, the effect will work as normal.)"
+          "text": "If an effect says to set your life total to a certain number, and that number is higher than your current life total, that effect will normally cause you to gain life equal to the difference. With Everlasting Torment on the battlefield, that part of the effect won't do anything. (If the number is lower than your current life total, the effect will work as normal.)"
         },
         {
           "date": "2008-05-01",
-          "text": "The “damage can’t be prevented” statement overrides all forms of preventing damage, including protection abilities. Damage prevention spells and abilities can still be cast and played; they just don’t do anything."
+          "text": "The \"damage can't be prevented\" statement overrides all forms of preventing damage, including protection abilities. Damage prevention spells and abilities can still be cast and played; they just don't do anything."
         },
         {
           "date": "2008-05-01",
-          "text": "Spells and abilities that replace or redirect damage aren’t affected by Everlasting Torment’s second ability. They’ll work as normal."
+          "text": "Spells and abilities that replace or redirect damage aren't affected by Everlasting Torment's second ability. They'll work as normal."
         },
         {
           "date": "2008-05-01",
-          "text": "The last ability affects all damage, whether it’s dealt by creatures, other permanents, spells, or cards that aren’t on the battlefield. Wither works everywhere."
+          "text": "The last ability affects all damage, whether it's dealt by creatures, other permanents, spells, or cards that aren't on the battlefield. Wither works everywhere."
         }
       ],
       "text": "Players can't gain life.\nDamage can't be prevented.\nAll damage is dealt as though its source had wither. (A source with wither deals damage to creatures in the form of -1/-1 counters.)",
@@ -21038,7 +21038,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The triggered ability is mandatory. If you’re the only player who controls any creatures when it triggers, you must target one of them."
+          "text": "The triggered ability is mandatory. If you're the only player who controls any creatures when it triggers, you must target one of them."
         }
       ],
       "subtypes": [
@@ -21150,7 +21150,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "This checks your opponents’ creatures for any kind of counters, not just -1/-1 counters."
+          "text": "This checks your opponents' creatures for any kind of counters, not just -1/-1 counters."
         }
       ],
       "subtypes": [
@@ -21371,7 +21371,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Murderous Redcap’s power is checked at the time the ability resolves. If it’s left the battlefield by then, its last known information is used."
+          "text": "Murderous Redcap's power is checked at the time the ability resolves. If it's left the battlefield by then, its last known information is used."
         },
         {
           "date": "2013-06-07",
@@ -21383,23 +21383,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -22035,7 +22035,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Spiteful Visions’s second ability triggers any time any player draws a card, not just when a player draws a card as a result of its first ability."
+          "text": "Spiteful Visions's second ability triggers any time any player draws a card, not just when a player draws a card as a result of its first ability."
         },
         {
           "date": "2013-04-15",
@@ -22153,7 +22153,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -22263,7 +22263,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you use conspire to copy Traitor’s Roar, but you don’t change its target, the copy will resolve just fine but the original will be countered on resolution. That’s because the copy will resolve first, and as part of its resolution, it will tap the targeted creature. Then, when the original Traitor’s Roar tries to resolve, it will have an illegal target (since it must target an untapped creature)."
+          "text": "If you use conspire to copy Traitor's Roar, but you don't change its target, the copy will resolve just fine but the original will be countered on resolution. That's because the copy will resolve first, and as part of its resolution, it will tap the targeted creature. Then, when the original Traitor's Roar tries to resolve, it will have an illegal target (since it must target an untapped creature)."
         }
       ],
       "text": "Tap target untapped creature. It deals damage equal to its power to its controller.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
@@ -22695,7 +22695,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "This ability will trigger when Deus of Calamity deals 6 damage to an opponent at one time. It won’t keep track of the accumulated damage that it deals at different times."
+          "text": "This ability will trigger when Deus of Calamity deals 6 damage to an opponent at one time. It won't keep track of the accumulated damage that it deals at different times."
         },
         {
           "date": "2008-05-01",
@@ -22816,7 +22816,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -22927,7 +22927,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "The easiest way to choose a card at random from your graveyard is to turn your graveyard face down, shuffle it, and pick a card. You’re not normally allowed to reorder your graveyard, but since this card lets you do it anyway, it’s okay to mix the cards up while you’re picking randomly."
+          "text": "The easiest way to choose a card at random from your graveyard is to turn your graveyard face down, shuffle it, and pick a card. You're not normally allowed to reorder your graveyard, but since this card lets you do it anyway, it's okay to mix the cards up while you're picking randomly."
         },
         {
           "date": "2008-05-01",
@@ -22935,7 +22935,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Except for the card that you return to your hand, reordering your graveyard won’t affect anything that’s currently targeting or enchanting a card in your graveyard. Whatever it is will be able to track the card it’s targeting or enchanting as your graveyard is reordered."
+          "text": "Except for the card that you return to your hand, reordering your graveyard won't affect anything that's currently targeting or enchanting a card in your graveyard. Whatever it is will be able to track the card it's targeting or enchanting as your graveyard is reordered."
         },
         {
           "date": "2008-05-01",
@@ -23046,7 +23046,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The delayed triggered ability that exiles the token isn’t a characteristic of the token. If an effect such as populate copies the token, the new token won’t be exiled."
+          "text": "The delayed triggered ability that exiles the token isn't a characteristic of the token. If an effect such as populate copies the token, the new token won't be exiled."
         }
       ],
       "text": "Create a 4/4 red and green Giant Warrior creature token with haste. Exile it at the beginning of the next end step.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)",
@@ -23255,11 +23255,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you put a creature onto the battlefield and a different player takes control of it before the end of the turn, you can’t sacrifice it at end of turn. It will remain on the battlefield. It will have haste as long as it’s on the battlefield."
+          "text": "If you put a creature onto the battlefield and a different player takes control of it before the end of the turn, you can't sacrifice it at end of turn. It will remain on the battlefield. It will have haste as long as it's on the battlefield."
         },
         {
           "date": "2008-05-01",
-          "text": "If the ability is activated after the current turn’s End step has begun, the creature won’t be sacrificed until the next turn’s End step."
+          "text": "If the ability is activated after the current turn's End step has begun, the creature won't be sacrificed until the next turn's End step."
         }
       ],
       "text": "{2}{R/G}: Reveal the top card of your library. If it isn't a creature card, put it into your graveyard. Otherwise, put that card onto the battlefield. That creature gains haste. Sacrifice it at the beginning of the next end step.",
@@ -23787,19 +23787,19 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "A “cost that contains {X}” may be a spell’s total cost, an activated ability’s cost, a suspend cost, or a cost you’re asked to pay as part of the resolution of a spell or ability (such as Broken Ambitions). A spell’s total cost includes either its mana cost (printed in the upper right corner) or its alternative cost (such as suspend), as well as any additional costs (such as kicker). Basically, if it’s something you can spend mana on, it’s a cost. If that cost includes the {X} mana symbol in it, you can spend mana generated by Rosheen on that cost."
+          "text": "A \"cost that contains {X}\" may be a spell's total cost, an activated ability's cost, a suspend cost, or a cost you're asked to pay as part of the resolution of a spell or ability (such as Broken Ambitions). A spell's total cost includes either its mana cost (printed in the upper right corner) or its alternative cost (such as suspend), as well as any additional costs (such as kicker). Basically, if it's something you can spend mana on, it's a cost. If that cost includes the {X} mana symbol in it, you can spend mana generated by Rosheen on that cost."
         },
         {
           "date": "2008-05-01",
-          "text": "You can spend mana generated by Rosheen on any part of a cost that contains {X}. You’re not limited to spending it only on the {X} part."
+          "text": "You can spend mana generated by Rosheen on any part of a cost that contains {X}. You're not limited to spending it only on the {X} part."
         },
         {
           "date": "2008-05-01",
-          "text": "You can spend mana generated by Rosheen on a cost that includes {X} even if you’ve chosen an X of 0, or the card specifies that you can spend only colored mana on X. (You’ll have to spend Rosheen’s mana on a different part of that cost, of course.)"
+          "text": "You can spend mana generated by Rosheen on a cost that includes {X} even if you've chosen an X of 0, or the card specifies that you can spend only colored mana on X. (You'll have to spend Rosheen's mana on a different part of that cost, of course.)"
         },
         {
           "date": "2008-05-01",
-          "text": "You don’t have to spend all four mana on the same cost."
+          "text": "You don't have to spend all four mana on the same cost."
         }
       ],
       "subtypes": [
@@ -24031,23 +24031,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -24266,7 +24266,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An object that’s both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
+          "text": "An object that's both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
         }
       ],
       "subtypes": [
@@ -24595,7 +24595,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The second ability is a mana ability. It doesn’t target a player and it doesn’t use the stack. If the player who adds {G}{G}{G} to his or her mana pool can’t spend all of it before the phase ends, the remaining mana will leave his or her mana pool at the end of the current step (or phase)."
+          "text": "The second ability is a mana ability. It doesn't target a player and it doesn't use the stack. If the player who adds {G}{G}{G} to his or her mana pool can't spend all of it before the phase ends, the remaining mana will leave his or her mana pool at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -24709,11 +24709,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "After Vexing Shusher’s ability resolves, any spells or abilities that would counter the targeted spell will still resolve. They just won’t counter that spell."
+          "text": "After Vexing Shusher's ability resolves, any spells or abilities that would counter the targeted spell will still resolve. They just won't counter that spell."
         },
         {
           "date": "2008-05-01",
-          "text": "Vexing Shusher’s ability won’t prevent the targeted spell from being countered by the game rules (for example, if all its targets are illegal)."
+          "text": "Vexing Shusher's ability won't prevent the targeted spell from being countered by the game rules (for example, if all its targets are illegal)."
         }
       ],
       "subtypes": [
@@ -24826,27 +24826,27 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If a spell gains a second instance of conspire from Wort’s ability, you may choose to pay for one, both, or none of those abilities. Each conspire ability triggers only if you tap two creatures specifically for that ability."
+          "text": "If a spell gains a second instance of conspire from Wort's ability, you may choose to pay for one, both, or none of those abilities. Each conspire ability triggers only if you tap two creatures specifically for that ability."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. A different mode can’t be chosen."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. A different mode can't be chosen."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Bonfire of the Damned does), the copy will have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Bonfire of the Damned does), the copy will have the same value of X."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell has damage divided as it was cast (like Fiery Justice does), the division can’t be changed (although the targets receiving that damage still can)."
+          "text": "If the spell has damage divided as it was cast (like Fiery Justice does), the division can't be changed (although the targets receiving that damage still can)."
         },
         {
           "date": "2017-03-14",
-          "text": "Some spells instruct you to sacrifice a creature as an additional cost to cast that spell. If you sacrifice Wort to pay that cost, that spell won’t have conspire at the moment it becomes cast, so conspire won’t trigger, even if you tapped two creatures."
+          "text": "Some spells instruct you to sacrifice a creature as an additional cost to cast that spell. If you sacrifice Wort to pay that cost, that spell won't have conspire at the moment it becomes cast, so conspire won't trigger, even if you tapped two creatures."
         },
         {
           "date": "2017-03-14",
-          "text": "If you’re casting a spell for its flashback cost, you can’t pay another alternative cost (such as an overload cost or a Trap’s alternative cost) instead. You may pay additional costs, such as conspire."
+          "text": "If you're casting a spell for its flashback cost, you can't pay another alternative cost (such as an overload cost or a Trap's alternative cost) instead. You may pay additional costs, such as conspire."
         }
       ],
       "subtypes": [
@@ -25061,11 +25061,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you spent both {G} and {W} to cast Dawnglow Infusion, you’ll gain (X + X) life. An ability that triggers whenever you gain life will trigger just once."
+          "text": "If you spent both {G} and {W} to cast Dawnglow Infusion, you'll gain (X + X) life. An ability that triggers whenever you gain life will trigger just once."
         },
         {
           "date": "2008-05-01",
-          "text": "Whether you choose to spend both {G} and {W} to cast Dawnglow Infusion has no bearing on the value of X. For example, say you decide that X is 4 and you’ll spend {G} on {G/W}. If you end up spending {W}{W}{R}{R}{G} to pay the cost, X is still 4 and you’ve spent both {G} and {W}. You’ll gain a total of 8 life."
+          "text": "Whether you choose to spend both {G} and {W} to cast Dawnglow Infusion has no bearing on the value of X. For example, say you decide that X is 4 and you'll spend {G} on {G/W}. If you end up spending {W}{W}{R}{R}{G} to pay the cost, X is still 4 and you've spent both {G} and {W}. You'll gain a total of 8 life."
         },
         {
           "date": "2016-06-08",
@@ -25073,7 +25073,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -25292,7 +25292,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If an artifact or enchantment remains on the battlefield because it was regenerated or has indestructible, you won’t gain life for it."
+          "text": "If an artifact or enchantment remains on the battlefield because it was regenerated or has indestructible, you won't gain life for it."
         }
       ],
       "text": "Destroy all artifacts and enchantments. You gain 2 life for each permanent destroyed this way.",
@@ -25407,23 +25407,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -25545,23 +25545,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -25677,7 +25677,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "You may target a permanent that doesn’t have a counter on it."
+          "text": "You may target a permanent that doesn't have a counter on it."
         }
       ],
       "subtypes": [
@@ -26326,7 +26326,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Regenerating a planeswalker will prevent it from being destroyed as a result of a “destroy” effect (like the one from Reaper King). However, it won’t prevent that planeswalker from being put into its owner’s graveyard when its loyalty becomes 0."
+          "text": "Regenerating a planeswalker will prevent it from being destroyed as a result of a \"destroy\" effect (like the one from Reaper King). However, it won't prevent that planeswalker from being put into its owner's graveyard when its loyalty becomes 0."
         }
       ],
       "text": "Regenerate target permanent.",
@@ -26543,7 +26543,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An object that’s both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
+          "text": "An object that's both of the listed colors will cause both abilities to trigger. You can put them on the stack in either order."
         }
       ],
       "subtypes": [
@@ -26665,23 +26665,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -27004,11 +27004,11 @@
         },
         {
           "date": "2008-05-01",
-          "text": "If an effect would simultaneously destroy Shield of the Oversoul and a green creature it’s enchanting, only the Shield is destroyed."
+          "text": "If an effect would simultaneously destroy Shield of the Oversoul and a green creature it's enchanting, only the Shield is destroyed."
         },
         {
           "date": "2013-07-01",
-          "text": "If a green creature enchanted by Shield of the Oversoul is dealt lethal damage, the creature isn’t destroyed, but the damage remains on the creature. If Shield of the Oversoul stops enchanting that creature later in the turn, the creature will lose indestructible and will be destroyed."
+          "text": "If a green creature enchanted by Shield of the Oversoul is dealt lethal damage, the creature isn't destroyed, but the damage remains on the creature. If Shield of the Oversoul stops enchanting that creature later in the turn, the creature will lose indestructible and will be destroyed."
         }
       ],
       "subtypes": [
@@ -27118,15 +27118,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Wheel of Sun and Moon’s replacement effect will apply to cards that would be put into the enchanted player’s graveyard from any game zone. This includes from the battlefield (if a nontoken permanent is destroyed or would otherwise be put into the graveyard), from the stack (if a spell is countered, or if an instant or sorcery spell resolves), from the player’s hand or library, and so on."
+          "text": "Wheel of Sun and Moon's replacement effect will apply to cards that would be put into the enchanted player's graveyard from any game zone. This includes from the battlefield (if a nontoken permanent is destroyed or would otherwise be put into the graveyard), from the stack (if a spell is countered, or if an instant or sorcery spell resolves), from the player's hand or library, and so on."
         },
         {
           "date": "2008-05-01",
-          "text": "Wheel of Sun and Moon won’t affect tokens that are put into the graveyard from the battlefield or copies of spells that resolve or are countered. They’re not cards, so they’ll go to the graveyard as normal, then cease to exist."
+          "text": "Wheel of Sun and Moon won't affect tokens that are put into the graveyard from the battlefield or copies of spells that resolve or are countered. They're not cards, so they'll go to the graveyard as normal, then cease to exist."
         },
         {
           "date": "2008-05-01",
-          "text": "If multiple cards would be put into the enchanted player’s graveyard at the same time (due to Millstone, for example), they are instead all revealed and put on the bottom of the enchanted player’s library at the same time. That player chooses what order to put them in. The order is not revealed to the other players."
+          "text": "If multiple cards would be put into the enchanted player's graveyard at the same time (due to Millstone, for example), they are instead all revealed and put on the bottom of the enchanted player's library at the same time. That player chooses what order to put them in. The order is not revealed to the other players."
         }
       ],
       "subtypes": [
@@ -27644,7 +27644,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If a nontoken creature that gains persist this way is put into a graveyard, that card will be returned to the battlefield with a -1/-1 counter on it. However, because it’s a new object with no relation to its previous existence, the returned creature will not have persist."
+          "text": "If a nontoken creature that gains persist this way is put into a graveyard, that card will be returned to the battlefield with a -1/-1 counter on it. However, because it's a new object with no relation to its previous existence, the returned creature will not have persist."
         },
         {
           "date": "2013-06-07",
@@ -27656,23 +27656,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "text": "{T}: Choose any number of target creatures. Each of those creatures gains persist until end of turn. (When it dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
@@ -27874,7 +27874,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Changing a land’s type doesn’t change its name or whether it’s legendary or basic."
+          "text": "Changing a land's type doesn't change its name or whether it's legendary or basic."
         },
         {
           "date": "2008-05-01",
@@ -28278,7 +28278,7 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Colorless is not a color. You can’t reveal two colorless cards from your hand to activate this ability because those cards don’t share a color with one another."
+          "text": "Colorless is not a color. You can't reveal two colorless cards from your hand to activate this ability because those cards don't share a color with one another."
         }
       ],
       "text": "{1}, {T}, Reveal two cards from your hand that share a color: Draw a card.",
@@ -28482,7 +28482,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you control a Lurebound Scarecrow but no color was chosen for it (perhaps because your Cemetery Puca turned into a Lurebound Scarecrow), the trigger condition will have an undefined value in it. It’ll never trigger, so you won’t have to sacrifice the Scarecrow."
+          "text": "If you control a Lurebound Scarecrow but no color was chosen for it (perhaps because your Cemetery Puca turned into a Lurebound Scarecrow), the trigger condition will have an undefined value in it. It'll never trigger, so you won't have to sacrifice the Scarecrow."
         }
       ],
       "subtypes": [
@@ -28592,23 +28592,23 @@
         },
         {
           "date": "2008-05-01",
-          "text": "This ability doesn’t overwrite any previous colors. Rather, it adds another color."
+          "text": "This ability doesn't overwrite any previous colors. Rather, it adds another color."
         },
         {
           "date": "2008-05-01",
-          "text": "The effects of multiple Painter’s Servants are cumulative."
+          "text": "The effects of multiple Painter's Servants are cumulative."
         },
         {
           "date": "2008-05-01",
-          "text": "While Painter’s Servant is on the battlefield, an effect that changes an object’s colors will overwrite Painter’s Servant’s effect. For example, casting Cerulean Wisps on a creature will turn it blue, regardless of the color chosen for Painter’s Servant."
+          "text": "While Painter's Servant is on the battlefield, an effect that changes an object's colors will overwrite Painter's Servant's effect. For example, casting Cerulean Wisps on a creature will turn it blue, regardless of the color chosen for Painter's Servant."
         },
         {
           "date": "2008-05-01",
-          "text": "Each card becomes a new object as it changes zones, so this effect will apply to it from scratch in the new zone. Zone-change replacement abilities that care about the new color (like “[color] permanents enter the battlefield tapped”) won’t work because those effects are applied as the card is entering its new zone. Zone-change triggered abilities that care about the new color (like “when a [color] permanent enters the battlefield” or “when you cast a [color] spell”) will work because those effects apply after the card is already in its new zone."
+          "text": "Each card becomes a new object as it changes zones, so this effect will apply to it from scratch in the new zone. Zone-change replacement abilities that care about the new color (like \"[color] permanents enter the battlefield tapped\") won't work because those effects are applied as the card is entering its new zone. Zone-change triggered abilities that care about the new color (like \"when a [color] permanent enters the battlefield\" or \"when you cast a [color] spell\") will work because those effects apply after the card is already in its new zone."
         },
         {
           "date": "2008-05-01",
-          "text": "If something affected by Painter’s Servant is normally colorless, it will simply be the new color. It won’t be both the new color and colorless."
+          "text": "If something affected by Painter's Servant is normally colorless, it will simply be the new color. It won't be both the new color and colorless."
         }
       ],
       "subtypes": [
@@ -28713,19 +28713,19 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If Pili-Pala is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If Pili-Pala is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "Pili-Pala’s ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Pili-Pala's ability is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2008-05-01",
-          "text": "Using this creature’s ability means you’re untapping it for mana, not tapping it for mana. Mana Reflection won’t cause it to produce extra mana."
+          "text": "Using this creature's ability means you're untapping it for mana, not tapping it for mana. Mana Reflection won't cause it to produce extra mana."
         }
       ],
       "subtypes": [
@@ -28837,23 +28837,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -28972,7 +28972,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -29185,11 +29185,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Scrapbasket’s ability won’t stop it from being an artifact. It’ll just be a colorful artifact."
+          "text": "Scrapbasket's ability won't stop it from being an artifact. It'll just be a colorful artifact."
         },
         {
           "date": "2008-05-01",
-          "text": "After Scrapbasket’s ability resolves, an effect that changes its colors will overwrite that ability’s effect. For example, casting Cerulean Wisps on it will turn it just blue."
+          "text": "After Scrapbasket's ability resolves, an effect that changes its colors will overwrite that ability's effect. For example, casting Cerulean Wisps on it will turn it just blue."
         }
       ],
       "subtypes": [
@@ -29294,11 +29294,11 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "An effect that changes a permanent’s colors overwrites all its old colors unless it specifically says “in addition to its other colors.” For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn’t matter what colors it used to be (even if, for example, it used to be blue and black)."
+          "text": "An effect that changes a permanent's colors overwrites all its old colors unless it specifically says \"in addition to its other colors.\" For example, after Cerulean Wisps resolves, the affected creature will just be blue. It doesn't matter what colors it used to be (even if, for example, it used to be blue and black)."
         },
         {
           "date": "2008-05-01",
-          "text": "Changing a permanent’s color won’t change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
+          "text": "Changing a permanent's color won't change its text. If you turn Wilt-Leaf Liege blue, it will still affect green creatures and white creatures."
         },
         {
           "date": "2008-05-01",
@@ -29306,11 +29306,11 @@
         },
         {
           "date": "2008-05-01",
-          "text": "For the second ability, you can choose any single color or any combination of more than one color. You can’t choose colorless."
+          "text": "For the second ability, you can choose any single color or any combination of more than one color. You can't choose colorless."
         },
         {
           "date": "2008-05-01",
-          "text": "The second ability won’t make an artifact creature stop being an artifact. It’ll just be a colorful artifact."
+          "text": "The second ability won't make an artifact creature stop being an artifact. It'll just be a colorful artifact."
         }
       ],
       "subtypes": [
@@ -29415,23 +29415,23 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Tatterkite’s ability prevents any kind of counter from being placed on it, not just -1/-1 counters."
+          "text": "Tatterkite's ability prevents any kind of counter from being placed on it, not just -1/-1 counters."
         },
         {
           "date": "2008-05-01",
-          "text": "A spell or ability whose effect would put a counter on Tatterkite simply doesn’t affect it. The spell or ability isn’t countered. If it would put counters on any other creatures, it continues to do so."
+          "text": "A spell or ability whose effect would put a counter on Tatterkite simply doesn't affect it. The spell or ability isn't countered. If it would put counters on any other creatures, it continues to do so."
         },
         {
           "date": "2008-05-01",
-          "text": "If Tatterkite is dealt damage by a creature with wither, that damage has no effect. It’s not prevented; it just doesn’t do anything. Abilities that trigger on damage being dealt will still trigger."
+          "text": "If Tatterkite is dealt damage by a creature with wither, that damage has no effect. It's not prevented; it just doesn't do anything. Abilities that trigger on damage being dealt will still trigger."
         },
         {
           "date": "2008-05-01",
-          "text": "You can’t pay a cost that includes putting a counter on Tatterkite. For example, if Tatterkite is the only creature you control, you can’t cast Scarscale Ritual because you can’t pay the additional cost."
+          "text": "You can't pay a cost that includes putting a counter on Tatterkite. For example, if Tatterkite is the only creature you control, you can't cast Scarscale Ritual because you can't pay the additional cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If Tatterkite would enter the battlefield with counters on it, it enters the battlefield but doesn’t have those counters. For example, if an effect grants it persist and then it’s destroyed, it returns to the battlefield without a -1/-1 counter on it."
+          "text": "If Tatterkite would enter the battlefield with counters on it, it enters the battlefield but doesn't have those counters. For example, if an effect grants it persist and then it's destroyed, it returns to the battlefield without a -1/-1 counter on it."
         }
       ],
       "subtypes": [
@@ -29727,15 +29727,15 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If the permanent is already untapped, you can’t activate its {Q} ability. That’s because you can’t pay the “Untap this permanent” cost."
+          "text": "If the permanent is already untapped, you can't activate its {Q} ability. That's because you can't pay the \"Untap this permanent\" cost."
         },
         {
           "date": "2008-05-01",
-          "text": "If a creature with an {Q} ability hasn’t been under your control since your most recent turn began, you can’t activate that ability, unless the creature has haste."
+          "text": "If a creature with an {Q} ability hasn't been under your control since your most recent turn began, you can't activate that ability, unless the creature has haste."
         },
         {
           "date": "2008-05-01",
-          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can’t be responded to. (The actual ability can be responded to, of course.)"
+          "text": "When you activate an {Q} ability, you untap the creature with that ability as a cost. The untap can't be responded to. (The actual ability can be responded to, of course.)"
         }
       ],
       "subtypes": [
@@ -30049,23 +30049,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If a permanent has multiple instances of persist, they’ll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
+          "text": "If a permanent has multiple instances of persist, they'll each trigger separately, but the redundant instances will have no effect. If one instance returns the card to the battlefield, the next to resolve will do nothing."
         },
         {
           "date": "2013-06-07",
-          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can’t return to the battlefield."
+          "text": "If a token with no -1/-1 counters on it has persist, the ability will trigger when the token is put into the graveyard. However, the token will cease to exist and can't return to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "When a permanent with persist returns to the battlefield, it’s a new object with no memory of or connection to its previous existence."
+          "text": "When a permanent with persist returns to the battlefield, it's a new object with no memory of or connection to its previous existence."
         },
         {
           "date": "2013-06-07",
-          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player’s persist creatures will return to the battlefield first, then the active player’s persist creatures do the same. The creatures return to the battlefield one at a time."
+          "text": "If multiple creatures with persist are put into the graveyard at the same time (due to combat damage or a spell that destroys all creatures, for example), the active player (the player whose turn it is) puts all of his or her persist triggers on the stack in any order, then each other player in turn order does the same. The last trigger put on the stack is the first one that resolves. That means that in a two-player game, the nonactive player's persist creatures will return to the battlefield first, then the active player's persist creatures do the same. The creatures return to the battlefield one at a time."
         },
         {
           "date": "2013-06-07",
-          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner’s graveyard for having 0 or less toughness, persist won’t trigger and the card won’t return to the battlefield. That’s because persist checks the creature’s existence just before it leaves the battlefield, and it still has all those counters on it at that point."
+          "text": "If a creature with persist that has +1/+1 counters on it receives enough -1/-1 counters to cause it to be destroyed by lethal damage or put into its owner's graveyard for having 0 or less toughness, persist won't trigger and the card won't return to the battlefield. That's because persist checks the creature's existence just before it leaves the battlefield, and it still has all those counters on it at that point."
         }
       ],
       "subtypes": [
@@ -30273,7 +30273,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "{B/R}, {T}” is the same as saying “{B}, {T} or {R}, {T}."
+          "text": "{B/R}, {T}\" is the same as saying \"{B}, {T} or {R}, {T}."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{B/R}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
@@ -30862,7 +30862,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Any change to a land’s type or splicing of text into a land can affect the types of mana a land can produce."
+          "text": "Any change to a land's type or splicing of text into a land can affect the types of mana a land can produce."
         },
         {
           "date": "2008-05-01",
@@ -30870,15 +30870,15 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Reflecting Pool checks the effects of all mana-producing abilities of lands you control, but it doesn’t check their costs. For example, Vivid Crag says “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If you control Vivid Crag and Reflecting Pool, you can tap Reflecting Pool for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Reflecting Pool checks the effects of all mana-producing abilities of lands you control, but it doesn't check their costs. For example, Vivid Crag says \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If you control Vivid Crag and Reflecting Pool, you can tap Reflecting Pool for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2008-05-01",
-          "text": "Reflecting Pool doesn’t care about any restrictions or riders your lands put on the mana they produce, such as Pillar of the Paruns and Hall of the Bandit Lord do. It just cares about types of mana."
+          "text": "Reflecting Pool doesn't care about any restrictions or riders your lands put on the mana they produce, such as Pillar of the Paruns and Hall of the Bandit Lord do. It just cares about types of mana."
         },
         {
           "date": "2008-05-01",
-          "text": "Multiple Reflecting Pools won’t help each other produce mana. If you control a Reflecting Pool, and all other lands you control either lack mana abilities or are other Reflecting Pools, you may still activate Reflecting Pool’s ability — it just won’t produce any mana."
+          "text": "Multiple Reflecting Pools won't help each other produce mana. If you control a Reflecting Pool, and all other lands you control either lack mana abilities or are other Reflecting Pools, you may still activate Reflecting Pool's ability — it just won't produce any mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any type that a land you control could produce.",
@@ -35779,9 +35779,29 @@
           "multiverseid": 177864
         },
         {
+          "language": "Chinese Traditional",
+          "name": "Mountain",
+          "multiverseid": 177720
+        },
+        {
           "language": "French",
           "name": "Montagne",
           "multiverseid": 177885
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177886
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177887
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177888
         },
         {
           "language": "Italian",
@@ -35862,26 +35882,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 177745
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177838
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177839
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177840
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177841
         }
       ],
       "id": "4d78cf86fcdfb36611059b7926854dbf81746fa3",
@@ -36164,9 +36164,29 @@
           "multiverseid": 177864
         },
         {
+          "language": "Chinese Traditional",
+          "name": "Mountain",
+          "multiverseid": 177720
+        },
+        {
           "language": "French",
           "name": "Montagne",
           "multiverseid": 177885
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177886
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177887
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177888
         },
         {
           "language": "Italian",
@@ -36247,26 +36267,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 177745
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177838
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177839
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177840
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177841
         }
       ],
       "id": "6b018920d607b1f7a324da1c53f990940650f6e4",
@@ -36549,9 +36549,29 @@
           "multiverseid": 177864
         },
         {
+          "language": "Chinese Traditional",
+          "name": "Mountain",
+          "multiverseid": 177720
+        },
+        {
           "language": "French",
           "name": "Montagne",
           "multiverseid": 177885
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177886
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177887
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177888
         },
         {
           "language": "Italian",
@@ -36632,26 +36652,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 177745
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177838
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177839
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177840
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177841
         }
       ],
       "id": "9554fbe44972fd759fabe164cc9955593e499496",
@@ -36934,9 +36934,29 @@
           "multiverseid": 177864
         },
         {
+          "language": "Chinese Traditional",
+          "name": "Mountain",
+          "multiverseid": 177720
+        },
+        {
           "language": "French",
           "name": "Montagne",
           "multiverseid": 177885
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177886
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177887
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 177888
         },
         {
           "language": "Italian",
@@ -37017,26 +37037,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 177745
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177838
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177839
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177840
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 177841
         }
       ],
       "id": "1a564751633bd916a853e8ad917b3ec95622d064",

--- a/json/SOI.json
+++ b/json/SOI.json
@@ -259,7 +259,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If Angel of Deliverance deals damage to multiple creatures, players, or planeswalkers at once (for example, if it’s blocked by two smaller creatures) its last ability triggers only once."
+          "text": "If Angel of Deliverance deals damage to multiple creatures, players, or planeswalkers at once (for example, if it's blocked by two smaller creatures) its last ability triggers only once."
         },
         {
           "date": "2016-04-08",
@@ -267,11 +267,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If Angel of Deliverance deals lethal damage to a creature, that creature can’t be targeted by Angel of Deliverance’s triggered ability. It’s already in its owner’s graveyard."
+          "text": "If Angel of Deliverance deals lethal damage to a creature, that creature can't be targeted by Angel of Deliverance's triggered ability. It's already in its owner's graveyard."
         },
         {
           "date": "2016-04-08",
-          "text": "If you have three noncreature card types among cards in your graveyard and Angel of Deliverance deals damage at the same time another creature you control is dealt lethal damage, the ability won’t trigger. The creature doesn’t die until after Angel of Deliverance’s ability checks to see if it triggers."
+          "text": "If you have three noncreature card types among cards in your graveyard and Angel of Deliverance deals damage at the same time another creature you control is dealt lethal damage, the ability won't trigger. The creature doesn't die until after Angel of Deliverance's ability checks to see if it triggers."
         },
         {
           "date": "2016-04-08",
@@ -279,19 +279,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -632,11 +632,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Archangel Avacyn’s delayed triggered ability triggers at the beginning of the next upkeep regardless of whose turn it is."
+          "text": "Archangel Avacyn's delayed triggered ability triggers at the beginning of the next upkeep regardless of whose turn it is."
         },
         {
           "date": "2016-04-08",
-          "text": "Archangel Avacyn’s delayed triggered ability won’t cause it to transform back into Archangel Avacyn if it has already transformed into Avacyn, the Purifier, perhaps because several creatures died in one turn."
+          "text": "Archangel Avacyn's delayed triggered ability won't cause it to transform back into Archangel Avacyn if it has already transformed into Avacyn, the Purifier, perhaps because several creatures died in one turn."
         },
         {
           "date": "2016-07-13",
@@ -1010,7 +1010,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If Lunarch Inquisitors leaves the battlefield before its triggered ability resolves, the target creature won’t be exiled."
+          "text": "If Lunarch Inquisitors leaves the battlefield before its triggered ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2016-04-08",
@@ -1018,15 +1018,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2016-04-08",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2016-04-08",
-          "text": "In a multiplayer game, if Lunarch Inquisitors’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Lunarch Inquisitors's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "subtypes": [
@@ -1147,7 +1147,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "You control Bound by Moonsilver even while it enchants an opponent’s creature. Only you can activate its last ability."
+          "text": "You control Bound by Moonsilver even while it enchants an opponent's creature. Only you can activate its last ability."
         }
       ],
       "subtypes": [
@@ -1263,11 +1263,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for an alternative cost, such as a madness cost, doesn’t change its converted mana cost. For example, casting Twins of Maurer Estate (a card with mana cost {4}{B} and madness cost {2}{B}) for its madness cost will not cause Bygone Bishop’s ability to trigger."
+          "text": "Casting a spell for an alternative cost, such as a madness cost, doesn't change its converted mana cost. For example, casting Twins of Maurer Estate (a card with mana cost {4}{B} and madness cost {2}{B}) for its madness cost will not cause Bygone Bishop's ability to trigger."
         },
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -1275,7 +1275,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "subtypes": [
@@ -1394,7 +1394,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cathar’s Companion’s triggered ability resolves before the spell that causes it to trigger."
+          "text": "Cathar's Companion's triggered ability resolves before the spell that causes it to trigger."
         }
       ],
       "subtypes": [
@@ -1731,7 +1731,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Declaration in Stone has only one target. The other creatures with that name aren’t targeted. For example, a creature with hexproof will be exiled if it has the same name as the target creature."
+          "text": "Declaration in Stone has only one target. The other creatures with that name aren't targeted. For example, a creature with hexproof will be exiled if it has the same name as the target creature."
         },
         {
           "date": "2016-04-08",
@@ -1739,19 +1739,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "It’s possible to have a creature and a noncreature permanent with the same name, such as two copies of the same land, one of which has become a land creature. Only creatures with that name are exiled by Declaration in Stone."
+          "text": "It's possible to have a creature and a noncreature permanent with the same name, such as two copies of the same land, one of which has become a land creature. Only creatures with that name are exiled by Declaration in Stone."
         },
         {
           "date": "2016-04-08",
-          "text": "A face-down creature, such as one cast with a megamorph ability from the Dragons of Tarkir set, has no name and can’t share a name with any other creatures."
+          "text": "A face-down creature, such as one cast with a megamorph ability from the Dragons of Tarkir set, has no name and can't share a name with any other creatures."
         },
         {
           "date": "2016-04-08",
-          "text": "Unless a token is a copy, or unless specified by the effect that created it, a token’s name is the same as its subtypes at the time it was created."
+          "text": "Unless a token is a copy, or unless specified by the effect that created it, a token's name is the same as its subtypes at the time it was created."
         },
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -1759,7 +1759,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "text": "Exile target creature and all other creatures its controller controls with the same name as that creature. That player investigates for each nontoken creature exiled this way.",
@@ -1872,11 +1872,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If you have three non-sorcery card types among cards in your graveyard at the time Descend upon the Sinful resolves, you won’t get an Angel token. Descend upon the Sinful isn’t put into your graveyard until after it’s finished resolving."
+          "text": "If you have three non-sorcery card types among cards in your graveyard at the time Descend upon the Sinful resolves, you won't get an Angel token. Descend upon the Sinful isn't put into your graveyard until after it's finished resolving."
         },
         {
           "date": "2016-04-08",
-          "text": "If one of those creatures was enchanted, its Aura won’t be put into a player’s graveyard until after Descend upon the Sinful has finished resolving. If the controller of Descend upon the Sinful owned the Aura, it won’t be in the graveyard in time to be counted for the delirium ability."
+          "text": "If one of those creatures was enchanted, its Aura won't be put into a player's graveyard until after Descend upon the Sinful has finished resolving. If the controller of Descend upon the Sinful owned the Aura, it won't be in the graveyard in time to be counted for the delirium ability."
         },
         {
           "date": "2016-04-08",
@@ -1884,15 +1884,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "text": "Exile all creatures.\nDelirium — Create a 4/4 white Angel creature token with flying if there are four or more card types among cards in your graveyard.",
@@ -2234,11 +2234,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Auras attached to the exiled creatures will be put into their owners’ graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled creatures will cease to exist."
+          "text": "Auras attached to the exiled creatures will be put into their owners' graveyards. Equipment attached to the exiled creatures will become unattached and remain on the battlefield. Any counters on the exiled creatures will cease to exist."
         },
         {
           "date": "2016-04-08",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2016-04-08",
@@ -2355,15 +2355,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Emissary of the Sleepless’s last ability checks only if a creature died earlier in the turn. The creature card doesn’t need to still be in the graveyard."
+          "text": "Emissary of the Sleepless's last ability checks only if a creature died earlier in the turn. The creature card doesn't need to still be in the graveyard."
         },
         {
           "date": "2016-04-08",
-          "text": "Token creatures that are destroyed or put into a graveyard from the battlefield for other reasons do die—they go to their owner’s graveyard before ceasing to exist."
+          "text": "Token creatures that are destroyed or put into a graveyard from the battlefield for other reasons do die—they go to their owner's graveyard before ceasing to exist."
         },
         {
           "date": "2016-04-08",
-          "text": "Emissary of the Sleepless’s last ability doesn’t create additional Spirit tokens if more than one creature died this turn."
+          "text": "Emissary of the Sleepless's last ability doesn't create additional Spirit tokens if more than one creature died this turn."
         }
       ],
       "subtypes": [
@@ -2480,7 +2480,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The set of creatures affected by Ethereal Guidance is determined as the spell resolves. Creatures you begin to control later in the turn won’t get +2/+1."
+          "text": "The set of creatures affected by Ethereal Guidance is determined as the spell resolves. Creatures you begin to control later in the turn won't get +2/+1."
         }
       ],
       "text": "Creatures you control get +2/+1 until end of turn.",
@@ -2597,11 +2597,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If Expose Evil has at least one target and all of those targets become illegal, the spell is countered and you won’t investigate."
+          "text": "If Expose Evil has at least one target and all of those targets become illegal, the spell is countered and you won't investigate."
         },
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -2609,7 +2609,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "text": "Tap up to two target creatures.\nInvestigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -2721,7 +2721,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If you activate Gryff’s Boon’s last ability and the target creature becomes an illegal target in response, the ability is countered and Gryff’s Boon remains in your graveyard."
+          "text": "If you activate Gryff's Boon's last ability and the target creature becomes an illegal target in response, the ability is countered and Gryff's Boon remains in your graveyard."
         }
       ],
       "subtypes": [
@@ -2842,15 +2842,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If you don’t control four or more creatures (including Hanweir Militia Captain itself) at the moment your upkeep begins, its ability doesn’t trigger. You can’t wait for other effects in your upkeep to provide creatures."
+          "text": "If you don't control four or more creatures (including Hanweir Militia Captain itself) at the moment your upkeep begins, its ability doesn't trigger. You can't wait for other effects in your upkeep to provide creatures."
         },
         {
           "date": "2016-04-08",
-          "text": "If you don’t control four or more creatures as Hanweir Militia Captain’s ability resolves, it won’t transform."
+          "text": "If you don't control four or more creatures as Hanweir Militia Captain's ability resolves, it won't transform."
         },
         {
           "date": "2016-04-08",
-          "text": "Once Hanweir Militia Captain has transformed into Westvale Cult Leader, controlling fewer than four creatures won’t cause it to transform back."
+          "text": "Once Hanweir Militia Captain has transformed into Westvale Cult Leader, controlling fewer than four creatures won't cause it to transform back."
         },
         {
           "date": "2016-07-13",
@@ -2975,11 +2975,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Once Hanweir Militia Captain has transformed into Westvale Cult Leader, controlling fewer than four creatures won’t cause it to transform back."
+          "text": "Once Hanweir Militia Captain has transformed into Westvale Cult Leader, controlling fewer than four creatures won't cause it to transform back."
         },
         {
           "date": "2016-04-08",
-          "text": "Westvale Cult Leader’s first ability counts itself, so it will normally be at least 1/1."
+          "text": "Westvale Cult Leader's first ability counts itself, so it will normally be at least 1/1."
         }
       ],
       "subtypes": [
@@ -3097,7 +3097,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Hope Against Hope’s second ability counts the enchanted creature, so that creature will normally get at least +1/+1."
+          "text": "Hope Against Hope's second ability counts the enchanted creature, so that creature will normally get at least +1/+1."
         }
       ],
       "subtypes": [
@@ -3213,7 +3213,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -3221,11 +3221,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won’t investigate."
+          "text": "You can't cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won't investigate."
         }
       ],
       "text": "Destroy target creature with power 4 or greater.\nInvestigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -3339,7 +3339,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Gaining vigilance any time after the moment you choose to attack with Inquisitor’s Ox won’t cause it to become untapped."
+          "text": "Gaining vigilance any time after the moment you choose to attack with Inquisitor's Ox won't cause it to become untapped."
         },
         {
           "date": "2016-04-08",
@@ -3347,15 +3347,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -3473,7 +3473,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The set of creatures affected by Inspiring Captain’s ability is determined as the ability resolves. Creatures you begin to control later in the turn won’t get +1/+1."
+          "text": "The set of creatures affected by Inspiring Captain's ability is determined as the ability resolves. Creatures you begin to control later in the turn won't get +1/+1."
         }
       ],
       "subtypes": [
@@ -3592,11 +3592,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Militant Inquisitor’s ability counts all Equipment you control, regardless of whether they’re attached to a creature."
+          "text": "Militant Inquisitor's ability counts all Equipment you control, regardless of whether they're attached to a creature."
         },
         {
           "date": "2016-04-08",
-          "text": "Militant Inquisitor’s ability applies in addition to any effects from those Equipment that are attached to it."
+          "text": "Militant Inquisitor's ability applies in addition to any effects from those Equipment that are attached to it."
         }
       ],
       "subtypes": [
@@ -3715,7 +3715,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Flying only matters as blockers are chosen. Causing Moorland Drifter to gain flying after blockers are chosen won’t cause it to become unblocked."
+          "text": "Flying only matters as blockers are chosen. Causing Moorland Drifter to gain flying after blockers are chosen won't cause it to become unblocked."
         },
         {
           "date": "2016-04-08",
@@ -3723,15 +3723,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -3849,11 +3849,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Players can respond to the triggered ability of Nahiri’s Machinations by destroying the creature you target before the ability that gives it indestructible has resolved."
+          "text": "Players can respond to the triggered ability of Nahiri's Machinations by destroying the creature you target before the ability that gives it indestructible has resolved."
         },
         {
           "date": "2016-04-08",
-          "text": "Destroying a blocking creature doesn’t cause the creature it was blocking to become unblocked."
+          "text": "Destroying a blocking creature doesn't cause the creature it was blocking to become unblocked."
         }
       ],
       "text": "At the beginning of combat on your turn, target creature you control gains indestructible until end of turn.\n{1}{R}: Nahiri's Machinations deals 1 damage to target blocking creature.",
@@ -4078,7 +4078,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You choose whether to put the target card on the top or bottom of its owner’s library as Not Forgotten resolves."
+          "text": "You choose whether to put the target card on the top or bottom of its owner's library as Not Forgotten resolves."
         },
         {
           "date": "2016-04-08",
@@ -4195,11 +4195,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Odric’s ability triggers at the beginning of each combat, not just combat on your turn, whether or not any creatures you control have any of the listed abilities. If a creature gains one of the listed abilities before Odric’s triggered ability resolves, perhaps due to another ability that triggered at the beginning of combat, then creatures you control will gain that ability."
+          "text": "Odric's ability triggers at the beginning of each combat, not just combat on your turn, whether or not any creatures you control have any of the listed abilities. If a creature gains one of the listed abilities before Odric's triggered ability resolves, perhaps due to another ability that triggered at the beginning of combat, then creatures you control will gain that ability."
         },
         {
           "date": "2016-04-08",
-          "text": "The set of creatures affected by Odric’s ability and how they are affected is determined as the ability resolves. Creatures you begin to control later in the turn won’t gain any abilities or cause creatures to gain new abilities, and the abilities gained won’t change even if every creature that normally had the abilities leaves the battlefield."
+          "text": "The set of creatures affected by Odric's ability and how they are affected is determined as the ability resolves. Creatures you begin to control later in the turn won't gain any abilities or cause creatures to gain new abilities, and the abilities gained won't change even if every creature that normally had the abilities leaves the battlefield."
         },
         {
           "date": "2016-04-08",
@@ -4432,7 +4432,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Losing or gaining first strike after first-strike damage has been dealt won’t cause Paranoid Parish-Blade to deal combat damage twice or to not deal combat damage."
+          "text": "Losing or gaining first strike after first-strike damage has been dealt won't cause Paranoid Parish-Blade to deal combat damage twice or to not deal combat damage."
         },
         {
           "date": "2016-04-08",
@@ -4440,15 +4440,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -4572,7 +4572,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If Pious Evangel enters the battlefield at the same time as another creature you control, Pious Evangel’s ability triggers once for the other creature as well as once for itself."
+          "text": "If Pious Evangel enters the battlefield at the same time as another creature you control, Pious Evangel's ability triggers once for the other creature as well as once for itself."
         },
         {
           "date": "2016-07-13",
@@ -4699,7 +4699,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If Wayward Disciple dies at the same time as another creature you control, Wayward Disciple’s ability triggers once for the other creature as well as once for itself."
+          "text": "If Wayward Disciple dies at the same time as another creature you control, Wayward Disciple's ability triggers once for the other creature as well as once for itself."
         }
       ],
       "subtypes": [
@@ -4826,11 +4826,11 @@
         },
         {
           "date": "2010-06-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step."
         },
         {
           "date": "2010-06-15",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures that it was blocking are no longer on the battlefield or have otherwise left combat by then."
         }
       ],
       "text": "Destroy target attacking or blocking creature with power 3 or less.",
@@ -4947,15 +4947,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
@@ -5409,7 +5409,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The Equipment you control doesn’t have to be attached to a creature."
+          "text": "The Equipment you control doesn't have to be attached to a creature."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn. If you control an Equipment, create a 1/1 white Human Soldier creature token.",
@@ -5522,7 +5522,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -5530,11 +5530,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won’t investigate."
+          "text": "You can't cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won't investigate."
         }
       ],
       "text": "Target creature gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\nInvestigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -5647,11 +5647,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The set of creatures affected by Tenacity is determined as the spell resolves. Creatures you begin to control later in the turn won’t get +1/+1 or gain lifelink."
+          "text": "The set of creatures affected by Tenacity is determined as the spell resolves. Creatures you begin to control later in the turn won't get +1/+1 or gain lifelink."
         },
         {
           "date": "2016-04-08",
-          "text": "Multiple instances of lifelink are redundant."
+          "text": "multiple instances of lifelink on the same creature are redundant."
         }
       ],
       "text": "Creatures you control get +1/+1 and gain lifelink until end of turn. Untap those creatures.",
@@ -5764,7 +5764,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If Thalia’s Lieutenant enters the battlefield at the same time as another Human, each of Thalia’s Lieutenant’s abilities will trigger. You’ll put a +1/+1 counter on both cards."
+          "text": "If Thalia's Lieutenant enters the battlefield at the same time as another Human, each of Thalia's Lieutenant's abilities will trigger. You'll put a +1/+1 counter on both cards."
         }
       ],
       "subtypes": [
@@ -5883,7 +5883,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -5891,7 +5891,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "subtypes": [
@@ -6014,19 +6014,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -6149,7 +6149,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can tap any untapped creature you control, including one you haven’t controlled continuously since the beginning of your most recent turn, to pay the cost of Town Gossipmonger’s activated ability. You must have controlled Town Gossipmonger continuously since the beginning of your most recent turn, however."
+          "text": "You can tap any untapped creature you control, including one you haven't controlled continuously since the beginning of your most recent turn, to pay the cost of Town Gossipmonger's activated ability. You must have controlled Town Gossipmonger continuously since the beginning of your most recent turn, however."
         },
         {
           "date": "2016-07-13",
@@ -6275,11 +6275,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Incited Rabble’s controller still chooses which player or planeswalker it attacks."
+          "text": "Incited Rabble's controller still chooses which player or planeswalker it attacks."
         },
         {
           "date": "2016-04-08",
-          "text": "If, during its controller’s declare attackers step, Incited Rabble is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having Incited Rabble attack, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either. Note that transforming Town Gossipmonger won’t untap it."
+          "text": "If, during its controller's declare attackers step, Incited Rabble is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having Incited Rabble attack, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either. Note that transforming Town Gossipmonger won't untap it."
         }
       ],
       "subtypes": [
@@ -6402,7 +6402,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If Unruly Mob and another creature you control die simultaneously (perhaps because they were both attacking or blocking), Unruly Mob won’t be on the battlefield as its triggered ability resolves. It can’t be saved by the +1/+1 counter that would have been put on it."
+          "text": "If Unruly Mob and another creature you control die simultaneously (perhaps because they were both attacking or blocking), Unruly Mob won't be on the battlefield as its triggered ability resolves. It can't be saved by the +1/+1 counter that would have been put on it."
         }
       ],
       "subtypes": [
@@ -6631,7 +6631,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "No player may take any action between the two steps of Aberrant Researcher’s triggered ability. If the card put into your graveyard is an instant or sorcery card, Aberrant Researcher will have transformed before a player can take any action."
+          "text": "No player may take any action between the two steps of Aberrant Researcher's triggered ability. If the card put into your graveyard is an instant or sorcery card, Aberrant Researcher will have transformed before a player can take any action."
         },
         {
           "date": "2016-04-08",
@@ -6873,15 +6873,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -6889,7 +6889,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -6897,11 +6897,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -7132,15 +7132,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The card returned to its owner’s hand may be the card he or she discards. If it’s the only card in that player’s hand, it must be discarded."
+          "text": "The card returned to its owner's hand may be the card he or she discards. If it's the only card in that player's hand, it must be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "Compelling Deterrence targets only the nonland permanent. If that permanent becomes an illegal target, Compelling Deterrence is countered and that player doesn’t discard a card."
+          "text": "Compelling Deterrence targets only the nonland permanent. If that permanent becomes an illegal target, Compelling Deterrence is countered and that player doesn't discard a card."
         },
         {
           "date": "2016-04-08",
-          "text": "If you target the only Zombie you control with Compelling Deterrence, you won’t discard a card."
+          "text": "If you target the only Zombie you control with Compelling Deterrence, you won't discard a card."
         }
       ],
       "text": "Return target nonland permanent to its owner's hand. Then that player discards a card if you control a Zombie.",
@@ -7253,7 +7253,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -7261,11 +7261,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won’t investigate."
+          "text": "You can't cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won't investigate."
         }
       ],
       "text": "Counter target spell.\nInvestigate three times. (To investigate, create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -7383,7 +7383,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If Daring Sleuth’s ability triggers multiple times before any of those abilities resolves, only the first one to resolve will cause it to transform."
+          "text": "If Daring Sleuth's ability triggers multiple times before any of those abilities resolves, only the first one to resolve will cause it to transform."
         },
         {
           "date": "2016-07-13",
@@ -7508,7 +7508,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -7516,7 +7516,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "subtypes": [
@@ -7742,7 +7742,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -7750,7 +7750,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "subtypes": [
@@ -8088,7 +8088,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "X can be 0, and piles can be empty. If X is 0, you’ll reveal one card and one pile will be empty. Your opponent may choose the empty pile to put into your hand."
+          "text": "X can be 0, and piles can be empty. If X is 0, you'll reveal one card and one pile will be empty. Your opponent may choose the empty pile to put into your hand."
         }
       ],
       "text": "Reveal the top X plus one cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
@@ -8317,11 +8317,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2016-04-08",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2016-04-08",
@@ -8437,11 +8437,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue to pay the cost of a spell or ability, Fleeting Memories’s second ability will resolve before that spell or ability."
+          "text": "If you sacrifice a Clue to pay the cost of a spell or ability, Fleeting Memories's second ability will resolve before that spell or ability."
         },
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -8449,7 +8449,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "text": "When Fleeting Memories enters the battlefield, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, target player puts the top three cards of his or her library into his or her graveyard.",
@@ -8563,15 +8563,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The upkeep step is before the draw step, after the untap step. If you have no cards in hand, you can’t draw for the turn and then discard that card to draw a new one because Forgotten Creation’s last ability will already have triggered and resolved."
+          "text": "The upkeep step is before the draw step, after the untap step. If you have no cards in hand, you can't draw for the turn and then discard that card to draw a new one because Forgotten Creation's last ability will already have triggered and resolved."
         },
         {
           "date": "2016-04-08",
-          "text": "Skulk matters only as blockers are chosen. Modifying either creature’s power after blockers are chosen won’t cause the attacking creature to become unblocked."
+          "text": "Skulk matters only as blockers are chosen. Modifying either creature's power after blockers are chosen won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won’t be blocked, but it won’t deal combat damage and won’t trigger any abilities that trigger when combat damage is dealt."
+          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won't be blocked, but it won't deal combat damage and won't trigger any abilities that trigger when combat damage is dealt."
         }
       ],
       "subtypes": [
@@ -8690,11 +8690,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Skulk matters only as blockers are chosen. Modifying either creature’s power after blockers are chosen won’t cause the attacking creature to become unblocked."
+          "text": "Skulk matters only as blockers are chosen. Modifying either creature's power after blockers are chosen won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won’t be blocked, but it won’t deal combat damage and won’t trigger any abilities that trigger when combat damage is dealt."
+          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won't be blocked, but it won't deal combat damage and won't trigger any abilities that trigger when combat damage is dealt."
         }
       ],
       "subtypes": [
@@ -8811,11 +8811,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Geralf’s Masterpiece’s last ability can only be activated while it’s in your graveyard."
+          "text": "Geralf's Masterpiece's last ability can only be activated while it's in your graveyard."
         },
         {
           "date": "2016-04-08",
-          "text": "If a spell or ability causes you to draw cards and then discard cards, Geralf’s Masterpiece may have a toughness of 0 while you choose which cards to discard. As long as it has toughness 1 or greater again after the spell or ability resolves, it will survive."
+          "text": "If a spell or ability causes you to draw cards and then discard cards, Geralf's Masterpiece may have a toughness of 0 while you choose which cards to discard. As long as it has toughness 1 or greater again after the spell or ability resolves, it will survive."
         }
       ],
       "subtypes": [
@@ -8937,15 +8937,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You control Ghostly Wings even while it enchants an opponent’s creature. Only you can activate the last ability of Ghostly Wings."
+          "text": "You control Ghostly Wings even while it enchants an opponent's creature. Only you can activate the last ability of Ghostly Wings."
         },
         {
           "date": "2016-04-08",
-          "text": "After the last ability of Ghostly Wings resolves, it will be an Aura on the battlefield that isn’t attached to a creature and will immediately be put into its owner’s graveyard."
+          "text": "After the last ability of Ghostly Wings resolves, it will be an Aura on the battlefield that isn't attached to a creature and will immediately be put into its owner's graveyard."
         },
         {
           "date": "2016-04-08",
-          "text": "If Ghostly Wings leaves the battlefield before its activated ability resolves, the creature that was enchanted immediately before Ghostly Wings left is the one that will be returned to its owner’s hand, if it’s still on the battlefield."
+          "text": "If Ghostly Wings leaves the battlefield before its activated ability resolves, the creature that was enchanted immediately before Ghostly Wings left is the one that will be returned to its owner's hand, if it's still on the battlefield."
         },
         {
           "date": "2016-04-08",
@@ -9065,7 +9065,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -9073,11 +9073,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won’t investigate."
+          "text": "You can't cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won't investigate."
         }
       ],
       "text": "Put target permanent on top of its owner's library.\nInvestigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -9189,7 +9189,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Invasive Surgery’s delirium ability isn’t checked until after the sorcery spell has been countered. If that spell is put into your graveyard, it will be counted."
+          "text": "Invasive Surgery's delirium ability isn't checked until after the sorcery spell has been countered. If that spell is put into your graveyard, it will be counted."
         },
         {
           "date": "2016-04-08",
@@ -9197,15 +9197,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "text": "Counter target sorcery spell.\nDelirium — If there are four or more card types among cards in your graveyard, search the graveyard, hand, and library of that spell's controller for any number of cards with the same name as that spell, exile those cards, then that player shuffles his or her library.",
@@ -9318,15 +9318,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The emblem’s triggered ability counters the first spell an opponent casts on each turn, not just that opponent’s turn."
+          "text": "The emblem's triggered ability counters the first spell an opponent casts on each turn, not just that opponent's turn."
         },
         {
           "date": "2016-04-08",
-          "text": "If Jace’s emblem’s triggered ability doesn’t counter the first spell an opponent casts (perhaps because that spell can’t be countered), it won’t trigger again in the same turn to try to counter that player’s second spell."
+          "text": "If Jace's emblem's triggered ability doesn't counter the first spell an opponent casts (perhaps because that spell can't be countered), it won't trigger again in the same turn to try to counter that player's second spell."
         },
         {
           "date": "2016-04-08",
-          "text": "If you have multiple opponents, Jace’s emblem can trigger once each turn for each opponent."
+          "text": "If you have multiple opponents, Jace's emblem can trigger once each turn for each opponent."
         }
       ],
       "subtypes": [
@@ -9442,7 +9442,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -9450,11 +9450,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won’t investigate."
+          "text": "You can't cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won't investigate."
         }
       ],
       "text": "Target creature gets -4/-0 until end of turn.\nInvestigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -9567,15 +9567,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -9583,7 +9583,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -9591,11 +9591,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -9825,7 +9825,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The upkeep step is before the draw step, after the untap step. Manic Scribe’s delirium ability mills an opponent’s library before that player draws a card during his or her draw step."
+          "text": "The upkeep step is before the draw step, after the untap step. Manic Scribe's delirium ability mills an opponent's library before that player draws a card during his or her draw step."
         },
         {
           "date": "2016-04-08",
@@ -9833,19 +9833,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -9962,19 +9962,19 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If there is only one card left in your library, you’ll put it into your hand. You won’t lose the game for having zero cards in your library until you’re required to draw a card."
+          "text": "If there is only one card left in your library, you'll put it into your hand. You won't lose the game for having zero cards in your library until you're required to draw a card."
         },
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -9982,7 +9982,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -9990,11 +9990,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -10334,11 +10334,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "In a Two-Headed Giant game, if you control more than one attacking creature, you may have your creatures deal damage to different opponents so that Ongoing Investigation’s first ability triggers twice."
+          "text": "In a Two-Headed Giant game, if you control more than one attacking creature, you may have your creatures deal damage to different opponents so that Ongoing Investigation's first ability triggers twice."
         },
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -10346,7 +10346,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "text": "Whenever one or more creatures you control deal combat damage to a player, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\n{1}{G}, Exile a creature card from your graveyard: Investigate. You gain 2 life.",
@@ -10471,7 +10471,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"‘I'm certain that the fate of Markov Manor is connected to these cryptoliths . . .' This Tamiyo was on to something.\"",
+      "flavor": "\"'I'm certain that the fate of Markov Manor is connected to these cryptoliths . . .' This Tamiyo was on to something.\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -10679,7 +10679,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -10687,11 +10687,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won’t investigate."
+          "text": "You can't cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won't investigate."
         }
       ],
       "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nInvestigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -11035,7 +11035,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Rise from the Tides isn’t put into your graveyard until after it’s finished resolving. It won’t be counted among the instant and sorcery cards in your graveyard."
+          "text": "Rise from the Tides isn't put into your graveyard until after it's finished resolving. It won't be counted among the instant and sorcery cards in your graveyard."
         }
       ],
       "text": "Create a tapped 2/2 black Zombie creature token for each instant and sorcery card in your graveyard.",
@@ -11259,7 +11259,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "It doesn’t matter whether the noncreature spell resolved or was countered, as long as it was cast."
+          "text": "It doesn't matter whether the noncreature spell resolved or was countered, as long as it was cast."
         }
       ],
       "subtypes": [
@@ -11719,15 +11719,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "A sorcery can’t be put onto the battlefield and a permanent can’t transform into a sorcery. If an effect exiles Persistent Nightmare and then instructs you to return it to the battlefield, it remains face up in exile (unless that effect instructs you to put it onto the battlefield transformed, in which case it returns as Persistent Nightmare). If an effect instructs you to transform Persistent Nightmare, the instruction is ignored."
+          "text": "A sorcery can't be put onto the battlefield and a permanent can't transform into a sorcery. If an effect exiles Persistent Nightmare and then instructs you to return it to the battlefield, it remains face up in exile (unless that effect instructs you to put it onto the battlefield transformed, in which case it returns as Persistent Nightmare). If an effect instructs you to transform Persistent Nightmare, the instruction is ignored."
         },
         {
           "date": "2016-04-08",
-          "text": "Skulk matters only as blockers are chosen. Modifying either creature’s power after blockers are chosen won’t cause the attacking creature to become unblocked."
+          "text": "Skulk matters only as blockers are chosen. Modifying either creature's power after blockers are chosen won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won’t be blocked, but it won’t deal combat damage and won’t trigger any abilities that trigger when combat damage is dealt."
+          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won't be blocked, but it won't deal combat damage and won't trigger any abilities that trigger when combat damage is dealt."
         }
       ],
       "subtypes": [
@@ -11957,7 +11957,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Stitchwing Skaab’s last ability can only be activated while it’s in your graveyard."
+          "text": "Stitchwing Skaab's last ability can only be activated while it's in your graveyard."
         }
       ],
       "subtypes": [
@@ -12191,11 +12191,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "When Thing in the Ice’s triggered ability removes the last counter from it, Awoken Horror’s ability will trigger and resolve before the spell that caused Thing in the Ice’s last ability to trigger."
+          "text": "When Thing in the Ice's triggered ability removes the last counter from it, Awoken Horror's ability will trigger and resolve before the spell that caused Thing in the Ice's last ability to trigger."
         },
         {
           "date": "2016-04-08",
-          "text": "Removing all ice counters from Thing in the Ice some other way will not cause it to transform. You’ll need to cast an instant or sorcery spell and cause its last ability to trigger."
+          "text": "Removing all ice counters from Thing in the Ice some other way will not cause it to transform. You'll need to cast an instant or sorcery spell and cause its last ability to trigger."
         },
         {
           "date": "2016-07-13",
@@ -12432,7 +12432,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -12440,7 +12440,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -12558,11 +12558,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Skulk matters only as blockers are chosen. Modifying either creature’s power after blockers are chosen won’t cause the attacking creature to become unblocked."
+          "text": "Skulk matters only as blockers are chosen. Modifying either creature's power after blockers are chosen won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won’t be blocked, but it won’t deal combat damage and won’t trigger any abilities that trigger when combat damage is dealt."
+          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won't be blocked, but it won't deal combat damage and won't trigger any abilities that trigger when combat damage is dealt."
         },
         {
           "date": "2016-07-13",
@@ -12904,19 +12904,19 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The toughness of the creature is checked only as Welcome to the Fold resolves. It doesn’t matter if it has higher toughness as you cast Welcome to the Fold, or if its toughness becomes higher after Welcome to the Fold has resolved."
+          "text": "The toughness of the creature is checked only as Welcome to the Fold resolves. It doesn't matter if it has higher toughness as you cast Welcome to the Fold, or if its toughness becomes higher after Welcome to the Fold has resolved."
         },
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -12924,7 +12924,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -12932,11 +12932,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -13057,11 +13057,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Accursed Witch’s first ability affects all spells cast by your opponents that target it, including Aura spells and spells that have additional targets. It doesn’t affect abilities."
+          "text": "Accursed Witch's first ability affects all spells cast by your opponents that target it, including Aura spells and spells that have additional targets. It doesn't affect abilities."
         },
         {
           "date": "2016-04-08",
-          "text": "If an effect causes Accursed Witch to transform on the battlefield, rather than leaving it and returning transformed, then Infectious Curse doesn’t become attached to any player and is put into your graveyard. This won’t cause abilities that trigger when a creature leaves the battlefield to trigger."
+          "text": "If an effect causes Accursed Witch to transform on the battlefield, rather than leaving it and returning transformed, then Infectious Curse doesn't become attached to any player and is put into your graveyard. This won't cause abilities that trigger when a creature leaves the battlefield to trigger."
         },
         {
           "date": "2016-07-13",
@@ -13185,11 +13185,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Infectious Curse’s middle ability affects all spells you cast that target the enchanted player, including Aura spells and spells that have additional targets. It doesn’t affect abilities."
+          "text": "Infectious Curse's middle ability affects all spells you cast that target the enchanted player, including Aura spells and spells that have additional targets. It doesn't affect abilities."
         },
         {
           "date": "2016-04-08",
-          "text": "If an effect causes Accursed Witch to transform on the battlefield, rather than leaving it and returning transformed, then Infectious Curse doesn’t become attached to any player and is put into your graveyard. This won’t cause abilities that trigger when a creature leaves the battlefield to trigger."
+          "text": "If an effect causes Accursed Witch to transform on the battlefield, rather than leaving it and returning transformed, then Infectious Curse doesn't become attached to any player and is put into your graveyard. This won't cause abilities that trigger when a creature leaves the battlefield to trigger."
         }
       ],
       "subtypes": [
@@ -13305,15 +13305,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -13321,7 +13321,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -13329,18 +13329,18 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
           "text": "If you discard a card with madness while resolving a spell or ability, it moves immediately to exile. Continue resolving that spell or ability—the card is not in your graveyard at this time. Its madness trigger will be placed onto the stack once that spell or ability has completely resolved."
         }
       ],
-      "text": "Target opponent loses 3 life and you gain 3 life. \nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+      "text": "Target opponent loses 3 life and you gain 3 life.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -13451,27 +13451,27 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The upkeep step is before the draw step, after the untap step. Asylum Visitor’s first ability will trigger and resolve before the active player draws a card in his or her draw step if that player has no cards in hand."
+          "text": "The upkeep step is before the draw step, after the untap step. Asylum Visitor's first ability will trigger and resolve before the active player draws a card in his or her draw step if that player has no cards in hand."
         },
         {
           "date": "2016-04-08",
-          "text": "Asylum Visitor’s triggered ability checks the active player’s hand as the upkeep begins and as the trigger resolves. If that player has a card in hand as it resolves, you won’t draw a card or lose 1 life. Notably, if you control multiple Asylum Visitors during your upkeep, whichever one’s first ability resolves first will stop the other’s first ability from having any effect unless you have a way to get the card you drew out of your hand before it resolves."
+          "text": "Asylum Visitor's triggered ability checks the active player's hand as the upkeep begins and as the trigger resolves. If that player has a card in hand as it resolves, you won't draw a card or lose 1 life. Notably, if you control multiple Asylum Visitors during your upkeep, whichever one's first ability resolves first will stop the other's first ability from having any effect unless you have a way to get the card you drew out of your hand before it resolves."
         },
         {
           "date": "2016-04-08",
-          "text": "On an opponent’s turn, triggered abilities you control will resolve before any triggered abilities of permanents that opponent controls if they trigger at the same time. This means that if you and your opponent each control an Asylum Visitor during your opponent’s upkeep, and he or she has no cards in hand, you’ll always draw a card before your opponent has a card in his or her hand."
+          "text": "On an opponent's turn, triggered abilities you control will resolve before any triggered abilities of permanents that opponent controls if they trigger at the same time. This means that if you and your opponent each control an Asylum Visitor during your opponent's upkeep, and he or she has no cards in hand, you'll always draw a card before your opponent has a card in his or her hand."
         },
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -13479,7 +13479,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -13487,11 +13487,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -13614,11 +13614,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Skulk matters only as blockers are chosen. Modifying either creature’s power after blockers are chosen won’t cause the attacking creature to become unblocked."
+          "text": "Skulk matters only as blockers are chosen. Modifying either creature's power after blockers are chosen won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won’t be blocked, but it won’t deal combat damage and won’t trigger any abilities that trigger when combat damage is dealt."
+          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won't be blocked, but it won't deal combat damage and won't trigger any abilities that trigger when combat damage is dealt."
         }
       ],
       "text": "Creatures you control have skulk. (They can't be blocked by creatures with greater power.)\n{4}{W}: Creatures you control get +1/+1 until end of turn.",
@@ -13838,19 +13838,19 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The set of creatures affected by Biting Rain is determined as the spell resolves. Creatures that enter the battlefield later in the turn won’t get -2/-2."
+          "text": "The set of creatures affected by Biting Rain is determined as the spell resolves. Creatures that enter the battlefield later in the turn won't get -2/-2."
         },
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -13858,7 +13858,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -13866,18 +13866,18 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
           "text": "If you discard a card with madness while resolving a spell or ability, it moves immediately to exile. Continue resolving that spell or ability—the card is not in your graveyard at this time. Its madness trigger will be placed onto the stack once that spell or ability has completely resolved."
         }
       ],
-      "text": "All creatures get -2/-2 until end of turn. \nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+      "text": "All creatures get -2/-2 until end of turn.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -13987,7 +13987,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can activate Call the Bloodline’s ability once on each player’s turn, not just your own."
+          "text": "You can activate Call the Bloodline's ability once on each player's turn, not just your own."
         }
       ],
       "text": "{1}, Discard a card: Create a 1/1 black Vampire Knight creature token with lifelink. Activate this ability only once each turn.",
@@ -14103,11 +14103,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The card types that may be shared for Creeping Dread’s ability are artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal (a card type that appears on some older cards). Supertypes (such as legendary and basic) and subtypes (such as Human and Equipment) are not counted."
+          "text": "The card types that may be shared for Creeping Dread's ability are artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal (a card type that appears on some older cards). Supertypes (such as legendary and basic) and subtypes (such as Human and Equipment) are not counted."
         },
         {
           "date": "2016-04-08",
-          "text": "If a player has no cards in hand, that player doesn’t discard a card while everyone else does. If you didn’t discard a card, no player can have discarded a card that shares a card type with the card you discarded, so no player loses 3 life."
+          "text": "If a player has no cards in hand, that player doesn't discard a card while everyone else does. If you didn't discard a card, no player can have discarded a card that shares a card type with the card you discarded, so no player loses 3 life."
         },
         {
           "date": "2016-04-08",
@@ -14115,7 +14115,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, a double-faced card with different card types among its faces (such as Skin Invasion) only compares its front face to the other discarded cards."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, a double-faced card with different card types among its faces (such as Skin Invasion) only compares its front face to the other discarded cards."
         }
       ],
       "text": "At the beginning of your upkeep, each player discards a card. Each opponent who discarded a card that shares a card type with the card you discarded loses 3 life. (Players reveal the discarded cards simultaneously.)",
@@ -14228,7 +14228,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The triggered ability triggers both when Crow of Dark Tidings enters the battlefield and when it dies. You don’t have to choose only one."
+          "text": "The triggered ability triggers both when Crow of Dark Tidings enters the battlefield and when it dies. You don't have to choose only one."
         }
       ],
       "subtypes": [
@@ -14465,7 +14465,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Diregraf Colossus’s last ability won’t trigger when you cast it because it’s not on the battlefield yet."
+          "text": "Diregraf Colossus's last ability won't trigger when you cast it because it's not on the battlefield yet."
         }
       ],
       "subtypes": [
@@ -14589,7 +14589,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can activate Elusive Tormentor’s ability multiple times to discard multiple cards. Only the first instance of the ability to resolve will cause it to transform."
+          "text": "You can activate Elusive Tormentor's ability multiple times to discard multiple cards. Only the first instance of the ability to resolve will cause it to transform."
         },
         {
           "date": "2016-04-08",
@@ -14597,7 +14597,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Once blockers have been chosen, transforming Elusive Tormentor into Insidious Mist won’t cause it to become unblocked."
+          "text": "Once blockers have been chosen, transforming Elusive Tormentor into Insidious Mist won't cause it to become unblocked."
         },
         {
           "date": "2016-07-13",
@@ -14833,7 +14833,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If a targeted creature card is normally colorless, it will simply become black. It won’t be both black and colorless."
+          "text": "If a targeted creature card is normally colorless, it will simply become black. It won't be both black and colorless."
         }
       ],
       "text": "Return up to two target creature cards from your graveyard to the battlefield. Each of those creatures is a black Zombie in addition to its other colors and types. Put Ever After on the bottom of its owner's library.",
@@ -14947,11 +14947,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Skulk matters only as blockers are chosen. Modifying either creature’s power after blockers are chosen won’t cause the attacking creature to become unblocked."
+          "text": "Skulk matters only as blockers are chosen. Modifying either creature's power after blockers are chosen won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won’t be blocked, but it won’t deal combat damage and won’t trigger any abilities that trigger when combat damage is dealt."
+          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won't be blocked, but it won't deal combat damage and won't trigger any abilities that trigger when combat damage is dealt."
         }
       ],
       "subtypes": [
@@ -15067,15 +15067,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -15083,7 +15083,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -15091,11 +15091,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -15326,7 +15326,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Ghoulsteed’s ability can only be activated while it’s in your graveyard."
+          "text": "Ghoulsteed's ability can only be activated while it's in your graveyard."
         }
       ],
       "subtypes": [
@@ -15444,15 +15444,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -15460,7 +15460,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -15468,11 +15468,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -15588,7 +15588,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Multiple instances of lifelink are redundant."
+          "text": "multiple instances of lifelink on the same creature are redundant."
         }
       ],
       "text": "Target creature gets +3/+1 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
@@ -15940,7 +15940,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Menace only matters as blockers are chosen. Causing Hound of the Farbogs to gain menace after blockers are chosen won’t cause it to become unblocked."
+          "text": "Menace only matters as blockers are chosen. Causing Hound of the Farbogs to gain menace after blockers are chosen won't cause it to become unblocked."
         },
         {
           "date": "2016-04-08",
@@ -15948,15 +15948,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -16197,7 +16197,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Activating Kindly Stranger’s ability twice won’t cause it to transform back into Kindly Stranger once it has already transformed into Demon-Possessed Witch."
+          "text": "Activating Kindly Stranger's ability twice won't cause it to transform back into Kindly Stranger once it has already transformed into Demon-Possessed Witch."
         },
         {
           "date": "2016-04-08",
@@ -16205,15 +16205,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
@@ -16454,7 +16454,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You don’t lose the game for having zero cards in your library until you’re instructed to draw a card. X can be greater than or equal to the number of cards in your library without causing you to lose the game."
+          "text": "You don't lose the game for having zero cards in your library until you're instructed to draw a card. X can be greater than or equal to the number of cards in your library without causing you to lose the game."
         }
       ],
       "text": "Put the top X cards of your library into your graveyard. Target player loses 2 life for each creature card put into your graveyard this way.",
@@ -16573,11 +16573,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If you have no other cards in hand, you’ll have to discard one of the creature cards you return to your hand."
+          "text": "If you have no other cards in hand, you'll have to discard one of the creature cards you return to your hand."
         },
         {
           "date": "2016-04-08",
-          "text": "You may cast Macabre Waltz targeting one or zero creature cards. You’ll still discard a card, even if you target no creature cards."
+          "text": "You may cast Macabre Waltz targeting one or zero creature cards. You'll still discard a card, even if you target no creature cards."
         }
       ],
       "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
@@ -16803,11 +16803,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You must sacrifice exactly one creature or land to cast Merciless Resolve. You can’t cast it without sacrificing a permanent, and you can’t sacrifice additional permanents."
+          "text": "You must sacrifice exactly one creature or land to cast Merciless Resolve. You can't cast it without sacrificing a permanent, and you can't sacrifice additional permanents."
         },
         {
           "date": "2016-04-08",
-          "text": "Players can respond to this spell only after it’s been cast and all its costs have been paid. No one can try to destroy the creature or land you sacrificed to stop you from casting this spell or to make you sacrifice a different one."
+          "text": "Players can respond to this spell only after it's been cast and all its costs have been paid. No one can try to destroy the creature or land you sacrificed to stop you from casting this spell or to make you sacrifice a different one."
         }
       ],
       "text": "As an additional cost to cast Merciless Resolve, sacrifice a creature or land.\nDraw two cards.",
@@ -16921,7 +16921,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Mindwrack Demon’s delirium triggered ability does not include an intervening “if” clause. This ability triggers at the beginning of your upkeep regardless of the number of types in your graveyard, and it checks that number as it resolves to determine whether you lose 4 life or not."
+          "text": "Mindwrack Demon's delirium triggered ability does not include an intervening \"if\" clause. This ability triggers at the beginning of your upkeep regardless of the number of types in your graveyard, and it checks that number as it resolves to determine whether you lose 4 life or not."
         },
         {
           "date": "2016-04-08",
@@ -16929,15 +16929,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -17055,11 +17055,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "When Morkrut Necropod attacks, its trigger doesn’t resolve until after all attackers have been chosen. The same is true for when it blocks. This means that another creature, such as one enchanted with Invocation of Saint Traft, can also attack or block and then be sacrificed. Sacrificing a blocking creature this way doesn’t cause the creature it blocked to become unblocked."
+          "text": "When Morkrut Necropod attacks, its trigger doesn't resolve until after all attackers have been chosen. The same is true for when it blocks. This means that another creature, such as one enchanted with Invocation of Saint Traft, can also attack or block and then be sacrificed. Sacrificing a blocking creature this way doesn't cause the creature it blocked to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "In the unusual situation that you control no other creatures or lands, the last ability won’t do anything. Morkrut Necropod can attack or block with no penalty."
+          "text": "In the unusual situation that you control no other creatures or lands, the last ability won't do anything. Morkrut Necropod can attack or block with no penalty."
         }
       ],
       "subtypes": [
@@ -17177,15 +17177,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -17193,7 +17193,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -17201,11 +17201,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -17441,11 +17441,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Skulk matters only as blockers are chosen. Modifying either creature’s power after blockers are chosen won’t cause the attacking creature to become unblocked."
+          "text": "Skulk matters only as blockers are chosen. Modifying either creature's power after blockers are chosen won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won’t be blocked, but it won’t deal combat damage and won’t trigger any abilities that trigger when combat damage is dealt."
+          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won't be blocked, but it won't deal combat damage and won't trigger any abilities that trigger when combat damage is dealt."
         }
       ],
       "subtypes": [
@@ -17561,7 +17561,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If there is no nonland card to choose, and you have four or more card types among cards in your graveyard, you’ll search that player’s library even though you won’t be able to find any cards. That library will be shuffled."
+          "text": "If there is no nonland card to choose, and you have four or more card types among cards in your graveyard, you'll search that player's library even though you won't be able to find any cards. That library will be shuffled."
         },
         {
           "date": "2016-04-08",
@@ -17569,15 +17569,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose a nonland card from it and exile that card.\nDelirium — If there are four or more card types among cards in your graveyard, search that player's graveyard, hand, and library for any number of cards with the same name as the exiled card, exile those cards, then that player shuffles his or her library.",
@@ -17691,11 +17691,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Skulk matters only as blockers are chosen. Modifying either creature’s power after blockers are chosen won’t cause the attacking creature to become unblocked."
+          "text": "Skulk matters only as blockers are chosen. Modifying either creature's power after blockers are chosen won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won’t be blocked, but it won’t deal combat damage and won’t trigger any abilities that trigger when combat damage is dealt."
+          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won't be blocked, but it won't deal combat damage and won't trigger any abilities that trigger when combat damage is dealt."
         }
       ],
       "subtypes": [
@@ -17813,11 +17813,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Relentless Dead’s last two abilities trigger at the same time and can be put on the stack in either order. The ability put on the stack first will be the last to resolve."
+          "text": "Relentless Dead's last two abilities trigger at the same time and can be put on the stack in either order. The ability put on the stack first will be the last to resolve."
         },
         {
           "date": "2016-04-08",
-          "text": "You decide whether to pay for each triggered ability as it resolves. If you do, the rest of that ability’s effect happens before any player may take actions."
+          "text": "You decide whether to pay for each triggered ability as it resolves. If you do, the rest of that ability's effect happens before any player may take actions."
         }
       ],
       "subtypes": [
@@ -18271,7 +18271,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You may pay Sinister Concoction’s costs in any order. However, once you’ve decided to activate the ability and you’ve seen the top card of your library, you can’t change your mind."
+          "text": "You may pay Sinister Concoction's costs in any order. However, once you've decided to activate the ability and you've seen the top card of your library, you can't change your mind."
         }
       ],
       "text": "{B}, Pay 1 life, Put the top card of your library into your graveyard, Discard a card, Sacrifice Sinister Concoction: Destroy target creature.",
@@ -18389,15 +18389,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
@@ -18744,7 +18744,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If the delirium ability applies, that player must sacrifice a creature object and a planeswalker object if able. In the unusual case that the player controls a single permanent that’s both a creature and a planeswalker, that player must sacrifice another creature or planeswalker (unless he or she controls no other creatures and no other planeswalkers)."
+          "text": "If the delirium ability applies, that player must sacrifice a creature object and a planeswalker object if able. In the unusual case that the player controls a single permanent that's both a creature and a planeswalker, that player must sacrifice another creature or planeswalker (unless he or she controls no other creatures and no other planeswalkers)."
         },
         {
           "date": "2016-04-08",
@@ -18752,19 +18752,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Some delirium abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect when they resolve if there are four or more card types among cards in your graveyard. They check that number only while they’re resolving and don’t count themselves, since they aren’t in your graveyard yet. You only get the upgraded effect, not both effects."
+          "text": "Some delirium abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect when they resolve if there are four or more card types among cards in your graveyard. They check that number only while they're resolving and don't count themselves, since they aren't in your graveyard yet. You only get the upgraded effect, not both effects."
         }
       ],
       "text": "Target player sacrifices a creature or planeswalker.\nDelirium — If there are four or more card types among cards in your graveyard, instead that player sacrifices a creature and a planeswalker.",
@@ -18882,19 +18882,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -19015,15 +19015,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose Triskaidekaphobia’s second mode and begin to resolve it while an opponent’s life total is 13 and your life total is 1, that opponent will lose the game before you lose 1 life."
+          "text": "If you choose Triskaidekaphobia's second mode and begin to resolve it while an opponent's life total is 13 and your life total is 1, that opponent will lose the game before you lose 1 life."
         },
         {
           "date": "2016-04-08",
-          "text": "In a Two-Headed Giant game, each team with 13 life would lose the game, then each player on each team gains or loses 1 life, causing the team’s life total to go up or down by 2."
+          "text": "In a Two-Headed Giant game, each team with 13 life would lose the game, then each player on each team gains or loses 1 life, causing the team's life total to go up or down by 2."
         },
         {
           "date": "2016-04-08",
-          "text": "If each player has 13 life as Triskaidekaphobia’s ability resolves, the game ends in a draw."
+          "text": "If each player has 13 life as Triskaidekaphobia's ability resolves, the game ends in a draw."
         }
       ],
       "text": "At the beginning of your upkeep, choose one —\n• Each player with exactly 13 life loses the game, then each player gains 1 life.\n• Each player with exactly 13 life loses the game, then each player loses 1 life.",
@@ -19137,15 +19137,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -19153,7 +19153,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -19161,11 +19161,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -19396,7 +19396,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You won’t see the player’s hand while resolving Vessel of Malignity’s ability. That player chooses two cards, exiles them face up, and then you get to see what was exiled."
+          "text": "You won't see the player's hand while resolving Vessel of Malignity's ability. That player chooses two cards, exiles them face up, and then you get to see what was exiled."
         }
       ],
       "text": "{1}{B}, Sacrifice Vessel of Malignity: Target opponent exiles two cards from his or her hand. Activate this ability only any time you could cast a sorcery.",
@@ -19508,27 +19508,27 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You announce how the damage will be divided as part of casting Avacyn’s Judgment. Each chosen target must receive at least 1 damage."
+          "text": "You announce how the damage will be divided as part of casting Avacyn's Judgment. Each chosen target must receive at least 1 damage."
         },
         {
           "date": "2016-04-08",
-          "text": "You can redirect damage that Avacyn’s Judgment would deal to an opponent to a planeswalker that player controls. However, Avacyn’s Judgment can’t deal damage to both a planeswalker and that planeswalker’s controller."
+          "text": "You can redirect damage that Avacyn's Judgment would deal to an opponent to a planeswalker that player controls. However, Avacyn's Judgment can't deal damage to both a planeswalker and that planeswalker's controller."
         },
         {
           "date": "2016-04-08",
-          "text": "If Avacyn’s Judgment has multiple targets, and some but not all of them are illegal targets when Avacyn’s Judgment resolves, Avacyn’s Judgment will still deal damage to the remaining legal targets according to the original damage division."
+          "text": "If Avacyn's Judgment has multiple targets, and some but not all of them are illegal targets when Avacyn's Judgment resolves, Avacyn's Judgment will still deal damage to the remaining legal targets according to the original damage division."
         },
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -19536,7 +19536,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -19544,11 +19544,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -19665,15 +19665,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -19681,7 +19681,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -19689,11 +19689,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -19820,7 +19820,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -19947,11 +19947,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -20071,11 +20071,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If Burn from Within doesn’t deal damage to the target creature (perhaps because that damage was prevented or X is 0), neither additional effect will apply. It won’t lose indestructible, and it won’t be exiled instead of dying that turn."
+          "text": "If Burn from Within doesn't deal damage to the target creature (perhaps because that damage was prevented or X is 0), neither additional effect will apply. It won't lose indestructible, and it won't be exiled instead of dying that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "You can target a creature that doesn’t have indestructible with Burn from Within. It will still be exiled if it would die this turn."
+          "text": "You can target a creature that doesn't have indestructible with Burn from Within. It will still be exiled if it would die this turn."
         }
       ],
       "text": "Burn from Within deals X damage to target creature or player. If a creature is dealt damage this way, it loses indestructible until end of turn. If that creature would die this turn, exile it instead.",
@@ -20193,7 +20193,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -20319,11 +20319,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -20654,7 +20654,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Destroying a blocking creature doesn’t cause the attacking creature it blocked to become unblocked."
+          "text": "Destroying a blocking creature doesn't cause the attacking creature it blocked to become unblocked."
         }
       ],
       "text": "Target blocking creature fights another target blocking creature.",
@@ -20767,7 +20767,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can’t target the same creature twice to have Dual Shot deal 2 damage to it."
+          "text": "You can't target the same creature twice to have Dual Shot deal 2 damage to it."
         }
       ],
       "text": "Dual Shot deals 1 damage to each of up to two target creatures.",
@@ -20992,7 +20992,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Falkenrath Gorger’s ability only applies while it’s on the battlefield. If you discard it, it won’t give itself madness."
+          "text": "Falkenrath Gorger's ability only applies while it's on the battlefield. If you discard it, it won't give itself madness."
         },
         {
           "date": "2016-04-08",
@@ -21000,19 +21000,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a Vampire creature card that already has a madness ability, you’ll choose which madness ability exiles it. You may choose either the one it normally has or the one it gains from Falkenrath Gorger."
+          "text": "If you discard a Vampire creature card that already has a madness ability, you'll choose which madness ability exiles it. You may choose either the one it normally has or the one it gains from Falkenrath Gorger."
         },
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -21020,7 +21020,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -21028,11 +21028,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -21165,15 +21165,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -21181,7 +21181,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -21189,11 +21189,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -21311,11 +21311,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If a source deals damage to you and/or one or more permanents you control at the same time, Flameblade Angel’s last ability will trigger that many times. For example, if a creature with trample deals damage to a blocking creature you control and you, Flameblade Angel’s ability will trigger two times."
+          "text": "If a source deals damage to you and/or one or more permanents you control at the same time, Flameblade Angel's last ability will trigger that many times. For example, if a creature with trample deals damage to a blocking creature you control and you, Flameblade Angel's ability will trigger two times."
         },
         {
           "date": "2016-04-08",
-          "text": "Note that the last ability is optional. Say two players each control a Flameblade Angel, and a source controlled by the first player deals damage to the second player or a permanent he or she controls. The resulting triggered ability may deal damage to the first player, causing the ability of that player’s Flameblade Angel to trigger. That ability may deal damage to the second player, and so on. This cycle will repeat until the game ends or one player declines to use the ability, putting an end to the carnage."
+          "text": "Note that the last ability is optional. Say two players each control a Flameblade Angel, and a source controlled by the first player deals damage to the second player or a permanent he or she controls. The resulting triggered ability may deal damage to the first player, causing the ability of that player's Flameblade Angel to trigger. That ability may deal damage to the second player, and so on. This cycle will repeat until the game ends or one player declines to use the ability, putting an end to the carnage."
         }
       ],
       "subtypes": [
@@ -21437,7 +21437,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -21562,11 +21562,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -21688,7 +21688,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -21818,15 +21818,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If a creature with haste transforms and no longer has haste on the same turn that it comes under your control, such as if you cast a Geier Reach Bandit when you already control a Vildin-Pack Alpha, it won’t be able to attack that turn."
+          "text": "If a creature with haste transforms and no longer has haste on the same turn that it comes under your control, such as if you cast a Geier Reach Bandit when you already control a Vildin-Pack Alpha, it won't be able to attack that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -21943,27 +21943,27 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Geistblast’s ability can copy any instant or sorcery spell, not just one with targets."
+          "text": "Geistblast's ability can copy any instant or sorcery spell, not just one with targets."
         },
         {
           "date": "2016-04-08",
-          "text": "When Geistblast’s ability resolves, it creates a copy of the instant or sorcery spell. The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, before the original spell resolves but after players get a chance to cast spells and activate abilities."
+          "text": "When Geistblast's ability resolves, it creates a copy of the instant or sorcery spell. The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, before the original spell resolves but after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2016-04-08",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2016-04-08",
-          "text": "If the spell being copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell being copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2016-04-08",
-          "text": "If the spell being copied has an X whose value was determined as it was cast (like Avacyn’s Judgment’s madness cost has), the copy will have the same value of X."
+          "text": "If the spell being copied has an X whose value was determined as it was cast (like Avacyn's Judgment's madness cost has), the copy will have the same value of X."
         },
         {
           "date": "2016-04-08",
-          "text": "If the spell has damage divided as it was cast (also like Avacyn’s Judgment), the division can’t be changed (although the targets receiving that damage still can)."
+          "text": "If the spell has damage divided as it was cast (also like Avacyn's Judgment), the division can't be changed (although the targets receiving that damage still can)."
         },
         {
           "date": "2016-04-08",
@@ -22084,19 +22084,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -22213,7 +22213,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If multiple replacement effects could apply to damage being dealt to you or Goldnight Castigator, you choose the order to apply those effects. Notably, if a source an opponent controls would deal noncombat damage to you while you control a planeswalker, you can have that opponent choose whether or not to redirect the damage to that planeswalker before the damage is doubled. If you do, damage redirected to that planeswalker won’t be doubled."
+          "text": "If multiple replacement effects could apply to damage being dealt to you or Goldnight Castigator, you choose the order to apply those effects. Notably, if a source an opponent controls would deal noncombat damage to you while you control a planeswalker, you can have that opponent choose whether or not to redirect the damage to that planeswalker before the damage is doubled. If you do, damage redirected to that planeswalker won't be doubled."
         },
         {
           "date": "2016-04-08",
@@ -22334,19 +22334,19 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You must choose a target for Harness the Storm’s ability (if one exists) immediately after you’ve cast an instant or sorcery spell. There’s no way for that spell to be countered and then targeted by Harness the Storm once it’s in the graveyard."
+          "text": "You must choose a target for Harness the Storm's ability (if one exists) immediately after you've cast an instant or sorcery spell. There's no way for that spell to be countered and then targeted by Harness the Storm once it's in the graveyard."
         },
         {
           "date": "2016-04-08",
-          "text": "You choose whether to cast the targeted card as the ability resolves. You can’t wait to cast it later, and there’s no way for your opponents to set up a situation where you have to cast the card but don’t want to."
+          "text": "You choose whether to cast the targeted card as the ability resolves. You can't wait to cast it later, and there's no way for your opponents to set up a situation where you have to cast the card but don't want to."
         },
         {
           "date": "2016-04-08",
-          "text": "If the spell you cast from your hand is countered in response to Harness the Storm’s triggered ability, you can still cast the target card while the ability is resolving."
+          "text": "If the spell you cast from your hand is countered in response to Harness the Storm's triggered ability, you can still cast the target card while the ability is resolving."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you’re paying the spell’s costs, you can pay alternative costs, such as awaken costs and surge costs from the Battle for Zendikar block. You can also pay additional costs, such as kicker costs. If the card has a mandatory additional cost, like Lightning Axe, you must pay it to cast the card."
+          "text": "Because you're paying the spell's costs, you can pay alternative costs, such as awaken costs and surge costs from the Battle for Zendikar block. You can also pay additional costs, such as kicker costs. If the card has a mandatory additional cost, like Lightning Axe, you must pay it to cast the card."
         },
         {
           "date": "2016-04-08",
@@ -22354,7 +22354,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The spell you cast from your graveyard resolves before the spell you cast from your hand. It’s put into your graveyard as it resolves."
+          "text": "The spell you cast from your graveyard resolves before the spell you cast from your hand. It's put into your graveyard as it resolves."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell from your hand, you may cast target card with the same name as that spell from your graveyard. (You still pay its costs.)",
@@ -22696,15 +22696,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -22712,7 +22712,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -22720,11 +22720,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -23068,11 +23068,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Kessig Forgemaster’s first ability triggers once for each creature blocking or blocked by it. The ability resolves and deals damage to that creature before combat damage is dealt. If that damage destroys a creature blocking Kessig Forgemaster, Kessig Forgemaster doesn’t become unblocked."
+          "text": "Kessig Forgemaster's first ability triggers once for each creature blocking or blocked by it. The ability resolves and deals damage to that creature before combat damage is dealt. If that damage destroys a creature blocking Kessig Forgemaster, Kessig Forgemaster doesn't become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -23198,15 +23198,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Flameheart Werewolf’s first ability triggers once for each creature blocking or blocked by it. The ability resolves and deals damage to that creature before combat damage is dealt. If that damage destroys a creature blocking Flameheart Werewolf, Flameheart Werewolf doesn’t become unblocked."
+          "text": "Flameheart Werewolf's first ability triggers once for each creature blocking or blocked by it. The ability resolves and deals damage to that creature before combat damage is dealt. If that damage destroys a creature blocking Flameheart Werewolf, Flameheart Werewolf doesn't become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -23328,7 +23328,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "This has an additional cost with an option. Essentially, the card’s cost to cast is either {5}{R} or {R} and a discard. But its mana cost is always {R} and its converted mana cost is always 1."
+          "text": "This has an additional cost with an option. Essentially, the card's cost to cast is either {5}{R} or {R} and a discard. But its mana cost is always {R} and its converted mana cost is always 1."
         },
         {
           "date": "2016-04-08",
@@ -23452,7 +23452,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "Discarding a card is part of the ability’s activation cost. You can’t activate the ability if you have no cards in hand."
+          "text": "Discarding a card is part of the ability's activation cost. You can't activate the ability if you have no cards in hand."
         }
       ],
       "subtypes": [
@@ -23575,7 +23575,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Because Magmatic Chasm’s effect doesn’t change the characteristics of any permanents, the set of creatures affected by Magmatic Chasm is constantly updated. Creatures without flying that enter the battlefield later in the turn won’t be able to block."
+          "text": "Because Magmatic Chasm's effect doesn't change the characteristics of any permanents, the set of creatures affected by Magmatic Chasm is constantly updated. Creatures without flying that enter the battlefield later in the turn won't be able to block."
         }
       ],
       "text": "Creatures without flying can't block this turn.",
@@ -23687,23 +23687,23 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Malevolent Whispers can target any creature, even one that’s untapped or one you already control."
+          "text": "Malevolent Whispers can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2016-04-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it, even though those remain attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it, even though those remain attached to it."
         },
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -23711,7 +23711,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -23719,18 +23719,18 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
           "text": "If you discard a card with madness while resolving a spell or ability, it moves immediately to exile. Continue resolving that spell or ability—the card is not in your graveyard at this time. Its madness trigger will be placed onto the stack once that spell or ability has completely resolved."
         }
       ],
-      "text": "Gain control of target creature until end of turn. Untap that creature. It gets +2/+0 and gains haste until end of turn. \nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+      "text": "Gain control of target creature until end of turn. Untap that creature. It gets +2/+0 and gains haste until end of turn.\nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -23841,7 +23841,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Pyre Hound’s triggered ability resolves before the spell that causes it to trigger."
+          "text": "Pyre Hound's triggered ability resolves before the spell that causes it to trigger."
         }
       ],
       "subtypes": [
@@ -23960,7 +23960,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can activate Ravenous Bloodseeker’s ability any number of times to discard several cards. It will be put into its owner’s graveyard once its toughness is 0 or less. Any other instances of the ability still on the stack will resolve with no effect."
+          "text": "You can activate Ravenous Bloodseeker's ability any number of times to discard several cards. It will be put into its owner's graveyard once its toughness is 0 or less. Any other instances of the ability still on the stack will resolve with no effect."
         }
       ],
       "subtypes": [
@@ -24415,15 +24415,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -24540,15 +24540,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -24556,7 +24556,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -24564,11 +24564,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -24688,7 +24688,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Each opponent in turn order, starting with the one after you in turn order, may choose to have you put that card into your graveyard. Once a player does so, Sin Prodder deals damage equal to that card’s converted mana cost to that player immediately and Sin Prodder’s trigger has no further action."
+          "text": "Each opponent in turn order, starting with the one after you in turn order, may choose to have you put that card into your graveyard. Once a player does so, Sin Prodder deals damage equal to that card's converted mana cost to that player immediately and Sin Prodder's trigger has no further action."
         }
       ],
       "subtypes": [
@@ -24812,11 +24812,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The enchanted creature’s controller still chooses which player or planeswalker that creature attacks."
+          "text": "The enchanted creature's controller still chooses which player or planeswalker that creature attacks."
         },
         {
           "date": "2016-04-08",
-          "text": "If, during your declare attackers step, the enchanted creature is tapped or is affected by a spell or ability that says it can’t attack, then it doesn’t attack. If there’s a cost associated with having that creature attack, its controller isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, the enchanted creature is tapped or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2016-07-13",
@@ -25159,19 +25159,19 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Losing or gaining first strike after first-strike damage has been dealt won’t cause a creature to deal combat damage twice or to not deal combat damage."
+          "text": "Losing or gaining first strike after first-strike damage has been dealt won't cause a creature to deal combat damage twice or to not deal combat damage."
         },
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -25179,7 +25179,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -25187,11 +25187,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -25427,7 +25427,7 @@
       "rulings": [
         {
           "date": "2015-02-25",
-          "text": "Because discarding a card is an additional cost, you can’t cast Tormenting Voice if you have no other cards in hand."
+          "text": "Because discarding a card is an additional cost, you can't cast Tormenting Voice if you have no other cards in hand."
         }
       ],
       "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
@@ -25872,7 +25872,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -25997,11 +25997,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -26232,15 +26232,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can’t choose to discard a card without also paying {1}{R}."
+          "text": "You can't choose to discard a card without also paying {1}{R}."
         },
         {
           "date": "2016-04-08",
-          "text": "If a card with {X} in its mana cost is discarded to Wolf of Devil’s Breach’s ability, X is considered to be 0."
+          "text": "If a card with {X} in its mana cost is discarded to Wolf of Devil's Breach's ability, X is considered to be 0."
         },
         {
           "date": "2016-04-08",
-          "text": "You choose the target creature or planeswalker as the triggered ability of Wolf of Devil’s Breach is put onto the stack. You choose which card to discard, if any, as the ability resolves. While players may respond to the triggered ability once you’ve chosen a target, no player may take actions between the time you discard the card and the time damage is dealt."
+          "text": "You choose the target creature or planeswalker as the triggered ability of Wolf of Devil's Breach is put onto the stack. You choose which card to discard, if any, as the ability resolves. While players may respond to the triggered ability once you've chosen a target, no player may take actions between the time you discard the card and the time damage is dealt."
         }
       ],
       "subtypes": [
@@ -26358,11 +26358,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Aim High can target a creature that’s already untapped."
+          "text": "Aim High can target a creature that's already untapped."
         },
         {
           "date": "2016-04-08",
-          "text": "Untapping an attacking creature doesn’t cause it to be removed from combat."
+          "text": "Untapping an attacking creature doesn't cause it to be removed from combat."
         }
       ],
       "text": "Untap target creature. It gets +2/+2 and gains reach until end of turn. (It can block creatures with flying.)",
@@ -26483,19 +26483,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         },
         {
           "date": "2016-07-13",
@@ -26728,15 +26728,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Briarbridge Patrol’s first ability will only trigger once per combat damage step, regardless of how many creatures it deals damage to."
+          "text": "Briarbridge Patrol's first ability will only trigger once per combat damage step, regardless of how many creatures it deals damage to."
         },
         {
           "date": "2016-04-08",
-          "text": "Briarbridge Patrol’s second ability looks at the entire turn, even if Briarbridge Patrol wasn’t on the battlefield for some of the turn. It will see Clues sacrificed for any reason, not just Clues sacrificed to their own ability."
+          "text": "Briarbridge Patrol's second ability looks at the entire turn, even if Briarbridge Patrol wasn't on the battlefield for some of the turn. It will see Clues sacrificed for any reason, not just Clues sacrificed to their own ability."
         },
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -26744,7 +26744,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "subtypes": [
@@ -26863,7 +26863,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -26871,7 +26871,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "subtypes": [
@@ -26989,7 +26989,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can cast Clip Wings even if some (or all) of your opponents don’t control a creature with flying. Those who do must each choose a flying creature to sacrifice, and those who don’t are unaffected."
+          "text": "You can cast Clip Wings even if some (or all) of your opponents don't control a creature with flying. Those who do must each choose a flying creature to sacrifice, and those who don't are unaffected."
         }
       ],
       "text": "Each opponent sacrifices a creature with flying.",
@@ -27106,7 +27106,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -27114,11 +27114,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won’t investigate."
+          "text": "You can't cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won't investigate."
         }
       ],
       "text": "Investigate, then target creature gets +1/+1 until end of turn for each Clue you control. (To investigate, create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -27230,7 +27230,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If multiple land cards are put into your graveyard at once, Crawling Sensation’s last ability triggers only once. This could happen because an effect (such as that of Crawling Sensation’s first ability) put them there from your library at once, or because they were destroyed at the same time (such as two land creatures that were dealt lethal combat damage)."
+          "text": "If multiple land cards are put into your graveyard at once, Crawling Sensation's last ability triggers only once. This could happen because an effect (such as that of Crawling Sensation's first ability) put them there from your library at once, or because they were destroyed at the same time (such as two land creatures that were dealt lethal combat damage)."
         }
       ],
       "text": "At the beginning of your upkeep, you may put the top two cards of your library into your graveyard.\nWhenever one or more land cards are put into your graveyard from anywhere for the first time each turn, create a 1/1 green Insect creature token.",
@@ -27343,7 +27343,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If a creature has multiple mana abilities with a cost of {T}, such as if you control two Cryptolith Rites, you can only activate one of them at a time. Tapping the creature doesn’t produce multiple mana."
+          "text": "If a creature has multiple mana abilities with a cost of {T}, such as if you control two Cryptolith Rites, you can only activate one of them at a time. Tapping the creature doesn't produce multiple mana."
         }
       ],
       "text": "Creatures you control have \"{T}: Add one mana of any color to your mana pool.\"",
@@ -27457,11 +27457,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "A permanent transforms into a non-Human creature if it transforms and is a creature without the creature type Human after transforming, regardless of whether it was a Human creature (or a creature at all) before it transformed. For example, Westvale Abbey and Thraben Gargoyle will both cause Cult of the Waxing Moon’s ability to trigger when they transform."
+          "text": "A permanent transforms into a non-Human creature if it transforms and is a creature without the creature type Human after transforming, regardless of whether it was a Human creature (or a creature at all) before it transformed. For example, Westvale Abbey and Thraben Gargoyle will both cause Cult of the Waxing Moon's ability to trigger when they transform."
         },
         {
           "date": "2016-04-08",
-          "text": "A non-Human creature that’s put onto the battlefield transformed, such as Skin Shedder, will not cause Cult of the Waxing Moon’s ability to trigger."
+          "text": "A non-Human creature that's put onto the battlefield transformed, such as Skin Shedder, will not cause Cult of the Waxing Moon's ability to trigger."
         }
       ],
       "subtypes": [
@@ -27581,7 +27581,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If you have three noncreature card types among cards in your graveyard at the time damage is dealt by Deathcap Cultivator, and lethal damage is dealt to another creature you control at the same time, the damage from Deathcap Cultivator won’t be from a source with deathtouch."
+          "text": "If you have three noncreature card types among cards in your graveyard at the time damage is dealt by Deathcap Cultivator, and lethal damage is dealt to another creature you control at the same time, the damage from Deathcap Cultivator won't be from a source with deathtouch."
         },
         {
           "date": "2016-04-08",
@@ -27589,15 +27589,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -27719,11 +27719,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can activate Duskwatch Recruiter’s first ability in response to its triggered ability."
+          "text": "You can activate Duskwatch Recruiter's first ability in response to its triggered ability."
         },
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -27849,19 +27849,19 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Krallenhorde Howler’s first ability can only reduce the generic mana portion of a creature spell’s cost."
+          "text": "Krallenhorde Howler's first ability can only reduce the generic mana portion of a creature spell's cost."
         },
         {
           "date": "2016-04-08",
-          "text": "Krallenhorde Howler’s first ability can reduce alternative costs such as madness costs."
+          "text": "Krallenhorde Howler's first ability can reduce alternative costs such as madness costs."
         },
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -28562,7 +28562,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -28696,11 +28696,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -28822,7 +28822,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -28948,11 +28948,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -29176,7 +29176,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker Inexorable Blob is attacking."
+          "text": "You declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Inexorable Blob is attacking."
         },
         {
           "date": "2016-04-08",
@@ -29192,19 +29192,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -29435,7 +29435,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Trample matters only as combat damage is being assigned, before it’s dealt. If Kessig Dire Swine doesn’t have trample while assigning its combat damage, it won’t matter if a creature dying due to combat damage causes Kessig Dire Swine to gain trample."
+          "text": "Trample matters only as combat damage is being assigned, before it's dealt. If Kessig Dire Swine doesn't have trample while assigning its combat damage, it won't matter if a creature dying due to combat damage causes Kessig Dire Swine to gain trample."
         },
         {
           "date": "2016-04-08",
@@ -29443,15 +29443,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -29573,11 +29573,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If Lambholt Pacifist’s power becomes 4 or greater, it fulfills its own restriction and can attack."
+          "text": "If Lambholt Pacifist's power becomes 4 or greater, it fulfills its own restriction and can attack."
         },
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -29704,11 +29704,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -29826,7 +29826,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can tap any untapped creature you control, including one you haven’t controlled continuously since the beginning of your most recent turn, to pay the cost of Loam Dryad’s activated ability. You must have controlled Loam Dryad continuously since the beginning of your most recent turn, however."
+          "text": "You can tap any untapped creature you control, including one you haven't controlled continuously since the beginning of your most recent turn, to pay the cost of Loam Dryad's activated ability. You must have controlled Loam Dryad continuously since the beginning of your most recent turn, however."
         }
       ],
       "subtypes": [
@@ -29947,19 +29947,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Some delirium abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect when they resolve if there are four or more card types among cards in your graveyard. They check that number only while they’re resolving and don’t count themselves, since they aren’t in your graveyard yet. You only get the upgraded effect, not both effects."
+          "text": "Some delirium abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect when they resolve if there are four or more card types among cards in your graveyard. They check that number only while they're resolving and don't count themselves, since they aren't in your graveyard yet. You only get the upgraded effect, not both effects."
         }
       ],
       "text": "Put two +1/+1 counters on target creature.\nDelirium — Put three +1/+1 counters on that creature instead if there are four or more card types among cards in your graveyard.",
@@ -30077,15 +30077,15 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         }
       ],
       "subtypes": [
@@ -30309,7 +30309,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Both of Obsessive Skinner’s abilities can target Obsessive Skinner itself."
+          "text": "Both of Obsessive Skinner's abilities can target Obsessive Skinner itself."
         },
         {
           "date": "2016-04-08",
@@ -30317,19 +30317,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -30672,7 +30672,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If either creature is an illegal target as Rabid Bite tries to resolve, the creature you control won’t deal damage."
+          "text": "If either creature is an illegal target as Rabid Bite tries to resolve, the creature you control won't deal damage."
         }
       ],
       "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
@@ -30784,7 +30784,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -30792,11 +30792,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won’t investigate."
+          "text": "You can't cast a spell without choosing legal targets. If all of those targets become illegal, the spell is countered and you won't investigate."
         }
       ],
       "text": "Destroy target artifact or enchantment.\nInvestigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -30913,11 +30913,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If you have no cards in hand after Sage of Ancient Lore enters the battlefield, it will be put into your graveyard before its first triggered ability resolves. You’ll draw a card, but Sage of Ancient Lore will already be gone."
+          "text": "If you have no cards in hand after Sage of Ancient Lore enters the battlefield, it will be put into your graveyard before its first triggered ability resolves. You'll draw a card, but Sage of Ancient Lore will already be gone."
         },
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -31043,11 +31043,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -31164,7 +31164,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The phrase “different converted mana costs” compares the mana costs of cards in your graveyard to one another, not to Seasons Past. You may return a card with a converted mana cost of 6."
+          "text": "The phrase \"different converted mana costs\" compares the mana costs of cards in your graveyard to one another, not to Seasons Past. You may return a card with a converted mana cost of 6."
         },
         {
           "date": "2016-04-08",
@@ -31289,7 +31289,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Second Harvest copies the original characteristics of each token as stated by the effect that put the token onto the battlefield. It doesn’t copy whether that token is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Second Harvest copies the original characteristics of each token as stated by the effect that put the token onto the battlefield. It doesn't copy whether that token is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2016-04-08",
@@ -31524,7 +31524,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-07-13",
@@ -31651,11 +31651,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn’t on the battlefield for some or all of that turn."
+          "text": "The abilities that transform a Werewolf back and forth look at the entire previous turn, even if the Werewolf with that ability wasn't on the battlefield for some or all of that turn."
         },
         {
           "date": "2016-04-08",
-          "text": "To trigger the Werewolf’s back face’s transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won’t trigger."
+          "text": "To trigger the Werewolf's back face's transform ability, a single player must have cast two or more spells during the previous turn. If multiple players each cast just one spell during the previous turn, the ability won't trigger."
         }
       ],
       "subtypes": [
@@ -31777,19 +31777,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Most triggered delirium abilities use an intervening “if” clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There’s no way to have the ability trigger if there aren’t enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
+          "text": "Most triggered delirium abilities use an intervening \"if\" clause. There must be four or more card types among cards in your graveyard in order for these abilities to trigger, otherwise they never trigger at all. There's no way to have the ability trigger if there aren't enough card types, even if you intend to raise that number in response to the triggered ability. The number of card types is checked again as the trigger resolves, and if it has become too low somehow, the ability does nothing. If which card types are in your graveyard changes but the quantity of card types stays the same (or increases), then the delirium triggered ability will still resolve."
         }
       ],
       "subtypes": [
@@ -32128,7 +32128,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -32136,7 +32136,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "subtypes": [
@@ -32261,19 +32261,19 @@
         },
         {
           "date": "2016-04-08",
-          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain’s Blessing (a sorcery) will enable delirium."
+          "text": "The number of card types matters, not the number of cards. For example, Wicker Witch (an artifact creature) along with Catalog (an instant) and Chaplain's Blessing (a sorcery) will enable delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "Because you consider only the characteristics of a double-faced card’s front face while it’s not on the battlefield, the types of its back face won’t be counted for delirium."
+          "text": "Because you consider only the characteristics of a double-faced card's front face while it's not on the battlefield, the types of its back face won't be counted for delirium."
         },
         {
           "date": "2016-04-08",
-          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object’s delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
+          "text": "In some rare cases, you can have a token or a copy of a spell in your graveyard at the moment that an object's delirium ability counts the card types among cards in your graveyard, before that token or copy ceases to exist. Because tokens and copies of spells are not cards, even if they are copies of cards, their types will never be counted."
         },
         {
           "date": "2016-04-08",
-          "text": "Some delirium abilities that appear on instants and sorceries use the word “instead.” These spells have an upgraded effect when they resolve if there are four or more card types among cards in your graveyard. They check that number only while they’re resolving and don’t count themselves, since they aren’t in your graveyard yet. You only get the upgraded effect, not both effects."
+          "text": "Some delirium abilities that appear on instants and sorceries use the word \"instead.\" These spells have an upgraded effect when they resolve if there are four or more card types among cards in your graveyard. They check that number only while they're resolving and don't count themselves, since they aren't in your graveyard yet. You only get the upgraded effect, not both effects."
         }
       ],
       "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\nDelirium — If there are four or more card types among cards in your graveyard, instead search your library for a creature or land card, reveal it, put it into your hand, then shuffle your library.",
@@ -32496,7 +32496,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -32504,7 +32504,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "text": "Whenever a nontoken creature you control dies, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token.",
@@ -32948,7 +32948,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -32956,7 +32956,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "subtypes": [
@@ -33074,15 +33074,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Altered Ego copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Altered Ego copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2016-04-08",
-          "text": "If you copy a double-faced creature, Altered Ego will be a copy of the face that’s up when Altered Ego enters the battlefield. Because Altered Ego is not a double-faced card, it won’t be able to transform. If an effect instructs you to return it to the battlefield transformed when it leaves the battlefield, it won’t return and will remain in its new zone."
+          "text": "If you copy a double-faced creature, Altered Ego will be a copy of the face that's up when Altered Ego enters the battlefield. Because Altered Ego is not a double-faced card, it won't be able to transform. If an effect instructs you to return it to the battlefield transformed when it leaves the battlefield, it won't return and will remain in its new zone."
         },
         {
           "date": "2016-04-08",
-          "text": "If the chosen creature has {X} in its mana cost, that X is considered to be 0. The value of X in Altered Ego’s last ability will be whatever value was chosen for X while casting Altered Ego."
+          "text": "If the chosen creature has {X} in its mana cost, that X is considered to be 0. The value of X in Altered Ego's last ability will be whatever value was chosen for X while casting Altered Ego."
         },
         {
           "date": "2016-04-08",
@@ -33090,23 +33090,23 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If the chosen creature is a token, Altered Ego copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Altered Ego isn’t a token."
+          "text": "If the chosen creature is a token, Altered Ego copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Altered Ego isn't a token."
         },
         {
           "date": "2016-04-08",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Altered Ego enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Altered Ego enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2016-04-08",
-          "text": "If Altered Ego somehow enters the battlefield at the same time as another creature, Altered Ego can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Altered Ego somehow enters the battlefield at the same time as another creature, Altered Ego can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2016-04-08",
-          "text": "You can choose not to copy anything. In that case, Altered Ego enters the battlefield as a 0/0 creature, and is probably put into the graveyard immediately. It won’t have +1/+1 counters placed on it by its ability."
+          "text": "You can choose not to copy anything. In that case, Altered Ego enters the battlefield as a 0/0 creature, and is probably put into the graveyard immediately. It won't have +1/+1 counters placed on it by its ability."
         },
         {
           "date": "2016-04-08",
-          "text": "X can be 0. Altered Ego won’t enter with any additional +1/+1 counters, and it will just be a copy of the chosen creature."
+          "text": "X can be 0. Altered Ego won't enter with any additional +1/+1 counters, and it will just be a copy of the chosen creature."
         }
       ],
       "subtypes": [
@@ -33225,7 +33225,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If the nonland permanent becomes an illegal target, Anguished Unmaking is countered. You won’t lose 3 life."
+          "text": "If the nonland permanent becomes an illegal target, Anguished Unmaking is countered. You won't lose 3 life."
         }
       ],
       "text": "Exile target nonland permanent. You lose 3 life.",
@@ -33344,11 +33344,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The “planeswalker uniqueness rule” looks for planeswalkers that share a planeswalker type. If you control Arlinn Kord and Arlinn, Embraced by the Moon at the same time, you’ll choose one to put into its owner’s graveyard."
+          "text": "The \"planeswalker uniqueness rule\" looks for planeswalkers that share a planeswalker type. If you control Arlinn Kord and Arlinn, Embraced by the Moon at the same time, you'll choose one to put into its owner's graveyard."
         },
         {
           "date": "2016-04-08",
-          "text": "Arlinn Kord is not a Werewolf card; that is, she doesn’t have the creature type Werewolf. Spells and abilities that refer to Werewolf cards or Werewolves don’t apply to Arlinn."
+          "text": "Arlinn Kord is not a Werewolf card; that is, she doesn't have the creature type Werewolf. Spells and abilities that refer to Werewolf cards or Werewolves don't apply to Arlinn."
         },
         {
           "date": "2016-04-08",
@@ -33356,11 +33356,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "When the ability that transforms Arlinn Kord into Arlinn, Embraced by the Moon (or vice versa) resolves, the number of loyalty counters on her doesn’t change."
+          "text": "When the ability that transforms Arlinn Kord into Arlinn, Embraced by the Moon (or vice versa) resolves, the number of loyalty counters on her doesn't change."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t activate Arlinn Kord’s second ability and, after she transforms, activate a loyalty ability of Arlinn, Embraced by the Moon during that turn (or vice versa)."
+          "text": "You can't activate Arlinn Kord's second ability and, after she transforms, activate a loyalty ability of Arlinn, Embraced by the Moon during that turn (or vice versa)."
         },
         {
           "date": "2016-07-13",
@@ -33484,33 +33484,33 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The “planeswalker uniqueness rule” looks for planeswalkers that share a planeswalker type. If you control Arlinn Kord and Arlinn, Embraced by the Moon at the same time, you’ll choose one to put into its owner’s graveyard."
+          "text": "The \"planeswalker uniqueness rule\" looks for planeswalkers that share a planeswalker type. If you control Arlinn Kord and Arlinn, Embraced by the Moon at the same time, you'll choose one to put into its owner's graveyard."
         },
         {
           "date": "2016-04-08",
-          "text": "Arlinn, Embraced by the Moon is not a Werewolf card; that is, she doesn’t have the creature type Werewolf. Spells and abilities that refer to Werewolf cards or Werewolves don’t apply to Arlinn."
+          "text": "Arlinn, Embraced by the Moon is not a Werewolf card; that is, she doesn't have the creature type Werewolf. Spells and abilities that refer to Werewolf cards or Werewolves don't apply to Arlinn."
         },
         {
           "date": "2016-04-08",
-          "text": "When the ability that transforms Arlinn Kord into Arlinn, Embraced by the Moon (or vice versa) resolves, the number of loyalty counters on her doesn’t change."
+          "text": "When the ability that transforms Arlinn Kord into Arlinn, Embraced by the Moon (or vice versa) resolves, the number of loyalty counters on her doesn't change."
         },
         {
           "date": "2016-04-08",
-          "text": "You can’t activate Arlinn Kord’s second ability and, after she transforms, activate a loyalty ability of Arlinn, Embraced by the Moon during that turn (or vice versa)."
+          "text": "You can't activate Arlinn Kord's second ability and, after she transforms, activate a loyalty ability of Arlinn, Embraced by the Moon during that turn (or vice versa)."
         },
         {
           "date": "2016-04-08",
-          "text": "The set of creatures affected by the first ability of Arlinn, Embraced by the Moon is determined as the ability resolves. Creatures you begin to control later in the turn won’t get +1/+1 or gain trample."
+          "text": "The set of creatures affected by the first ability of Arlinn, Embraced by the Moon is determined as the ability resolves. Creatures you begin to control later in the turn won't get +1/+1 or gain trample."
         },
         {
           "date": "2016-04-08",
-          "text": "The emblem grants the activated ability to your creatures. Use the power of the creature as the activated ability resolves to determine how much damage is dealt. If the creature isn’t on the battlefield at that time, use its power as it last existed on the battlefield. Note that this works differently than the fight keyword action, which requires both creatures to be on the battlefield for any damage to be dealt."
+          "text": "The emblem grants the activated ability to your creatures. Use the power of the creature as the activated ability resolves to determine how much damage is dealt. If the creature isn't on the battlefield at that time, use its power as it last existed on the battlefield. Note that this works differently than the fight keyword action, which requires both creatures to be on the battlefield for any damage to be dealt."
         }
       ],
       "subtypes": [
         "Arlinn"
       ],
-      "text": "+1: Creatures you control get +1/+1 and gain trample until end of turn.\n−1: Arlinn, Embraced by the Moon deals 3 damage to target creature or player. Transform Arlinn, Embraced by the Moon.\n−6: You get an emblem with \"Creatures you control have haste and ‘{T}: This creature deals damage equal to its power to target creature or player.'\"",
+      "text": "+1: Creatures you control get +1/+1 and gain trample until end of turn.\n−1: Arlinn, Embraced by the Moon deals 3 damage to target creature or player. Transform Arlinn, Embraced by the Moon.\n−6: You get an emblem with \"Creatures you control have haste and '{T}: This creature deals damage equal to its power to target creature or player.'\"",
       "type": "Planeswalker — Arlinn",
       "types": [
         "Planeswalker"
@@ -33622,7 +33622,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "No player may take any action in between the two steps of Fevered Visions’s triggered ability, so if your opponent has four or more cards in hand after drawing a card, Fevered Visions will deal 2 damage to that player."
+          "text": "No player may take any action in between the two steps of Fevered Visions's triggered ability, so if your opponent has four or more cards in hand after drawing a card, Fevered Visions will deal 2 damage to that player."
         }
       ],
       "text": "At the beginning of each player's end step, that player draws a card. If the player is your opponent and has four or more cards in hand, Fevered Visions deals 2 damage to him or her.",
@@ -33737,7 +33737,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If multiple land cards are put into your graveyard at once, The Gitrog Monster’s last ability triggers only once. This could happen because an effect (such as that of Crawling Sensation’s first ability) put them there from your library at once, or because they were destroyed at the same time (such as two land creatures that were dealt lethal combat damage)."
+          "text": "If multiple land cards are put into your graveyard at once, The Gitrog Monster's last ability triggers only once. This could happen because an effect (such as that of Crawling Sensation's first ability) put them there from your library at once, or because they were destroyed at the same time (such as two land creatures that were dealt lethal combat damage)."
         }
       ],
       "subtypes": [
@@ -33859,7 +33859,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn’t have to be the same player or planeswalker the enchanted creature is attacking."
+          "text": "You declare which player or planeswalker the token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker the enchanted creature is attacking."
         },
         {
           "date": "2016-04-08",
@@ -33871,7 +33871,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Removing Invocation of Saint Traft or the enchanted creature from the battlefield won’t stop the delayed triggered ability from exiling the Angel token at end of combat."
+          "text": "Removing Invocation of Saint Traft or the enchanted creature from the battlefield won't stop the delayed triggered ability from exiling the Angel token at end of combat."
         }
       ],
       "subtypes": [
@@ -33989,15 +33989,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You can activate Nahiri’s first ability with no intention of discarding a card just to add loyalty to Nahiri."
+          "text": "You can activate Nahiri's first ability with no intention of discarding a card just to add loyalty to Nahiri."
         },
         {
           "date": "2016-04-08",
-          "text": "If you find a noncreature artifact with Nahiri’s third ability, it will still gain haste, even though it won’t be meaningful unless that artifact becomes a creature."
+          "text": "If you find a noncreature artifact with Nahiri's third ability, it will still gain haste, even though it won't be meaningful unless that artifact becomes a creature."
         },
         {
           "date": "2016-04-08",
-          "text": "If the artifact or creature put onto the battlefield with Nahiri’s third ability leaves the battlefield before the next end step, it won’t be returned to your hand from its new zone."
+          "text": "If the artifact or creature put onto the battlefield with Nahiri's third ability leaves the battlefield before the next end step, it won't be returned to your hand from its new zone."
         }
       ],
       "subtypes": [
@@ -34115,7 +34115,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You decide whether to discard a card as the triggered ability of Olivia, Mobilized for War resolves. If you do, the rest of the ability’s effects happen before any player may take actions."
+          "text": "You decide whether to discard a card as the triggered ability of Olivia, Mobilized for War resolves. If you do, the rest of the ability's effects happen before any player may take actions."
         },
         {
           "date": "2016-04-08",
@@ -34251,7 +34251,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Prized Amalgam’s ability triggers only if it’s in your graveyard immediately after a creature enters the battlefield from your graveyard or you cast a creature from your graveyard. A Prized Amalgam that’s already on the battlefield won’t be returned at the beginning of the next end step if it’s put into your graveyard later."
+          "text": "Prized Amalgam's ability triggers only if it's in your graveyard immediately after a creature enters the battlefield from your graveyard or you cast a creature from your graveyard. A Prized Amalgam that's already on the battlefield won't be returned at the beginning of the next end step if it's put into your graveyard later."
         }
       ],
       "subtypes": [
@@ -34370,7 +34370,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "As long as you have hexproof, your opponents can’t target you with spells or abilities that cause damage to be dealt, even if they intend to redirect that damage to a planeswalker you control."
+          "text": "As long as you have hexproof, your opponents can't target you with spells or abilities that cause damage to be dealt, even if they intend to redirect that damage to a planeswalker you control."
         }
       ],
       "subtypes": [
@@ -34609,11 +34609,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If Brain in a Jar leaves the battlefield before its first ability resolves, use the number of counters on it at the moment it left to determine what spell you may cast. That number won’t change because you can’t put a new counter on Brain in a Jar."
+          "text": "If Brain in a Jar leaves the battlefield before its first ability resolves, use the number of counters on it at the moment it left to determine what spell you may cast. That number won't change because you can't put a new counter on Brain in a Jar."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs, such as awaken costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, such as that of Lightning Axe, you must pay those to cast the card."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs, such as awaken costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, such as that of Lightning Axe, you must pay those to cast the card."
         },
         {
           "date": "2016-04-08",
@@ -34724,11 +34724,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Colorless cards have no color, so you can’t add {C} to your mana pool this way."
+          "text": "Colorless cards have no color, so you can't add {C} to your mana pool this way."
         },
         {
           "date": "2016-04-08",
-          "text": "Players can’t respond to mana abilities, so no player can take any action to stop you from getting the color of mana you expect to produce once you announce the ability."
+          "text": "Players can't respond to mana abilities, so no player can take any action to stop you from getting the color of mana you expect to produce once you announce the ability."
         }
       ],
       "text": "Corrupted Grafstone enters the battlefield tapped.\n{T}: Choose a color of a card in your graveyard. Add one mana of that color to your mana pool.",
@@ -35266,7 +35266,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If a creature enters the battlefield under your control and gains haste, but then loses it before attacking, it won’t be able to attack that turn. This means that you can’t use one Haunted Cloak to allow two new creatures to attack in the same turn."
+          "text": "If a creature enters the battlefield under your control and gains haste, but then loses it before attacking, it won't be able to attack that turn. This means that you can't use one Haunted Cloak to allow two new creatures to attack in the same turn."
         }
       ],
       "subtypes": [
@@ -35376,7 +35376,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -35384,7 +35384,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}, {T}: Investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
@@ -35599,7 +35599,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "When Neglected Heirloom transforms, it remains attached to the creature it’s attached to. If the equipped creature transforms into a noncreature permanent, Neglected Heirloom will become unattached before it transforms into Ashmouth Blade."
+          "text": "When Neglected Heirloom transforms, it remains attached to the creature it's attached to. If the equipped creature transforms into a noncreature permanent, Neglected Heirloom will become unattached before it transforms into Ashmouth Blade."
         },
         {
           "date": "2016-07-13",
@@ -36029,11 +36029,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Skulk matters only as blockers are chosen. Modifying either creature’s power after blockers are chosen won’t cause the attacking creature to become unblocked."
+          "text": "Skulk matters only as blockers are chosen. Modifying either creature's power after blockers are chosen won't cause the attacking creature to become unblocked."
         },
         {
           "date": "2016-04-08",
-          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won’t be blocked, but it won’t deal combat damage and won’t trigger any abilities that trigger when combat damage is dealt."
+          "text": "If you cause a creature to have 0 power or less, use the actual value (which may be negative) to determine whether it can block or be blocked. A creature with skulk and 0 or less power most likely won't be blocked, but it won't deal combat damage and won't trigger any abilities that trigger when combat damage is dealt."
         }
       ],
       "subtypes": [
@@ -36246,7 +36246,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn’t a creature type."
+          "text": "The token is named Clue and has the artifact subtype Clue. Clue isn't a creature type."
         },
         {
           "date": "2016-04-08",
@@ -36254,7 +36254,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you sacrifice a Clue for another card’s cost or effect, such as that of Angelic Purge or Tamiyo’s Journal, you can’t also pay {2} and sacrifice it to draw a card."
+          "text": "If you sacrifice a Clue for another card's cost or effect, such as that of Angelic Purge or Tamiyo's Journal, you can't also pay {2} and sacrifice it to draw a card."
         }
       ],
       "supertypes": [
@@ -36907,11 +36907,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You may reveal any land card with either or both of the appropriate subtypes. It doesn’t have to be a basic land. For example, you could reveal Prairie Stream from the Battle for Zendikar set to satisfy the ability of Choked Estuary."
+          "text": "You may reveal any land card with either or both of the appropriate subtypes. It doesn't have to be a basic land. For example, you could reveal Prairie Stream from the Battle for Zendikar set to satisfy the ability of Choked Estuary."
         },
         {
           "date": "2016-04-08",
-          "text": "Lands don’t have a subtype just because they can produce mana of the corresponding color. Choked Estuary itself is neither an Island nor a Swamp, even though it produces blue and black mana, so you can’t reveal one to satisfy the ability of another."
+          "text": "Lands don't have a subtype just because they can produce mana of the corresponding color. Choked Estuary itself is neither an Island nor a Swamp, even though it produces blue and black mana, so you can't reveal one to satisfy the ability of another."
         },
         {
           "date": "2016-04-08",
@@ -37337,11 +37337,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You may reveal any land card with either or both of the appropriate subtypes. It doesn’t have to be a basic land. For example, you could reveal Prairie Stream from the Battle for Zendikar set to satisfy the ability of Fortified Village."
+          "text": "You may reveal any land card with either or both of the appropriate subtypes. It doesn't have to be a basic land. For example, you could reveal Prairie Stream from the Battle for Zendikar set to satisfy the ability of Fortified Village."
         },
         {
           "date": "2016-04-08",
-          "text": "Lands don’t have a subtype just because they can produce mana of the corresponding color. Fortified Village itself is neither a Forest nor a Plains, even though it produces green and white mana, so you can’t reveal one to satisfy the ability of another."
+          "text": "Lands don't have a subtype just because they can produce mana of the corresponding color. Fortified Village itself is neither a Forest nor a Plains, even though it produces green and white mana, so you can't reveal one to satisfy the ability of another."
         },
         {
           "date": "2016-04-08",
@@ -37565,11 +37565,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You may reveal any land card with either or both of the appropriate subtypes. It doesn’t have to be a basic land. For example, you could reveal Canopy Vista from the Battle for Zendikar set to satisfy the ability of Game Trail."
+          "text": "You may reveal any land card with either or both of the appropriate subtypes. It doesn't have to be a basic land. For example, you could reveal Canopy Vista from the Battle for Zendikar set to satisfy the ability of Game Trail."
         },
         {
           "date": "2016-04-08",
-          "text": "Lands don’t have a subtype just because they can produce mana of the corresponding color. Game Trail itself is neither a Mountain nor a Forest, even though it produces red and green mana, so you can’t reveal one to satisfy the ability of another."
+          "text": "Lands don't have a subtype just because they can produce mana of the corresponding color. Game Trail itself is neither a Mountain nor a Forest, even though it produces red and green mana, so you can't reveal one to satisfy the ability of another."
         },
         {
           "date": "2016-04-08",
@@ -37794,11 +37794,11 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You may reveal any land card with either or both of the appropriate subtypes. It doesn’t have to be a basic land. For example, you could reveal Canopy Vista from the Battle for Zendikar set to satisfy the ability of Port Town."
+          "text": "You may reveal any land card with either or both of the appropriate subtypes. It doesn't have to be a basic land. For example, you could reveal Canopy Vista from the Battle for Zendikar set to satisfy the ability of Port Town."
         },
         {
           "date": "2016-04-08",
-          "text": "Lands don’t have a subtype just because they can produce mana of the corresponding color. Port Town itself is neither a Plains nor an Island, even though it produces white and blue mana, so you can’t reveal one to satisfy the ability of another."
+          "text": "Lands don't have a subtype just because they can produce mana of the corresponding color. Port Town itself is neither a Plains nor an Island, even though it produces white and blue mana, so you can't reveal one to satisfy the ability of another."
         },
         {
           "date": "2016-04-08",
@@ -38486,19 +38486,19 @@
           "multiverseid": 412692
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 412693
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 413352
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 412694
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 413353
         },
         {
-          "language": "Russian",
-          "name": "Равнина",
-          "multiverseid": 413022
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 413354
         }
       ],
       "id": "10b441a561eb8963fe6ebf567faa4861038fac71",
@@ -38866,19 +38866,19 @@
           "multiverseid": 412692
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 412693
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 413352
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 412694
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 413353
         },
         {
-          "language": "Russian",
-          "name": "Равнина",
-          "multiverseid": 413022
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 413354
         }
       ],
       "id": "d9b36230487e8c1b233be3b2b2041d1ff6ee57f7",
@@ -39246,19 +39246,19 @@
           "multiverseid": 412692
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 412693
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 413352
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Planície",
-          "multiverseid": 412694
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 413353
         },
         {
-          "language": "Russian",
-          "name": "Равнина",
-          "multiverseid": 413022
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 413354
         }
       ],
       "id": "370c1191e0321627d6f4f25a52f9118bc5a9efc7",
@@ -40760,19 +40760,19 @@
           "multiverseid": 412698
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 412699
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 413358
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 412700
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 413359
         },
         {
-          "language": "Russian",
-          "name": "Болото",
-          "multiverseid": 413028
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 413360
         }
       ],
       "id": "4dd14c87ad668c1173196cc9426b7e8794e7bc98",
@@ -41526,19 +41526,19 @@
           "multiverseid": 412698
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 412699
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 413358
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Pântano",
-          "multiverseid": 412700
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 413359
         },
         {
-          "language": "Russian",
-          "name": "Болото",
-          "multiverseid": 413028
+          "language": "Spanish",
+          "name": "Pantano",
+          "multiverseid": 413360
         }
       ],
       "id": "ba0d28af35233d517ed49a466a19300a5e98bdc6",
@@ -41904,24 +41904,24 @@
           "multiverseid": 412373
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 412701
-        },
-        {
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 413031
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 413032
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 413361
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 413033
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 413362
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 413363
         }
       ],
       "id": "412adb3be5e9728a55411a886acc2f95711e1ee4",
@@ -42288,24 +42288,24 @@
           "multiverseid": 412373
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 412701
-        },
-        {
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 413031
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 413032
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 413361
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 413033
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 413362
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 413363
         }
       ],
       "id": "211b08d3ff7128a9fd04d09dec543037e251fd1a",
@@ -42672,24 +42672,24 @@
           "multiverseid": 412373
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 412701
-        },
-        {
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 413031
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 413032
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 413361
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 413033
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 413362
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 413363
         }
       ],
       "id": "3ad0bff1ff61d99d6979ef1a301e291a51b089b8",
@@ -42951,6 +42951,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "树林",
+          "multiverseid": 410394
+        },
+        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 410724
@@ -43046,6 +43051,16 @@
           "multiverseid": 412704
         },
         {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 412705
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 412706
+        },
+        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 413034
@@ -43059,21 +43074,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 413036
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 413364
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 413365
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 413366
         }
       ],
       "id": "12f0211ccfbdb31ca67e51d51f5a71ef2171a9ce",
@@ -43333,6 +43333,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "树林",
+          "multiverseid": 410394
+        },
+        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 410724
@@ -43428,6 +43433,16 @@
           "multiverseid": 412704
         },
         {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 412705
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 412706
+        },
+        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 413034
@@ -43441,21 +43456,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 413036
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 413364
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 413365
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 413366
         }
       ],
       "id": "25b40995295be221d1b5899076d7614902d6990c",
@@ -43715,6 +43715,11 @@
       ],
       "foreignNames": [
         {
+          "language": "Chinese Simplified",
+          "name": "树林",
+          "multiverseid": 410394
+        },
+        {
           "language": "Chinese Traditional",
           "name": "樹林",
           "multiverseid": 410724
@@ -43810,6 +43815,16 @@
           "multiverseid": 412704
         },
         {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 412705
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta",
+          "multiverseid": 412706
+        },
+        {
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 413034
@@ -43823,21 +43838,6 @@
           "language": "Russian",
           "name": "Лес",
           "multiverseid": 413036
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 413364
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 413365
-        },
-        {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 413366
         }
       ],
       "id": "0f29a51e8abf4ede6f2b6bb25da74422b098d259",

--- a/json/SOK.json
+++ b/json/SOK.json
@@ -311,7 +311,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal’s converted mana cost is 4. Shining Shoal also has an ability that says “You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal’s mana cost”; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
+          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal's converted mana cost is 4. Shining Shoal also has an ability that says \"You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal's mana cost\"; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
         }
       ],
       "subtypes": [
@@ -596,7 +596,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "An attacking unblocked creature exists from the time the defending player chooses not to block that creature until the combat phase ends. Curtain of Light doesn’t have any legal targets outside of the combat phase."
+          "text": "An attacking unblocked creature exists from the time the defending player chooses not to block that creature until the combat phase ends. Curtain of Light doesn't have any legal targets outside of the combat phase."
         },
         {
           "date": "2005-06-01",
@@ -604,11 +604,11 @@
         },
         {
           "date": "2005-06-01",
-          "text": "Curtain of Light isn’t particularly effective against creatures with trample. Since the creature with trample has no blocker to assign damage to, all the damage will be assigned to the defending player."
+          "text": "Curtain of Light isn't particularly effective against creatures with trample. Since the creature with trample has no blocker to assign damage to, all the damage will be assigned to the defending player."
         },
         {
           "date": "2013-09-20",
-          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it’s after the beginning of that phase’s Declare Blockers Step."
+          "text": "If a turn has multiple combat phases, this spell can be cast during any of them as long as it's after the beginning of that phase's Declare Blockers Step."
         }
       ],
       "text": "Cast Curtain of Light only during combat after blockers are declared.\nTarget unblocked attacking creature becomes blocked. (This spell works on creatures that can't be blocked.)\nDraw a card.",
@@ -704,11 +704,11 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If any opponent has more cards or as many cards in hand as Descendant of Kiyomaro’s controller, Descendant of Kiyomaro doesn’t get any bonus."
+          "text": "If any opponent has more cards or as many cards in hand as Descendant of Kiyomaro's controller, Descendant of Kiyomaro doesn't get any bonus."
         },
         {
           "date": "2005-06-01",
-          "text": "Changing the number of cards in any player’s hand can cause Descendant of Kiyomaro to lose the life-gain triggered ability. Once an ability triggers, however, it exists independently of its source."
+          "text": "Changing the number of cards in any player's hand can cause Descendant of Kiyomaro to lose the life-gain triggered ability. Once an ability triggers, however, it exists independently of its source."
         }
       ],
       "subtypes": [
@@ -1086,7 +1086,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "You choose how the damage will be divided among the target creatures at the time you cast Hail of Arrows. Each target must be dealt at least 1 damage. If any of those creatures becomes an illegal target before Hail of Arrows resolves, the division of damage among the remaining creatures doesn’t change."
+          "text": "You choose how the damage will be divided among the target creatures at the time you cast Hail of Arrows. Each target must be dealt at least 1 damage. If any of those creatures becomes an illegal target before Hail of Arrows resolves, the division of damage among the remaining creatures doesn't change."
         }
       ],
       "text": "Hail of Arrows deals X damage divided as you choose among any number of target attacking creatures.",
@@ -1755,15 +1755,15 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Kiyomaro’s power and toughness don’t affect whether it has vigilance or the life-gain ability."
+          "text": "Kiyomaro's power and toughness don't affect whether it has vigilance or the life-gain ability."
         },
         {
           "date": "2005-06-01",
-          "text": "Losing vigilance after attackers are declared doesn’t cause Kiyomaro to tap."
+          "text": "Losing vigilance after attackers are declared doesn't cause Kiyomaro to tap."
         },
         {
           "date": "2005-06-01",
-          "text": "If you have seven or more cards in hand when Kiyomaro’s triggered ability goes on the stack but less than seven when the ability resolves, the ability does nothing."
+          "text": "If you have seven or more cards in hand when Kiyomaro's triggered ability goes on the stack but less than seven when the ability resolves, the ability does nothing."
         }
       ],
       "subtypes": [
@@ -1866,7 +1866,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "One permanent is sacrificed each time an opponent’s source deals damage to Michiko Konda’s controller. The amount of damage doesn’t matter."
+          "text": "One permanent is sacrificed each time an opponent's source deals damage to Michiko Konda's controller. The amount of damage doesn't matter."
         },
         {
           "date": "2005-06-01",
@@ -1874,7 +1874,7 @@
         },
         {
           "date": "2005-06-01",
-          "text": "Spells that deal damage repeatedly trigger Michiko Konda’s ability each time they deal damage. For example, a Glacial Ray spliced onto another Glacial Ray triggers the ability twice (once for each “2 damage” event from the Glacial Ray)."
+          "text": "Spells that deal damage repeatedly trigger Michiko Konda's ability each time they deal damage. For example, a Glacial Ray spliced onto another Glacial Ray triggers the ability twice (once for each \"2 damage\" event from the Glacial Ray)."
         }
       ],
       "subtypes": [
@@ -2439,7 +2439,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "The first part of Pure Intentions is the effect of casting Pure Intentions. The second part is a triggered ability that triggers whenever an opponent’s spell or ability causes a player to discard Pure Intentions."
+          "text": "The first part of Pure Intentions is the effect of casting Pure Intentions. The second part is a triggered ability that triggers whenever an opponent's spell or ability causes a player to discard Pure Intentions."
         },
         {
           "date": "2005-06-01",
@@ -2447,11 +2447,11 @@
         },
         {
           "date": "2005-06-01",
-          "text": "Discarding Pure Intentions to your own spell or ability doesn’t trigger its abilities."
+          "text": "Discarding Pure Intentions to your own spell or ability doesn't trigger its abilities."
         },
         {
           "date": "2005-06-01",
-          "text": "If a spell or ability an opponent controls causes a player to discard multiple cards, such as Waking Nightmare or Three Tragedies, Pure Intentions doesn’t return to hand until its triggered ability has resolved. A player can’t discard the same Pure Intentions twice for the same discard effect."
+          "text": "If a spell or ability an opponent controls causes a player to discard multiple cards, such as Waking Nightmare or Three Tragedies, Pure Intentions doesn't return to hand until its triggered ability has resolved. A player can't discard the same Pure Intentions twice for the same discard effect."
         }
       ],
       "subtypes": [
@@ -2549,7 +2549,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures with power 2 or less can't attack you.",
@@ -2570,37 +2570,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "符尾菁华",
+          "name": "Rune-Tail, Kitsune Ascendant",
           "multiverseid": 105010
         },
         {
           "language": "French",
-          "name": "Essence de Queue-de-runes",
+          "name": "Rune-Tail, Kitsune Ascendant",
           "multiverseid": 105175
         },
         {
           "language": "German",
-          "name": "Runenenschwanz' Substanz",
+          "name": "Rune-Tail, Kitsune Ascendant",
           "multiverseid": 105340
         },
         {
           "language": "Italian",
-          "name": "Essenza di Coda-Runa",
+          "name": "Rune-Tail, Kitsune Ascendant",
           "multiverseid": 105505
         },
         {
           "language": "Japanese",
-          "name": "呪之尾の本質",
+          "name": "Rune-Tail, Kitsune Ascendant",
           "multiverseid": 105670
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Essência de Cauda-Runa",
+          "name": "Rune-Tail, Kitsune Ascendant",
           "multiverseid": 105835
         },
         {
           "language": "Spanish",
-          "name": "Esencia de Cola-runa",
+          "name": "Rune-Tail, Kitsune Ascendant",
           "multiverseid": 106000
         }
       ],
@@ -2942,15 +2942,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -3141,7 +3141,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal’s converted mana cost is 4. Shining Shoal also has an ability that says “You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal’s mana cost”; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
+          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal's converted mana cost is 4. Shining Shoal also has an ability that says \"You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal's mana cost\"; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
         }
       ],
       "subtypes": [
@@ -3529,15 +3529,15 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Erayo’s Essence triggers only for the first spell an opponent casts in a given turn. It doesn’t trigger off any other spell that player casts after the first."
+          "text": "Erayo's Essence triggers only for the first spell an opponent casts in a given turn. It doesn't trigger off any other spell that player casts after the first."
         },
         {
           "date": "2005-06-01",
-          "text": "If Erayo, Soratami Ascendant flips while an opponent’s first spell for the turn is still on the stack, the ability of Erayo’s Essence doesn’t trigger because the opponent’s spell has already been cast. The spell isn’t countered."
+          "text": "If Erayo, Soratami Ascendant flips while an opponent's first spell for the turn is still on the stack, the ability of Erayo's Essence doesn't trigger because the opponent's spell has already been cast. The spell isn't countered."
         },
         {
           "date": "2005-06-01",
-          "text": "If you have multiple opponents, Erayo’s Essence can trigger once for each opponent."
+          "text": "If you have multiple opponents, Erayo's Essence can trigger once for each opponent."
         },
         {
           "date": "2005-06-01",
@@ -3570,37 +3570,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "伟代菁华",
+          "name": "Erayo, Soratami Ascendant",
           "multiverseid": 104918
         },
         {
           "language": "French",
-          "name": "Essence d'Erayo",
+          "name": "Erayo, Soratami Ascendant",
           "multiverseid": 105083
         },
         {
           "language": "German",
-          "name": "Erayos Substanz",
+          "name": "Erayo, Soratami Ascendant",
           "multiverseid": 105248
         },
         {
           "language": "Italian",
-          "name": "Essenza di Erayo",
+          "name": "Erayo, Soratami Ascendant",
           "multiverseid": 105413
         },
         {
           "language": "Japanese",
-          "name": "エラヨウの本質",
+          "name": "Erayo, Soratami Ascendant",
           "multiverseid": 105578
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Essência de Erayo",
+          "name": "Erayo, Soratami Ascendant",
           "multiverseid": 105743
         },
         {
           "language": "Spanish",
-          "name": "Esencia de Erayo",
+          "name": "Erayo, Soratami Ascendant",
           "multiverseid": 105908
         }
       ],
@@ -3828,15 +3828,15 @@
         },
         {
           "date": "2005-06-01",
-          "text": "Evermind is a blue Arcane instant card. Cards that check whether a card has any of those attributes will affect Evermind. For example, you can exile it (as a blue card) to pay the alternative costs of spells like Force of Will and Disrupting Shoal (X = 0). You could search for it with Mystical Tutor because it’s an instant or Eerie Procession because it’s an Arcane spell."
+          "text": "Evermind is a blue Arcane instant card. Cards that check whether a card has any of those attributes will affect Evermind. For example, you can exile it (as a blue card) to pay the alternative costs of spells like Force of Will and Disrupting Shoal (X = 0). You could search for it with Mystical Tutor because it's an instant or Eerie Procession because it's an Arcane spell."
         },
         {
           "date": "2006-10-15",
-          "text": "If a spell or effect, such as Parallectric Feedback, asks for Evermind’s converted mana cost, it’s 0."
+          "text": "If a spell or effect, such as Parallectric Feedback, asks for Evermind's converted mana cost, it's 0."
         },
         {
           "date": "2006-10-15",
-          "text": "Evermind has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Sunforger or Kaho, Minamo Historian."
+          "text": "Evermind has no mana cost, which means it can't normally be cast as a spell. You could, however, cast it via some alternate means, like with Sunforger or Kaho, Minamo Historian."
         },
         {
           "date": "2013-06-07",
@@ -3844,23 +3844,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "subtypes": [
@@ -4143,7 +4143,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If you don’t have three or more cards in hand at the end of turn, you discard what cards you have."
+          "text": "If you don't have three or more cards in hand at the end of turn, you discard what cards you have."
         }
       ],
       "subtypes": [
@@ -4241,15 +4241,15 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If an effect takes a card Kaho exiled out of the Exile zone, then you can’t use Kaho’s ability to cast that card."
+          "text": "If an effect takes a card Kaho exiled out of the Exile zone, then you can't use Kaho's ability to cast that card."
         },
         {
           "date": "2005-06-01",
-          "text": "If another player gains control of Kaho, that player may cast any of the cards exiled with Kaho’s ability."
+          "text": "If another player gains control of Kaho, that player may cast any of the cards exiled with Kaho's ability."
         },
         {
           "date": "2005-06-01",
-          "text": "Kaho’s activated ability refers only to cards exiled by its triggered ability. If another effect exiled the cards, you won’t be able to use Kaho to cast those cards."
+          "text": "Kaho's activated ability refers only to cards exiled by its triggered ability. If another effect exiled the cards, you won't be able to use Kaho to cast those cards."
         }
       ],
       "subtypes": [
@@ -4753,7 +4753,7 @@
         },
         {
           "date": "2005-06-01",
-          "text": "The land’s name as well as any supertype it might have (such as legendary) remains unchanged."
+          "text": "The land's name as well as any supertype it might have (such as legendary) remains unchanged."
         }
       ],
       "subtypes": [
@@ -5041,11 +5041,11 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "The errata makes the ability temporary. As printed, the effect didn’t end."
+          "text": "The errata makes the ability temporary. As printed, the effect didn't end."
         },
         {
           "date": "2005-06-01",
-          "text": "The X will usually include the land returned to pay the ability’s cost."
+          "text": "The X will usually include the land returned to pay the ability's cost."
         }
       ],
       "subtypes": [
@@ -5325,7 +5325,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Rushing-Tide Zubera’s ability counts all damage dealt to it this turn, from all sources."
+          "text": "Rushing-Tide Zubera's ability counts all damage dealt to it this turn, from all sources."
         }
       ],
       "subtypes": [
@@ -5425,11 +5425,11 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If there is no creature on the battlefield or if you don’t choose a creature as Sakashima enters the battlefield, Sakashima remains a 3/1 Human Rogue."
+          "text": "If there is no creature on the battlefield or if you don't choose a creature as Sakashima enters the battlefield, Sakashima remains a 3/1 Human Rogue."
         },
         {
           "date": "2005-06-01",
-          "text": "Sakashima doesn’t get the return to hand ability unless a creature is copied as Sakashima enters the battlefield. Sakashima can’t copy itself because the choice is made as part of the event that puts it onto the battlefield, and whatever will be copied must already be on the battlefield."
+          "text": "Sakashima doesn't get the return to hand ability unless a creature is copied as Sakashima enters the battlefield. Sakashima can't copy itself because the choice is made as part of the event that puts it onto the battlefield, and whatever will be copied must already be on the battlefield."
         },
         {
           "date": "2005-06-01",
@@ -5631,27 +5631,27 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "This ability triggers once for each creature blocked by or blocking Shape Stealer. If multiple creatures block it, Shape Stealer’s power and toughness will change for each one in succession. The first trigger put on the stack will be the last to resolve, so that will set Shape Stealer’s final power and toughness."
+          "text": "This ability triggers once for each creature blocked by or blocking Shape Stealer. If multiple creatures block it, Shape Stealer's power and toughness will change for each one in succession. The first trigger put on the stack will be the last to resolve, so that will set Shape Stealer's final power and toughness."
         },
         {
           "date": "2005-06-01",
-          "text": "The other creature’s power and toughness are determined as the triggered ability resolves."
+          "text": "The other creature's power and toughness are determined as the triggered ability resolves."
         },
         {
           "date": "2005-06-01",
-          "text": "If the other creature has bushido, whether Shape Stealer gets the bushido bonus depends on whose turn it is. If Shape Stealer is blocking, it won’t get the attacker’s bushido bonus. If the Shape Stealer is being blocked, the bushido ability will resolve just before Shape Stealer determines what the creature’s power and toughness are."
+          "text": "If the other creature has bushido, whether Shape Stealer gets the bushido bonus depends on whose turn it is. If Shape Stealer is blocking, it won't get the attacker's bushido bonus. If the Shape Stealer is being blocked, the bushido ability will resolve just before Shape Stealer determines what the creature's power and toughness are."
         },
         {
           "date": "2005-06-01",
-          "text": "If Shape Stealer’s new toughness is less than any damage on Shape Stealer, Shape Stealer will be destroyed as a state-based action once the triggered ability resolves."
+          "text": "If Shape Stealer's new toughness is less than any damage on Shape Stealer, Shape Stealer will be destroyed as a state-based action once the triggered ability resolves."
         },
         {
           "date": "2005-06-01",
-          "text": "Once the ability resolves, changing the other creature’s power or toughness doesn’t affect Shape Stealer."
+          "text": "Once the ability resolves, changing the other creature's power or toughness doesn't affect Shape Stealer."
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -5750,7 +5750,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If one of the targeted lands isn’t a legal target as Shifting Borders resolves (say, because it has left the battlefield or become untargetable), the exchange doesn’t occur."
+          "text": "If one of the targeted lands isn't a legal target as Shifting Borders resolves (say, because it has left the battlefield or become untargetable), the exchange doesn't occur."
         },
         {
           "date": "2013-06-07",
@@ -5758,15 +5758,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -6156,27 +6156,27 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "You can’t choose to pay any additional costs for the copy. However, effects based on any additional costs paid for the targeted spell are copied as though those same costs were paid for the copy too."
+          "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs paid for the targeted spell are copied as though those same costs were paid for the copy too."
         },
         {
           "date": "2005-06-01",
-          "text": "Twincast copies any text spliced onto the targeted spell, but you can’t splice additional text onto the copy."
+          "text": "Twincast copies any text spliced onto the targeted spell, but you can't splice additional text onto the copy."
         },
         {
           "date": "2009-10-01",
-          "text": "Twincast can target (and copy) any instant or sorcery spell, not just one with targets. It doesn’t matter who controls it."
+          "text": "Twincast can target (and copy) any instant or sorcery spell, not just one with targets. It doesn't matter who controls it."
         },
         {
           "date": "2009-10-01",
-          "text": "As Twincast resolves, it creates a copy of a spell. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "As Twincast resolves, it creates a copy of a spell. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2009-10-01",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2009-10-01",
-          "text": "If the spell Twincast copies is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. You can’t choose a different one."
+          "text": "If the spell Twincast copies is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. You can't choose a different one."
         },
         {
           "date": "2009-10-01",
@@ -6184,7 +6184,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the copy says that it affects “you,” it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an “opponent,” it affects an opponent of the copy’s controller, not an opponent of the original spell’s controller."
+          "text": "If the copy says that it affects \"you,\" it affects the controller of the copy, not the controller of the original spell. Similarly, if the copy says that it affects an \"opponent,\" it affects an opponent of the copy's controller, not an opponent of the original spell's controller."
         }
       ],
       "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
@@ -6385,7 +6385,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "After the opponent chooses a number, Choice of Damnations’ controller may choose to make that opponent either lose that much life or make that opponent sacrifice permanents."
+          "text": "After the opponent chooses a number, Choice of Damnations' controller may choose to make that opponent either lose that much life or make that opponent sacrifice permanents."
         },
         {
           "date": "2005-06-01",
@@ -7136,7 +7136,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify a player’s hand size, apply them in timestamp order. For example, if you put Cursed Rack (an artifact that sets a chosen player’s maximum hand size to four) onto the battlefield choosing your opponent and then put Gnat Miser onto the battlefield, your opponent will have a maximum hand size of three. However, if those permanents entered the battlefield in the opposite order, your opponent’s maximum hand size would be four."
+          "text": "If multiple effects modify a player's hand size, apply them in timestamp order. For example, if you put Cursed Rack (an artifact that sets a chosen player's maximum hand size to four) onto the battlefield choosing your opponent and then put Gnat Miser onto the battlefield, your opponent will have a maximum hand size of three. However, if those permanents entered the battlefield in the opposite order, your opponent's maximum hand size would be four."
         }
       ],
       "subtypes": [
@@ -7332,7 +7332,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal’s converted mana cost is 4. Shining Shoal also has an ability that says “You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal’s mana cost”; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
+          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal's converted mana cost is 4. Shining Shoal also has an ability that says \"You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal's mana cost\"; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
         }
       ],
       "subtypes": [
@@ -7831,37 +7831,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "苦御菁华",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 104966
         },
         {
           "language": "French",
-          "name": "Essence de Kuon",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105131
         },
         {
           "language": "German",
-          "name": "Kuons Substanz",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105296
         },
         {
           "language": "Italian",
-          "name": "Essenza di Kuon",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105461
         },
         {
           "language": "Japanese",
-          "name": "苦御の本質",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105626
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Essência de Kuon",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105791
         },
         {
           "language": "Spanish",
-          "name": "Esencia de Kuon",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105956
         }
       ],
@@ -7909,7 +7909,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Kuon’s flip ability looks at everything that happened during that turn, even before Kuon entered the battlefield."
+          "text": "Kuon's flip ability looks at everything that happened during that turn, even before Kuon entered the battlefield."
         },
         {
           "date": "2005-06-01",
@@ -7946,37 +7946,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "苦御菁华",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 104966
         },
         {
           "language": "French",
-          "name": "Essence de Kuon",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105131
         },
         {
           "language": "German",
-          "name": "Kuons Substanz",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105296
         },
         {
           "language": "Italian",
-          "name": "Essenza di Kuon",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105461
         },
         {
           "language": "Japanese",
-          "name": "苦御の本質",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105626
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Essência de Kuon",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105791
         },
         {
           "language": "Spanish",
-          "name": "Esencia de Kuon",
+          "name": "Kuon, Ogre Ascendant",
           "multiverseid": 105956
         }
       ],
@@ -8211,7 +8211,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify a player’s hand size, apply them in timestamp order. For example, if you put Cursed Rack (an artifact that sets a chosen player’s maximum hand size to four) onto the battlefield choosing your opponent and then put Locust Miser onto the battlefield, your opponent will have a maximum hand size of two. However, if those permanents entered the battlefield in the opposite order, your opponent’s maximum hand size would be four."
+          "text": "If multiple effects modify a player's hand size, apply them in timestamp order. For example, if you put Cursed Rack (an artifact that sets a chosen player's maximum hand size to four) onto the battlefield choosing your opponent and then put Locust Miser onto the battlefield, your opponent will have a maximum hand size of two. However, if those permanents entered the battlefield in the opposite order, your opponent's maximum hand size would be four."
         }
       ],
       "subtypes": [
@@ -8407,7 +8407,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Once the at-end-of-turn ability triggers, it affects the player who controlled Measure of Wickedness at that time. If Measure of Wickedness is under a different player’s control as its at-end-of-turn ability resolves, however, Measure of Wickedness stays on the battlefield."
+          "text": "Once the at-end-of-turn ability triggers, it affects the player who controlled Measure of Wickedness at that time. If Measure of Wickedness is under a different player's control as its at-end-of-turn ability resolves, however, Measure of Wickedness stays on the battlefield."
         }
       ],
       "text": "At the beginning of your end step, sacrifice Measure of Wickedness and you lose 8 life.\nWhenever another card is put into your graveyard from anywhere, target opponent gains control of Measure of Wickedness.",
@@ -9267,7 +9267,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"What part of ‘hayaku ikee!' did you not understand?\"",
+      "flavor": "\"What part of 'hayaku ikee!' did you not understand?\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -9631,7 +9631,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Burning-Eye Zubera’s ability counts all damage dealt to it this turn, from all sources."
+          "text": "Burning-Eye Zubera's ability counts all damage dealt to it this turn, from all sources."
         }
       ],
       "subtypes": [
@@ -10285,7 +10285,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Since the player’s life total is checked only as the spell resolves, you can cast Hidetsugu’s Second Rite targeting any player, regardless of life total. If the player isn’t at 10 life as Hidetsugu’s Second Rite begins resolving, it does nothing and finishes resolving. Note that since having 10 life is not a targeting restriction, the spell won’t actually be countered for having an illegal target; it just won’t do anything."
+          "text": "Since the player's life total is checked only as the spell resolves, you can cast Hidetsugu's Second Rite targeting any player, regardless of life total. If the player isn't at 10 life as Hidetsugu's Second Rite begins resolving, it does nothing and finishes resolving. Note that since having 10 life is not a targeting restriction, the spell won't actually be countered for having an illegal target; it just won't do anything."
         }
       ],
       "text": "If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player.",
@@ -10306,37 +10306,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Homura, Human Ascendant",
+          "name": "焰村菁华",
           "multiverseid": 104940
         },
         {
           "language": "French",
-          "name": "Homura, Human Ascendant",
+          "name": "Essence d'Homura",
           "multiverseid": 105105
         },
         {
           "language": "German",
-          "name": "Homura, Human Ascendant",
+          "name": "Homuras Substanz",
           "multiverseid": 105270
         },
         {
           "language": "Italian",
-          "name": "Homura, Human Ascendant",
+          "name": "Essenza di Homura",
           "multiverseid": 105435
         },
         {
           "language": "Japanese",
-          "name": "Homura, Human Ascendant",
+          "name": "焔村の本質",
           "multiverseid": 105600
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Homura, Human Ascendant",
+          "name": "Essência de Homura",
           "multiverseid": 105765
         },
         {
           "language": "Spanish",
-          "name": "Homura, Human Ascendant",
+          "name": "Esencia de Homura",
           "multiverseid": 105930
         }
       ],
@@ -10413,37 +10413,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "Homura, Human Ascendant",
+          "name": "焰村菁华",
           "multiverseid": 104940
         },
         {
           "language": "French",
-          "name": "Homura, Human Ascendant",
+          "name": "Essence d'Homura",
           "multiverseid": 105105
         },
         {
           "language": "German",
-          "name": "Homura, Human Ascendant",
+          "name": "Homuras Substanz",
           "multiverseid": 105270
         },
         {
           "language": "Italian",
-          "name": "Homura, Human Ascendant",
+          "name": "Essenza di Homura",
           "multiverseid": 105435
         },
         {
           "language": "Japanese",
-          "name": "Homura, Human Ascendant",
+          "name": "焔村の本質",
           "multiverseid": 105600
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Homura, Human Ascendant",
+          "name": "Essência de Homura",
           "multiverseid": 105765
         },
         {
           "language": "Spanish",
-          "name": "Homura, Human Ascendant",
+          "name": "Esencia de Homura",
           "multiverseid": 105930
         }
       ],
@@ -10771,15 +10771,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "A card with a splice ability can’t be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
+          "text": "A card with a splice ability can't be spliced onto itself because the spell is on the stack (and not in your hand) when you reveal the cards you want to splice onto it."
         },
         {
           "date": "2013-06-07",
-          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word “target” on the resulting spell."
+          "text": "You choose all targets for the spell after revealing cards you want to splice, including any targets required by the text of any of those cards. You may choose a different target for each instance of the word \"target\" on the resulting spell."
         },
         {
           "date": "2013-06-07",
-          "text": "If all of the spell’s targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
+          "text": "If all of the spell's targets are illegal when the spell tries to resolve, it will be countered and none of its effects will happen."
         }
       ],
       "subtypes": [
@@ -11440,7 +11440,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal’s converted mana cost is 4. Shining Shoal also has an ability that says “You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal’s mana cost”; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
+          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal's converted mana cost is 4. Shining Shoal also has an ability that says \"You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal's mana cost\"; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
         }
       ],
       "subtypes": [
@@ -11543,7 +11543,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If multiple players are tied for the most cards in hand, either when Sokenzan Renegade’s ability triggers or as it resolves, the ability does nothing."
+          "text": "If multiple players are tied for the most cards in hand, either when Sokenzan Renegade's ability triggers or as it resolves, the ability does nothing."
         }
       ],
       "subtypes": [
@@ -12296,7 +12296,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Nonland legendary permanents don’t affect whether Ayumi can be blocked or not, only legendary lands."
+          "text": "Nonland legendary permanents don't affect whether Ayumi can be blocked or not, only legendary lands."
         }
       ],
       "subtypes": [
@@ -12399,7 +12399,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal’s converted mana cost is 4. Shining Shoal also has an ability that says “You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal’s mana cost”; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
+          "text": "If the Spirit or Arcane spell has {X} in the mana cost, then you use the value of {X} on the stack. For example, Shining Shoal costs {X}{W}{W}. If you choose X = 2, then Shining Shoal's converted mana cost is 4. Shining Shoal also has an ability that says \"You may exile a white card with converted mana cost X from your hand rather than pay Shining Shoal's mana cost\"; if you choose to pay the alternative cost and exile a card with converted mana cost 2, then X is 2 while Shining Shoal is on the stack and its converted mana cost is 4."
         }
       ],
       "subtypes": [
@@ -12691,7 +12691,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Descendant of Masumaro’s printed power and toughness is 1/1, so removing all the +1/+1 counters usually doesn’t reduce the creature’s toughness to 0."
+          "text": "Descendant of Masumaro's printed power and toughness is 1/1, so removing all the +1/+1 counters usually doesn't reduce the creature's toughness to 0."
         },
         {
           "date": "2005-06-01",
@@ -14203,7 +14203,7 @@
         },
         {
           "date": "2005-06-01",
-          "text": "Lands aren’t spells."
+          "text": "Lands aren't spells."
         }
       ],
       "subtypes": [
@@ -14419,37 +14419,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "筱弥菁华",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105014
         },
         {
           "language": "French",
-          "name": "Essence de Sasaya",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105179
         },
         {
           "language": "German",
-          "name": "Sasayas Substanz",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105344
         },
         {
           "language": "Italian",
-          "name": "Essenza di Sasaya",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105509
         },
         {
           "language": "Japanese",
-          "name": "ささ弥の本質",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105674
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Essência de Sasaya",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105839
         },
         {
           "language": "Spanish",
-          "name": "Esencia de Sasaya",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 106004
         }
       ],
@@ -14497,31 +14497,31 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "You don’t need to have seven lands in hand to reveal your hand. You leave your hand revealed until the ability resolves. If you don’t have seven or more land cards in your hand at that time, the effect does nothing."
+          "text": "You don't need to have seven lands in hand to reveal your hand. You leave your hand revealed until the ability resolves. If you don't have seven or more land cards in your hand at that time, the effect does nothing."
         },
         {
           "date": "2005-06-01",
-          "text": "You don’t need to tap Sasaya to use its ability, so you can activate the ability on the turn Sasaya comes under your control."
+          "text": "You don't need to tap Sasaya to use its ability, so you can activate the ability on the turn Sasaya comes under your control."
         },
         {
           "date": "2005-06-01",
-          "text": "Sasaya’s Essence has a triggered mana ability. Like activated mana abilities, the triggered mana ability doesn’t use the stack."
+          "text": "Sasaya's Essence has a triggered mana ability. Like activated mana abilities, the triggered mana ability doesn't use the stack."
         },
         {
           "date": "2005-06-01",
-          "text": "The triggered mana ability counts the number of other lands with that same name and adds that much mana to the player’s mana pool. The type (that is, the color of mana or colorless mana) is the same as the mana the land just produced."
+          "text": "The triggered mana ability counts the number of other lands with that same name and adds that much mana to the player's mana pool. The type (that is, the color of mana or colorless mana) is the same as the mana the land just produced."
         },
         {
           "date": "2005-06-01",
-          "text": "If Sasaya’s Essence’s controller has four Forests and taps one of them for {G}, the Essence will add {G}{G}{G} to that player’s mana pool for a total of {G}{G}{G}{G}."
+          "text": "If Sasaya's Essence's controller has four Forests and taps one of them for {G}, the Essence will add {G}{G}{G} to that player's mana pool for a total of {G}{G}{G}{G}."
         },
         {
           "date": "2005-06-01",
-          "text": "If Sasaya’s Essence’s controller has four Mossfire Valley and taps one of them for {R}{G}, the Essence will add three mana (one for each other Mossfire Valley) of any combination of {R} and/or {G} to that player’s mana pool."
+          "text": "If Sasaya's Essence's controller has four Mossfire Valley and taps one of them for {R}{G}, the Essence will add three mana (one for each other Mossfire Valley) of any combination of {R} and/or {G} to that player's mana pool."
         },
         {
           "date": "2005-06-01",
-          "text": "If Sasaya’s Essence’s controller has two Brushlands and taps one of them for {W}, Sasaya’s Essence adds another {W} to that player’s mana pool. It won’t produce {G} or {C} unless the land was tapped for {G} or {C} instead."
+          "text": "If Sasaya's Essence's controller has two Brushlands and taps one of them for {W}, Sasaya's Essence adds another {W} to that player's mana pool. It won't produce {G} or {C} unless the land was tapped for {G} or {C} instead."
         },
         {
           "date": "2005-06-01",
@@ -14554,37 +14554,37 @@
       "foreignNames": [
         {
           "language": "Chinese Simplified",
-          "name": "筱弥菁华",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105014
         },
         {
           "language": "French",
-          "name": "Essence de Sasaya",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105179
         },
         {
           "language": "German",
-          "name": "Sasayas Substanz",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105344
         },
         {
           "language": "Italian",
-          "name": "Essenza di Sasaya",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105509
         },
         {
           "language": "Japanese",
-          "name": "ささ弥の本質",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105674
         },
         {
           "language": "Portuguese (Brazil)",
-          "name": "Essência de Sasaya",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 105839
         },
         {
           "language": "Spanish",
-          "name": "Esencia de Sasaya",
+          "name": "Sasaya, Orochi Ascendant",
           "multiverseid": 106004
         }
       ],
@@ -14912,7 +14912,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Damage that can’t be prevented still causes counters to be removed from Sekki and puts creature tokens onto the battlefield."
+          "text": "Damage that can't be prevented still causes counters to be removed from Sekki and puts creature tokens onto the battlefield."
         },
         {
           "date": "2005-06-01",
@@ -14920,11 +14920,11 @@
         },
         {
           "date": "2005-06-01",
-          "text": "Increasing Sekki’s toughness with a card like Indomitable Will allows Sekki to prevent damage and make tokens even it if has no +1/+1 counters to be removed."
+          "text": "Increasing Sekki's toughness with a card like Indomitable Will allows Sekki to prevent damage and make tokens even it if has no +1/+1 counters to be removed."
         },
         {
           "date": "2005-08-01",
-          "text": "You can sacrifice any eight Spirits to pay for Sekki’s activated ability, not just the Spirit creature tokens."
+          "text": "You can sacrifice any eight Spirits to pay for Sekki's activated ability, not just the Spirit creature tokens."
         }
       ],
       "subtypes": [
@@ -15120,7 +15120,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "The ability that returns a creature doesn’t target anything. You can return a creature with shroud or protection from green, for example. You don’t decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Serow itself."
+          "text": "The ability that returns a creature doesn't target anything. You can return a creature with shroud or protection from green, for example. You don't decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Serow itself."
         },
         {
           "date": "2014-02-01",
@@ -15226,19 +15226,19 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Effects that put Iname onto the battlefield don’t cause its enters-the-battlefield ability to trigger."
+          "text": "Effects that put Iname onto the battlefield don't cause its enters-the-battlefield ability to trigger."
         },
         {
           "date": "2005-06-01",
-          "text": "Iname can target itself with the graveyard-triggered ability, but it will be exiled and the ability won’t be able to return Iname."
+          "text": "Iname can target itself with the graveyard-triggered ability, but it will be exiled and the ability won't be able to return Iname."
         },
         {
           "date": "2005-06-01",
-          "text": "You aren’t required to exile Iname. If you don’t, the target Spirit card isn’t returned to the battlefield."
+          "text": "You aren't required to exile Iname. If you don't, the target Spirit card isn't returned to the battlefield."
         },
         {
           "date": "2013-04-15",
-          "text": "In a Commander game, you may send Iname to the Command Zone instead of exiling it during the resolution of its ability. If you do, its ability still works. Iname’s ability only requires that you attempted to exile it, not that it actually gets to the exile zone. This is similar to how destroying a creature (with, for example, Rest in Peace) doesn’t necessarily ensure that creature will end up in the graveyard; it just so happens that the action of exiling something and the exile zone both use the same word: “exile”."
+          "text": "In a Commander game, you may send Iname to the Command Zone instead of exiling it during the resolution of its ability. If you do, its ability still works. Iname's ability only requires that you attempted to exile it, not that it actually gets to the exile zone. This is similar to how destroying a creature (with, for example, Rest in Peace) doesn't necessarily ensure that creature will end up in the graveyard; it just so happens that the action of exiling something and the exile zone both use the same word: \"exile\"."
         },
         {
           "date": "2013-07-01",
@@ -15246,7 +15246,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -15431,11 +15431,11 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "A player who controls no permanents doesn’t need to pay 2 life (although that player can choose to do so)."
+          "text": "A player who controls no permanents doesn't need to pay 2 life (although that player can choose to do so)."
         },
         {
           "date": "2005-06-01",
-          "text": "A player with less than 2 life can’t pay 2 life and must return a permanent."
+          "text": "A player with less than 2 life can't pay 2 life and must return a permanent."
         },
         {
           "date": "2005-06-01",
@@ -15778,7 +15778,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "O-Naginata becomes unattached if the equipped creature’s power is less than 3 as state-based actions are checked."
+          "text": "O-Naginata becomes unattached if the equipped creature's power is less than 3 as state-based actions are checked."
         }
       ],
       "subtypes": [
@@ -15877,15 +15877,15 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Pithing Needle affects cards regardless of what zone they’re in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can’t cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
+          "text": "Pithing Needle affects cards regardless of what zone they're in. This includes cards in hand, cards in the graveyard, and exiled cards. For example, a player can't cycle Eternal Dragon or return an Eternal Dragon from his or her graveyard to hand if Pithing Needle naming Eternal Dragon is on the battlefield."
         },
         {
           "date": "2005-06-01",
-          "text": "You can name any card, even if that card doesn’t normally have an activated ability. You can’t name a token unless that token has the same name as a card."
+          "text": "You can name any card, even if that card doesn't normally have an activated ability. You can't name a token unless that token has the same name as a card."
         },
         {
           "date": "2005-06-01",
-          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can’t be activated."
+          "text": "If you name a card that has both a mana ability and another activated ability, the mana ability can be activated but the other ability can't be activated."
         },
         {
           "date": "2009-10-01",
@@ -15893,7 +15893,7 @@
         },
         {
           "date": "2012-10-01",
-          "text": "Activated abilities include a colon and are written in the form “[cost]: [effect].” Triggered abilities and static abilities of the named card work normally."
+          "text": "Activated abilities include a colon and are written in the form \"[cost]: [effect].\" Triggered abilities and static abilities of the named card work normally."
         }
       ],
       "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
@@ -16484,7 +16484,7 @@
       "rulings": [
         {
           "date": "2005-06-01",
-          "text": "Activating Tomb of Urami’s second ability requires sacrificing all lands you control, including Tomb of Urami."
+          "text": "Activating Tomb of Urami's second ability requires sacrificing all lands you control, including Tomb of Urami."
         }
       ],
       "supertypes": [

--- a/json/SOM.json
+++ b/json/SOM.json
@@ -260,7 +260,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -482,11 +482,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "For the purposes of blocking (either because Auriok Sunchaser is attacking or because a creature with flying is attacking Auriok Sunchaser’s controller), whether Auriok Sunchaser has flying is checked only as the declare blockers step begins."
+          "text": "For the purposes of blocking (either because Auriok Sunchaser is attacking or because a creature with flying is attacking Auriok Sunchaser's controller), whether Auriok Sunchaser has flying is checked only as the declare blockers step begins."
         },
         {
           "date": "2011-01-01",
-          "text": "If Auriok Sunchaser blocks a creature with flying, causing it to lose flying (by destroying an artifact its controller controls, for example) won’t change that."
+          "text": "If Auriok Sunchaser blocks a creature with flying, causing it to lose flying (by destroying an artifact its controller controls, for example) won't change that."
         }
       ],
       "subtypes": [
@@ -703,7 +703,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Elspeth Tirel’s last ability resolves, each permanent that isn’t a token, a land, or Elspeth Tirel herself is destroyed."
+          "text": "As Elspeth Tirel's last ability resolves, each permanent that isn't a token, a land, or Elspeth Tirel herself is destroyed."
         }
       ],
       "subtypes": [
@@ -811,7 +811,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You must target two creatures as you cast Fulgent Distraction. If you can’t (because there’s just one creature on the battlefield, perhaps), you can’t cast the spell."
+          "text": "You must target two creatures as you cast Fulgent Distraction. If you can't (because there's just one creature on the battlefield, perhaps), you can't cast the spell."
         },
         {
           "date": "2011-01-01",
@@ -819,7 +819,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If one of the targeted creatures is an illegal target by the time Fulgent Distraction resolves, that creature won’t become tapped and no Equipment will be unattached from it. The other creature will still be affected. If both of the targeted creatures are illegal targets by the time Fulgent Distraction resolves, the spell is countered."
+          "text": "If one of the targeted creatures is an illegal target by the time Fulgent Distraction resolves, that creature won't become tapped and no Equipment will be unattached from it. The other creature will still be affected. If both of the targeted creatures are illegal targets by the time Fulgent Distraction resolves, the spell is countered."
         }
       ],
       "text": "Choose two target creatures. Tap those creatures, then unattach all Equipment from them.",
@@ -1033,7 +1033,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If a token is exiled this way, it ceases to exist and won’t return to the battlefield."
+          "text": "If a token is exiled this way, it ceases to exist and won't return to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -1041,11 +1041,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the exiled card is an Aura, that card’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything (so it could be attached to a permanent with shroud, for example), but the Aura’s enchant ability restricts what it can be attached to. If the Aura can’t legally be attached to anything, it remains exiled."
+          "text": "If the exiled card is an Aura, that card's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything (so it could be attached to a permanent with shroud, for example), but the Aura's enchant ability restricts what it can be attached to. If the Aura can't legally be attached to anything, it remains exiled."
         },
         {
           "date": "2016-06-08",
-          "text": "If Glimmerpoint Stag somehow enters the battlefield during a turn’s end step, the exiled card won’t be returned to the battlefield until the beginning of the following turn’s end step."
+          "text": "If Glimmerpoint Stag somehow enters the battlefield during a turn's end step, the exiled card won't be returned to the battlefield until the beginning of the following turn's end step."
         }
       ],
       "subtypes": [
@@ -1160,7 +1160,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You choose which artifact to return to its owner’s hand as the triggered ability resolves. If you control no artifacts at that time, you must sacrifice Glint Hawk. Although players can respond to the ability, once it starts to resolve and you choose an artifact you control to return to its owner’s hand, it’s too late for players to respond."
+          "text": "You choose which artifact to return to its owner's hand as the triggered ability resolves. If you control no artifacts at that time, you must sacrifice Glint Hawk. Although players can respond to the ability, once it starts to resolve and you choose an artifact you control to return to its owner's hand, it's too late for players to respond."
         }
       ],
       "subtypes": [
@@ -1405,7 +1405,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"We're now to dispense aid to any Mirran we see battling anything . . . ‘strange.' Regent's orders.\"\n—Ranya, skyhunter captain",
+      "flavor": "\"We're now to dispense aid to any Mirran we see battling anything . . . 'strange.' Regent's orders.\"\n—Ranya, skyhunter captain",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -1600,31 +1600,31 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If an effect says “You may search your library . . . If you do, shuffle your library,” and you haven’t paid {2}, you can’t choose to search, so you won’t shuffle."
+          "text": "If an effect says \"You may search your library . . . If you do, shuffle your library,\" and you haven't paid {2}, you can't choose to search, so you won't shuffle."
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says “Search your library . . . Then shuffle your library,” and you haven’t paid {2}, the search effect fails, but you will still have to shuffle."
+          "text": "If an effect says \"Search your library . . . Then shuffle your library,\" and you haven't paid {2}, the search effect fails, but you will still have to shuffle."
         },
         {
           "date": "2011-01-01",
-          "text": "Since players who haven’t paid {2} can’t search, they won’t be able to find any cards in a library. The effect applies to all players and all libraries. If a spell or ability’s effect has other parts that don’t depend on searching for or finding cards, they will still work normally."
+          "text": "Since players who haven't paid {2} can't search, they won't be able to find any cards in a library. The effect applies to all players and all libraries. If a spell or ability's effect has other parts that don't depend on searching for or finding cards, they will still work normally."
         },
         {
           "date": "2011-01-01",
-          "text": "Effects that tell a player to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word “search” will fail unless a player pays {2}."
+          "text": "Effects that tell a player to reveal cards from a library or look at cards from the top of a library will still work. Only effects that use the word \"search\" will fail unless a player pays {2}."
         },
         {
           "date": "2011-01-01",
-          "text": "Paying {2} to ignore Leonin Arbiter’s effect is a special action. Any player may take this special action any time he or she has priority. It doesn’t use the stack and can’t be responded to."
+          "text": "Paying {2} to ignore Leonin Arbiter's effect is a special action. Any player may take this special action any time he or she has priority. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2011-01-01",
-          "text": "Paying {2} doesn’t let a player pick up a library and search it — it just allows him or her to ignore Leonin Arbiter’s effect that turn. That player can search a library only if another spell or ability instructs him or her to do so."
+          "text": "Paying {2} doesn't let a player pick up a library and search it — it just allows him or her to ignore Leonin Arbiter's effect that turn. That player can search a library only if another spell or ability instructs him or her to do so."
         },
         {
           "date": "2011-01-01",
-          "text": "If a player pays {2}, that enables only him or her to ignore Leonin Arbiter’s effect that turn. Each other player is still affected by it."
+          "text": "If a player pays {2}, that enables only him or her to ignore Leonin Arbiter's effect that turn. Each other player is still affected by it."
         },
         {
           "date": "2011-01-01",
@@ -1960,7 +1960,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If the artifact card in your graveyard is an illegal target by the time the ability resolves, the ability will be countered. You won’t gain any life."
+          "text": "If the artifact card in your graveyard is an illegal target by the time the ability resolves, the ability will be countered. You won't gain any life."
         },
         {
           "date": "2011-01-01",
@@ -2503,7 +2503,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The second ability destroys each creature that’s tapped at the time it resolves, including creatures you control. If Sunblast Angel has become tapped by the time its ability resolves, it will be destroyed too."
+          "text": "The second ability destroys each creature that's tapped at the time it resolves, including creatures you control. If Sunblast Angel has become tapped by the time its ability resolves, it will be destroyed too."
         }
       ],
       "subtypes": [
@@ -2615,7 +2615,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If all Equipment attached to Sunspear Shikari somehow becomes unequipped after it deals combat damage in the first combat damage step, it won’t assign combat damage in the second combat damage step."
+          "text": "If all Equipment attached to Sunspear Shikari somehow becomes unequipped after it deals combat damage in the first combat damage step, it won't assign combat damage in the second combat damage step."
         }
       ],
       "subtypes": [
@@ -2928,7 +2928,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it’s too late for any player to respond since the ability is already in the midst of resolving."
+          "text": "As the ability resolves, you choose a value for X and decide whether to pay {X}. If you do decide to pay {X}, it's too late for any player to respond since the ability is already in the midst of resolving."
         }
       ],
       "text": "Whenever a creature you control dies, you may pay {X}. If you do, you gain X life.",
@@ -3136,15 +3136,15 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If you activate Argent Sphinx’s metalcraft ability, Argent Sphinx will return to the battlefield at the beginning of the next end step no matter how many artifacts you control at that time."
+          "text": "If you activate Argent Sphinx's metalcraft ability, Argent Sphinx will return to the battlefield at the beginning of the next end step no matter how many artifacts you control at that time."
         },
         {
           "date": "2011-01-01",
-          "text": "If you activate Argent Sphinx’s metalcraft ability during a turn’s end step, Argent Sphinx will return to the battlefield at the beginning of the following turn’s end step."
+          "text": "If you activate Argent Sphinx's metalcraft ability during a turn's end step, Argent Sphinx will return to the battlefield at the beginning of the following turn's end step."
         },
         {
           "date": "2011-01-01",
-          "text": "If you control an Argent Sphinx owned by another player and activate its ability, Argent Sphinx will return to the battlefield under your control at the beginning of the next end step. You’ll retain control of it indefinitely."
+          "text": "If you control an Argent Sphinx owned by another player and activate its ability, Argent Sphinx will return to the battlefield under your control at the beginning of the next end step. You'll retain control of it indefinitely."
         }
       ],
       "subtypes": [
@@ -3581,7 +3581,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The ability triggers whenever you’re dealt any damage (not just combat damage) by any permanent (not just creatures). This includes permanents you control."
+          "text": "The ability triggers whenever you're dealt any damage (not just combat damage) by any permanent (not just creatures). This includes permanents you control."
         }
       ],
       "text": "Whenever a permanent deals damage to you, return it to its owner's hand.",
@@ -3695,7 +3695,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Since Grand Architect’s last ability doesn’t have a tap symbol in its cost, you can tap a blue creature (including Grand Architect itself) that hasn’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since Grand Architect's last ability doesn't have a tap symbol in its cost, you can tap a blue creature (including Grand Architect itself) that hasn't been under your control since your most recent turn began to pay the cost."
         }
       ],
       "subtypes": [
@@ -3911,11 +3911,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -3923,11 +3923,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         },
         {
           "date": "2011-01-01",
-          "text": "Whenever you cast a spell, Inexorable Tide’s ability triggers and goes on the stack on top of it. It will resolve (and you’ll proliferate) before the spell resolves."
+          "text": "Whenever you cast a spell, Inexorable Tide's ability triggers and goes on the stack on top of it. It will resolve (and you'll proliferate) before the spell resolves."
         }
       ],
       "text": "Whenever you cast a spell, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -4034,7 +4034,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The triggered ability is mandatory. If you control three or more artifacts as Lumengrid Drake enters the battlefield, you must target a creature. If there are no other creatures on the battlefield, you must target Lumengrid Drake itself. As the ability resolves, if you control three or more artifacts, you must return the targeted creature to its owner’s hand."
+          "text": "The triggered ability is mandatory. If you control three or more artifacts as Lumengrid Drake enters the battlefield, you must target a creature. If there are no other creatures on the battlefield, you must target Lumengrid Drake itself. As the ability resolves, if you control three or more artifacts, you must return the targeted creature to its owner's hand."
         }
       ],
       "subtypes": [
@@ -4356,7 +4356,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Except for its power and toughness, Quicksilver Gargantuan copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Except for its power and toughness, Quicksilver Gargantuan copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2011-01-01",
@@ -4372,15 +4372,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If Quicksilver Gargantuan is not a creature (for example, if it entered the battlefield as a copy of an animated land), it will not have the characteristics of power or toughness at all, so it won’t be 7/7. If it later becomes a creature, its power and toughness will be determined by the effect that causes it to become a creature; again, it won’t be 7/7."
+          "text": "If Quicksilver Gargantuan is not a creature (for example, if it entered the battlefield as a copy of an animated land), it will not have the characteristics of power or toughness at all, so it won't be 7/7. If it later becomes a creature, its power and toughness will be determined by the effect that causes it to become a creature; again, it won't be 7/7."
         },
         {
           "date": "2011-01-01",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Quicksilver Gargantuan enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Quicksilver Gargantuan enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2011-01-01",
-          "text": "If Quicksilver Gargantuan somehow enters the battlefield at the same time as another creature (due to Mass Polymorph or Liliana Vess’s third ability, for example), Quicksilver Gargantuan can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Quicksilver Gargantuan somehow enters the battlefield at the same time as another creature (due to Mass Polymorph or Liliana Vess's third ability, for example), Quicksilver Gargantuan can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2011-01-01",
@@ -4827,11 +4827,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If there are no artifact cards in the player’s library, all the cards in that library are revealed, then the library is shuffled. (The targeted artifact remains sacrificed.)"
+          "text": "If there are no artifact cards in the player's library, all the cards in that library are revealed, then the library is shuffled. (The targeted artifact remains sacrificed.)"
         },
         {
           "date": "2011-01-01",
-          "text": "If the targeted artifact’s controller can’t sacrifice it (due to Tajuru Preserver, perhaps), the other effects of the spell will still happen."
+          "text": "If the targeted artifact's controller can't sacrifice it (due to Tajuru Preserver, perhaps), the other effects of the spell will still happen."
         }
       ],
       "text": "The controller of target artifact sacrifices it, then reveals cards from the top of his or her library until he or she reveals an artifact card. That player puts that card onto the battlefield, then shuffles all other cards revealed this way into his or her library.",
@@ -5047,11 +5047,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -5059,11 +5059,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         },
         {
           "date": "2011-01-01",
-          "text": "This spell has no targets. You can cast it even if there are no players or permanents with counters on them. If you do, you’ll simply draw a card as it resolves."
+          "text": "This spell has no targets. You can cast it even if there are no players or permanents with counters on them. If you do, you'll simply draw a card as it resolves."
         }
       ],
       "text": "Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)\nDraw a card.",
@@ -5170,7 +5170,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Stoic Rebuttal’s metalcraft ability functions while Stoic Rebuttal is on the stack."
+          "text": "Stoic Rebuttal's metalcraft ability functions while Stoic Rebuttal is on the stack."
         },
         {
           "date": "2011-01-01",
@@ -5286,11 +5286,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -5298,7 +5298,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         }
       ],
       "subtypes": [
@@ -5646,7 +5646,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "text": "Switch target creature's power and toughness until end of turn.\nDraw a card.",
@@ -5756,7 +5756,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "For flying to work as an evasion ability, Vault Skyward must be cast before the declare blockers step begins. Once a creature has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, Vault Skyward must be cast before the declare blockers step begins. Once a creature has become blocked, giving it flying won't change that."
         }
       ],
       "text": "Target creature gains flying until end of turn. Untap it.",
@@ -5972,11 +5972,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If the enchanted permanent is untapped as Volition Reins enters the battlefield, the triggered ability won’t trigger at all."
+          "text": "If the enchanted permanent is untapped as Volition Reins enters the battlefield, the triggered ability won't trigger at all."
         },
         {
           "date": "2011-01-01",
-          "text": "Gaining control of a permanent doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a permanent doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -6090,11 +6090,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -6102,7 +6102,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -6430,7 +6430,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Carnifex Demon’s last ability resolves, you’ll put a -1/-1 counter on each creature on the battlefield — including creatures you control — except for that Carnifex Demon."
+          "text": "As Carnifex Demon's last ability resolves, you'll put a -1/-1 counter on each creature on the battlefield — including creatures you control — except for that Carnifex Demon."
         }
       ],
       "subtypes": [
@@ -6545,11 +6545,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -6557,7 +6557,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -6672,7 +6672,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You may sacrifice Corrupted Harvester to pay for its own regeneration ability. If you do, however, it won’t regenerate. It’ll just end up in its owner’s graveyard as a result of the sacrifice."
+          "text": "You may sacrifice Corrupted Harvester to pay for its own regeneration ability. If you do, however, it won't regenerate. It'll just end up in its owner's graveyard as a result of the sacrifice."
         }
       ],
       "subtypes": [
@@ -6783,7 +6783,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You may sacrifice Dross Hopper to pay for its own ability. If you do, however, it won’t gain flying because it won’t be on the battlefield by the time the ability resolves."
+          "text": "You may sacrifice Dross Hopper to pay for its own ability. If you do, however, it won't gain flying because it won't be on the battlefield by the time the ability resolves."
         }
       ],
       "subtypes": [
@@ -6894,7 +6894,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Players can lose more life than they have. For example, say you’re playing a multiplayer game in which one of your opponents has 3 life and your other opponent has 10 life. If you cast Exsanguinate with X of 4, your opponents will wind up at -1 life and 6 life, respectively. You’ll gain 8 life."
+          "text": "Players can lose more life than they have. For example, say you're playing a multiplayer game in which one of your opponents has 3 life and your other opponent has 10 life. If you cast Exsanguinate with X of 4, your opponents will wind up at -1 life and 6 life, respectively. You'll gain 8 life."
         }
       ],
       "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
@@ -7007,7 +7007,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can target a creature you control, then sacrifice that creature to pay the additional cost. However, if you do, Flesh Allergy will be countered for having an illegal target. You won’t lose any life."
+          "text": "You can target a creature you control, then sacrifice that creature to pay the additional cost. However, if you do, Flesh Allergy will be countered for having an illegal target. You won't lose any life."
         },
         {
           "date": "2013-04-15",
@@ -7240,11 +7240,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "The X in Geth’s activation cost must be exactly the converted mana cost of the targeted artifact or creature card. You can’t pay more than X to put more cards from the opponent’s library into his or her graveyard."
+          "text": "The X in Geth's activation cost must be exactly the converted mana cost of the targeted artifact or creature card. You can't pay more than X to put more cards from the opponent's library into his or her graveyard."
         },
         {
           "date": "2011-01-01",
-          "text": "If the targeted artifact or creature card leaves the graveyard by the time the ability resolves, the ability is countered. The player won’t put any cards into his graveyard."
+          "text": "If the targeted artifact or creature card leaves the graveyard by the time the ability resolves, the ability is countered. The player won't put any cards into his graveyard."
         },
         {
           "date": "2011-01-01",
@@ -7474,11 +7474,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -7486,7 +7486,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -7494,7 +7494,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Whenever you cast a creature spell with infect, Hand of the Praetors’s last ability triggers and goes on the stack on top of it. It will resolve before the creature spell does."
+          "text": "Whenever you cast a creature spell with infect, Hand of the Praetors's last ability triggers and goes on the stack on top of it. It will resolve before the creature spell does."
         },
         {
           "date": "2011-01-01",
@@ -7612,11 +7612,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -7624,7 +7624,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -7632,7 +7632,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If Ichor Rats’s last ability causes each player to have ten poison counters, the game is a draw."
+          "text": "If Ichor Rats's last ability causes each player to have ten poison counters, the game is a draw."
         }
       ],
       "subtypes": [
@@ -7844,7 +7844,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Because you’re searching for “any number” of cards with the chosen name, you can opt to find all of them, none of them, or any number in between. That means you may leave any cards with that name in that target’s graveyard, hand, and/or library."
+          "text": "Because you're searching for \"any number\" of cards with the chosen name, you can opt to find all of them, none of them, or any number in between. That means you may leave any cards with that name in that target's graveyard, hand, and/or library."
         }
       ],
       "text": "Choose a nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
@@ -8161,15 +8161,15 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Necrotic Ooze gains only activated abilities. It doesn’t gain keyword abilities (unless those keyword abilities are activated), triggered abilities, or static abilities."
+          "text": "Necrotic Ooze gains only activated abilities. It doesn't gain keyword abilities (unless those keyword abilities are activated), triggered abilities, or static abilities."
         },
         {
           "date": "2011-01-01",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities; they have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities; they have colons in their reminder text."
         },
         {
           "date": "2011-01-01",
-          "text": "If an activated ability of a card in a graveyard references the card it’s printed on by name, treat Necrotic Ooze’s version of that ability as though it referenced Necrotic Ooze by name instead. For example, if Cudgel Troll (which says “{G}: Regenerate Cudgel Troll”) is in a graveyard, Necrotic Ooze has the ability “{G}: Regenerate Necrotic Ooze.”"
+          "text": "If an activated ability of a card in a graveyard references the card it's printed on by name, treat Necrotic Ooze's version of that ability as though it referenced Necrotic Ooze by name instead. For example, if Cudgel Troll (which says \"{G}: Regenerate Cudgel Troll\") is in a graveyard, Necrotic Ooze has the ability \"{G}: Regenerate Necrotic Ooze.\""
         }
       ],
       "subtypes": [
@@ -8279,7 +8279,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Whenever an opponent casts a spell, Painful Quandary’s ability triggers and goes on the stack on top of it. It will resolve before the spell does."
+          "text": "Whenever an opponent casts a spell, Painful Quandary's ability triggers and goes on the stack on top of it. It will resolve before the spell does."
         }
       ],
       "text": "Whenever an opponent casts a spell, that player loses 5 life unless he or she discards a card.",
@@ -8497,11 +8497,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -8509,7 +8509,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -8624,7 +8624,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If a land card is discarded this way, Psychic Miasma is returned to its owner’s hand from the stack. It finishes resolving, but it isn’t put into the graveyard."
+          "text": "If a land card is discarded this way, Psychic Miasma is returned to its owner's hand from the stack. It finishes resolving, but it isn't put into the graveyard."
         }
       ],
       "text": "Target player discards a card. If a land card is discarded this way, return Psychic Miasma to its owner's hand.",
@@ -8730,19 +8730,19 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Relic Putrescence may target and may enchant an artifact that’s already tapped. It won’t do anything until the enchanted artifact changes from being untapped to being tapped."
+          "text": "Relic Putrescence may target and may enchant an artifact that's already tapped. It won't do anything until the enchanted artifact changes from being untapped to being tapped."
         },
         {
           "date": "2011-01-01",
-          "text": "When the enchanted artifact becomes tapped, Relic Putrescence’s ability triggers. The player who gets the poison counter is the player who, at the time the ability resolves, controls the artifact that became tapped. If that artifact is no longer on the battlefield, its last existence on the battlefield is checked to determine its controller. It doesn’t matter whether Relic Putrescence is still on the battlefield as the ability resolves, what artifact it’s enchanting at that time, who controlled the artifact at the time it became tapped, or who tapped it."
+          "text": "When the enchanted artifact becomes tapped, Relic Putrescence's ability triggers. The player who gets the poison counter is the player who, at the time the ability resolves, controls the artifact that became tapped. If that artifact is no longer on the battlefield, its last existence on the battlefield is checked to determine its controller. It doesn't matter whether Relic Putrescence is still on the battlefield as the ability resolves, what artifact it's enchanting at that time, who controlled the artifact at the time it became tapped, or who tapped it."
         },
         {
           "date": "2011-01-01",
-          "text": "If the enchanted artifact is tapped as a cost to activate a mana ability, the mana ability resolves immediately, then Relic Putrescence’s ability goes on the stack."
+          "text": "If the enchanted artifact is tapped as a cost to activate a mana ability, the mana ability resolves immediately, then Relic Putrescence's ability goes on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "If the enchanted artifact is tapped as a cost to activate an ability that’s not a mana ability, Relic Putrescence’s ability will go on the stack on top of that activated ability and resolve first."
+          "text": "If the enchanted artifact is tapped as a cost to activate an ability that's not a mana ability, Relic Putrescence's ability will go on the stack on top of that activated ability and resolve first."
         }
       ],
       "subtypes": [
@@ -8967,11 +8967,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -8979,7 +8979,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -9101,11 +9101,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -9113,7 +9113,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -9650,7 +9650,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Once Bloodshot Trainee’s ability is activated, it will resolve as normal even if Bloodshot Trainee’s power is less than 4 by the time the ability resolves."
+          "text": "Once Bloodshot Trainee's ability is activated, it will resolve as normal even if Bloodshot Trainee's power is less than 4 by the time the ability resolves."
         }
       ],
       "subtypes": [
@@ -9764,7 +9764,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Once the card is revealed, it’s too late for players to respond. The targeted opponent can’t, for example, see how much damage will be dealt, then cast a damage prevention spell or activate a regeneration ability. All such actions must be done before Cerebral Eruption starts to resolve."
+          "text": "Once the card is revealed, it's too late for players to respond. The targeted opponent can't, for example, see how much damage will be dealt, then cast a damage prevention spell or activate a regeneration ability. All such actions must be done before Cerebral Eruption starts to resolve."
         },
         {
           "date": "2011-01-01",
@@ -9776,11 +9776,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If the revealed card has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0."
+          "text": "If the revealed card has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0."
         },
         {
           "date": "2011-01-01",
-          "text": "If a land card is revealed this way, Cerebral Eruption is returned to its owner’s hand from the stack. It finishes resolving, but it isn’t put into the graveyard."
+          "text": "If a land card is revealed this way, Cerebral Eruption is returned to its owner's hand from the stack. It finishes resolving, but it isn't put into the graveyard."
         }
       ],
       "text": "Target opponent reveals the top card of his or her library. Cerebral Eruption deals damage equal to the revealed card's converted mana cost to that player and each creature he or she controls. If a land card is revealed this way, return Cerebral Eruption to its owner's hand.",
@@ -10098,11 +10098,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If, during your declare attackers step, Flameborn Hellion is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then it doesn’t attack. If there’s a cost associated with having Flameborn Hellion attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Flameborn Hellion is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then it doesn't attack. If there's a cost associated with having Flameborn Hellion attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2011-01-01",
-          "text": "If there are multiple combat phases in a turn, Flameborn Hellion must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Flameborn Hellion must attack only in the first one in which it's able to."
         }
       ],
       "subtypes": [
@@ -10213,15 +10213,15 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Furnace Celebration itself doesn’t allow you to sacrifice any permanents. Its ability triggers whenever you sacrifice a permanent because some other spell, ability, or cost instructed you to."
+          "text": "Furnace Celebration itself doesn't allow you to sacrifice any permanents. Its ability triggers whenever you sacrifice a permanent because some other spell, ability, or cost instructed you to."
         },
         {
           "date": "2011-01-01",
-          "text": "You choose the target when the ability triggers. You choose whether or not to pay {2} as the ability resolves. You can’t pay {2} more than once for a single sacrificed permanent."
+          "text": "You choose the target when the ability triggers. You choose whether or not to pay {2} as the ability resolves. You can't pay {2} more than once for a single sacrificed permanent."
         },
         {
           "date": "2011-01-01",
-          "text": "Although players may respond to the ability, once it starts to resolve and you decide to pay {2}, it’s too late for players to respond."
+          "text": "Although players may respond to the ability, once it starts to resolve and you decide to pay {2}, it's too late for players to respond."
         },
         {
           "date": "2011-01-01",
@@ -10432,7 +10432,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Goblin Gaveleer’s bonus is in addition to whatever bonus the Equipment gives it."
+          "text": "Goblin Gaveleer's bonus is in addition to whatever bonus the Equipment gives it."
         }
       ],
       "subtypes": [
@@ -10545,7 +10545,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If the targeted artifact is an illegal target by the time the activated ability resolves, the ability is countered. Hoard-Smelter Dragon won’t get the bonus."
+          "text": "If the targeted artifact is an illegal target by the time the activated ability resolves, the ability is countered. Hoard-Smelter Dragon won't get the bonus."
         },
         {
           "date": "2011-01-01",
@@ -10553,7 +10553,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If the activated ability resolves but the targeted artifact isn’t destroyed (perhaps because it has indestructible or it regenerates), Hoard-Smelter Dragon will still get the bonus."
+          "text": "If the activated ability resolves but the targeted artifact isn't destroyed (perhaps because it has indestructible or it regenerates), Hoard-Smelter Dragon will still get the bonus."
         }
       ],
       "subtypes": [
@@ -10664,29 +10664,29 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren’t permanents and don’t exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
+          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren't permanents and don't exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
         },
         {
           "date": "2011-01-01",
-          "text": "Koth’s first ability can target any Mountain, including an untapped Mountain and/or a Mountain another player controls."
+          "text": "Koth's first ability can target any Mountain, including an untapped Mountain and/or a Mountain another player controls."
         },
         {
           "date": "2011-01-01",
-          "text": "If Koth’s first ability animates a Mountain that came under your control that turn, it will have “summoning sickness” and be unable to attack. It will also be unable to be tapped to activate an ability with the {T} symbol in its cost, such as the Mountain’s mana ability or the ability granted to it by Koth’s emblem."
+          "text": "If Koth's first ability animates a Mountain that came under your control that turn, it will have \"summoning sickness\" and be unable to attack. It will also be unable to be tapped to activate an ability with the {T} symbol in its cost, such as the Mountain's mana ability or the ability granted to it by Koth's emblem."
         },
         {
           "date": "2011-01-01",
-          "text": "Loyalty abilities can’t be mana abilities. Koth’s second ability uses the stack and can be countered or otherwise responded to. Like all loyalty abilities, it can be activated only once per turn, during your main phase, when the stack is empty, and only if no other loyalty abilities of this permanent have been activated this turn."
+          "text": "Loyalty abilities can't be mana abilities. Koth's second ability uses the stack and can be countered or otherwise responded to. Like all loyalty abilities, it can be activated only once per turn, during your main phase, when the stack is empty, and only if no other loyalty abilities of this permanent have been activated this turn."
         },
         {
           "date": "2011-01-01",
-          "text": "Koth’s emblem grants an activated ability to each Mountain you control at any given time for the rest of the game. It will continuously check which permanents you control are Mountains to determine what has the ability. For example, a Mountain that comes under your control later in the game will have the ability, while a Mountain you controlled at the time the emblem was created, but that later came under the control of another player, will no longer have the ability."
+          "text": "Koth's emblem grants an activated ability to each Mountain you control at any given time for the rest of the game. It will continuously check which permanents you control are Mountains to determine what has the ability. For example, a Mountain that comes under your control later in the game will have the ability, while a Mountain you controlled at the time the emblem was created, but that later came under the control of another player, will no longer have the ability."
         }
       ],
       "subtypes": [
         "Koth"
       ],
-      "text": "+1: Untap target Mountain. It becomes a 4/4 red Elemental creature until end of turn. It's still a land.\n−2: Add {R} to your mana pool for each Mountain you control.\n−5: You get an emblem with \"Mountains you control have ‘{T}: This land deals 1 damage to target creature or player.'\"",
+      "text": "+1: Untap target Mountain. It becomes a 4/4 red Elemental creature until end of turn. It's still a land.\n−2: Add {R} to your mana pool for each Mountain you control.\n−5: You get an emblem with \"Mountains you control have '{T}: This land deals 1 damage to target creature or player.'\"",
       "type": "Planeswalker — Koth",
       "types": [
         "Planeswalker"
@@ -10788,7 +10788,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You can activate Kuldotha Phoenix’s ability only if it’s in your graveyard."
+          "text": "You can activate Kuldotha Phoenix's ability only if it's in your graveyard."
         }
       ],
       "subtypes": [
@@ -11103,11 +11103,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If a player doesn’t have any cards in his or her hand, the player will still shuffle his or her library."
+          "text": "If a player doesn't have any cards in his or her hand, the player will still shuffle his or her library."
         },
         {
           "date": "2011-01-01",
-          "text": "The metalcraft effect counts all cards each opponent drew for any reason during that turn, not just the cards those opponents drew due to Molten Psyche’s first effect."
+          "text": "The metalcraft effect counts all cards each opponent drew for any reason during that turn, not just the cards those opponents drew due to Molten Psyche's first effect."
         }
       ],
       "text": "Each player shuffles the cards from his or her hand into his or her library, then draws that many cards.\nMetalcraft — If you control three or more artifacts, Molten Psyche deals damage to each opponent equal to the number of cards that player has drawn this turn.",
@@ -11214,19 +11214,19 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If the targeted Equipment can’t be attached to Ogre Geargrabber for some reason, you’ll still gain control of it until end of turn."
+          "text": "If the targeted Equipment can't be attached to Ogre Geargrabber for some reason, you'll still gain control of it until end of turn."
         },
         {
           "date": "2011-01-01",
-          "text": "Any ability of the targeted Equipment that triggers “whenever equipped creature attacks” won’t trigger. That’s because Ogre Geargrabber is already attacking at the time that Equipment becomes attached to it."
+          "text": "Any ability of the targeted Equipment that triggers \"whenever equipped creature attacks\" won't trigger. That's because Ogre Geargrabber is already attacking at the time that Equipment becomes attached to it."
         },
         {
           "date": "2011-01-01",
-          "text": "The delayed triggered ability (“When you lose control of that Equipment, unattach it”) triggers the next time you lose control of the Equipment for any reason, not just when Ogre Geargrabber’s control-changing effect ends. The Equipment will become unattached from whatever creature it happens to be attached to at that time. It doesn’t matter if Ogre Geargrabber is still on the battlefield at this time."
+          "text": "The delayed triggered ability (\"When you lose control of that Equipment, unattach it\") triggers the next time you lose control of the Equipment for any reason, not just when Ogre Geargrabber's control-changing effect ends. The Equipment will become unattached from whatever creature it happens to be attached to at that time. It doesn't matter if Ogre Geargrabber is still on the battlefield at this time."
         },
         {
           "date": "2011-01-01",
-          "text": "Ogre Geargrabber’s control-changing effect ends during the cleanup step, at the same time that damage marked on permanents is removed. If you still controlled the Equipment at that time, this causes the delayed triggered ability to trigger. It goes on the stack and players can respond (which normally doesn’t happen during the cleanup step), then, once that cleanup step ends, another one begins."
+          "text": "Ogre Geargrabber's control-changing effect ends during the cleanup step, at the same time that damage marked on permanents is removed. If you still controlled the Equipment at that time, this causes the delayed triggered ability to trigger. It goes on the stack and players can respond (which normally doesn't happen during the cleanup step), then, once that cleanup step ends, another one begins."
         }
       ],
       "subtypes": [
@@ -11444,7 +11444,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "This ability is mandatory. If you’re the only player who controls any artifacts, you must target one of them."
+          "text": "This ability is mandatory. If you're the only player who controls any artifacts, you must target one of them."
         }
       ],
       "subtypes": [
@@ -11912,11 +11912,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Whenever a land enters the battlefield under an opponent’s control, this ability triggers only if another land had already entered the battlefield under that opponent’s control this turn. It doesn’t matter if that other land is still on the battlefield, is still under that player’s control, or is still a land."
+          "text": "Whenever a land enters the battlefield under an opponent's control, this ability triggers only if another land had already entered the battlefield under that opponent's control this turn. It doesn't matter if that other land is still on the battlefield, is still under that player's control, or is still a land."
         },
         {
           "date": "2011-01-01",
-          "text": "If multiple lands enter the battlefield under an opponent’s control at the same time, Tunnel Ignus’s ability triggers that many times, even if no other lands had entered the battlefield under that player’s control earlier in the turn. That’s because each ability takes into consideration the other land(s) that entered the battlefield at the same time as the one that caused it to trigger."
+          "text": "If multiple lands enter the battlefield under an opponent's control at the same time, Tunnel Ignus's ability triggers that many times, even if no other lands had entered the battlefield under that player's control earlier in the turn. That's because each ability takes into consideration the other land(s) that entered the battlefield at the same time as the one that caused it to trigger."
         }
       ],
       "subtypes": [
@@ -12666,11 +12666,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -12678,7 +12678,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -13008,11 +13008,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -13020,7 +13020,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -13133,11 +13133,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Copperhorn Scout’s ability resolves, you’ll untap each other creature you control regardless of whether that creature was attacking."
+          "text": "As Copperhorn Scout's ability resolves, you'll untap each other creature you control regardless of whether that creature was attacking."
         },
         {
           "date": "2011-01-01",
-          "text": "Untapping an attacking creature doesn’t cause it to stop attacking."
+          "text": "Untapping an attacking creature doesn't cause it to stop attacking."
         }
       ],
       "subtypes": [
@@ -13253,11 +13253,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -13265,7 +13265,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -13380,7 +13380,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Engulfing Slagwurm’s ability triggers and resolves during the declare blockers step. Creatures destroyed this way will not deal combat damage."
+          "text": "Engulfing Slagwurm's ability triggers and resolves during the declare blockers step. Creatures destroyed this way will not deal combat damage."
         },
         {
           "date": "2011-01-01",
@@ -13388,15 +13388,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If Engulfing Slagwurm’s ability resolves and the other creature is not destroyed (perhaps because it has already left the battlefield or it regenerates), you’ll still gain life equal to that creature’s toughness."
+          "text": "If Engulfing Slagwurm's ability resolves and the other creature is not destroyed (perhaps because it has already left the battlefield or it regenerates), you'll still gain life equal to that creature's toughness."
         },
         {
           "date": "2011-01-01",
-          "text": "As each ability resolves, the amount of life you gain is equal to the appropriate creature’s current toughness (if it’s somehow still on the battlefield), or its toughness as it last existed on the battlefield (in all other cases)."
+          "text": "As each ability resolves, the amount of life you gain is equal to the appropriate creature's current toughness (if it's somehow still on the battlefield), or its toughness as it last existed on the battlefield (in all other cases)."
         },
         {
           "date": "2011-01-01",
-          "text": "Even if the ability of an attacking Engulfing Slagwurm destroys each creature blocking it, Engulfing Slagwurm won’t deal combat damage to the player or planeswalker it’s attacking unless it somehow gains trample."
+          "text": "Even if the ability of an attacking Engulfing Slagwurm destroys each creature blocking it, Engulfing Slagwurm won't deal combat damage to the player or planeswalker it's attacking unless it somehow gains trample."
         }
       ],
       "subtypes": [
@@ -13509,11 +13509,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Ezuri’s first ability can’t affect itself, but its second ability does."
+          "text": "Ezuri's first ability can't affect itself, but its second ability does."
         },
         {
           "date": "2011-01-01",
-          "text": "Only Elf creatures you control when the last ability resolves will get +3/+3 and gain trample until end of turn. Non-Elf creatures that become Elves or Elf creatures that enter the battlefield under your control later in the turn won’t get the bonuses."
+          "text": "Only Elf creatures you control when the last ability resolves will get +3/+3 and gain trample until end of turn. Non-Elf creatures that become Elves or Elf creatures that enter the battlefield under your control later in the turn won't get the bonuses."
         }
       ],
       "subtypes": [
@@ -13627,7 +13627,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If Ezuri’s Archers somehow blocks multiple creatures with flying (perhaps because it’s equipped by Echo Circlet), its ability triggers that many times."
+          "text": "If Ezuri's Archers somehow blocks multiple creatures with flying (perhaps because it's equipped by Echo Circlet), its ability triggers that many times."
         }
       ],
       "subtypes": [
@@ -13859,11 +13859,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If a card in your library has no mana symbols in its upper right corner (because it’s a land card, for example), its converted mana cost is 0. Such cards can always be put onto the battlefield with Genesis Wave."
+          "text": "If a card in your library has no mana symbols in its upper right corner (because it's a land card, for example), its converted mana cost is 0. Such cards can always be put onto the battlefield with Genesis Wave."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to put permanent cards revealed this way onto the battlefield if you choose not to, regardless of their converted mana costs."
+          "text": "You don't have to put permanent cards revealed this way onto the battlefield if you choose not to, regardless of their converted mana costs."
         }
       ],
       "text": "Reveal the top X cards of your library. You may put any number of permanent cards with converted mana cost X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
@@ -13977,7 +13977,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If all awakening counters on a land are moved to a land without an awakening counter on it (perhaps by using Fate Transfer), the animation effect doesn’t follow them. The first land is no longer an 8/8 green Elemental creature because it no longer has an awakening counter on it. The second land isn’t an 8/8 green Elemental creature because Liege of the Tangle didn’t target it."
+          "text": "If all awakening counters on a land are moved to a land without an awakening counter on it (perhaps by using Fate Transfer), the animation effect doesn't follow them. The first land is no longer an 8/8 green Elemental creature because it no longer has an awakening counter on it. The second land isn't an 8/8 green Elemental creature because Liege of the Tangle didn't target it."
         }
       ],
       "subtypes": [
@@ -14194,7 +14194,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If Molder Beast and an artifact creature are both involved in combat during the same combat damage step, and that artifact creature is destroyed due to lethal combat damage, Molder Beast’s triggered ability will trigger — but it will get the bonus too late to affect that combat."
+          "text": "If Molder Beast and an artifact creature are both involved in combat during the same combat damage step, and that artifact creature is destroyed due to lethal combat damage, Molder Beast's triggered ability will trigger — but it will get the bonus too late to affect that combat."
         }
       ],
       "subtypes": [
@@ -14308,11 +14308,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -14320,7 +14320,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -14347,7 +14347,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"The hypocrisy of these elves is thicker than steel—destroying ‘unnatural metal' with their own enchanted swords.\"\n—Kara Vrist, Neurok agent",
+      "flavor": "\"The hypocrisy of these elves is thicker than steel—destroying 'unnatural metal' with their own enchanted swords.\"\n—Kara Vrist, Neurok agent",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -14540,11 +14540,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -14552,7 +14552,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -14560,19 +14560,19 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You may activate Tangle Angler’s second ability multiple times in a turn to force multiple creatures to block it."
+          "text": "You may activate Tangle Angler's second ability multiple times in a turn to force multiple creatures to block it."
         },
         {
           "date": "2011-01-01",
-          "text": "Activating Tangle Angler’s second ability doesn’t force you to attack with Tangle Angler that turn. If it doesn’t attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "Activating Tangle Angler's second ability doesn't force you to attack with Tangle Angler that turn. If it doesn't attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2011-01-01",
-          "text": "If you attack with Tangle Angler but a creature you targeted with its activated ability isn’t able to block it (for example, because an effect has granted Tangle Angler intimidate and the other creature is white), the other creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "If you attack with Tangle Angler but a creature you targeted with its activated ability isn't able to block it (for example, because an effect has granted Tangle Angler intimidate and the other creature is white), the other creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2011-01-01",
-          "text": "Tapped creatures, creatures that can’t block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren’t controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Tangle Angler’s activated ability, but the requirement to block does nothing."
+          "text": "Tapped creatures, creatures that can't block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren't controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Tangle Angler's activated ability, but the requirement to block does nothing."
         }
       ],
       "subtypes": [
@@ -14682,7 +14682,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "“Protection from artifacts” means the following: -- The affected creature can't be blocked by artifact creatures. -- The affected creature can't be equipped. If any Equipment are attached to it, they become unattached. The affected creature also can't be enchanted by Auras that have somehow become artifacts in addition to enchantments. -- The affected creature can't be targeted by abilities from artifact sources. -- All damage that would be dealt to the affected creature by artifact sources is prevented."
+          "text": "\"Protection from artifacts\" means the following: -- The affected creature can't be blocked by artifact creatures. -- The affected creature can't be equipped. If any Equipment are attached to it, they become unattached. The affected creature also can't be enchanted by Auras that have somehow become artifacts in addition to enchantments. -- The affected creature can't be targeted by abilities from artifact sources. -- All damage that would be dealt to the affected creature by artifact sources is prevented."
         }
       ],
       "text": "Target creature gains protection from artifacts until end of turn.\nDraw a card.",
@@ -14793,11 +14793,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -14805,7 +14805,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -14813,7 +14813,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "“Protection from artifacts” means the following: -- Tel-Jilad Fallen can't be blocked by artifact creatures. -- Tel-Jilad Fallen can't be equipped. It also can't be enchanted by Auras that have somehow become artifacts in addition to enchantments. -- Tel-Jilad Fallen can't be targeted by abilities from artifact sources. -- All damage that would be dealt to Tel-Jilad Fallen by artifact sources is prevented."
+          "text": "\"Protection from artifacts\" means the following: -- Tel-Jilad Fallen can't be blocked by artifact creatures. -- Tel-Jilad Fallen can't be equipped. It also can't be enchanted by Auras that have somehow become artifacts in addition to enchantments. -- Tel-Jilad Fallen can't be targeted by abilities from artifact sources. -- All damage that would be dealt to Tel-Jilad Fallen by artifact sources is prevented."
         }
       ],
       "subtypes": [
@@ -15024,7 +15024,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "It doesn’t matter who controlled the artifact while it was on the battlefield, only whose graveyard it was put into."
+          "text": "It doesn't matter who controlled the artifact while it was on the battlefield, only whose graveyard it was put into."
         }
       ],
       "text": "Whenever an artifact is put into an opponent's graveyard from the battlefield, you may draw a card.",
@@ -15130,7 +15130,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If either target has become illegal by the time Wing Puncture resolves, the spell will still resolve but have no effect. If the first target is illegal, it can’t perform any actions, so it can’t deal damage. If the second target is illegal, there’s nothing for the first target to deal damage to. If both targets have become illegal, the spell will be countered."
+          "text": "If either target has become illegal by the time Wing Puncture resolves, the spell will still resolve but have no effect. If the first target is illegal, it can't perform any actions, so it can't deal damage. If the second target is illegal, there's nothing for the first target to deal damage to. If both targets have become illegal, the spell will be countered."
         }
       ],
       "text": "Target creature you control deals damage equal to its power to target creature with flying.",
@@ -15339,7 +15339,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren’t permanents and don’t exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
+          "text": "Emblems behave similarly to enchantments: They have an ability that, in a general sense, continually affects the game. The primary difference between them is that emblems aren't permanents and don't exist on the battlefield. Nothing in the game can remove an emblem, simply because no other spell or ability references them. Once you get an emblem, you keep it for the rest of the game. Emblems have no color, name, card type, or other characteristics beyond the listed ability."
         },
         {
           "date": "2011-01-01",
@@ -15347,7 +15347,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If the first ability exiles a token, that token will cease to exist. It won’t return to the battlefield."
+          "text": "If the first ability exiles a token, that token will cease to exist. It won't return to the battlefield."
         },
         {
           "date": "2011-01-01",
@@ -15355,19 +15355,19 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Venser’s second ability doesn’t lock in what it applies to. That’s because the effect states a true thing about creatures, but doesn’t actually change the characteristics of those creatures. As a result, all creatures can’t be blocked that turn, including creatures you don’t control, creatures that weren’t on the battlefield at the time the ability resolved, and creatures that have lost all abilities."
+          "text": "Venser's second ability doesn't lock in what it applies to. That's because the effect states a true thing about creatures, but doesn't actually change the characteristics of those creatures. As a result, all creatures can't be blocked that turn, including creatures you don't control, creatures that weren't on the battlefield at the time the ability resolved, and creatures that have lost all abilities."
         },
         {
           "date": "2011-01-01",
-          "text": "Venser’s last ability creates an emblem with a triggered ability. The emblem is the source of the triggered ability. Because emblems are colorless, you can target permanents with protection from white or from blue, for example, with the triggered ability."
+          "text": "Venser's last ability creates an emblem with a triggered ability. The emblem is the source of the triggered ability. Because emblems are colorless, you can target permanents with protection from white or from blue, for example, with the triggered ability."
         },
         {
           "date": "2011-01-01",
-          "text": "Whenever you cast a spell, the emblem’s ability triggers and goes on the stack on top of it. It will resolve before the spell does."
+          "text": "Whenever you cast a spell, the emblem's ability triggers and goes on the stack on top of it. It will resolve before the spell does."
         },
         {
           "date": "2011-01-01",
-          "text": "If you control more than one such emblem, each one’s ability will trigger separately whenever you cast a spell."
+          "text": "If you control more than one such emblem, each one's ability will trigger separately whenever you cast a spell."
         }
       ],
       "subtypes": [
@@ -15679,7 +15679,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You choose a source of damage as the ability resolves. Since the ability doesn’t target the source, you could choose a source with protection from artifacts, for example."
+          "text": "You choose a source of damage as the ability resolves. Since the ability doesn't target the source, you could choose a source with protection from artifacts, for example."
         },
         {
           "date": "2011-01-01",
@@ -15986,7 +15986,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If you activate Chimeric Mass’s last ability while it has no charge counters on it, it will become a 0/0 creature and be put into its owner’s graveyard as a state-based action."
+          "text": "If you activate Chimeric Mass's last ability while it has no charge counters on it, it will become a 0/0 creature and be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2011-01-01",
@@ -15994,7 +15994,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "For example, say you activate the last ability of a Chimeric Mass with three charge counters on it. After it resolves, you cast Giant Growth targeting it. It’s now 6/6. Then Diminish (“Target creature becomes 1/1 until end of turn”) is cast targeting it. Once Diminish resolves, Chimeric Mass would be 4/4. Activating Chimeric Mass’s last ability a second time would make it 6/6 again until end of turn."
+          "text": "For example, say you activate the last ability of a Chimeric Mass with three charge counters on it. After it resolves, you cast Giant Growth targeting it. It's now 6/6. Then Diminish (\"Target creature becomes 1/1 until end of turn\") is cast targeting it. Once Diminish resolves, Chimeric Mass would be 4/4. Activating Chimeric Mass's last ability a second time would make it 6/6 again until end of turn."
         }
       ],
       "text": "Chimeric Mass enters the battlefield with X charge counters on it.\n{1}: Until end of turn, Chimeric Mass becomes a Construct artifact creature with \"This creature's power and toughness are each equal to the number of charge counters on it.\"",
@@ -16194,19 +16194,19 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If you have fewer than four cards in your library as Clone Shell’s first ability resolves, you’ll look at all of them."
+          "text": "If you have fewer than four cards in your library as Clone Shell's first ability resolves, you'll look at all of them."
         },
         {
           "date": "2011-01-01",
-          "text": "As Clone Shell’s first ability resolves, you must exile one of the cards you look at, even if none of them is a creature card."
+          "text": "As Clone Shell's first ability resolves, you must exile one of the cards you look at, even if none of them is a creature card."
         },
         {
           "date": "2011-01-01",
-          "text": "As Clone Shell’s second ability resolves, if the exiled card is not a creature card, it simply remains in exile face up."
+          "text": "As Clone Shell's second ability resolves, if the exiled card is not a creature card, it simply remains in exile face up."
         },
         {
           "date": "2011-01-01",
-          "text": "If you gain control of another player’s Clone Shell, you won’t be able to look at the face-down exiled card. However, if Clone Shell is put into a graveyard, you will turn that card face up as the ability resolves and, if it’s a creature card, you will put it onto the battlefield under your control (even if you don’t want to)."
+          "text": "If you gain control of another player's Clone Shell, you won't be able to look at the face-down exiled card. However, if Clone Shell is put into a graveyard, you will turn that card face up as the ability resolves and, if it's a creature card, you will put it onto the battlefield under your control (even if you don't want to)."
         }
       ],
       "subtypes": [
@@ -16316,11 +16316,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -16328,11 +16328,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         },
         {
           "date": "2011-01-01",
-          "text": "Contagion Clasp’s first ability is mandatory. If you’re the only player who controls a creature, you must target one of them."
+          "text": "Contagion Clasp's first ability is mandatory. If you're the only player who controls a creature, you must target one of them."
         }
       ],
       "text": "When Contagion Clasp enters the battlefield, put a -1/-1 counter on target creature.\n{4}, {T}: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
@@ -16435,11 +16435,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -16447,15 +16447,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         },
         {
           "date": "2011-01-01",
-          "text": "As Contagion Engine’s activated ability resolves, you’ll complete an entire proliferate action, then you’ll complete a second proliferate action. You may choose different players and/or permanents, or different counters on those permanents, when you proliferate the second time."
+          "text": "As Contagion Engine's activated ability resolves, you'll complete an entire proliferate action, then you'll complete a second proliferate action. You may choose different players and/or permanents, or different counters on those permanents, when you proliferate the second time."
         },
         {
           "date": "2011-01-01",
-          "text": "Players can’t respond between the first and the second proliferate actions."
+          "text": "Players can't respond between the first and the second proliferate actions."
         }
       ],
       "text": "When Contagion Engine enters the battlefield, put a -1/-1 counter on each creature target player controls.\n{4}, {T}: Proliferate, then proliferate again. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there. Then do it again.)",
@@ -16668,11 +16668,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -16680,7 +16680,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -16790,7 +16790,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Culling Dais’s last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
+          "text": "As Culling Dais's last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
         }
       ],
       "text": "{T}, Sacrifice a creature: Put a charge counter on Culling Dais.\n{1}, Sacrifice Culling Dais: Draw a card for each charge counter on Culling Dais.",
@@ -16891,11 +16891,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Darksteel Axe itself has indestructible, not the creature it’s equipping."
+          "text": "Darksteel Axe itself has indestructible, not the creature it's equipping."
         },
         {
           "date": "2013-07-01",
-          "text": "Although Darksteel Axe has indestructible, it can still be put into the graveyard for other reasons. The most likely reason is if it’s sacrificed."
+          "text": "Although Darksteel Axe has indestructible, it can still be put into the graveyard for other reasons. The most likely reason is if it's sacrificed."
         }
       ],
       "subtypes": [
@@ -16999,19 +16999,19 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Since Darksteel Juggernaut is itself an artifact, its power and toughness will always be at least 1 while it’s on the battlefield (unless a spell or ability somehow changes its card type)."
+          "text": "Since Darksteel Juggernaut is itself an artifact, its power and toughness will always be at least 1 while it's on the battlefield (unless a spell or ability somehow changes its card type)."
         },
         {
           "date": "2011-01-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause Darksteel Juggernaut to be put into the graveyard. However, it can be put into the graveyard for a number of other reasons. The most likely reasons are if its toughness is 0 or less or it’s sacrificed."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause Darksteel Juggernaut to be put into the graveyard. However, it can be put into the graveyard for a number of other reasons. The most likely reasons are if its toughness is 0 or less or it's sacrificed."
         },
         {
           "date": "2011-01-01",
-          "text": "If, during your declare attackers step, Darksteel Juggernaut is tapped, is affected by a spell or ability that says it can’t attack, or is affected by “summoning sickness,” then it doesn’t attack. If there’s a cost associated with having Darksteel Juggernaut attack, you aren’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Darksteel Juggernaut is tapped, is affected by a spell or ability that says it can't attack, or is affected by \"summoning sickness,\" then it doesn't attack. If there's a cost associated with having Darksteel Juggernaut attack, you aren't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2011-01-01",
-          "text": "If there are multiple combat phases in a turn, Darksteel Juggernaut must attack only in the first one in which it’s able to."
+          "text": "If there are multiple combat phases in a turn, Darksteel Juggernaut must attack only in the first one in which it's able to."
         },
         {
           "date": "2011-01-01",
@@ -17322,7 +17322,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Echo Circlet’s effect is cumulative. If it equips a creature that can already block an additional creature, now it can block three creatures. The same is true if two Echo Circlets equip the same creature, for example."
+          "text": "Echo Circlet's effect is cumulative. If it equips a creature that can already block an additional creature, now it can block three creatures. The same is true if two Echo Circlets equip the same creature, for example."
         }
       ],
       "subtypes": [
@@ -17427,7 +17427,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "“Protection from all colors” means protection from white, from blue, from black, from red, and from green. (In other words, it doesn’t just mean “protection from objects that have all five colors.”)"
+          "text": "\"Protection from all colors\" means protection from white, from blue, from black, from red, and from green. (In other words, it doesn't just mean \"protection from objects that have all five colors.\")"
         }
       ],
       "subtypes": [
@@ -17534,7 +17534,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "For flying to work as an evasion ability, an attacking creature must be granted flying before the declare blockers step begins. Once an attacking creature has become blocked, giving it flying won’t change that."
+          "text": "For flying to work as an evasion ability, an attacking creature must be granted flying before the declare blockers step begins. Once an attacking creature has become blocked, giving it flying won't change that."
         }
       ],
       "text": "{T}, Sacrifice Flight Spellbomb: Target creature gains flying until end of turn.\nWhen Flight Spellbomb is put into a graveyard from the battlefield, you may pay {U}. If you do, draw a card.",
@@ -17637,23 +17637,23 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The creature type “Bird” was inadvertently omitted from each of Glint Hawk Idol’s abilities. It has received errata to correct this omission; when either of its abilities resolves, it will become a Bird artifact creature."
+          "text": "The creature type \"Bird\" was inadvertently omitted from each of Glint Hawk Idol's abilities. It has received errata to correct this omission; when either of its abilities resolves, it will become a Bird artifact creature."
         },
         {
           "date": "2011-01-01",
-          "text": "If Glint Hawk Idol becomes a creature before you begin a turn with it under your control, it will be affected by “summoning sickness.”"
+          "text": "If Glint Hawk Idol becomes a creature before you begin a turn with it under your control, it will be affected by \"summoning sickness.\""
         },
         {
           "date": "2011-01-01",
-          "text": "If Glint Hawk Idol and another artifact enter the battlefield under your control at the same time, Glint Hawk Idol’s first ability will trigger. You may have it become a creature, but since it will be affected by “summoning sickness,” it won’t be able to attack that turn."
+          "text": "If Glint Hawk Idol and another artifact enter the battlefield under your control at the same time, Glint Hawk Idol's first ability will trigger. You may have it become a creature, but since it will be affected by \"summoning sickness,\" it won't be able to attack that turn."
         },
         {
           "date": "2011-01-01",
-          "text": "If either of Glint Hawk Idol’s two abilities resolve while it’s a creature, that ability will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
+          "text": "If either of Glint Hawk Idol's two abilities resolve while it's a creature, that ability will override any effects that set its power and/or toughness to another number, but effects that modify power and/or toughness without directly setting them will still apply."
         },
         {
           "date": "2011-01-01",
-          "text": "For example, say one of Glint Hawk Idol’s abilities has resolved and it’s a 2/2 creature. You cast Giant Growth targeting it. It’s now 5/5. Then Diminish (“Target creature becomes 1/1 until end of turn”) is cast targeting it. Once Diminish resolves, Glint Hawk Idol would be 4/4. Activating Glint Hawk Idol’s last ability at this point would make it 5/5 again until end of turn."
+          "text": "For example, say one of Glint Hawk Idol's abilities has resolved and it's a 2/2 creature. You cast Giant Growth targeting it. It's now 5/5. Then Diminish (\"Target creature becomes 1/1 until end of turn\") is cast targeting it. Once Diminish resolves, Glint Hawk Idol would be 4/4. Activating Glint Hawk Idol's last ability at this point would make it 5/5 again until end of turn."
         }
       ],
       "text": "Whenever another artifact enters the battlefield under your control, you may have Glint Hawk Idol become a 2/2 Bird artifact creature with flying until end of turn.\n{W}: Glint Hawk Idol becomes a 2/2 Bird artifact creature with flying until end of turn.",
@@ -17861,7 +17861,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Golden Urn’s last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
+          "text": "As Golden Urn's last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
         }
       ],
       "text": "At the beginning of your upkeep, you may put a charge counter on Golden Urn.\n{T}, Sacrifice Golden Urn: You gain life equal to the number of charge counters on Golden Urn.",
@@ -17962,11 +17962,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Both of Golem Artisan’s abilities may target any artifact creature, including itself."
+          "text": "Both of Golem Artisan's abilities may target any artifact creature, including itself."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t choose whether the targeted artifact creature gains flying, trample, or haste until Golem Artisan’s second ability resolves."
+          "text": "You don't choose whether the targeted artifact creature gains flying, trample, or haste until Golem Artisan's second ability resolves."
         }
       ],
       "subtypes": [
@@ -18070,7 +18070,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Whenever you cast an artifact spell, Golem Foundry’s first ability triggers and goes on the stack on top of it. It will resolve before the artifact spell does."
+          "text": "Whenever you cast an artifact spell, Golem Foundry's first ability triggers and goes on the stack on top of it. It will resolve before the artifact spell does."
         }
       ],
       "text": "Whenever you cast an artifact spell, you may put a charge counter on Golem Foundry.\nRemove three charge counters from Golem Foundry: Create a 3/3 colorless Golem artifact creature token.",
@@ -18171,11 +18171,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Unlike Golem Foundry and the Smith cycle, Golem’s Heart’s ability triggers whenever any player casts an artifact spell, not just when you do."
+          "text": "Unlike Golem Foundry and the Smith cycle, Golem's Heart's ability triggers whenever any player casts an artifact spell, not just when you do."
         },
         {
           "date": "2011-01-01",
-          "text": "Whenever a player casts an artifact spell, Golem’s Heart’s ability triggers and goes on the stack on top of it. It will resolve before the artifact spell does."
+          "text": "Whenever a player casts an artifact spell, Golem's Heart's ability triggers and goes on the stack on top of it. It will resolve before the artifact spell does."
         }
       ],
       "text": "Whenever a player casts an artifact spell, you may gain 1 life.",
@@ -18278,11 +18278,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -18290,7 +18290,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -18298,11 +18298,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "In addition to the effect of its equip ability, Grafted Exoskeleton becomes unattached from the creature it’s equipping if a spell or ability (such as Fulgent Distraction) causes it to become unattached, if Grafted Exoskeleton leaves the battlefield, if the equipped creature ceases to be a creature, or if Grafted Exoskeleton ceases to be an Equipment. (It also becomes unattached if the equipped creature leaves the battlefield, but the triggered ability won’t do anything in that case.)"
+          "text": "In addition to the effect of its equip ability, Grafted Exoskeleton becomes unattached from the creature it's equipping if a spell or ability (such as Fulgent Distraction) causes it to become unattached, if Grafted Exoskeleton leaves the battlefield, if the equipped creature ceases to be a creature, or if Grafted Exoskeleton ceases to be an Equipment. (It also becomes unattached if the equipped creature leaves the battlefield, but the triggered ability won't do anything in that case.)"
         },
         {
           "date": "2011-01-01",
-          "text": "If Grafted Exoskeleton’s last ability triggers, but you don’t control the permanent it became unattached from at the time that ability resolves (perhaps because another player has somehow gained control of it), you won’t be able to sacrifice it."
+          "text": "If Grafted Exoskeleton's last ability triggers, but you don't control the permanent it became unattached from at the time that ability resolves (perhaps because another player has somehow gained control of it), you won't be able to sacrifice it."
         }
       ],
       "subtypes": [
@@ -18406,7 +18406,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "If Grindclock isn’t on the battlefield when its last ability resolves, use the number of charge counters on it when it left the battlefield to determine how many cards to put into the graveyard."
+          "text": "If Grindclock isn't on the battlefield when its last ability resolves, use the number of charge counters on it when it left the battlefield to determine how many cards to put into the graveyard."
         }
       ],
       "text": "{T}: Put a charge counter on Grindclock.\n{T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of charge counters on Grindclock.",
@@ -18509,15 +18509,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If the equipped creature’s ability is activated, that creature is the source of the damage. It doesn’t matter if Heavy Arbalest leaves the battlefield or somehow becomes attached to another creature by that time."
+          "text": "If the equipped creature's ability is activated, that creature is the source of the damage. It doesn't matter if Heavy Arbalest leaves the battlefield or somehow becomes attached to another creature by that time."
         },
         {
           "date": "2011-01-01",
-          "text": "The equipped creature is the source of both the damage ability and the resultant damage, not Heavy Arbalest. For example, you can activate the ability to target and deal damage to a creature with protection from artifacts (assuming the equipped creature isn’t an artifact itself, of course)."
+          "text": "The equipped creature is the source of both the damage ability and the resultant damage, not Heavy Arbalest. For example, you can activate the ability to target and deal damage to a creature with protection from artifacts (assuming the equipped creature isn't an artifact itself, of course)."
         },
         {
           "date": "2011-01-01",
-          "text": "The creature that doesn’t untap during its controller’s untap step is the one that Heavy Arbalest is equipped to at that time. If a different creature was tapped to activate the ability granted to it by the Arbalest, but the Arbalest is no longer equipping it, it will untap as normal."
+          "text": "The creature that doesn't untap during its controller's untap step is the one that Heavy Arbalest is equipped to at that time. If a different creature was tapped to activate the ability granted to it by the Arbalest, but the Arbalest is no longer equipping it, it will untap as normal."
         }
       ],
       "subtypes": [
@@ -18622,7 +18622,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "When you sacrifice Horizon Spellbomb, it’s search ability goes on the stack, and then the triggered draw ability goes on the stack on top of it. This means you first choose whether to pay {G} and draw a card, then you search; you do not search first."
+          "text": "When you sacrifice Horizon Spellbomb, it's search ability goes on the stack, and then the triggered draw ability goes on the stack on top of it. This means you first choose whether to pay {G} and draw a card, then you search; you do not search first."
         }
       ],
       "text": "{2}, {T}, Sacrifice Horizon Spellbomb: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.\nWhen Horizon Spellbomb is put into a graveyard from the battlefield, you may pay {G}. If you do, draw a card.",
@@ -18726,11 +18726,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -18738,7 +18738,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -18851,7 +18851,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If the equipped creature becomes blocked by multiple creatures, Infiltration Lens’s ability triggers that many times."
+          "text": "If the equipped creature becomes blocked by multiple creatures, Infiltration Lens's ability triggers that many times."
         }
       ],
       "subtypes": [
@@ -19283,7 +19283,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Becoming an artifact doesn’t change what color(s) a permanent is."
+          "text": "Becoming an artifact doesn't change what color(s) a permanent is."
         }
       ],
       "text": "{T}: Target permanent becomes an artifact in addition to its other types until end of turn.",
@@ -19386,7 +19386,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "The equipped creature is the source of both the triggered ability and the resultant damage, not Livewire Lash. For example, you can target and deal damage to a creature with protection from artifacts (assuming the equipped creature isn’t an artifact itself, of course)."
+          "text": "The equipped creature is the source of both the triggered ability and the resultant damage, not Livewire Lash. For example, you can target and deal damage to a creature with protection from artifacts (assuming the equipped creature isn't an artifact itself, of course)."
         }
       ],
       "subtypes": [
@@ -19685,15 +19685,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Exiling the card as the first ability resolves is optional. If you choose not to exile it, or you can’t exile it because the card has somehow left the graveyard before the ability resolves, the ability simply doesn’t do anything as it resolves. Any card currently exiled by Mimic Vat remains exiled."
+          "text": "Exiling the card as the first ability resolves is optional. If you choose not to exile it, or you can't exile it because the card has somehow left the graveyard before the ability resolves, the ability simply doesn't do anything as it resolves. Any card currently exiled by Mimic Vat remains exiled."
         },
         {
           "date": "2011-01-01",
-          "text": "If multiple nontoken creatures are put into their owners’ graveyards from the battlefield at the same time, the imprint ability will trigger that many times. You put the triggered abilities on the stack in any order, so you’ll determine in which order they resolve. However, since exiling those cards is optional, and choosing to exile a card this way causes the previously exiled cards to return to their owners’ graveyards, the order generally doesn’t matter: You’ll wind up with at most one of those cards exiled, and the rest will be in the appropriate graveyards."
+          "text": "If multiple nontoken creatures are put into their owners' graveyards from the battlefield at the same time, the imprint ability will trigger that many times. You put the triggered abilities on the stack in any order, so you'll determine in which order they resolve. However, since exiling those cards is optional, and choosing to exile a card this way causes the previously exiled cards to return to their owners' graveyards, the order generally doesn't matter: You'll wind up with at most one of those cards exiled, and the rest will be in the appropriate graveyards."
         },
         {
           "date": "2011-01-01",
-          "text": "You may exile a noncreature card with Mimic Vat’s first ability. For example, if a nontoken artifact that’s become a creature is put into a graveyard from the battlefield, Mimic Vat’s first ability triggers and you may exile that card."
+          "text": "You may exile a noncreature card with Mimic Vat's first ability. For example, if a nontoken artifact that's become a creature is put into a graveyard from the battlefield, Mimic Vat's first ability triggers and you may exile that card."
         },
         {
           "date": "2011-01-01",
@@ -19701,7 +19701,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If the token is a copy of a noncreature card, it will still have haste, though that won’t matter unless that token somehow becomes a creature."
+          "text": "If the token is a copy of a noncreature card, it will still have haste, though that won't matter unless that token somehow becomes a creature."
         },
         {
           "date": "2011-01-01",
@@ -19713,7 +19713,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Any enters-the-battlefield abilities of the exiled card will trigger when the token is put onto the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the exiled card will also work."
+          "text": "Any enters-the-battlefield abilities of the exiled card will trigger when the token is put onto the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the exiled card will also work."
         },
         {
           "date": "2011-01-01",
@@ -19721,15 +19721,15 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If Mimic Vat’s second ability is activated during a turn’s end step, the token will be exiled at the beginning of the following turn’s end step."
+          "text": "If Mimic Vat's second ability is activated during a turn's end step, the token will be exiled at the beginning of the following turn's end step."
         },
         {
           "date": "2011-01-01",
-          "text": "If the token isn’t exiled when the delayed triggered ability resolves (due to Stifle, perhaps), it remains on the battlefield indefinitely. It continues to have haste."
+          "text": "If the token isn't exiled when the delayed triggered ability resolves (due to Stifle, perhaps), it remains on the battlefield indefinitely. It continues to have haste."
         },
         {
           "date": "2016-07-13",
-          "text": "If a melded permanent dies and triggers Mimic Vat’s triggered ability, both of its component cards are exiled. As Mimic Vat’s second ability resolves, its controller chooses one of those cards to make a token copy of."
+          "text": "If a melded permanent dies and triggers Mimic Vat's triggered ability, both of its component cards are exiled. As Mimic Vat's second ability resolves, its controller chooses one of those cards to make a token copy of."
         }
       ],
       "text": "Imprint — Whenever a nontoken creature dies, you may exile that card. If you do, return each other card exiled with Mimic Vat to its owner's graveyard.\n{3}, {T}: Create a token that's a copy of a card exiled with Mimic Vat. It gains haste. Exile it at the beginning of the next end step.",
@@ -19842,31 +19842,31 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You could gain control of yourself using Mindslaver, but gaining control of yourself doesn’t really do anything."
+          "text": "You could gain control of yourself using Mindslaver, but gaining control of yourself doesn't really do anything."
         },
         {
           "date": "2004-12-01",
-          "text": "You don’t control any of the other player’s permanents, spells, or abilities."
+          "text": "You don't control any of the other player's permanents, spells, or abilities."
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t make the other player concede. A player can choose to concede at any time."
+          "text": "You can't make the other player concede. A player can choose to concede at any time."
         },
         {
           "date": "2004-12-01",
-          "text": "You get to make every decision the other player would have made during that turn. You can’t make any illegal decisions or illegal choices — you can’t do anything that player couldn’t do. You can spend mana in the player’s mana pool only on that player’s spells and abilities. The mana in your mana pool can be spent only on your spells and abilities."
+          "text": "You get to make every decision the other player would have made during that turn. You can't make any illegal decisions or illegal choices — you can't do anything that player couldn't do. You can spend mana in the player's mana pool only on that player's spells and abilities. The mana in your mana pool can be spent only on your spells and abilities."
         },
         {
           "date": "2004-12-01",
-          "text": "You choose which spells the other player casts, and make all decisions as those spells are cast and when they resolve. For example, you choose the target for that player’s Shock, and what card that player gets with Diabolic Tutor."
+          "text": "You choose which spells the other player casts, and make all decisions as those spells are cast and when they resolve. For example, you choose the target for that player's Shock, and what card that player gets with Diabolic Tutor."
         },
         {
           "date": "2004-12-01",
-          "text": "You choose which activated abilities the other player activates, and make all decisions as those abilities are activated and when they resolve. For example, you can have your opponent sacrifice his or her creatures to his or her Nantuko Husk or have your opponent’s Timberwatch Elf give your blocking creature +X/+X."
+          "text": "You choose which activated abilities the other player activates, and make all decisions as those abilities are activated and when they resolve. For example, you can have your opponent sacrifice his or her creatures to his or her Nantuko Husk or have your opponent's Timberwatch Elf give your blocking creature +X/+X."
         },
         {
           "date": "2004-12-01",
-          "text": "You make all decisions for the other player’s triggered abilities, including what they target and any decisions made when they resolve."
+          "text": "You make all decisions for the other player's triggered abilities, including what they target and any decisions made when they resolve."
         },
         {
           "date": "2004-12-01",
@@ -19878,19 +19878,19 @@
         },
         {
           "date": "2004-12-01",
-          "text": "You can’t make any decisions that aren’t called for or allowed by the game rules, or by any cards, permanents, spells, abilities, and so on."
+          "text": "You can't make any decisions that aren't called for or allowed by the game rules, or by any cards, permanents, spells, abilities, and so on."
         },
         {
           "date": "2004-12-01",
-          "text": "If you make another player cast Shahrazad, you don’t control that player in the subgame, but you continue to control them once the subgame is completed."
+          "text": "If you make another player cast Shahrazad, you don't control that player in the subgame, but you continue to control them once the subgame is completed."
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "supertypes": [
@@ -20297,11 +20297,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You choose the value for X as the last ability resolves. You can’t choose a value for X that’s greater than the number of untapped Myr you control."
+          "text": "You choose the value for X as the last ability resolves. You can't choose a value for X that's greater than the number of untapped Myr you control."
         },
         {
           "date": "2011-01-01",
-          "text": "You can tap any untapped Myr you control as the last ability resolves, not just the Myr tokens you put onto the battlefield with the first ability. This includes Myr that haven’t been under your control since your most recent turn began."
+          "text": "You can tap any untapped Myr you control as the last ability resolves, not just the Myr tokens you put onto the battlefield with the first ability. This includes Myr that haven't been under your control since your most recent turn began."
         },
         {
           "date": "2011-01-01",
@@ -20309,7 +20309,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "As the last ability resolves, you can tap untapped Myr you control even if Myr Battlesphere is no longer on the battlefield by then. If that has happened, Myr Battlesphere won’t be able to get the +X/+0 bonus, but it will still deal X damage to the defending player."
+          "text": "As the last ability resolves, you can tap untapped Myr you control even if Myr Battlesphere is no longer on the battlefield by then. If that has happened, Myr Battlesphere won't be able to get the +X/+0 bonus, but it will still deal X damage to the defending player."
         }
       ],
       "subtypes": [
@@ -20516,19 +20516,19 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Normally, when a token is created by this ability, it will simply be a Myr Propagator, so it’ll also have the token-creating ability. (See below for weird exceptions.)"
+          "text": "Normally, when a token is created by this ability, it will simply be a Myr Propagator, so it'll also have the token-creating ability. (See below for weird exceptions.)"
         },
         {
           "date": "2011-01-01",
-          "text": "Here’s the detailed version of what happens. As the token is created, it checks the printed values of the Myr Propagator it’s copying — or, if the Myr Propagator whose ability was activated was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the Myr Propagator, nor will it copy other effects that have changed Myr Propagator’s power, toughness, types, color, or so on."
+          "text": "Here's the detailed version of what happens. As the token is created, it checks the printed values of the Myr Propagator it's copying — or, if the Myr Propagator whose ability was activated was itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the Myr Propagator, nor will it copy other effects that have changed Myr Propagator's power, toughness, types, color, or so on."
         },
         {
           "date": "2011-01-01",
-          "text": "If Myr Propagator has left the battlefield by the time its ability resolves, you’ll still put a token onto the battlefield. That token has the copiable values of the characteristics of Myr Propagator as it last existed on the battlefield."
+          "text": "If Myr Propagator has left the battlefield by the time its ability resolves, you'll still put a token onto the battlefield. That token has the copiable values of the characteristics of Myr Propagator as it last existed on the battlefield."
         },
         {
           "date": "2011-01-01",
-          "text": "Here are the weird exceptions promised above. If any copy effects have affected the Myr Propagator whose ability was activated, they’re taken into account when the token is created. For example: If Myr Propagator’s ability is activated, then Myr Propagator temporarily becomes a copy of another creature before its ability resolves (due to Cytoshape, perhaps), the token will be a copy of whatever creature the Myr Propagator is currently a copy of. After the turn ends, the Cytoshaped Myr Propagator reverts back to what it was, but the token will stay as it is. Also, if the copy ability of a creature (such as Cemetery Puca, perhaps) makes it become a copy of Myr Propagator and gain another ability, the token created by this creature’s ability will be a Myr Propagator with that additional ability."
+          "text": "Here are the weird exceptions promised above. If any copy effects have affected the Myr Propagator whose ability was activated, they're taken into account when the token is created. For example: If Myr Propagator's ability is activated, then Myr Propagator temporarily becomes a copy of another creature before its ability resolves (due to Cytoshape, perhaps), the token will be a copy of whatever creature the Myr Propagator is currently a copy of. After the turn ends, the Cytoshaped Myr Propagator reverts back to what it was, but the token will stay as it is. Also, if the copy ability of a creature (such as Cemetery Puca, perhaps) makes it become a copy of Myr Propagator and gain another ability, the token created by this creature's ability will be a Myr Propagator with that additional ability."
         }
       ],
       "subtypes": [
@@ -20633,11 +20633,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You can use the mana produced by Myr Reservoir’s first ability to pay an alternative cost or additional cost incurred while casting a Myr spell. It’s not limited to just that spell’s mana cost."
+          "text": "You can use the mana produced by Myr Reservoir's first ability to pay an alternative cost or additional cost incurred while casting a Myr spell. It's not limited to just that spell's mana cost."
         },
         {
           "date": "2011-01-01",
-          "text": "The mana can’t be spent to activate activated abilities of Myr sources that aren’t on the battlefield."
+          "text": "The mana can't be spent to activate activated abilities of Myr sources that aren't on the battlefield."
         },
         {
           "date": "2011-01-01",
@@ -20839,11 +20839,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -20851,7 +20851,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -21072,7 +21072,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You may activate Nihil Spellbomb’s first ability targeting any player, even one whose graveyard has no cards in it."
+          "text": "You may activate Nihil Spellbomb's first ability targeting any player, even one whose graveyard has no cards in it."
         }
       ],
       "text": "{T}, Sacrifice Nihil Spellbomb: Exile all cards from target player's graveyard.\nWhen Nihil Spellbomb is put into a graveyard from the battlefield, you may pay {B}. If you do, draw a card.",
@@ -21175,11 +21175,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Nim Deathmantle’s color-changing and type-changing effects override the equipped creature’s previous colors and creature types. After Nim Deathmantle becomes equipped to a creature, that creature will be a black Zombie, not any other colors or creature types."
+          "text": "Nim Deathmantle's color-changing and type-changing effects override the equipped creature's previous colors and creature types. After Nim Deathmantle becomes equipped to a creature, that creature will be a black Zombie, not any other colors or creature types."
         },
         {
           "date": "2011-01-01",
-          "text": "Nim Deathmantle causes the equipped creature to be a black Zombie even if it didn’t return that creature to the battlefield from the graveyard."
+          "text": "Nim Deathmantle causes the equipped creature to be a black Zombie even if it didn't return that creature to the battlefield from the graveyard."
         },
         {
           "date": "2011-01-01",
@@ -21187,19 +21187,19 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You choose whether to pay {4} as Nim Deathmantle’s second ability resolves. Although players may respond to this ability, once it begins to resolve and you decide whether to pay, it’s too late for players to respond."
+          "text": "You choose whether to pay {4} as Nim Deathmantle's second ability resolves. Although players may respond to this ability, once it begins to resolve and you decide whether to pay, it's too late for players to respond."
         },
         {
           "date": "2011-01-01",
-          "text": "If the nontoken creature that caused Nim Deathmantle’s second ability to trigger is somehow removed from your graveyard before that ability resolves, you may still pay {4} as it resolves. Even if you do, however, no card will be returned to the battlefield."
+          "text": "If the nontoken creature that caused Nim Deathmantle's second ability to trigger is somehow removed from your graveyard before that ability resolves, you may still pay {4} as it resolves. Even if you do, however, no card will be returned to the battlefield."
         },
         {
           "date": "2011-01-01",
-          "text": "Nim Deathmantle’s second ability may return a card it can’t equip to the battlefield. For example, if a nontoken artifact that’s become a creature is put into your graveyard from the battlefield, Nim Deathmantle’s second ability triggers. If you pay {4} as it resolves, you’ll return that card to the battlefield. However, Nim Deathmantle can’t equip it, so Nim Deathmantle remains attached to whatever it was already equipping (or, if it was unattached, it remains so). The same is true if a nontoken creature with protection from artifacts is put into your graveyard from the battlefield, for example."
+          "text": "Nim Deathmantle's second ability may return a card it can't equip to the battlefield. For example, if a nontoken artifact that's become a creature is put into your graveyard from the battlefield, Nim Deathmantle's second ability triggers. If you pay {4} as it resolves, you'll return that card to the battlefield. However, Nim Deathmantle can't equip it, so Nim Deathmantle remains attached to whatever it was already equipping (or, if it was unattached, it remains so). The same is true if a nontoken creature with protection from artifacts is put into your graveyard from the battlefield, for example."
         },
         {
           "date": "2011-01-01",
-          "text": "If multiple nontoken creatures are put into your graveyard from the battlefield at the same time, Nim Deathmantle’s second ability triggers that many times. You put the triggered abilities on the stack in any order, so you’ll determine in which order they resolve. If you pay {4} more than once, each card you paid {4} for will end up on the battlefield under your control, and Nim Deathmantle will end up attached to the last card that returned to the battlefield this way that it could equip."
+          "text": "If multiple nontoken creatures are put into your graveyard from the battlefield at the same time, Nim Deathmantle's second ability triggers that many times. You put the triggered abilities on the stack in any order, so you'll determine in which order they resolve. If you pay {4} more than once, each card you paid {4} for will end up on the battlefield under your control, and Nim Deathmantle will end up attached to the last card that returned to the battlefield this way that it could equip."
         }
       ],
       "subtypes": [
@@ -21697,11 +21697,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The ability doesn’t prevent damage. Rather, it changes the results of that damage. For example, if a creature with lifelink deals damage to you, you won’t lose any life, but its controller will still gain that much life. Similarly, if a creature you control with lifelink deals damage to another player, that player will lose life but you won’t gain any life. Notably, if a creature with infect deals damage to you, you’ll get that many poison counters."
+          "text": "The ability doesn't prevent damage. Rather, it changes the results of that damage. For example, if a creature with lifelink deals damage to you, you won't lose any life, but its controller will still gain that much life. Similarly, if a creature you control with lifelink deals damage to another player, that player will lose life but you won't gain any life. Notably, if a creature with infect deals damage to you, you'll get that many poison counters."
         },
         {
           "date": "2011-01-01",
-          "text": "Abilities that trigger whenever damage is dealt to you will still trigger because that damage is still dealt, even though your life total doesn’t change as a result."
+          "text": "Abilities that trigger whenever damage is dealt to you will still trigger because that damage is still dealt, even though your life total doesn't change as a result."
         },
         {
           "date": "2011-01-01",
@@ -21709,31 +21709,31 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can’t pay a cost that includes the payment of any amount of life other than 0 life."
+          "text": "You can't pay a cost that includes the payment of any amount of life other than 0 life."
         },
         {
           "date": "2011-01-01",
-          "text": "If a cost would include causing you to gain life (like the alternative cost of an opponent’s Invigorate does), that cost can’t be paid."
+          "text": "If a cost would include causing you to gain life (like the alternative cost of an opponent's Invigorate does), that cost can't be paid."
         },
         {
           "date": "2011-01-01",
-          "text": "Effects that would replace having you gain life with some other effect won’t be able to be applied because it’s impossible for you to gain life. The same is true for events that would replace having you lose life with some other effect."
+          "text": "Effects that would replace having you gain life with some other effect won't be able to be applied because it's impossible for you to gain life. The same is true for events that would replace having you lose life with some other effect."
         },
         {
           "date": "2011-01-01",
-          "text": "Effects that replace an event with having you gain life (like Words of Worship’s effect does) or having you lose life will end up replacing the event with nothing."
+          "text": "Effects that replace an event with having you gain life (like Words of Worship's effect does) or having you lose life will end up replacing the event with nothing."
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says to set your life total to a certain number that’s different than your current life total, that part of the effect won’t do anything."
+          "text": "If an effect says to set your life total to a certain number that's different than your current life total, that part of the effect won't do anything."
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect would cause you to exchange life totals with another player, the exchange won’t happen. Neither player’s life total changes."
+          "text": "If an effect would cause you to exchange life totals with another player, the exchange won't happen. Neither player's life total changes."
         },
         {
           "date": "2011-01-01",
-          "text": "The ability won’t preclude you from losing the game. It just precludes your life total from changing."
+          "text": "The ability won't preclude you from losing the game. It just precludes your life total from changing."
         }
       ],
       "subtypes": [
@@ -21839,35 +21839,35 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "The second ability triggers whenever a player casts an instant or sorcery spell that targets only one Golem and no other object or player. That Golem can be Precursor Golem itself, one of the Golem tokens it created, or any other Golem. It doesn’t matter who controls the Golem."
+          "text": "The second ability triggers whenever a player casts an instant or sorcery spell that targets only one Golem and no other object or player. That Golem can be Precursor Golem itself, one of the Golem tokens it created, or any other Golem. It doesn't matter who controls the Golem."
         },
         {
           "date": "2011-01-01",
-          "text": "If an instant or sorcery spell has multiple targets, but it’s targeting the same Golem with all of them (such as Agony Warp targeting the same Golem twice), Precursor Golem’s last ability will trigger."
+          "text": "If an instant or sorcery spell has multiple targets, but it's targeting the same Golem with all of them (such as Agony Warp targeting the same Golem twice), Precursor Golem's last ability will trigger."
         },
         {
           "date": "2011-01-01",
-          "text": "Any Golem that couldn’t be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Precursor Golem’s second ability."
+          "text": "Any Golem that couldn't be targeted by the original spell (due to shroud, protection abilities, targeting restrictions, or any other reason) is just ignored by Precursor Golem's second ability."
         },
         {
           "date": "2011-01-01",
-          "text": "The controller of the spell that caused Precursor Golem’s second ability to trigger also controls all the copies. That player chooses the order the copies are put onto the stack. The original spell will be on the stack beneath those copies and will resolve last."
+          "text": "The controller of the spell that caused Precursor Golem's second ability to trigger also controls all the copies. That player chooses the order the copies are put onto the stack. The original spell will be on the stack beneath those copies and will resolve last."
         },
         {
           "date": "2011-01-01",
-          "text": "The copies that Precursor Golem’s second ability creates are created on the stack, so they’re not “cast.” Abilities that trigger when a player casts a spell (like Precursor Golem’s second ability itself) won’t trigger."
+          "text": "The copies that Precursor Golem's second ability creates are created on the stack, so they're not \"cast.\" Abilities that trigger when a player casts a spell (like Precursor Golem's second ability itself) won't trigger."
         },
         {
           "date": "2011-01-01",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copies will have the same mode. Their controller can’t choose a different one."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copies will have the same mode. Their controller can't choose a different one."
         },
         {
           "date": "2011-01-01",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Fireball does), the copies have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Fireball does), the copies have the same value of X."
         },
         {
           "date": "2011-01-01",
-          "text": "The controller of a copy can’t choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
+          "text": "The controller of a copy can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
         }
       ],
       "subtypes": [
@@ -21971,23 +21971,23 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If Prototype Portal has left the battlefield by the time its second ability resolves, you’ll still put a token onto the battlefield that’s a copy of the exiled card. On the other hand, if Prototype Portal is still on the battlefield at this time but there is no exiled card (because, perhaps, Riftsweeper’s ability caused the exiled card to be put into its owner’s library), no token is created."
+          "text": "If Prototype Portal has left the battlefield by the time its second ability resolves, you'll still put a token onto the battlefield that's a copy of the exiled card. On the other hand, if Prototype Portal is still on the battlefield at this time but there is no exiled card (because, perhaps, Riftsweeper's ability caused the exiled card to be put into its owner's library), no token is created."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t choose the value of {X}. Rather, the value of X is defined by the activated ability."
+          "text": "You don't choose the value of {X}. Rather, the value of X is defined by the activated ability."
         },
         {
           "date": "2011-01-01",
-          "text": "If the exiled card has {X} in its mana cost (such as Chalice of the Void), that X is considered to be 0. The {X} in Prototype Portal’s activation cost takes this into account, though it may be greater than 0 if the exiled card has other mana symbols in its mana cost (such as Riptide Replicator)."
+          "text": "If the exiled card has {X} in its mana cost (such as Chalice of the Void), that X is considered to be 0. The {X} in Prototype Portal's activation cost takes this into account, though it may be greater than 0 if the exiled card has other mana symbols in its mana cost (such as Riptide Replicator)."
         },
         {
           "date": "2011-01-01",
-          "text": "You may not activate the second ability if no card has been exiled with Prototype Portal. In that case, the value of {X} is undefined and can’t be paid."
+          "text": "You may not activate the second ability if no card has been exiled with Prototype Portal. In that case, the value of {X} is undefined and can't be paid."
         },
         {
           "date": "2011-01-01",
-          "text": "Any enters-the-battlefield abilities of the exiled card will trigger when the token is put onto the battlefield. Any “as [this permanent] enters the battlefield” or “[this permanent] enters the battlefield with” abilities of the exiled card will also work."
+          "text": "Any enters-the-battlefield abilities of the exiled card will trigger when the token is put onto the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the exiled card will also work."
         }
       ],
       "text": "Imprint — When Prototype Portal enters the battlefield, you may exile an artifact card from your hand.\n{X}, {T}: Create a token that's a copy of the exiled card. X is the converted mana cost of that card.",
@@ -22088,23 +22088,23 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "As Ratchet Bomb’s last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
+          "text": "As Ratchet Bomb's last ability resolves, its last existence on the battlefield is checked to determine how many charge counters were on it."
         },
         {
           "date": "2011-01-01",
-          "text": "Ratchet Bomb’s second ability destroys only those nonland permanents whose converted mana cost is exactly equal to the number of charge counters on Ratchet Bomb. It doesn’t matter who controls them."
+          "text": "Ratchet Bomb's second ability destroys only those nonland permanents whose converted mana cost is exactly equal to the number of charge counters on Ratchet Bomb. It doesn't matter who controls them."
         },
         {
           "date": "2011-01-01",
-          "text": "If Ratchet Bomb’s second ability is activated while it has no charge counters on it, it will destroy each nonland permanent with converted mana cost 0."
+          "text": "If Ratchet Bomb's second ability is activated while it has no charge counters on it, it will destroy each nonland permanent with converted mana cost 0."
         },
         {
           "date": "2011-01-01",
-          "text": "The converted mana cost of a permanent is determined solely by the mana symbols printed in its upper right corner, unless it’s copying something else (see below). The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {3}{U}{U} has converted mana cost 5."
+          "text": "The converted mana cost of a permanent is determined solely by the mana symbols printed in its upper right corner, unless it's copying something else (see below). The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {3}{U}{U} has converted mana cost 5."
         },
         {
           "date": "2011-01-01",
-          "text": "If a permanent is copying something else, its converted mana cost is the converted mana cost of whatever it’s copying."
+          "text": "If a permanent is copying something else, its converted mana cost is the converted mana cost of whatever it's copying."
         },
         {
           "date": "2011-01-01",
@@ -22116,7 +22116,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If a nonland permanent has no mana symbols in its upper right corner (because it’s a token that’s not copying something else, for example), its converted mana cost is 0."
+          "text": "If a nonland permanent has no mana symbols in its upper right corner (because it's a token that's not copying something else, for example), its converted mana cost is 0."
         }
       ],
       "text": "{T}: Put a charge counter on Ratchet Bomb.\n{T}, Sacrifice Ratchet Bomb: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Ratchet Bomb.",
@@ -22314,23 +22314,23 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "You may target a tapped artifact with Rust Tick’s activated ability."
+          "text": "You may target a tapped artifact with Rust Tick's activated ability."
         },
         {
           "date": "2011-01-01",
-          "text": "If the affected artifact is untapped by some other spell or ability, Rust Tick’s effect will not end. If you keep Rust Tick tapped, and that artifact becomes tapped again, Rust Tick will continue to prevent it from being untapped during its controller’s untap step."
+          "text": "If the affected artifact is untapped by some other spell or ability, Rust Tick's effect will not end. If you keep Rust Tick tapped, and that artifact becomes tapped again, Rust Tick will continue to prevent it from being untapped during its controller's untap step."
         },
         {
           "date": "2011-01-01",
-          "text": "Rust Tick doesn’t track the artifact’s controller. If the affected artifact changes controllers, Rust Tick will prevent it from being untapped during its new controller’s untap step."
+          "text": "Rust Tick doesn't track the artifact's controller. If the affected artifact changes controllers, Rust Tick will prevent it from being untapped during its new controller's untap step."
         },
         {
           "date": "2011-01-01",
-          "text": "If Rust Tick untaps or leaves the battlefield, its effect will end. This has no immediate visible effect on the affected artifact. (It doesn’t untap immediately, for example.) The artifact will just untap as normal during its controller’s next untap step."
+          "text": "If Rust Tick untaps or leaves the battlefield, its effect will end. This has no immediate visible effect on the affected artifact. (It doesn't untap immediately, for example.) The artifact will just untap as normal during its controller's next untap step."
         },
         {
           "date": "2011-01-01",
-          "text": "If you control both Rust Tick and the affected artifact, that artifact won’t untap during the untap step in which you choose to untap Rust Tick. (It will untap during your next one.)"
+          "text": "If you control both Rust Tick and the affected artifact, that artifact won't untap during the untap step in which you choose to untap Rust Tick. (It will untap during your next one.)"
         }
       ],
       "subtypes": [
@@ -22436,11 +22436,11 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If Rusted Relic stops being a creature during combat (because you lose control of one or more artifacts, perhaps), it is removed from combat and will not deal or be dealt combat damage. Creatures it was blocking remain blocked. It won’t re-enter that combat, even if you wind up controlling three or more artifacts again during that combat phase."
+          "text": "If Rusted Relic stops being a creature during combat (because you lose control of one or more artifacts, perhaps), it is removed from combat and will not deal or be dealt combat damage. Creatures it was blocking remain blocked. It won't re-enter that combat, even if you wind up controlling three or more artifacts again during that combat phase."
         },
         {
           "date": "2011-01-01",
-          "text": "Whether Rusted Relic has “summoning sickness” is based on how long you have continuously controlled it, not on how long it has continuously been a creature."
+          "text": "Whether Rusted Relic has \"summoning sickness\" is based on how long you have continuously controlled it, not on how long it has continuously been a creature."
         }
       ],
       "text": "Metalcraft — Rusted Relic is a 5/5 Golem artifact creature as long as you control three or more artifacts.",
@@ -22647,23 +22647,23 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Spells you cast that share multiple card types with the exiled card still cost just {2} less to cast. They don’t get a greater cost reduction."
+          "text": "Spells you cast that share multiple card types with the exiled card still cost just {2} less to cast. They don't get a greater cost reduction."
         },
         {
           "date": "2011-01-01",
-          "text": "Semblance Anvil takes the total cost to cast a spell into account, not just its mana cost. This includes additional costs (such as kicker) and alternative costs (such as evoke). It also includes cost increases from other sources (such as Lodestone Golem’s ability)."
+          "text": "Semblance Anvil takes the total cost to cast a spell into account, not just its mana cost. This includes additional costs (such as kicker) and alternative costs (such as evoke). It also includes cost increases from other sources (such as Lodestone Golem's ability)."
         },
         {
           "date": "2011-01-01",
-          "text": "Semblance Anvil won’t affect the part of a spell’s cost represented by colored mana symbols. For example, a spell that normally costs {1}{U} to cast would cost {U} if it shared a card type with the exiled card."
+          "text": "Semblance Anvil won't affect the part of a spell's cost represented by colored mana symbols. For example, a spell that normally costs {1}{U} to cast would cost {U} if it shared a card type with the exiled card."
         },
         {
           "date": "2011-01-01",
-          "text": "Semblance Anvil can reduce the amount you pay for a spell’s cost that includes {X}. For example, Blaze is a sorcery that costs {X}{R}. If the card exiled with Semblance Anvil is a sorcery, and you want to cast Blaze with X equal to 5, you’ll have to pay only {3}{R}. This is true even if the ability states that {X} must be paid with a certain color of mana (as Drain Life does)."
+          "text": "Semblance Anvil can reduce the amount you pay for a spell's cost that includes {X}. For example, Blaze is a sorcery that costs {X}{R}. If the card exiled with Semblance Anvil is a sorcery, and you want to cast Blaze with X equal to 5, you'll have to pay only {3}{R}. This is true even if the ability states that {X} must be paid with a certain color of mana (as Drain Life does)."
         },
         {
           "date": "2011-01-01",
-          "text": "Semblance Anvil’s cost reduction effect is mandatory."
+          "text": "Semblance Anvil's cost reduction effect is mandatory."
         }
       ],
       "text": "Imprint — When Semblance Anvil enters the battlefield, you may exile a nonland card from your hand.\nSpells you cast that share a card type with the exiled card cost {2} less to cast.",
@@ -22874,7 +22874,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "For the purposes of combat, whether Snapsail Glider has flying is relevant only as the declare blockers step begins. If an attacking Snapsail Glider without flying becomes blocked, gaining control of enough artifacts to cause it to have flying won’t change that. Similarly, if a Snapsail Glider with flying blocks another creature with flying, losing control of enough artifacts to cause the Glider to lose flying won’t change that."
+          "text": "For the purposes of combat, whether Snapsail Glider has flying is relevant only as the declare blockers step begins. If an attacking Snapsail Glider without flying becomes blocked, gaining control of enough artifacts to cause it to have flying won't change that. Similarly, if a Snapsail Glider with flying blocks another creature with flying, losing control of enough artifacts to cause the Glider to lose flying won't change that."
         }
       ],
       "subtypes": [
@@ -23084,27 +23084,27 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Steel Hellkite’s last ability destroys only nonland permanents whose converted mana cost is exactly equal to X, and only those controlled by players who have been dealt combat damage by Steel Hellkite this turn."
+          "text": "Steel Hellkite's last ability destroys only nonland permanents whose converted mana cost is exactly equal to X, and only those controlled by players who have been dealt combat damage by Steel Hellkite this turn."
         },
         {
           "date": "2011-01-01",
-          "text": "It doesn’t matter who controlled those permanents at the time Steel Hellkite dealt combat damage, or if those permanents were even on the battlefield at that time."
+          "text": "It doesn't matter who controlled those permanents at the time Steel Hellkite dealt combat damage, or if those permanents were even on the battlefield at that time."
         },
         {
           "date": "2011-01-01",
-          "text": "You may activate the last ability even if Steel Hellkite hasn’t dealt combat damage to any players that turn. If you do, the ability won’t do anything."
+          "text": "You may activate the last ability even if Steel Hellkite hasn't dealt combat damage to any players that turn. If you do, the ability won't do anything."
         },
         {
           "date": "2011-01-01",
-          "text": "If Steel Hellkite’s third ability is activated with X equal to 0, it will destroy each nonland permanent with converted mana cost 0 the appropriate players control."
+          "text": "If Steel Hellkite's third ability is activated with X equal to 0, it will destroy each nonland permanent with converted mana cost 0 the appropriate players control."
         },
         {
           "date": "2011-01-01",
-          "text": "The converted mana cost of a permanent is determined solely by the mana symbols printed in its upper right corner, unless it’s copying something else (see below). The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {3}{U}{U} has converted mana cost 5."
+          "text": "The converted mana cost of a permanent is determined solely by the mana symbols printed in its upper right corner, unless it's copying something else (see below). The converted mana cost is the total amount of mana in that cost, regardless of color. For example, a card with mana cost {3}{U}{U} has converted mana cost 5."
         },
         {
           "date": "2011-01-01",
-          "text": "If a permanent is copying something else, its converted mana cost is the converted mana cost of whatever it’s copying."
+          "text": "If a permanent is copying something else, its converted mana cost is the converted mana cost of whatever it's copying."
         },
         {
           "date": "2011-01-01",
@@ -23116,7 +23116,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If a nonland permanent has no mana symbols in its upper right corner (because it’s a token that’s not copying of something else, for example), its converted mana cost is 0."
+          "text": "If a nonland permanent has no mana symbols in its upper right corner (because it's a token that's not copying of something else, for example), its converted mana cost is 0."
         }
       ],
       "subtypes": [
@@ -23431,7 +23431,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If there are fewer than ten cards in that player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than ten cards in that player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "subtypes": [
@@ -23534,7 +23534,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If Sylvok Lifestaff and the equipped creature are put into their owners’ graveyards at the same time (due to Planar Cleansing, perhaps), the triggered ability will still trigger. You’ll gain 3 life."
+          "text": "If Sylvok Lifestaff and the equipped creature are put into their owners' graveyards at the same time (due to Planar Cleansing, perhaps), the triggered ability will still trigger. You'll gain 3 life."
         }
       ],
       "subtypes": [
@@ -23750,11 +23750,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can’t choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
+          "text": "You can choose any permanent that has a counter, including ones controlled by opponents. You can't choose cards in any zone other than the battlefield, even if they have counters on them, such as suspended cards or a Lightning Storm on the stack."
         },
         {
           "date": "2011-01-01",
-          "text": "You don’t have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since “any number” includes zero, you don’t have to choose any permanents at all, and you don’t have to choose any players at all."
+          "text": "You don't have to choose every permanent or player that has a counter, only the ones you want to add another counter to. Since \"any number\" includes zero, you don't have to choose any permanents at all, and you don't have to choose any players at all."
         },
         {
           "date": "2011-01-01",
@@ -23762,7 +23762,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it’s too late for anyone to respond."
+          "text": "Players can respond to the spell or ability whose effect includes proliferating. Once that spell or ability starts to resolve, however, and its controller chooses which permanents and players will get new counters, it's too late for anyone to respond."
         },
         {
           "date": "2011-01-01",
@@ -24062,11 +24062,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -24074,7 +24074,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -24569,11 +24569,11 @@
         },
         {
           "date": "2011-01-01",
-          "text": "Infect’s effect applies to any damage, not just combat damage."
+          "text": "Infect's effect applies to any damage, not just combat damage."
         },
         {
           "date": "2011-01-01",
-          "text": "The -1/-1 counters remain on the creature indefinitely. They’re not removed if the creature regenerates or the turn ends."
+          "text": "The -1/-1 counters remain on the creature indefinitely. They're not removed if the creature regenerates or the turn ends."
         },
         {
           "date": "2011-01-01",
@@ -24581,7 +24581,7 @@
         },
         {
           "date": "2011-01-01",
-          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn’t get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn’t get -1/-1 counters."
+          "text": "If damage from a source with infect that would be dealt to a player is prevented, that player doesn't get poison counters. If damage from a source with infect that would be dealt to a creature is prevented, that creature doesn't get -1/-1 counters."
         },
         {
           "date": "2011-01-01",
@@ -24691,7 +24691,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Venser’s Journal onto the battlefield, you’ll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Venser's Journal onto the battlefield, you'll have no maximum hand size. However, if those permanents enter the battlefield in the opposite order, your maximum hand size would be two."
         }
       ],
       "text": "You have no maximum hand size.\nAt the beginning of your upkeep, you gain 1 life for each card in your hand.",
@@ -25115,7 +25115,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Blackcleave Cliffs enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {R} to your mana pool.",
@@ -25221,7 +25221,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Copperline Gorge enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {G} to your mana pool.",
@@ -25327,7 +25327,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Darkslick Shores enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {B} to your mana pool.",
@@ -25534,7 +25534,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Razorverge Thicket enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {W} to your mana pool.",
@@ -25640,7 +25640,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn’t take those lands into consideration when determining how many other lands you control."
+          "text": "If one of these lands enters the battlefield at the same time as one or more other lands (due to Oblivion Sower or Warp World, perhaps), it doesn't take those lands into consideration when determining how many other lands you control."
         }
       ],
       "text": "Seachrome Coast enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {U} to your mana pool.",
@@ -30335,27 +30335,27 @@
         {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
-          "multiverseid": 231037
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 231038
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
           "multiverseid": 231039
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 231040
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232780
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 231535
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232781
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232782
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232783
         }
       ],
       "id": "b67b08ce11eec127343298547a438dd8beac6107",
@@ -31105,27 +31105,27 @@
         {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
-          "multiverseid": 231037
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 231038
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
           "multiverseid": 231039
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 231040
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232780
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 231535
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232781
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232782
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232783
         }
       ],
       "id": "504c2109bcf6a74972057c6fd60073b39a470605",
@@ -31490,27 +31490,27 @@
         {
           "language": "Portuguese (Brazil)",
           "name": "Montanha",
-          "multiverseid": 231037
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 231038
-        },
-        {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
           "multiverseid": 231039
         },
         {
-          "language": "Portuguese (Brazil)",
-          "name": "Montanha",
-          "multiverseid": 231040
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232780
         },
         {
-          "language": "Russian",
-          "name": "Гора",
-          "multiverseid": 231535
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232781
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232782
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 232783
         }
       ],
       "id": "d85df3bdb8b7fa4090a149e20445c7a0aa02dd41",

--- a/json/STH.json
+++ b/json/STH.json
@@ -83,11 +83,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -414,7 +414,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"The plants said, ‘We will fight the stone with root and stem and seed. We are patient. We will win.'\"\n—Skyshroud myth of the forest",
+      "flavor": "\"The plants said, 'We will fight the stone with root and stem and seed. We are patient. We will win.'\"\n—Skyshroud myth of the forest",
       "id": "6bbe95f44c7b742c6677eb79bf5b454472ffe367",
       "imageName": "burgeoning",
       "layout": "normal",
@@ -504,11 +504,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -671,7 +671,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Change of Heart will not remove an already attacking creature from combat. It must be cast before attackers are declared or it won’t have any noticeable effect on the game."
+          "text": "Change of Heart will not remove an already attacking creature from combat. It must be cast before attackers are declared or it won't have any noticeable effect on the game."
         }
       ],
       "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nTarget creature can't attack this turn.",
@@ -941,7 +941,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Players don’t have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Conviction to its owner’s hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get +1/+3)."
+          "text": "Players don't have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Conviction to its owner's hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get +1/+3)."
         }
       ],
       "subtypes": [
@@ -997,11 +997,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -1058,11 +1058,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -1307,11 +1307,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -2001,6 +2001,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -2030,11 +2034,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "The sacrificed creature’s last known existence on the battlefield is checked to determine its power."
+          "text": "The sacrificed creature's last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         },
         {
           "date": "2013-04-15",
@@ -2149,7 +2153,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It will be put into its owner’s graveyard as soon as one of its abilities resolves that puts its toughness at zero (or less than the current amount of damage on it). This is a state-based action, so there is no way to activate its ability any more to increase its power further before it is put into the graveyard."
+          "text": "It will be put into its owner's graveyard as soon as one of its abilities resolves that puts its toughness at zero (or less than the current amount of damage on it). This is a state-based action, so there is no way to activate its ability any more to increase its power further before it is put into the graveyard."
         }
       ],
       "subtypes": [
@@ -2436,11 +2440,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -2619,11 +2623,11 @@
         },
         {
           "date": "2006-07-15",
-          "text": "Can’t reduce Snow mana costs."
+          "text": "Can't reduce Snow mana costs."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Activated abilities of creatures cost {1} less to activate. This effect can't reduce the amount of mana an ability costs to activate to less than one mana.",
@@ -2843,11 +2847,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -3116,7 +3120,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple creatures enter the battlefield at one time, this ability triggers once for each creature. This doesn’t matter much, but it can in some cases."
+          "text": "If multiple creatures enter the battlefield at one time, this ability triggers once for each creature. This doesn't matter much, but it can in some cases."
         }
       ],
       "text": "Creatures don't untap during their controllers' untap steps.\nWhenever a creature enters the battlefield, untap all creatures.",
@@ -3312,7 +3316,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It is possible to redirect more damage to a creature than that creature’s toughness."
+          "text": "It is possible to redirect more damage to a creature than that creature's toughness."
         },
         {
           "date": "2004-10-04",
@@ -3954,7 +3958,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Although Mogg Flunkies can’t attack alone, other attacking creature(s) don’t have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
+          "text": "Although Mogg Flunkies can't attack alone, other attacking creature(s) don't have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
         },
         {
           "date": "2017-03-14",
@@ -3962,7 +3966,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player’s blocking creatures."
+          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player's blocking creatures."
         }
       ],
       "subtypes": [
@@ -4226,7 +4230,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you don’t discard a land card, Mox Diamond never enters the battlefield. It won’t trigger abilities that look for something entering the battlefield, and you won’t get the opportunity to tap it for mana."
+          "text": "If you don't discard a land card, Mox Diamond never enters the battlefield. It won't trigger abilities that look for something entering the battlefield, and you won't get the opportunity to tap it for mana."
         }
       ],
       "text": "If Mox Diamond would enter the battlefield, you may discard a land card instead. If you do, put Mox Diamond onto the battlefield. If you don't, put it into its owner's graveyard.\n{T}: Add one mana of any color to your mana pool.",
@@ -4348,7 +4352,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It is possible to redirect more damage to a creature than that creature’s toughness."
+          "text": "It is possible to redirect more damage to a creature than that creature's toughness."
         },
         {
           "date": "2004-10-04",
@@ -4470,7 +4474,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Creatures which are phasing in will not trigger this card’s ability."
+          "text": "Creatures which are phasing in will not trigger this card's ability."
         },
         {
           "date": "2004-10-04",
@@ -4482,11 +4486,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The creature does enter the battlefield, so any other abilities that trigger on it entering the battlefield trigger. This follows the normal rules for timing triggered abilities: first, the current player puts his or her abilities on the stack in any order, then each other player in turn order does the same. Portcullis’ own ability is included in this, so it could result in the creature being exiled after some abilities have resolved, but before others."
+          "text": "The creature does enter the battlefield, so any other abilities that trigger on it entering the battlefield trigger. This follows the normal rules for timing triggered abilities: first, the current player puts his or her abilities on the stack in any order, then each other player in turn order does the same. Portcullis' own ability is included in this, so it could result in the creature being exiled after some abilities have resolved, but before others."
         },
         {
           "date": "2009-10-01",
-          "text": "The “when Portcullis leaves the battlefield” ability is set up as part of the ability that exiles the creature. It will trigger when Portcullis leaves the battlefield even if Portcullis has somehow lost its abilities at that time."
+          "text": "The \"when Portcullis leaves the battlefield\" ability is set up as part of the ability that exiles the creature. It will trigger when Portcullis leaves the battlefield even if Portcullis has somehow lost its abilities at that time."
         }
       ],
       "text": "Whenever a creature enters the battlefield, if there are two or more other creatures on the battlefield, exile that creature. Return that card to the battlefield under its owner's control when Portcullis leaves the battlefield.",
@@ -4792,7 +4796,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "You can’t use this on a spell unless the target spell is an Aura or uses the word “target” in its text. If it isn’t an Aura and the word “target” is not there, then the spell does not target a player at all—it just affects a player without targeting them."
+          "text": "You can't use this on a spell unless the target spell is an Aura or uses the word \"target\" in its text. If it isn't an Aura and the word \"target\" is not there, then the spell does not target a player at all—it just affects a player without targeting them."
         }
       ],
       "text": "Change the target of target spell that targets only a player. The new target must be a player.",
@@ -4913,7 +4917,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The ability that defines Revenant’s power and toughness applies in all zones, not just the battlefield. If Revenant is in your graveyard, its ability will count itself."
+          "text": "The ability that defines Revenant's power and toughness applies in all zones, not just the battlefield. If Revenant is in your graveyard, its ability will count itself."
         }
       ],
       "subtypes": [
@@ -5357,7 +5361,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It is possible to redirect more damage to a creature than that creature’s toughness."
+          "text": "It is possible to redirect more damage to a creature than that creature's toughness."
         },
         {
           "date": "2004-10-04",
@@ -6026,7 +6030,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "A “blocked creature” is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocked creature\" is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
         }
       ],
       "text": "Destroy target blocked creature.",
@@ -6475,11 +6479,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -6501,7 +6505,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"As it moved, the wurm's spines gathered up bits of flowstone, which took the shapes of dead villagers' heads. Each head spoke a single sound, but if taken together, they said, ‘Alas for the living.'\"\n—Dal myth of the wurm",
+      "flavor": "\"As it moved, the wurm's spines gathered up bits of flowstone, which took the shapes of dead villagers' heads. Each head spoke a single sound, but if taken together, they said, 'Alas for the living.'\"\n—Dal myth of the wurm",
       "id": "2cf680c50003e998d870ca8229f846aea3316966",
       "imageName": "spined wurm",
       "layout": "normal",
@@ -6610,7 +6614,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It is possible to redirect more damage to a creature than that creature’s toughness."
+          "text": "It is possible to redirect more damage to a creature than that creature's toughness."
         },
         {
           "date": "2004-10-04",
@@ -6938,11 +6942,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -6999,7 +7003,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -7210,7 +7214,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t return the same card you are discarding. This is because you pick the target before paying the costs."
+          "text": "You can't return the same card you are discarding. This is because you pick the target before paying the costs."
         }
       ],
       "text": "{B}, Discard a creature card: Return target creature card from your graveyard to your hand.",
@@ -7335,7 +7339,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nTarget land becomes a 2/2 creature that's still a land. (This effect lasts indefinitely.)",
@@ -7393,11 +7397,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -7562,15 +7566,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When it changes forms, any “enters the battlefield” abilities of the card it “copies” do not trigger."
+          "text": "When it changes forms, any \"enters the battlefield\" abilities of the card it \"copies\" do not trigger."
         },
         {
           "date": "2004-10-04",
-          "text": "A copy of a Volrath’s Shapeshifter will have the shapeshifting ability."
+          "text": "A copy of a Volrath's Shapeshifter will have the shapeshifting ability."
         },
         {
           "date": "2004-10-04",
-          "text": "If the top card in your graveyard isn’t a creature card (meaning a card with the type Creature, which may or may not have other types such as Artifact or Enchantment), then it’s just a 0/1 blue creature. Older cards of type Summon are also Creature cards."
+          "text": "If the top card in your graveyard isn't a creature card (meaning a card with the type Creature, which may or may not have other types such as Artifact or Enchantment), then it's just a 0/1 blue creature. Older cards of type Summon are also Creature cards."
         },
         {
           "date": "2008-08-01",
@@ -7798,7 +7802,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Essence’s triggered ability will trigger even if it’s dealt lethal damage. For example, if it’s dealt 7 combat damage, its ability will trigger and you’ll gain 7 life."
+          "text": "Wall of Essence's triggered ability will trigger even if it's dealt lethal damage. For example, if it's dealt 7 combat damage, its ability will trigger and you'll gain 7 life."
         }
       ],
       "subtypes": [
@@ -8081,7 +8085,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It is possible to redirect more damage to a creature than that creature’s toughness."
+          "text": "It is possible to redirect more damage to a creature than that creature's toughness."
         },
         {
           "date": "2004-10-04",

--- a/json/THS.json
+++ b/json/THS.json
@@ -151,11 +151,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -387,31 +387,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -525,23 +525,23 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the land Chained to the Rocks is enchanting stops being a Mountain or another player gains control of it, Chained to the Rocks will be put into its owner’s graveyard when state-based actions are performed."
+          "text": "If the land Chained to the Rocks is enchanting stops being a Mountain or another player gains control of it, Chained to the Rocks will be put into its owner's graveyard when state-based actions are performed."
         },
         {
           "date": "2013-09-15",
-          "text": "Chained to the Rocks’s ability causes a zone change with a duration, a style of ability introduced in Magic 2014 that’s somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Chained to the Rocks have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Chained to the Rocks leaves the battlefield."
+          "text": "Chained to the Rocks's ability causes a zone change with a duration, a style of ability introduced in Magic 2014 that's somewhat reminiscent of older cards like Oblivion Ring. However, unlike Oblivion Ring, cards like Chained to the Rocks have a single ability that creates two one-shot effects: one that exiles the creature when the ability resolves, and another that returns the exiled card to the battlefield immediately after Chained to the Rocks leaves the battlefield."
         },
         {
           "date": "2013-09-15",
-          "text": "If Chained to the Rocks leaves the battlefield before its triggered ability resolves, the target creature won’t be exiled."
+          "text": "If Chained to the Rocks leaves the battlefield before its triggered ability resolves, the target creature won't be exiled."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to the exiled creature will be put into their owners’ graveyards (unless they have bestow). Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+          "text": "Auras attached to the exiled creature will be put into their owners' graveyards (unless they have bestow). Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
         },
         {
           "date": "2013-09-15",
-          "text": "If a creature token is exiled, it ceases to exist. It won’t be returned to the battlefield."
+          "text": "If a creature token is exiled, it ceases to exist. It won't be returned to the battlefield."
         },
         {
           "date": "2013-09-15",
@@ -549,7 +549,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "In a multiplayer game, if Chained to the Rocks’s owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn’t an ability that goes on the stack, it won’t cease to exist along with the leaving player’s spells and abilities on the stack."
+          "text": "In a multiplayer game, if Chained to the Rocks's owner leaves the game, the exiled card will return to the battlefield. Because the one-shot effect that returns the card isn't an ability that goes on the stack, it won't cease to exist along with the leaving player's spells and abilities on the stack."
         }
       ],
       "subtypes": [
@@ -662,7 +662,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the target of an Aura is illegal when it tries to resolve, the Aura will be countered. The Aura doesn’t enter the battlefield, so you won’t get to draw a card."
+          "text": "If the target of an Aura is illegal when it tries to resolve, the Aura will be countered. The Aura doesn't enter the battlefield, so you won't get to draw a card."
         }
       ],
       "subtypes": [
@@ -995,15 +995,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         },
         {
           "date": "2012-07-01",
-          "text": "Destroying a blocking creature won’t cause any of the creatures it was blocking to become unblocked. They won’t deal combat damage to the defending player or planeswalker (unless they have trample)."
+          "text": "Destroying a blocking creature won't cause any of the creatures it was blocking to become unblocked. They won't deal combat damage to the defending player or planeswalker (unless they have trample)."
         }
       ],
       "text": "Destroy target attacking or blocking creature.",
@@ -1331,11 +1331,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -1343,7 +1343,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -1467,7 +1467,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -1590,7 +1590,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -1704,7 +1704,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the creature is no longer on the battlefield at the beginning of the next end step after it’s returned to the battlefield, Gift of Immortality will remain in its owner’s graveyard."
+          "text": "If the creature is no longer on the battlefield at the beginning of the next end step after it's returned to the battlefield, Gift of Immortality will remain in its owner's graveyard."
         },
         {
           "date": "2013-09-15",
@@ -1926,7 +1926,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You choose the color as Gods Willing resolves. Once the color is chosen, it’s too late for players to respond."
+          "text": "You choose the color as Gods Willing resolves. Once the color is chosen, it's too late for players to respond."
         },
         {
           "date": "2013-09-15",
@@ -1938,11 +1938,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Target creature you control gains protection from the color of your choice until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -2052,11 +2052,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -2064,11 +2064,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -2080,7 +2080,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -2088,7 +2088,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         }
       ],
       "subtypes": [
@@ -2206,31 +2206,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -2345,31 +2345,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -2485,15 +2485,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -2608,7 +2608,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If you don’t control an enchantment when Lagonna-Band Elder enters the battlefield, its ability won’t trigger. If it does trigger, but you don’t control an enchantment when the ability tries to resolve, you won’t gain life."
+          "text": "If you don't control an enchantment when Lagonna-Band Elder enters the battlefield, its ability won't trigger. If it does trigger, but you don't control an enchantment when the ability tries to resolve, you won't gain life."
         }
       ],
       "subtypes": [
@@ -2733,7 +2733,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the creature is an illegal target when Last Breath tries to resolve, it will be countered and none of its effects will happen. Its controller won’t gain 4 life."
+          "text": "If the creature is an illegal target when Last Breath tries to resolve, it will be countered and none of its effects will happen. Its controller won't gain 4 life."
         }
       ],
       "text": "Exile target creature with power 2 or less. Its controller gains 4 life.",
@@ -2954,31 +2954,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -3096,7 +3096,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won’t sacrifice the Ordeal until the next time the creature attacks."
+          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won't sacrifice the Ordeal until the next time the creature attacks."
         },
         {
           "date": "2013-09-15",
@@ -3223,7 +3223,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -3562,7 +3562,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -3679,7 +3679,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If Setessan Griffin’s ability is activated by one player, then another player gains control of it during the same turn, the second player can’t activate its ability that turn."
+          "text": "If Setessan Griffin's ability is activated by one player, then another player gains control of it during the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -3901,7 +3901,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Soldier of the Pantheon can’t be enchanted or equipped by multicolored Auras and Equipment, it can’t be blocked by multicolored creatures, it can’t be targeted by multicolored spells or abilities from multicolored sources, and all damage dealt to it by multicolored sources is prevented."
+          "text": "Soldier of the Pantheon can't be enchanted or equipped by multicolored Auras and Equipment, it can't be blocked by multicolored creatures, it can't be targeted by multicolored spells or abilities from multicolored sources, and all damage dealt to it by multicolored sources is prevented."
         },
         {
           "date": "2013-09-15",
@@ -4243,11 +4243,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -4366,7 +4366,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -4710,11 +4710,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -4831,11 +4831,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Artisan of Forms copies the printed values of the creature plus any copy effects that have been applied to it. It won’t copy any other effects that have changed that creature’s power, toughness, color, and so on. Artisan of Forms won’t copy any counters on the creature, but Artisan of Forms will retain any counters it already had on it."
+          "text": "Artisan of Forms copies the printed values of the creature plus any copy effects that have been applied to it. It won't copy any other effects that have changed that creature's power, toughness, color, and so on. Artisan of Forms won't copy any counters on the creature, but Artisan of Forms will retain any counters it already had on it."
         },
         {
           "date": "2013-09-15",
-          "text": "If Artisan of Forms becomes a copy of a token creature, it copies the original characteristics of that token as defined by the effect that put it onto the battlefield. It won’t become a token creature."
+          "text": "If Artisan of Forms becomes a copy of a token creature, it copies the original characteristics of that token as defined by the effect that put it onto the battlefield. It won't become a token creature."
         },
         {
           "date": "2013-09-15",
@@ -4843,11 +4843,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If the creature is an illegal target when the ability tries to resolve, the ability will be countered. Artisan of Forms won’t become a copy of that creature. It remains whatever it was a copy of."
+          "text": "If the creature is an illegal target when the ability tries to resolve, the ability will be countered. Artisan of Forms won't become a copy of that creature. It remains whatever it was a copy of."
         },
         {
           "date": "2013-09-15",
-          "text": "When Artisan of Forms becomes a copy of a creature, it’s neither entering nor leaving the battlefield. Any enters-the-battlefield or leaves-the-battlefield abilities won’t trigger."
+          "text": "When Artisan of Forms becomes a copy of a creature, it's neither entering nor leaving the battlefield. Any enters-the-battlefield or leaves-the-battlefield abilities won't trigger."
         },
         {
           "date": "2013-09-15",
@@ -4863,7 +4863,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -5093,7 +5093,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "supertypes": [
@@ -5319,7 +5319,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Coastline Chimera’s activated ability is cumulative. Activating it a second time will allow it to block three creatures, and so on."
+          "text": "Coastline Chimera's activated ability is cumulative. Activating it a second time will allow it to block three creatures, and so on."
         }
       ],
       "subtypes": [
@@ -5663,11 +5663,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -5777,7 +5777,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the target of an Aura is illegal when it tries to resolve, the Aura will be countered. The Aura doesn’t enter the battlefield, so you won’t get to draw a card."
+          "text": "If the target of an Aura is illegal when it tries to resolve, the Aura will be countered. The Aura doesn't enter the battlefield, so you won't get to draw a card."
         }
       ],
       "subtypes": [
@@ -6117,11 +6117,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -6243,11 +6243,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -6369,11 +6369,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -6381,7 +6381,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -6497,19 +6497,19 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Meletis Charlatan’s ability can target any instant or sorcery spell, not just one with targets and not just one that you control."
+          "text": "Meletis Charlatan's ability can target any instant or sorcery spell, not just one with targets and not just one that you control."
         },
         {
           "date": "2013-09-15",
-          "text": "When the ability resolves, it creates a copy of the spell. The controller of the original spell controls the copy. That copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
+          "text": "When the ability resolves, it creates a copy of the spell. The controller of the original spell controls the copy. That copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger. The copy will then resolve like a normal spell, after players get a chance to cast spells and activate abilities."
         },
         {
           "date": "2013-09-15",
-          "text": "The copy will have the same targets as the spell it’s copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. If, for one of the targets, that player can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless its controller chooses new ones. That player may change any number of the targets, including all of them or none of them. If, for one of the targets, that player can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2013-09-15",
-          "text": "If the spell being copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. Its controller can’t choose a different one."
+          "text": "If the spell being copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. Its controller can't choose a different one."
         },
         {
           "date": "2013-09-15",
@@ -6744,31 +6744,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -6894,11 +6894,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -7016,7 +7016,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won’t sacrifice the Ordeal until the next time the creature attacks."
+          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won't sacrifice the Ordeal until the next time the creature attacks."
         },
         {
           "date": "2013-09-15",
@@ -7133,7 +7133,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The triggered ability will resolve and you’ll scry before the instant or sorcery spell resolves."
+          "text": "The triggered ability will resolve and you'll scry before the instant or sorcery spell resolves."
         },
         {
           "date": "2013-09-15",
@@ -7145,11 +7145,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -7265,7 +7265,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You can activate Prognostic Sphinx’s ability even if it’s already tapped."
+          "text": "You can activate Prognostic Sphinx's ability even if it's already tapped."
         },
         {
           "date": "2013-09-15",
@@ -7277,11 +7277,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -7395,6 +7395,14 @@
       "rulings": [
         {
           "date": "2013-09-15",
+          "text": "You can cast Sea God's Revenge with no targets. If you do, you'll scry 1 when it resolves. If you choose at least one target, and all chosen targets are illegal when Sea God's Revenge tries to resolve, it will be countered and none of its effects will happen."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "In multiplayer games, the three target creatures can be controlled by different opponents."
+        },
+        {
+          "date": "2013-09-15",
           "text": "When you scry, you may put all the cards you look at back on top of your library, you may put all of those cards on the bottom of your library, or you may put some of those cards on top and the rest of them on the bottom."
         },
         {
@@ -7403,11 +7411,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Return up to three target creatures your opponents control to their owners' hands. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -7518,19 +7526,19 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The effect making the land an Island doesn’t have a duration and will last indefinitely. The land retains any land types and abilities it already had. An Island has the ability “{T}: Add {U} to your mana pool.”"
+          "text": "The effect making the land an Island doesn't have a duration and will last indefinitely. The land retains any land types and abilities it already had. An Island has the ability \"{T}: Add {U} to your mana pool.\""
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -7645,7 +7653,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If you lose control of Shipbreaker Kraken between when its last ability triggers and when that ability resolves, the target creatures will become tapped. However, they won’t be affected by the other effect and will untap as normal during their controllers’ untap steps."
+          "text": "If you lose control of Shipbreaker Kraken between when its last ability triggers and when that ability resolves, the target creatures will become tapped. However, they won't be affected by the other effect and will untap as normal during their controllers' untap steps."
         },
         {
           "date": "2013-09-15",
@@ -7653,23 +7661,23 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If you gain control of a creature that’s being prevented from untapping, that creature won’t untap during your untap step for as long as you control Shipbreaker Kraken."
+          "text": "If you gain control of a creature that's being prevented from untapping, that creature won't untap during your untap step for as long as you control Shipbreaker Kraken."
         },
         {
           "date": "2013-09-15",
-          "text": "The ability can target a tapped creature. If a targeted creature is already tapped when it resolves, that creature just remains tapped and doesn’t untap during its controller’s untap step."
+          "text": "The ability can target a tapped creature. If a targeted creature is already tapped when it resolves, that creature just remains tapped and doesn't untap during its controller's untap step."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -7783,7 +7791,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If Stymied Hopes resolves, you’ll scry whether the controller of the target spell pays {1} or not."
+          "text": "If Stymied Hopes resolves, you'll scry whether the controller of the target spell pays {1} or not."
         },
         {
           "date": "2013-09-15",
@@ -7795,11 +7803,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Counter target spell unless its controller pays {1}. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -7910,7 +7918,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Swan Song can target a spell that can’t be countered. That spell won’t be countered when Swan Song resolves, but its controller will get a Bird token."
+          "text": "Swan Song can target a spell that can't be countered. That spell won't be countered when Swan Song resolves, but its controller will get a Bird token."
         }
       ],
       "text": "Counter target enchantment, instant, or sorcery spell. Its controller creates a 2/2 blue Bird creature token with flying.",
@@ -8020,15 +8028,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Activating Thassa’s last ability after the target creature has been blocked won’t change or undo the block."
+          "text": "Activating Thassa's last ability after the target creature has been blocked won't change or undo the block."
         },
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -8036,7 +8044,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
@@ -8048,15 +8056,15 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -8068,7 +8076,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -8076,7 +8084,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         }
       ],
       "subtypes": [
@@ -8191,6 +8199,16 @@
         "THS"
       ],
       "rarity": "Common",
+      "rulings": [
+        {
+          "date": "2013-09-15",
+          "text": "If the target player is an illegal target when Thassa's Bounty tries to resolve, it will be countered and none of its effects will happen. You won't draw three cards."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "Follow the instructions in the order listed on the card: if you target yourself, you'll draw three cards, then put the top three cards of your library into your graveyard."
+        }
+      ],
       "text": "Draw three cards. Target player puts the top three cards of his or her library into his or her graveyard.",
       "type": "Sorcery",
       "types": [
@@ -8298,31 +8316,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -8446,7 +8464,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -8879,6 +8897,24 @@
         "THS"
       ],
       "rarity": "Common",
+      "rulings": [
+        {
+          "date": "2013-09-15",
+          "text": "When you scry, you may put all the cards you look at back on top of your library, you may put all of those cards on the bottom of your library, or you may put some of those cards on top and the rest of them on the bottom."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "You choose how to order cards returned to your library after scrying no matter where you put them."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
+        }
+      ],
       "text": "Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
       "type": "Instant",
       "types": [
@@ -8986,11 +9022,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Wavecrash Triton’s ability can target a creature that’s already tapped. That creature still won’t untap during its controller’s next untap step."
+          "text": "Wavecrash Triton's ability can target a creature that's already tapped. That creature still won't untap during its controller's next untap step."
         },
         {
           "date": "2013-09-15",
-          "text": "Wavecrash Triton’s ability tracks the creature, but not its controller. If the creature changes controllers before its first controller’s next untap step has come around, then it won’t untap during its new controller’s next untap step."
+          "text": "Wavecrash Triton's ability tracks the creature, but not its controller. If the creature changes controllers before its first controller's next untap step has come around, then it won't untap during its new controller's next untap step."
         },
         {
           "date": "2013-09-15",
@@ -9002,7 +9038,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -9118,11 +9154,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -9130,7 +9166,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -9253,7 +9289,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -9478,31 +9514,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -9727,7 +9763,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The loss of life is part of the spell’s effect. It’s not an additional cost. If Boon of Erebos is countered, you won’t lose life."
+          "text": "The loss of life is part of the spell's effect. It's not an additional cost. If Boon of Erebos is countered, you won't lose life."
         }
       ],
       "text": "Target creature gets +2/+0 until end of turn. Regenerate it. You lose 2 life.",
@@ -9837,31 +9873,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -10188,11 +10224,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -10200,7 +10236,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -10315,11 +10351,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -10327,11 +10363,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -10343,7 +10379,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -10351,7 +10387,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         }
       ],
       "subtypes": [
@@ -10469,35 +10505,35 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2014-02-01",
-          "text": "Only the controller of the Erebos’s Emissary may activate the ability, even if Erebos’s Emissary is attached to a creature another player controls."
+          "text": "Only the controller of the Erebos's Emissary may activate the ability, even if Erebos's Emissary is attached to a creature another player controls."
         }
       ],
       "subtypes": [
@@ -10829,11 +10865,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -10841,7 +10877,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -11060,15 +11096,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -11295,15 +11331,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -11526,7 +11562,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The activated ability doesn’t target any creature or make any specific creature have to block. Activating it more than once in a turn provides no additional benefit."
+          "text": "The activated ability doesn't target any creature or make any specific creature have to block. Activating it more than once in a turn provides no additional benefit."
         }
       ],
       "subtypes": [
@@ -11744,15 +11780,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Unlike most abilities that use devotion to determine the magnitude of an effect, Mogis’s Marauder uses devotion to determine the number of targets its ability has. Use your devotion to black as you put the ability on the stack. Mogis’s Marauder’s mana cost will always count toward your devotion to black. Once targets are chosen, it doesn’t matter if your devotion to black changes while the ability is on the stack. The number of targets is locked in."
+          "text": "Unlike most abilities that use devotion to determine the magnitude of an effect, Mogis's Marauder uses devotion to determine the number of targets its ability has. Use your devotion to black as you put the ability on the stack. Mogis's Marauder's mana cost will always count toward your devotion to black. Once targets are chosen, it doesn't matter if your devotion to black changes while the ability is on the stack. The number of targets is locked in."
         },
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -11873,35 +11909,35 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Nighthowler’s last ability functions only from the battlefield. In other zones, Nighthowler is a 0/0 enchantment creature."
+          "text": "Nighthowler's last ability functions only from the battlefield. In other zones, Nighthowler is a 0/0 enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -12019,7 +12055,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won’t sacrifice the Ordeal until the next time the creature attacks."
+          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won't sacrifice the Ordeal until the next time the creature attacks."
         },
         {
           "date": "2013-09-15",
@@ -12136,7 +12172,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the creature is an illegal target as Pharika’s Cure tries to resolve, it will be countered and none of its effects will happen. You won’t gain life. If, on the other hand, Pharika’s Cure does resolve but the damage is prevented, you’ll still gain life."
+          "text": "If the creature is an illegal target as Pharika's Cure tries to resolve, it will be countered and none of its effects will happen. You won't gain life. If, on the other hand, Pharika's Cure does resolve but the damage is prevented, you'll still gain life."
         }
       ],
       "text": "Pharika's Cure deals 2 damage to target creature and you gain 2 life.",
@@ -12249,7 +12285,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The loss of life is part of the spell’s effect. It’s not an additional cost. If Read the Bones is countered, you won’t lose life."
+          "text": "The loss of life is part of the spell's effect. It's not an additional cost. If Read the Bones is countered, you won't lose life."
         },
         {
           "date": "2013-09-15",
@@ -12261,11 +12297,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -12374,19 +12410,19 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once you announce you’re casting Rescue from the Underworld, no player may attempt to stop you from casting the spell by removing the creature you want to sacrifice."
+          "text": "Once you announce you're casting Rescue from the Underworld, no player may attempt to stop you from casting the spell by removing the creature you want to sacrifice."
         },
         {
           "date": "2013-09-15",
-          "text": "If you sacrifice a creature token to cast Rescue from the Underworld, it won’t return to the battlefield, although the target creature card will."
+          "text": "If you sacrifice a creature token to cast Rescue from the Underworld, it won't return to the battlefield, although the target creature card will."
         },
         {
           "date": "2013-09-15",
-          "text": "If either the sacrificed creature or the target creature card leaves the graveyard before the delayed triggered ability resolves during your next upkeep, it won’t return."
+          "text": "If either the sacrificed creature or the target creature card leaves the graveyard before the delayed triggered ability resolves during your next upkeep, it won't return."
         },
         {
           "date": "2013-09-15",
-          "text": "However, if the sacrificed creature is put into another public zone instead of the graveyard, perhaps because it’s your commander or because of another replacement effect, it will return to the battlefield from the zone it went to."
+          "text": "However, if the sacrificed creature is put into another public zone instead of the graveyard, perhaps because it's your commander or because of another replacement effect, it will return to the battlefield from the zone it went to."
         },
         {
           "date": "2013-09-15",
@@ -12722,7 +12758,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the target of an Aura is illegal when it tries to resolve, the Aura will be countered. The Aura doesn’t enter the battlefield, so you won’t get to draw a card."
+          "text": "If the target of an Aura is illegal when it tries to resolve, the Aura will be countered. The Aura doesn't enter the battlefield, so you won't get to draw a card."
         }
       ],
       "subtypes": [
@@ -12835,7 +12871,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the creature is an illegal target when Sip of Hemlock tries to resolve, it will be countered and none of its effects will occur. The creature’s controller won’t lose 2 life. However, if Sip of Hemlock resolves and the creature isn’t destroyed (perhaps because it regenerated or had indestructible), the creature’s controller will still lose 2 life."
+          "text": "If the creature is an illegal target when Sip of Hemlock tries to resolve, it will be countered and none of its effects will occur. The creature's controller won't lose 2 life. However, if Sip of Hemlock resolves and the creature isn't destroyed (perhaps because it regenerated or had indestructible), the creature's controller will still lose 2 life."
         }
       ],
       "text": "Destroy target creature. Its controller loses 2 life.",
@@ -12944,13 +12980,14 @@
       "originalType": "Sorcery",
       "printings": [
         "LRW",
-        "THS"
+        "THS",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The loss of life is part of the spell’s effect. It’s not an additional cost. If Thoughtseize is countered, you won’t lose life."
+          "text": "The loss of life is part of the spell's effect. It's not an additional cost. If Thoughtseize is countered, you won't lose life."
         },
         {
           "date": "2014-02-01",
@@ -13073,7 +13110,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -13295,19 +13332,19 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "At the beginning of the next end step, the creature returned to the battlefield with Whip of Erebos is exiled. This is a delayed triggered ability. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won’t trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
+          "text": "At the beginning of the next end step, the creature returned to the battlefield with Whip of Erebos is exiled. This is a delayed triggered ability. If the ability is countered, the creature will stay on the battlefield and the delayed trigger won't trigger again. However, the replacement effect will still exile the creature when it eventually leaves the battlefield."
         },
         {
           "date": "2013-09-15",
-          "text": "Whip of Erebos grants haste to the creature that’s returned to the battlefield. However, neither of the “exile” abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
+          "text": "Whip of Erebos grants haste to the creature that's returned to the battlefield. However, neither of the \"exile\" abilities is granted to that creature. If that creature loses all its abilities, it will still be exiled at the beginning of the end step, and if it would leave the battlefield, it is still exiled instead."
         },
         {
           "date": "2013-09-15",
-          "text": "If a creature returned to the battlefield with Whip of Erebos would leave the battlefield for any reason, it’s exiled instead. However, if that creature is already being exiled, then the replacement effect won’t apply. If the spell or ability that exiles it later returns it to the battlefield (as Chained to the Rocks might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The effects from Whip of Erebos will no longer apply to it."
+          "text": "If a creature returned to the battlefield with Whip of Erebos would leave the battlefield for any reason, it's exiled instead. However, if that creature is already being exiled, then the replacement effect won't apply. If the spell or ability that exiles it later returns it to the battlefield (as Chained to the Rocks might, for example), the creature card will return to the battlefield as a new object with no relation to its previous existence. The effects from Whip of Erebos will no longer apply to it."
         },
         {
           "date": "2013-09-15",
-          "text": "The exiled creature is never put into the graveyard. Any abilities the creature has that trigger when it dies won’t trigger."
+          "text": "The exiled creature is never put into the graveyard. Any abilities the creature has that trigger when it dies won't trigger."
         }
       ],
       "supertypes": [
@@ -13430,7 +13467,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -13545,7 +13582,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Creatures don’t necessarily have to be dealt lethal damage by Anger of the Gods to be exiled. After being dealt damage, if they would die for any reason that turn, they’ll be exiled instead."
+          "text": "Creatures don't necessarily have to be dealt lethal damage by Anger of the Gods to be exiled. After being dealt damage, if they would die for any reason that turn, they'll be exiled instead."
         }
       ],
       "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
@@ -13656,7 +13693,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The heroic ability won’t cause a creature that’s already blocking to stop blocking or be removed from combat."
+          "text": "The heroic ability won't cause a creature that's already blocking to stop blocking or be removed from combat."
         },
         {
           "date": "2013-09-15",
@@ -13668,7 +13705,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -13894,15 +13931,15 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If some but not all of Boulderfall’s targets become illegal, you can’t change the division of damage. Damage that would have been dealt to illegal targets simply isn’t dealt."
+          "text": "If some but not all of Boulderfall's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2013-09-15",
-          "text": "You can’t deal damage to both a player and a planeswalker that player controls using Boulderfall. You also can’t deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Boulderfall. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
         },
         {
           "date": "2013-09-15",
-          "text": "If an effect creates a copy of Boulderfall, the division of damage and number of targets can’t be changed. The effect that creates the copy may allow you to change targets, however."
+          "text": "If an effect creates a copy of Boulderfall, the division of damage and number of targets can't be changed. The effect that creates the copy may allow you to change targets, however."
         }
       ],
       "text": "Boulderfall deals 5 damage divided as you choose among any number of target creatures and/or players.",
@@ -14124,7 +14161,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If, during your declare attackers step, Deathbellow Raider is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under your control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, you’re not forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during your declare attackers step, Deathbellow Raider is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under your control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, you're not forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -14372,7 +14409,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If the target of an Aura is illegal when it tries to resolve, the Aura will be countered. The Aura doesn’t enter the battlefield, so you won’t get to draw a card."
+          "text": "If the target of an Aura is illegal when it tries to resolve, the Aura will be countered. The Aura doesn't enter the battlefield, so you won't get to draw a card."
         }
       ],
       "subtypes": [
@@ -14490,15 +14527,15 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -14612,11 +14649,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -14624,7 +14661,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -14740,11 +14777,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Firedrinker Satyr’s first ability will trigger even if it’s dealt lethal damage. For example, if it blocks a 7/7 creature, its ability will trigger and Firedrinker Satyr will deal 7 damage to you."
+          "text": "Firedrinker Satyr's first ability will trigger even if it's dealt lethal damage. For example, if it blocks a 7/7 creature, its ability will trigger and Firedrinker Satyr will deal 7 damage to you."
         },
         {
           "date": "2013-09-15",
-          "text": "Damage dealt by Firedrinker Satyr due to its first ability isn’t combat damage, even if combat damage caused the ability to trigger."
+          "text": "Damage dealt by Firedrinker Satyr due to its first ability isn't combat damage, even if combat damage caused the ability to trigger."
         }
       ],
       "subtypes": [
@@ -14860,7 +14897,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Flamespeaker Adept’s ability triggers once for each scry instruction, no matter how many cards you’re scrying."
+          "text": "Flamespeaker Adept's ability triggers once for each scry instruction, no matter how many cards you're scrying."
         },
         {
           "date": "2013-09-15",
@@ -14872,11 +14909,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -15101,15 +15138,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -15232,7 +15269,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -15469,11 +15506,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Magma Jet deals 2 damage to target creature or player. Scry 2.",
@@ -15804,7 +15841,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won’t sacrifice the Ordeal until the next time the creature attacks."
+          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won't sacrifice the Ordeal until the next time the creature attacks."
         },
         {
           "date": "2013-09-15",
@@ -15921,11 +15958,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Peak Eruption can target any land with the subtype Mountain, not just those named Mountain. It can’t target a land that doesn’t have that subtype, even if the land can tap for {R}."
+          "text": "Peak Eruption can target any land with the subtype Mountain, not just those named Mountain. It can't target a land that doesn't have that subtype, even if the land can tap for {R}."
         },
         {
           "date": "2013-09-15",
-          "text": "If the target Mountain is an illegal target when Peak Eruption tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt. However, if Peak Eruption resolves and the Mountain isn’t destroyed (perhaps because it has indestructible), damage will be dealt."
+          "text": "If the target Mountain is an illegal target when Peak Eruption tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt. However, if Peak Eruption resolves and the Mountain isn't destroyed (perhaps because it has indestructible), damage will be dealt."
         }
       ],
       "text": "Destroy target Mountain. Peak Eruption deals 3 damage to that land's controller.",
@@ -16034,11 +16071,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Portent of Betrayal can target any creature, even one that’s untapped or one you already control."
+          "text": "Portent of Betrayal can target any creature, even one that's untapped or one you already control."
         },
         {
           "date": "2013-09-15",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it, although those permanents will stay attached to the creature."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it, although those permanents will stay attached to the creature."
         },
         {
           "date": "2013-09-15",
@@ -16050,11 +16087,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -16275,11 +16312,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -16287,11 +16324,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -16303,7 +16340,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -16311,7 +16348,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         }
       ],
       "subtypes": [
@@ -16429,31 +16466,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -16567,7 +16604,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If Rage of Purphoros resolves but the damage is redirected to a different creature or to a player, the target creature still won’t be able to regenerate that turn. This is also true if the damage is prevented."
+          "text": "If Rage of Purphoros resolves but the damage is redirected to a different creature or to a player, the target creature still won't be able to regenerate that turn. This is also true if the damage is prevented."
         },
         {
           "date": "2013-09-15",
@@ -16579,11 +16616,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Rage of Purphoros deals 4 damage to target creature. It can't be regenerated this turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -16920,11 +16957,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Spark Jolt deals 1 damage to target creature or player. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
@@ -17034,31 +17071,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -17175,23 +17212,23 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If blockers have already been declared when Stoneshock Giant’s last ability resolves, those blocks won’t change or become undone."
+          "text": "If blockers have already been declared when Stoneshock Giant's last ability resolves, those blocks won't change or become undone."
         },
         {
           "date": "2013-09-15",
-          "text": "Your opponents can’t assign any creature without flying to block that turn, even if that creature had flying or wasn’t on the battlefield under one of your opponent’s control when Stoneshock Giant’s ability resolved."
+          "text": "Your opponents can't assign any creature without flying to block that turn, even if that creature had flying or wasn't on the battlefield under one of your opponent's control when Stoneshock Giant's ability resolved."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -17305,19 +17342,19 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "For each opponent, count the number of cards in that player’s hand when the last ability resolves to determine how much damage Stormbreath Dragon does to him or her."
+          "text": "For each opponent, count the number of cards in that player's hand when the last ability resolves to determine how much damage Stormbreath Dragon does to him or her."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -17537,6 +17574,24 @@
         "ORI"
       ],
       "rarity": "Common",
+      "rulings": [
+        {
+          "date": "2013-09-15",
+          "text": "When you scry, you may put all the cards you look at back on top of your library, you may put all of those cards on the bottom of your library, or you may put some of those cards on top and the rest of them on the bottom."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "You choose how to order cards returned to your library after scrying no matter where you put them."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
+        }
+      ],
       "text": "Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
       "type": "Instant",
       "types": [
@@ -17864,7 +17919,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Activating the ability of Agent of Horizons after it’s been blocked won’t change or undo the block."
+          "text": "Activating the ability of Agent of Horizons after it's been blocked won't change or undo the block."
         }
       ],
       "subtypes": [
@@ -17981,7 +18036,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If a land that hasn’t been under your control continuously since your last turn began becomes a creature, it can’t attack and its activated abilities that include {T} can’t be activated. Notably, it can’t be tapped for mana that turn."
+          "text": "If a land that hasn't been under your control continuously since your last turn began becomes a creature, it can't attack and its activated abilities that include {T} can't be activated. Notably, it can't be tapped for mana that turn."
         },
         {
           "date": "2013-09-15",
@@ -17993,7 +18048,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -18112,15 +18167,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -18234,7 +18289,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The artifact or enchantment won’t be on the battlefield when you scry, unless it regenerated or had indestructible."
+          "text": "The artifact or enchantment won't be on the battlefield when you scry, unless it regenerated or had indestructible."
         },
         {
           "date": "2013-09-15",
@@ -18246,11 +18301,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Destroy target artifact or enchantment. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
@@ -18360,31 +18415,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -18498,7 +18553,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You choose which mode you’re using as you activate the ability."
+          "text": "You choose which mode you're using as you activate the ability."
         }
       ],
       "supertypes": [
@@ -18621,7 +18676,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -19161,7 +19216,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If the green creature an opponent controls is an illegal target when Hunt the Hunter tries to resolve, but the green creature you control is still a legal target, the creature you control will get +2/+2, but the creatures won’t fight. Neither creature will deal or be dealt damage."
+          "text": "If the green creature an opponent controls is an illegal target when Hunt the Hunter tries to resolve, but the green creature you control is still a legal target, the creature you control will get +2/+2, but the creatures won't fight. Neither creature will deal or be dealt damage."
         }
       ],
       "text": "Target green creature you control gets +2/+2 until end of turn. It fights target green creature an opponent controls.",
@@ -19273,11 +19328,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "The activated ability is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -19285,7 +19344,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -19400,31 +19459,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -19540,7 +19599,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Spells that can’t be countered can still be chosen as the target of spells or abilities that try to counter them. Although the spell won’t be countered, the spell or ability that tries to counter it will resolve, and any other effects of that spell or ability will happen."
+          "text": "Spells that can't be countered can still be chosen as the target of spells or abilities that try to counter them. Although the spell won't be countered, the spell or ability that tries to counter it will resolve, and any other effects of that spell or ability will happen."
         }
       ],
       "subtypes": [
@@ -19658,19 +19717,19 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Once you declare you’re casting Nemesis of Mortals or activating its ability, it’s too late for players to try to change the number of creature cards in your graveyard to affect the cost of doing so."
+          "text": "Once you declare you're casting Nemesis of Mortals or activating its ability, it's too late for players to try to change the number of creature cards in your graveyard to affect the cost of doing so."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -19787,15 +19846,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -20022,11 +20081,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -20034,11 +20093,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color."
+          "text": "The type-changing ability that can make the God not be a creature functions only on the battlefield. It's always a creature card in other zones, regardless of your devotion to its color."
         },
         {
           "date": "2013-09-15",
@@ -20050,7 +20109,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The abilities of Gods function as long as they’re on the battlefield, regardless of whether they’re creatures."
+          "text": "The abilities of Gods function as long as they're on the battlefield, regardless of whether they're creatures."
         },
         {
           "date": "2013-09-15",
@@ -20058,7 +20117,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won’t matter because it has indestructible.)"
+          "text": "If a God is dealt damage, then stops being a creature, then becomes a creature again later in the same turn, the damage will still be marked on it. This is also true for any effects that were affecting the God when it was originally a creature. (Note that in most cases, the damage marked on the God won't matter because it has indestructible.)"
         }
       ],
       "subtypes": [
@@ -20176,11 +20235,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -20188,7 +20247,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -20303,31 +20362,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You don’t choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you’ve made this choice. For example, an effect that said you can cast creature spells as though they have flash won’t allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
+          "text": "You don't choose whether the spell is going to be an Aura spell or not until the spell is already on the stack. Abilities that affect when you can cast a spell, such as flash, will apply to the spell after you've made this choice. For example, an effect that said you can cast creature spells as though they have flash won't allow you to cast a creature card with bestow as an Aura spell anytime you could cast an instant, but one that said you can cast Aura spells as though they have flash will."
         },
         {
           "date": "2013-09-15",
-          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It’s never both, although it’s an enchantment spell in either case."
+          "text": "On the stack, a spell with bestow is either a creature spell or an Aura spell. It's never both, although it's an enchantment spell in either case."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Aura spells, an Aura spell with bestow isn’t countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
+          "text": "Unlike other Aura spells, an Aura spell with bestow isn't countered if its target is illegal as it begins to resolve. Rather, the effect making it an Aura spell ends, it loses enchant creature, it returns to being an enchantment creature spell, and it resolves and enters the battlefield as an enchantment creature."
         },
         {
           "date": "2013-09-15",
-          "text": "Unlike other Auras, an Aura with bestow isn’t put into its owner’s graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it’s been under your control continuously, even as an Aura, since your most recent turn began."
+          "text": "Unlike other Auras, an Aura with bestow isn't put into its owner's graveyard if it becomes unattached. Rather, the effect making it an Aura ends, it loses enchant creature, and it remains on the battlefield as an enchantment creature. It can attack (and its {T} abilities can be activated, if it has any) on the turn it becomes unattached if it's been under your control continuously, even as an Aura, since your most recent turn began."
         },
         {
           "date": "2013-09-15",
-          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can’t choose to pay the bestow cost and have it become an Aura."
+          "text": "If a permanent with bestow enters the battlefield by any method other than being cast, it will be an enchantment creature. You can't choose to pay the bestow cost and have it become an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "Auras attached to a creature don’t become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
+          "text": "Auras attached to a creature don't become tapped when the creature becomes tapped. Except in some rare cases, an Aura with bestow remains untapped when it becomes unattached and becomes a creature."
         },
         {
           "date": "2013-09-15",
-          "text": "An Aura that becomes a creature is no longer put into its owner’s graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it’s a creature. While it’s a creature, it can’t be attached to another permanent or player. An Aura that’s not attached to a legal permanent or player as defined by its enchant ability and also isn’t a creature will be put into its owner’s graveyard as a state-based action."
+          "text": "An Aura that becomes a creature is no longer put into its owner's graveyard as a state-based action. Rather, it becomes unattached and remains on the battlefield as long as it's a creature. While it's a creature, it can't be attached to another permanent or player. An Aura that's not attached to a legal permanent or player as defined by its enchant ability and also isn't a creature will be put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -20445,7 +20504,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Giving a land extra basic land types doesn’t change its name or whether it’s legendary or basic."
+          "text": "Giving a land extra basic land types doesn't change its name or whether it's legendary or basic."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "If the target of an Aura is illegal when it tries to resolve, the Aura will be countered. The Aura doesn't enter the battlefield, so you won't get to draw a card."
         }
       ],
       "subtypes": [
@@ -20561,7 +20624,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won’t sacrifice the Ordeal until the next time the creature attacks."
+          "text": "The check of whether the enchanted creature has three or more +1/+1 counters on it happens as part of the resolution of the attack triggered ability. If the third +1/+1 counter is put on the enchanted creature any other way, you won't sacrifice the Ordeal until the next time the creature attacks."
         },
         {
           "date": "2013-09-15",
@@ -20787,31 +20850,31 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The value of X in Polukranos’s last ability is equal to the value chosen for X when its activated ability was activated."
+          "text": "The value of X in Polukranos's last ability is equal to the value chosen for X when its activated ability was activated."
         },
         {
           "date": "2013-09-15",
-          "text": "The number of targets chosen for the triggered ability must be at least one (if X wasn’t 0) and at most X. You choose the division of damage as you put the ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. In multiplayer games, you may choose creatures controlled by different opponents."
+          "text": "The number of targets chosen for the triggered ability must be at least one (if X wasn't 0) and at most X. You choose the division of damage as you put the ability on the stack, not as it resolves. Each target must be assigned at least 1 damage. In multiplayer games, you may choose creatures controlled by different opponents."
         },
         {
           "date": "2013-09-15",
-          "text": "If some, but not all, of the ability’s targets become illegal, you can’t change the division of damage. Damage that would’ve been dealt to illegal targets simply isn’t dealt."
+          "text": "If some, but not all, of the ability's targets become illegal, you can't change the division of damage. Damage that would've been dealt to illegal targets simply isn't dealt."
         },
         {
           "date": "2013-09-15",
-          "text": "As Polukranos’s triggered ability resolves, Polukranos deals damage first, then the target creatures do. Although no creature will die until after the ability finishes resolving, the order could matter if Polukranos has wither or infect."
+          "text": "As Polukranos's triggered ability resolves, Polukranos deals damage first, then the target creatures do. Although no creature will die until after the ability finishes resolving, the order could matter if Polukranos has wither or infect."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -20928,11 +20991,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -20940,7 +21003,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "subtypes": [
@@ -21058,7 +21121,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Satyr Hedonist’s ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Satyr Hedonist's ability is a mana ability. It doesn't use the stack and can't be responded to."
         }
       ],
       "subtypes": [
@@ -21080,7 +21143,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"When I asked my commander the reward for killing that prancing nuisance, he told me, ‘None! I want to kill him myself!'\"\n—Phrogas, soldier of Akros",
+      "flavor": "\"When I asked my commander the reward for killing that prancing nuisance, he told me, 'None! I want to kill him myself!'\"\n—Phrogas, soldier of Akros",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -21629,7 +21692,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -21854,7 +21917,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Time to Feed has two targets: a creature an opponent controls and a creature you control. If only one of those creatures is a legal target when Time to Feed tries to resolve, the creatures won’t fight and neither will deal or be dealt damage. If the creature you don’t control is the illegal target, you won’t gain life when it dies."
+          "text": "Time to Feed has two targets: a creature an opponent controls and a creature you control. If only one of those creatures is a legal target when Time to Feed tries to resolve, the creatures won't fight and neither will deal or be dealt damage. If the creature you don't control is the illegal target, you won't gain life when it dies."
         },
         {
           "date": "2013-09-15",
@@ -21862,7 +21925,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If the first target creature dies that turn, you’ll gain 3 life no matter what caused the creature to die or who controls the creature at that time."
+          "text": "If the first target creature dies that turn, you'll gain 3 life no matter what caused the creature to die or who controls the creature at that time."
         }
       ],
       "text": "Choose target creature an opponent controls. When that creature dies this turn, you gain 3 life. Target creature you control fights that creature. (Each deals damage equal to its power to the other.)",
@@ -22304,7 +22367,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Once the ability resolves, the bonus won’t change even if the number of attacking creatures you control does."
+          "text": "Once the ability resolves, the bonus won't change even if the number of attacking creatures you control does."
         }
       ],
       "subtypes": [
@@ -22435,7 +22498,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         }
       ],
       "subtypes": [
@@ -22666,15 +22729,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Ashiok’s second ability refers to any creature card exiled because of Ashiok’s first or third ability."
+          "text": "Ashiok's second ability refers to any creature card exiled because of Ashiok's first or third ability."
         },
         {
           "date": "2013-09-15",
-          "text": "Ashiok’s second ability doesn’t target any creature card. You choose which creature card to return when that ability resolves, but you must choose one with converted mana cost equal to the value you chose for X when activating the ability."
+          "text": "Ashiok's second ability doesn't target any creature card. You choose which creature card to return when that ability resolves, but you must choose one with converted mana cost equal to the value you chose for X when activating the ability."
         },
         {
           "date": "2013-09-15",
-          "text": "If Ashiok leaves the battlefield, and later another Ashiok enters the battlefield, it is a new object (even if the two were represented by the same card). Creature cards exiled by the original Ashiok can’t be put onto the battlefield by the second ability of the new Ashiok."
+          "text": "If Ashiok leaves the battlefield, and later another Ashiok enters the battlefield, it is a new object (even if the two were represented by the same card). Creature cards exiled by the original Ashiok can't be put onto the battlefield by the second ability of the new Ashiok."
         },
         {
           "date": "2013-09-15",
@@ -22805,7 +22868,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Heroic abilities won’t trigger when a copy of a spell is created on the stack or when a spell’s targets are changed to include a creature with a heroic ability."
+          "text": "Heroic abilities won't trigger when a copy of a spell is created on the stack or when a spell's targets are changed to include a creature with a heroic ability."
         },
         {
           "date": "2013-09-15",
@@ -22817,11 +22880,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -23056,11 +23119,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If Daxos is blocked by a creature, raising that creature’s power to 3 or greater won’t change or undo the block."
+          "text": "If Daxos is blocked by a creature, raising that creature's power to 3 or greater won't change or undo the block."
         },
         {
           "date": "2013-09-15",
-          "text": "If the exiled card is a land card, you won’t gain any life and you won’t be able to play the land."
+          "text": "If the exiled card is a land card, you won't gain any life and you won't be able to play the land."
         },
         {
           "date": "2013-09-15",
@@ -23068,7 +23131,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "Daxos doesn’t change when you can cast the exiled card. For example, if you exile a creature card without flash, you can cast it only during your main phase when the stack is empty."
+          "text": "Daxos doesn't change when you can cast the exiled card. For example, if you exile a creature card without flash, you can cast it only during your main phase when the stack is empty."
         }
       ],
       "subtypes": [
@@ -23078,7 +23141,7 @@
       "supertypes": [
         "Legendary"
       ],
-      "text": "Daxos of Meletis can't be blocked by creatures with power 3 or greater.\nWhenever Daxos of Meletis deals combat damage to a player, exile the top card of that player's library. You gain life equal to that card's converted mana cost. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast it.",
+      "text": "Daxos of Meletis can't be blocked by creatures with power 3 or greater.\nWhenever Daxos of Meletis deals combat damage to a player, exile the top card of that player's library. You gain life equal to that card's converted mana cost. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
       "toughness": "2",
       "type": "Legendary Creature — Human Soldier",
       "types": [
@@ -23189,7 +23252,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "You must target an artifact or enchantment to cast Destructive Revelry. If that artifact or enchantment is an illegal target when Destructive Revelry tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt. However, if Destructive Revelry resolves and the artifact or enchantment isn’t destroyed (perhaps because it has indestructible), damage will be dealt."
+          "text": "You must target an artifact or enchantment to cast Destructive Revelry. If that artifact or enchantment is an illegal target when Destructive Revelry tries to resolve, it will be countered and none of its effects will happen. No damage will be dealt. However, if Destructive Revelry resolves and the artifact or enchantment isn't destroyed (perhaps because it has indestructible), damage will be dealt."
         }
       ],
       "text": "Destroy target artifact or enchantment. Destructive Revelry deals 2 damage to that permanent's controller.",
@@ -23301,15 +23364,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -23426,7 +23489,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If you draw multiple cards, Horizon Chimera’s ability will trigger that many times. Each of these abilities will cause a separate life-gaining event."
+          "text": "If you draw multiple cards, Horizon Chimera's ability will trigger that many times. Each of these abilities will cause a separate life-gaining event."
         }
       ],
       "subtypes": [
@@ -23654,11 +23717,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "An “extra turn” is any turn created by a spell or ability. Notably, it doesn’t include additional turns taken in tournaments after time expires for a round."
+          "text": "An \"extra turn\" is any turn created by a spell or ability. Notably, it doesn't include additional turns taken in tournaments after time expires for a round."
         },
         {
           "date": "2013-09-15",
-          "text": "It doesn’t matter whose turn it is. In very rare cases, an opponent may be taking an extra turn and gain control of Medomai. Medomai can’t attack during that turn."
+          "text": "It doesn't matter whose turn it is. In very rare cases, an opponent may be taking an extra turn and gain control of Medomai. Medomai can't attack during that turn."
         }
       ],
       "subtypes": [
@@ -23889,23 +23952,23 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "“Protection from enchantments” means that Polis Crusher can’t be enchanted, it can’t be targeted by Aura spells or by abilities of enchantments, all damage that would be dealt to it by enchantments is prevented, and it can’t be blocked by enchantment creatures. Notably, it doesn’t have protection from enchanted creatures (unless those creatures are also enchantments)."
+          "text": "\"Protection from enchantments\" means that Polis Crusher can't be enchanted, it can't be targeted by Aura spells or by abilities of enchantments, all damage that would be dealt to it by enchantments is prevented, and it can't be blocked by enchantment creatures. Notably, it doesn't have protection from enchanted creatures (unless those creatures are also enchantments)."
         },
         {
           "date": "2013-09-15",
-          "text": "Polis Crusher must be monstrous as it deals combat damage to a player in order for its last ability to trigger. Once the ability triggers, it resolves even if Polis Crusher isn’t on the battlefield at that time."
+          "text": "Polis Crusher must be monstrous as it deals combat damage to a player in order for its last ability to trigger. Once the ability triggers, it resolves even if Polis Crusher isn't on the battlefield at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -24023,23 +24086,23 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Creatures and lands you control untap at the same time as the active player’s permanents. You can’t choose to not untap them at that time."
+          "text": "Creatures and lands you control untap at the same time as the active player's permanents. You can't choose to not untap them at that time."
         },
         {
           "date": "2013-09-15",
-          "text": "Effects that state a creature or land you control doesn’t untap during your untap step won’t apply during another player’s untap step."
+          "text": "Effects that state a creature or land you control doesn't untap during your untap step won't apply during another player's untap step."
         },
         {
           "date": "2013-09-15",
-          "text": "Controlling more than one Prophet of Kruphix doesn’t allow you to untap any creature or land more than once during a single untap step."
+          "text": "Controlling more than one Prophet of Kruphix doesn't allow you to untap any creature or land more than once during a single untap step."
         },
         {
           "date": "2013-09-15",
-          "text": "If you’re casting a creature spell with bestow, whether or not it has flash will depend on if you’re casting it as a creature or as an Aura. Prophet of Kruphix won’t give flash to a spell with bestow you’re casting as an Aura."
+          "text": "If you're casting a creature spell with bestow, whether or not it has flash will depend on if you're casting it as a creature or as an Aura. Prophet of Kruphix won't give flash to a spell with bestow you're casting as an Aura."
         },
         {
           "date": "2013-09-15",
-          "text": "The last ability applies to creature cards in any zone, provided something is allowing you to cast them. For example, if you control a Zombie, you could cast Gravecrawler (a creature with “You may cast Gravecrawler from your graveyard as long as you control a Zombie”) from your graveyard as though it had flash."
+          "text": "The last ability applies to creature cards in any zone, provided something is allowing you to cast them. For example, if you control a Zombie, you could cast Gravecrawler (a creature with \"You may cast Gravecrawler from your graveyard as long as you control a Zombie\") from your graveyard as though it had flash."
         }
       ],
       "subtypes": [
@@ -24263,7 +24326,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Reaper of the Wilds’s first ability triggers separately for each creature. For example, if five creatures die at the same time, you’ll scry 1 five times. You won’t scry 5."
+          "text": "Reaper of the Wilds's first ability triggers separately for each creature. For example, if five creatures die at the same time, you'll scry 1 five times. You won't scry 5."
         },
         {
           "date": "2013-09-15",
@@ -24279,11 +24342,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "subtypes": [
@@ -24517,11 +24580,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         },
         {
           "date": "2013-09-15",
-          "text": "The last ability affects creatures that are already attacking when it resolves. Activating it before combat won’t affect any creatures that attack later that turn."
+          "text": "The last ability affects creatures that are already attacking when it resolves. Activating it before combat won't affect any creatures that attack later that turn."
         }
       ],
       "subtypes": [
@@ -24640,7 +24703,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The ability that defines Spellheart Chimera’s power functions in all zones, not just the battlefield."
+          "text": "The ability that defines Spellheart Chimera's power functions in all zones, not just the battlefield."
         }
       ],
       "subtypes": [
@@ -24758,7 +24821,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Steam Augury doesn’t target any opponent. In a multiplayer game, you choose the opponent as the spell resolves."
+          "text": "Steam Augury doesn't target any opponent. In a multiplayer game, you choose the opponent as the spell resolves."
         },
         {
           "date": "2013-09-15",
@@ -24874,7 +24937,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The creature that returns to the battlefield during the resolution of Triad of the Fate’s middle ability does so as a new object, with no memory of its previous existence. It won’t have a fate counter on it."
+          "text": "The creature that returns to the battlefield during the resolution of Triad of the Fate's middle ability does so as a new object, with no memory of its previous existence. It won't have a fate counter on it."
         }
       ],
       "subtypes": [
@@ -24995,7 +25058,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Tymaret’s last ability can be activated only if Tymaret is in your graveyard. Notably, Tymaret can’t be sacrificed to return itself."
+          "text": "Tymaret's last ability can be activated only if Tymaret is in your graveyard. Notably, Tymaret can't be sacrificed to return itself."
         }
       ],
       "subtypes": [
@@ -25115,11 +25178,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "If you can’t exile Underworld Cerberus when its last ability resolves, perhaps because it’s been exiled by another spell or ability, each player will still return all creature cards from his or her graveyard to his or her hand."
+          "text": "If you can't exile Underworld Cerberus when its last ability resolves, perhaps because it's been exiled by another spell or ability, each player will still return all creature cards from his or her graveyard to his or her hand."
         },
         {
           "date": "2013-09-15",
-          "text": "If two of these die at the same time, the last ability of each will trigger. If each player controlled one, the nonactive player’s ability will resolve first. The Underworld Cerberus controlled by that player will be exiled, and all other creature cards in graveyards (including the Underworld Cerberus controlled by the active player) will be returned to their owners’ hands. Then the active player’s ability will resolve. That Underworld Cerberus won’t be exiled, but any creature cards in graveyards at that time, perhaps because they died in response to this ability, will be returned to their owners’ hands."
+          "text": "If two of these die at the same time, the last ability of each will trigger. If each player controlled one, the nonactive player's ability will resolve first. The Underworld Cerberus controlled by that player will be exiled, and all other creature cards in graveyards (including the Underworld Cerberus controlled by the active player) will be returned to their owners' hands. Then the active player's ability will resolve. That Underworld Cerberus won't be exiled, but any creature cards in graveyards at that time, perhaps because they died in response to this ability, will be returned to their owners' hands."
         }
       ],
       "subtypes": [
@@ -25235,7 +25298,7 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Xenagos’s first ability isn’t a mana ability. It uses the stack and can be responded to. Count the number of creatures you control as the ability resolves to determine how much mana to add to your mana pool. You choose how much of that mana is red and how much is green at that time."
+          "text": "Xenagos's first ability isn't a mana ability. It uses the stack and can be responded to. Count the number of creatures you control as the ability resolves to determine how much mana to add to your mana pool. You choose how much of that mana is red and how much is green at that time."
         },
         {
           "date": "2013-09-15",
@@ -25347,11 +25410,11 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Akroan Horse’s enters-the-battlefield ability doesn’t target any opponent. In a multiplayer game, you choose the opponent as the ability resolves."
+          "text": "Akroan Horse's enters-the-battlefield ability doesn't target any opponent. In a multiplayer game, you choose the opponent as the ability resolves."
         },
         {
           "date": "2013-09-15",
-          "text": "In the last ability, “each opponent” refers to opponents of Akroan Horse’s controller. In most situations in two-player games, your opponent will control Akroan Horse and you’ll put Soldier tokens onto the battlefield."
+          "text": "In the last ability, \"each opponent\" refers to opponents of Akroan Horse's controller. In most situations in two-player games, your opponent will control Akroan Horse and you'll put Soldier tokens onto the battlefield."
         }
       ],
       "subtypes": [
@@ -25774,19 +25837,19 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "Colossus of Akros doesn’t lose defender when it’s monstrous. It’s just able to attack."
+          "text": "Colossus of Akros doesn't lose defender when it's monstrous. It's just able to attack."
         },
         {
           "date": "2013-09-15",
-          "text": "Once a creature becomes monstrous, it can’t become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
+          "text": "Once a creature becomes monstrous, it can't become monstrous again. If the creature is already monstrous when the monstrosity ability resolves, nothing happens."
         },
         {
           "date": "2013-09-15",
-          "text": "Monstrous isn’t an ability that a creature has. It’s just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
+          "text": "Monstrous isn't an ability that a creature has. It's just something true about that creature. If the creature stops being a creature or loses its abilities, it will continue to be monstrous."
         },
         {
           "date": "2013-09-15",
-          "text": "An ability that triggers when a creature becomes monstrous won’t trigger if that creature isn’t on the battlefield when its monstrosity ability resolves."
+          "text": "An ability that triggers when a creature becomes monstrous won't trigger if that creature isn't on the battlefield when its monstrosity ability resolves."
         }
       ],
       "subtypes": [
@@ -26408,7 +26471,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If Pyxis of Pandemonium leaves the battlefield, and later another Pyxis of Pandemonium enters the battlefield, it is a new object (even if the two were represented the same card). Cards exiled by the original one can’t be turned face up or put onto the battlefield by the second one."
+          "text": "If Pyxis of Pandemonium leaves the battlefield, and later another Pyxis of Pandemonium enters the battlefield, it is a new object (even if the two were represented the same card). Cards exiled by the original one can't be turned face up or put onto the battlefield by the second one."
         }
       ],
       "text": "{T}: Each player exiles the top card of his or her library face down.\n{7}, {T}, Sacrifice Pyxis of Pandemonium: Each player turns face up all cards he or she owns exiled with Pyxis of Pandemonium, then puts all permanent cards among them onto the battlefield.",
@@ -26477,6 +26540,10 @@
       "imageName": "traveler's amulet",
       "layout": "normal",
       "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
         {
           "format": "Commander",
           "legality": "Legal"
@@ -26617,6 +26684,24 @@
         "THS"
       ],
       "rarity": "Uncommon",
+      "rulings": [
+        {
+          "date": "2013-09-15",
+          "text": "When you scry, you may put all the cards you look at back on top of your library, you may put all of those cards on the bottom of your library, or you may put some of those cards on top and the rest of them on the bottom."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "You choose how to order cards returned to your library after scrying no matter where you put them."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
+        },
+        {
+          "date": "2013-09-15",
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
+        }
+      ],
       "subtypes": [
         "Equipment"
       ],
@@ -26718,15 +26803,15 @@
       "rulings": [
         {
           "date": "2013-09-15",
-          "text": "The second ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "The second ability is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-09-15",
-          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don’t count toward your devotion to any color."
+          "text": "Numeric mana symbols ({0}, {1}, and so on) in mana costs of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
-          "text": "Mana symbols in the text boxes of permanents you control don’t count toward your devotion to any color."
+          "text": "Mana symbols in the text boxes of permanents you control don't count toward your devotion to any color."
         },
         {
           "date": "2013-09-15",
@@ -26734,7 +26819,7 @@
         },
         {
           "date": "2013-09-15",
-          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it’s still on the battlefield at that time."
+          "text": "If an activated ability or triggered ability has an effect that depends on your devotion to a color, you count the number of mana symbols of that color among the mana costs of permanents you control as the ability resolves. The permanent with that ability will be counted if it's still on the battlefield at that time."
         }
       ],
       "supertypes": [
@@ -26850,11 +26935,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {R} or {G} to your mana pool.",
@@ -26967,11 +27052,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {U} or {B} to your mana pool.",
@@ -27085,11 +27170,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {G} or {U} to your mana pool.",
@@ -27202,11 +27287,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {W} or {B} to your mana pool.",
@@ -27319,11 +27404,11 @@
         },
         {
           "date": "2013-09-15",
-          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you’ll scry last. For others, that means you’ll scry and then perform other actions."
+          "text": "You perform the actions stated on a card in sequence. For some spells and abilities, that means you'll scry last. For others, that means you'll scry and then perform other actions."
         },
         {
           "date": "2013-09-15",
-          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability’s targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won’t scry."
+          "text": "Scry appears on some spells and abilities with one or more targets. If all of the spell or ability's targets are illegal when it tries to resolve, it will be countered and none of its effects will happen. You won't scry."
         }
       ],
       "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {R} or {W} to your mana pool.",
@@ -28587,11 +28672,6 @@
       ],
       "foreignNames": [
         {
-          "language": "Chinese Simplified",
-          "name": "平原",
-          "multiverseid": 373782
-        },
-        {
           "language": "Chinese Traditional",
           "name": "平原",
           "multiverseid": 374031
@@ -28677,21 +28757,6 @@
           "multiverseid": 375027
         },
         {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 375076
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 375148
-        },
-        {
-          "language": "Japanese",
-          "name": "平地",
-          "multiverseid": 375194
-        },
-        {
           "language": "Korean",
           "name": "들",
           "multiverseid": 375276
@@ -28710,6 +28775,26 @@
           "language": "Korean",
           "name": "들",
           "multiverseid": 375443
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 376023
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 376072
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 376144
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura",
+          "multiverseid": 376190
         }
       ],
       "id": "f7207bfef1ba679e6e20987ea13f1330e4256443",
@@ -33680,9 +33765,9 @@
           "multiverseid": 375431
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 376058
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 375809
         }
       ],
       "id": "d5c32cfc87621e66aeeecd647733a49cf5d237b8",
@@ -34063,9 +34148,9 @@
           "multiverseid": 375431
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 376058
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 375809
         }
       ],
       "id": "c71c95d25108f0ccd1224320c51724d03f3996a1",
@@ -34446,9 +34531,9 @@
           "multiverseid": 375431
         },
         {
-          "language": "Spanish",
-          "name": "Bosque",
-          "multiverseid": 376058
+          "language": "Russian",
+          "name": "Лес",
+          "multiverseid": 375809
         }
       ],
       "id": "63a800d61ec2c3fe5705d6d9d7e01620f6c5635a",
@@ -34794,21 +34879,6 @@
           "multiverseid": 375062
         },
         {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 375109
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 375119
-        },
-        {
-          "language": "Japanese",
-          "name": "森",
-          "multiverseid": 375182
-        },
-        {
           "language": "Korean",
           "name": "숲",
           "multiverseid": 375311
@@ -34832,6 +34902,21 @@
           "language": "Spanish",
           "name": "Bosque",
           "multiverseid": 376058
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 376105
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 376115
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque",
+          "multiverseid": 376178
         }
       ],
       "id": "48f0325939e91f340a8435de01fc5b4fb3a76ed9",

--- a/json/TMP.json
+++ b/json/TMP.json
@@ -281,11 +281,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t choose to cast a creature as though it had flash via Aluren and still pay the mana cost. You either cast the creature normally, or via Aluren without paying the mana cost."
+          "text": "You can't choose to cast a creature as though it had flash via Aluren and still pay the mana cost. You either cast the creature normally, or via Aluren without paying the mana cost."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t use Aluren when casting a creature using another alternate means, such as the Morph ability."
+          "text": "You can't use Aluren when casting a creature using another alternate means, such as the Morph ability."
         },
         {
           "date": "2008-08-01",
@@ -642,11 +642,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -885,11 +885,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -1211,7 +1211,8 @@
         "TMP",
         "6ED",
         "7ED",
-        "8ED"
+        "8ED",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Destroy all Islands.",
@@ -1262,23 +1263,23 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “if you do” part is only done if you successfully sacrifice this card. In other words, it has to be on the battlefield when the trigger resolves or it does not deal damage."
+          "text": "The \"if you do\" part is only done if you successfully sacrifice this card. In other words, it has to be on the battlefield when the trigger resolves or it does not deal damage."
         },
         {
           "date": "2005-08-01",
-          "text": "The choice of which card to name is part of the resolution of the spell or ability which puts Booby Trap onto the battlefield. It can’t be countered."
+          "text": "The choice of which card to name is part of the resolution of the spell or ability which puts Booby Trap onto the battlefield. It can't be countered."
         },
         {
           "date": "2005-08-01",
-          "text": "If an effect causes the player to draw multiple cards, each card is revealed as it’s drawn. If Booby Trap’s ability triggers, it will go on the stack once the card-drawing effect has concluded."
+          "text": "If an effect causes the player to draw multiple cards, each card is revealed as it's drawn. If Booby Trap's ability triggers, it will go on the stack once the card-drawing effect has concluded."
         },
         {
           "date": "2005-08-01",
-          "text": "If a single Booby Trap’s ability triggers multiple times, then only the first ability to resolve causes Booby Trap to be sacrificed and damage to be dealt."
+          "text": "If a single Booby Trap's ability triggers multiple times, then only the first ability to resolve causes Booby Trap to be sacrificed and damage to be dealt."
         },
         {
           "date": "2005-08-01",
-          "text": "If Booby Trap’s last ability is countered, Booby Trap remains on the battlefield (and no damage is dealt)."
+          "text": "If Booby Trap's last ability is countered, Booby Trap remains on the battlefield (and no damage is dealt)."
         }
       ],
       "text": "As Booby Trap enters the battlefield, choose an opponent and a card name other than a basic land card name.\nThe chosen player reveals each card he or she draws.\nWhen the chosen player draws a card with the chosen name, sacrifice Booby Trap. If you do, Booby Trap deals 10 damage to that player.",
@@ -1713,7 +1714,8 @@
       "printings": [
         "TMP",
         "pFNM",
-        "TPR"
+        "TPR",
+        "MPS_AKH"
       ],
       "rarity": "Common",
       "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nReturn target permanent to its owner's hand.",
@@ -1770,7 +1772,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "A creature with Protection from Creatures can’t be targeted by this card’s ability."
+          "text": "A creature with Protection from Creatures can't be targeted by this card's ability."
         }
       ],
       "subtypes": [
@@ -1985,7 +1987,8 @@
       "originalType": "Enchantment",
       "printings": [
         "TMP",
-        "8ED"
+        "8ED",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Islands don't untap during their controllers' untap steps.",
@@ -2103,7 +2106,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2179,7 +2182,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2255,7 +2258,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2335,7 +2338,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2463,7 +2466,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2576,11 +2579,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -3235,7 +3238,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you have no cards in hand, you still have to name a card. Then you fail to reveal one (since there aren’t any). Since the named card wasn’t revealed, no damage is dealt."
+          "text": "If you have no cards in hand, you still have to name a card. Then you fail to reveal one (since there aren't any). Since the named card wasn't revealed, no damage is dealt."
         }
       ],
       "text": "{3}, {T}: Choose a card name, then reveal a card at random from your hand. If that card has the chosen name, Cursed Scroll deals 2 damage to target creature or player.",
@@ -3763,7 +3766,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -3990,7 +3993,8 @@
         "pARL",
         "TMP",
         "BTD",
-        "TPR"
+        "TPR",
+        "MPS_AKH"
       ],
       "rarity": "Common",
       "text": "Target player sacrifices a creature.",
@@ -4046,7 +4050,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A spell or ability that tells a player to “put a land onto the battlefield” does not count as playing a land."
+          "text": "A spell or ability that tells a player to \"put a land onto the battlefield\" does not count as playing a land."
         }
       ],
       "subtypes": [
@@ -4513,7 +4517,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The cards are face down all the time. You can’t look at them. This applies even to cards from your hand that got swapped out. You have to remember what they were if you care."
+          "text": "The cards are face down all the time. You can't look at them. This applies even to cards from your hand that got swapped out. You have to remember what they were if you care."
         },
         {
           "date": "2008-04-01",
@@ -4521,7 +4525,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Taking control of another player’s Duplicity will trigger the ability that causes the cards they exiled to be put into their owner’s graveyard."
+          "text": "Taking control of another player's Duplicity will trigger the ability that causes the cards they exiled to be put into their owner's graveyard."
         }
       ],
       "text": "When Duplicity enters the battlefield, exile the top five cards of your library face down.\nAt the beginning of your upkeep, you may exile all cards from your hand face down. If you do, put all other cards you own exiled with Duplicity into your hand.\nAt the beginning of your end step, discard a card.\nWhen you lose control of Duplicity, put all cards exiled with Duplicity into their owner's graveyard.",
@@ -4948,7 +4952,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -4968,7 +4972,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Green spells you cast cost {1} less to cast.",
@@ -5222,11 +5226,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -5290,35 +5294,35 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Ertai’s Meddling can’t be cast through any way that doesn’t pay its mana cost. This is because the X in the Meddling’s mana cost can’t be 0, but effects that allow spells to be cast without paying their mana costs set X to 0."
+          "text": "Ertai's Meddling can't be cast through any way that doesn't pay its mana cost. This is because the X in the Meddling's mana cost can't be 0, but effects that allow spells to be cast without paying their mana costs set X to 0."
         },
         {
           "date": "2004-10-04",
-          "text": "If a copy of a spell (one that has no card representing it) is affected by Ertai’s Meddling, the spell ceases to exist when exiled. It will not gain counters and will not be put back on the stack."
+          "text": "If a copy of a spell (one that has no card representing it) is affected by Ertai's Meddling, the spell ceases to exist when exiled. It will not gain counters and will not be put back on the stack."
         },
         {
           "date": "2004-10-04",
-          "text": "Once it is put back on the stack, it is a “new” spell again and can be countered or even targeted by another Ertai’s Meddling."
+          "text": "Once it is put back on the stack, it is a \"new\" spell again and can be countered or even targeted by another Ertai's Meddling."
         },
         {
           "date": "2004-10-04",
-          "text": "If Ertai’s Meddling is used to copy a spell being cast face down due to Morph ability, the spell will create a face up, 2/2, colorless, nameless creature with no text. This may be a little counter-intuitive, because you might expect the card to enter the battlefield face down like it would have when originally cast, but Ertai’s Meddling copies only the original spell and not the entire card the spell represented."
+          "text": "If Ertai's Meddling is used to copy a spell being cast face down due to Morph ability, the spell will create a face up, 2/2, colorless, nameless creature with no text. This may be a little counter-intuitive, because you might expect the card to enter the battlefield face down like it would have when originally cast, but Ertai's Meddling copies only the original spell and not the entire card the spell represented."
         },
         {
           "date": "2008-04-01",
-          "text": "This now exiles the spell as part of Ertai’s Meddling’s resolution, instead of waiting for the targeted spell to start resolving."
+          "text": "This now exiles the spell as part of Ertai's Meddling's resolution, instead of waiting for the targeted spell to start resolving."
         },
         {
           "date": "2011-01-22",
-          "text": "If the spell was cast using flashback, Ertai’s Meddling will still exile it with delay counters on it. When the card is returned to the stack, it still “remembers” the flashback cost was originally paid. It’ll be exiled when it resolves or otherwise leaves the stack."
+          "text": "If the spell was cast using flashback, Ertai's Meddling will still exile it with delay counters on it. When the card is returned to the stack, it still \"remembers\" the flashback cost was originally paid. It'll be exiled when it resolves or otherwise leaves the stack."
         },
         {
           "date": "2013-04-15",
-          "text": "If Ertai’s Meddling is used to copy an arcane spell that had effects spliced onto it, it will create a spell with all of those effects. That spell’s controller will not be able to splice additional effects onto the spell, since they did not re-cast the spell and instead simply put it back onto the stack."
+          "text": "If Ertai's Meddling is used to copy an arcane spell that had effects spliced onto it, it will create a spell with all of those effects. That spell's controller will not be able to splice additional effects onto the spell, since they did not re-cast the spell and instead simply put it back onto the stack."
         },
         {
           "date": "2013-04-15",
-          "text": "Ertai’s Meddling has the spell’s controller put the spell back onto the stack; it does not have its controller cast the spell again. Anything that triggers off of casting spells, such as Contemplation , won’t trigger. Simillarly, effects that count spells that are cast (like Rule of Law) or prevent spells from being cast (like Iona, Shield of Emeria) won’t count or affect the copy that is put onto the stack since the copy wasn’t cast."
+          "text": "Ertai's Meddling has the spell's controller put the spell back onto the stack; it does not have its controller cast the spell again. Anything that triggers off of casting spells, such as Contemplation , won't trigger. Simillarly, effects that count spells that are cast (like Rule of Law) or prevent spells from being cast (like Iona, Shield of Emeria) won't count or affect the copy that is put onto the stack since the copy wasn't cast."
         }
       ],
       "text": "X can't be 0.\nTarget spell's controller exiles it with X delay counters on it.\nAt the beginning of each of that player's upkeeps, if that card is exiled, remove a delay counter from it. If the card has no delay counters on it, he or she puts it onto the stack as a copy of the original spell.",
@@ -5511,7 +5515,7 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "If a land with the supertype “basic” somehow has multiple subtypes, then the creature will gain landwalk of all those types."
+          "text": "If a land with the supertype \"basic\" somehow has multiple subtypes, then the creature will gain landwalk of all those types."
         }
       ],
       "text": "{T}, Sacrifice a basic land: Target creature gains landwalk of each of the land types of the sacrificed land until end of turn. (It can't be blocked as long as defending player controls a land of any of those types.)",
@@ -5660,7 +5664,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A creature card that you own but don’t control will be put into your graveyard if that creature dies, and Field of Souls’s ability will trigger."
+          "text": "A creature card that you own but don't control will be put into your graveyard if that creature dies, and Field of Souls's ability will trigger."
         }
       ],
       "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, create a 1/1 white Spirit creature token with flying.",
@@ -5931,7 +5935,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you choose White, the enchanted creature will have Protection from White. This will cause any other white Auras attached to that creature to be put into their owner’s graveyard, but Flickering Ward will remain on the battlefield."
+          "text": "If you choose White, the enchanted creature will have Protection from White. This will cause any other white Auras attached to that creature to be put into their owner's graveyard, but Flickering Ward will remain on the battlefield."
         }
       ],
       "subtypes": [
@@ -7366,7 +7370,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can’t normally end up with an odd amount of damage on something."
+          "text": "If a spell or ability damages multiple things, divide up the damage before applying this effect. This means you can't normally end up with an odd amount of damage on something."
         },
         {
           "date": "2004-10-04",
@@ -7382,7 +7386,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn.” Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn.\" Suppose a spell would deal 5 damage to a player who has cast Mending Hands targeting himself or herself. That player can either (a) prevent 4 damage first and then let Furnace of Rath double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         }
       ],
       "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
@@ -7841,6 +7845,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -7882,7 +7890,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -8106,7 +8114,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can’t pay this cost more than once to get a multiple effect."
+          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can't pay this cost more than once to get a multiple effect."
         },
         {
           "date": "2004-10-04",
@@ -8114,7 +8122,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
@@ -8222,11 +8230,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -8535,11 +8543,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -8667,11 +8675,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "This is the current interaction between Humility and Opalescence: The type-changing effect applies at layer 4, but the rest happens in the applicable layers. The rest of it will apply even if the permanent loses its ability before it’s finished applying. So if Opalescence, Humility, and Worship are on the battlefield and Opalescence entered the battlefield before Humility, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments. (Opalescence). Layer 6: Humility and Worship each lose their abilities. (Humility) Layer 7b: Humility becomes 4/4 and Worship becomes 4/4. (Opalescence). Humility becomes 1/1 and Worship becomes 1/1 (Humility). But if Humility entered the battlefield before Opalescence, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments (Opalescence). Layer 6: Humility and Worship each lose their abilities (Humility). Layer 7b: Humility becomes 1/1 and Worship becomes 1/1 (Humility). Humility becomes 4/4 and Worship becomes 4/4 (Opalescence)."
+          "text": "This is the current interaction between Humility and Opalescence: The type-changing effect applies at layer 4, but the rest happens in the applicable layers. The rest of it will apply even if the permanent loses its ability before it's finished applying. So if Opalescence, Humility, and Worship are on the battlefield and Opalescence entered the battlefield before Humility, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments. (Opalescence). Layer 6: Humility and Worship each lose their abilities. (Humility) Layer 7b: Humility becomes 4/4 and Worship becomes 4/4. (Opalescence). Humility becomes 1/1 and Worship becomes 1/1 (Humility). But if Humility entered the battlefield before Opalescence, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments (Opalescence). Layer 6: Humility and Worship each lose their abilities (Humility). Layer 7b: Humility becomes 1/1 and Worship becomes 1/1 (Humility). Humility becomes 4/4 and Worship becomes 4/4 (Opalescence)."
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "text": "All creatures lose all abilities and have base power and toughness 1/1.",
@@ -8821,7 +8829,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Counter target activated ability from an artifact, creature, enchantment, or land. That permanent's activated abilities can't be activated this turn. (Mana abilities can't be targeted.)\nDraw a card.",
@@ -8876,7 +8884,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Targets an opponent. You choose an opponent during announcement. If you can’t target an opponent, you can’t cast this card."
+          "text": "Targets an opponent. You choose an opponent during announcement. If you can't target an opponent, you can't cast this card."
         }
       ],
       "text": "Search your library for three cards and reveal them. Target opponent chooses one. Put that card into your hand and the rest into your graveyard. Then shuffle your library.",
@@ -10023,7 +10031,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -10043,7 +10051,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Black spells you cast cost {1} less to cast.",
@@ -10100,11 +10108,11 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The control-change effect has no duration. The targeted player retains control of Jinxed Idol until the game ends, Jinxed Idol leaves the battlefield, or an effect causes someone else to gain control of it (perhaps because Jinxed Idol’s ability is activated again)."
+          "text": "The control-change effect has no duration. The targeted player retains control of Jinxed Idol until the game ends, Jinxed Idol leaves the battlefield, or an effect causes someone else to gain control of it (perhaps because Jinxed Idol's ability is activated again)."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "text": "At the beginning of your upkeep, Jinxed Idol deals 2 damage to you.\nSacrifice a creature: Target opponent gains control of Jinxed Idol.",
@@ -10430,11 +10438,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -10491,7 +10499,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “power less than or equal to the number of treasure counters on this card” restriction is a targeting restriction and will be checked on resolution in addition to on announcement. If the creature’s power changes to be greater than this before the effect resolves, then the Legacy’s Allure triggered ability is countered, but the card stays in the graveyard."
+          "text": "The \"power less than or equal to the number of treasure counters on this card\" restriction is a targeting restriction and will be checked on resolution in addition to on announcement. If the creature's power changes to be greater than this before the effect resolves, then the Legacy's Allure triggered ability is countered, but the card stays in the graveyard."
         }
       ],
       "text": "At the beginning of your upkeep, you may put a treasure counter on Legacy's Allure.\nSacrifice Legacy's Allure: Gain control of target creature with power less than or equal to the number of treasure counters on Legacy's Allure. (This effect lasts indefinitely.)",
@@ -10509,7 +10517,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "Squee tucked the warm ball in his pocket and slipped a pebble in its place. ‘Glok,' he mumbled, and hid.",
+      "flavor": "Squee tucked the warm ball in his pocket and slipped a pebble in its place. 'Glok,' he mumbled, and hid.",
       "id": "2d471b4dc4d7717bbb71597ffb89f3c1dcb2d36b",
       "imageName": "legerdemain",
       "layout": "normal",
@@ -10545,7 +10553,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "You can’t cast Legerdemain unless both targets share a type at that time. It will also check to make sure they share a type as it resolves. If they no longer do so, the exchange will not occur."
+          "text": "You can't cast Legerdemain unless both targets share a type at that time. It will also check to make sure they share a type as it resolves. If they no longer do so, the exchange will not occur."
         }
       ],
       "text": "Exchange control of target artifact or creature and another target permanent that shares one of those types with it. (This effect lasts indefinitely.)",
@@ -10771,7 +10779,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures which are sacrificed can’t be regenerated."
+          "text": "The creatures which are sacrificed can't be regenerated."
         },
         {
           "date": "2004-10-04",
@@ -10779,7 +10787,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
+          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
         }
       ],
       "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -10839,7 +10847,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You only get to pick one card from the player’s hand."
+          "text": "You only get to pick one card from the player's hand."
         },
         {
           "date": "2004-10-04",
@@ -11004,7 +11012,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a creature can’t attack because of some restriction, or because it is tapped, it is destroyed at the end of the turn."
+          "text": "If a creature can't attack because of some restriction, or because it is tapped, it is destroyed at the end of the turn."
         }
       ],
       "subtypes": [
@@ -11617,11 +11625,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -11679,19 +11687,19 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast a Sliver as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast a Sliver as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -11748,7 +11756,7 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "The life is paid as Minion of the Wastes enters the battlefield. If Minion of the Wastes is countered, you don’t get the opportunity to pay any life."
+          "text": "The life is paid as Minion of the Wastes enters the battlefield. If Minion of the Wastes is countered, you don't get the opportunity to pay any life."
         }
       ],
       "subtypes": [
@@ -11854,11 +11862,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -11958,7 +11966,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -12029,7 +12037,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it’s too late to activate its ability before it’s destroyed."
+          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it's too late to activate its ability before it's destroyed."
         }
       ],
       "subtypes": [
@@ -13388,11 +13396,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -13507,7 +13515,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "All lands are 2/2 creatures that are still lands.",
@@ -13661,11 +13669,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -13967,7 +13975,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -14209,7 +14217,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -14229,7 +14237,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "White spells you cast cost {1} less to cast.",
@@ -14375,7 +14383,7 @@
         },
         {
           "date": "2006-10-15",
-          "text": "It does not target the cards, but it targets the opponent. If you can’t target an opponent, you can’t activate this ability."
+          "text": "It does not target the cards, but it targets the opponent. If you can't target an opponent, you can't activate this ability."
         }
       ],
       "text": "{4}, {T}: Target opponent chooses one of the top two cards of your graveyard. Exile that card and put the other one into your hand.",
@@ -15727,7 +15735,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -15854,7 +15862,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -15949,11 +15957,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -16097,7 +16105,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -16372,7 +16380,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You lose life equal to the converted mana cost of the card you’re bringing back, so if you Reanimate Volrath’s Shapeshifter, you lose three life, regardless of what the next card down is."
+          "text": "You lose life equal to the converted mana cost of the card you're bringing back, so if you Reanimate Volrath's Shapeshifter, you lose three life, regardless of what the next card down is."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
@@ -16605,7 +16613,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Any change to a land’s type or splicing of text into a land can affect the types of mana a land can produce."
+          "text": "Any change to a land's type or splicing of text into a land can affect the types of mana a land can produce."
         },
         {
           "date": "2008-05-01",
@@ -16613,15 +16621,15 @@
         },
         {
           "date": "2008-05-01",
-          "text": "Reflecting Pool checks the effects of all mana-producing abilities of lands you control, but it doesn’t check their costs. For example, Vivid Crag says “{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.” If you control Vivid Crag and Reflecting Pool, you can tap Reflecting Pool for any color of mana. It doesn’t matter whether Vivid Crag has a charge counter on it, and it doesn’t matter whether it’s untapped."
+          "text": "Reflecting Pool checks the effects of all mana-producing abilities of lands you control, but it doesn't check their costs. For example, Vivid Crag says \"{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.\" If you control Vivid Crag and Reflecting Pool, you can tap Reflecting Pool for any color of mana. It doesn't matter whether Vivid Crag has a charge counter on it, and it doesn't matter whether it's untapped."
         },
         {
           "date": "2008-05-01",
-          "text": "Reflecting Pool doesn’t care about any restrictions or riders your lands put on the mana they produce, such as Pillar of the Paruns and Hall of the Bandit Lord do. It just cares about types of mana."
+          "text": "Reflecting Pool doesn't care about any restrictions or riders your lands put on the mana they produce, such as Pillar of the Paruns and Hall of the Bandit Lord do. It just cares about types of mana."
         },
         {
           "date": "2008-05-01",
-          "text": "Multiple Reflecting Pools won’t help each other produce mana. If you control a Reflecting Pool, and all other lands you control either lack mana abilities or are other Reflecting Pools, you may still activate Reflecting Pool’s ability — it just won’t produce any mana."
+          "text": "Multiple Reflecting Pools won't help each other produce mana. If you control a Reflecting Pool, and all other lands you control either lack mana abilities or are other Reflecting Pools, you may still activate Reflecting Pool's ability — it just won't produce any mana."
         }
       ],
       "text": "{T}: Add to your mana pool one mana of any type that a land you control could produce.",
@@ -16840,7 +16848,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If X is greater than 0, you can’t choose zero targets. You must choose between one and X targets. If X is 0, you can’t choose any targets."
+          "text": "If X is greater than 0, you can't choose zero targets. You must choose between one and X targets. If X is 0, you can't choose any targets."
         },
         {
           "date": "2015-08-25",
@@ -16852,7 +16860,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can’t change the way damage is divided."
+          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can't change the way damage is divided."
         }
       ],
       "text": "Rolling Thunder deals X damage divided as you choose among any number of target creatures and/or players.",
@@ -17025,7 +17033,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -17239,11 +17247,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "A creature is “enchanted” if it has any Auras attached to it."
+          "text": "A creature is \"enchanted\" if it has any Auras attached to it."
         },
         {
           "date": "2007-07-15",
-          "text": "Unlike many similar creatures, Rootwater Matriarch untaps as normal during your untap step. Whether it’s tapped or untapped has no bearing on the control-change effect."
+          "text": "Unlike many similar creatures, Rootwater Matriarch untaps as normal during your untap step. Whether it's tapped or untapped has no bearing on the control-change effect."
         },
         {
           "date": "2009-02-01",
@@ -17351,7 +17359,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -17371,7 +17379,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Red spells you cast cost {1} less to cast.",
@@ -17583,7 +17591,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"I used to describe something stable as ‘rock solid.' So much for that expression.\"\n—Gerrard of the Weatherlight",
+      "flavor": "\"I used to describe something stable as 'rock solid.' So much for that expression.\"\n—Gerrard of the Weatherlight",
       "id": "127ce6b80634f2b3314f6ad16d00f134c2bab8b3",
       "imageName": "sandstone warrior",
       "layout": "normal",
@@ -17672,7 +17680,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -17692,7 +17700,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Blue spells you cast cost {1} less to cast.",
@@ -17953,7 +17961,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Side-effects of spells that would counter this card will still happen, because they happen even if the spell they’re trying to counter can’t be countered."
+          "text": "Side-effects of spells that would counter this card will still happen, because they happen even if the spell they're trying to counter can't be countered."
         },
         {
           "date": "2004-10-04",
@@ -17983,7 +17991,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"They are called ‘fowl' for a reason.\"\n—Mirri of the Weatherlight",
+      "flavor": "\"They are called 'fowl' for a reason.\"\n—Mirri of the Weatherlight",
       "id": "1b0bf0023241fe18bc2229b4056a2601f43b6566",
       "imageName": "screeching harpy",
       "layout": "normal",
@@ -19402,7 +19410,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "For a time, the ability that granted it first strike was a triggered ability. It has been restored to a static ability that applies continuously while the Lancer is attacking. There is never a time when the Lancer is attacking but doesn’t have first strike."
+          "text": "For a time, the ability that granted it first strike was a triggered ability. It has been restored to a static ability that applies continuously while the Lancer is attacking. There is never a time when the Lancer is attacking but doesn't have first strike."
         }
       ],
       "subtypes": [
@@ -19704,11 +19712,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -20022,11 +20030,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{6}: Stalking Stones becomes a 3/3 Elemental artifact creature that's still a land. (This effect lasts indefinitely.)",
@@ -20303,11 +20311,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Paying the cost to end the effect is a special action and can’t be responded to."
+          "text": "Paying the cost to end the effect is a special action and can't be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid’s controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
+          "text": "If a spell that can target enchantments but not creatures (such as Clear) is cast targeting the Licid after it has become an enchantment, but the Licid's controller pays the cost, the Licid will no longer be an enchantment. This will result in the spell being countered on resolution for having no legal targets."
         }
       ],
       "subtypes": [
@@ -20511,11 +20519,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Must be used before blockers are declared in order to affect blocking decisions. You can’t wait to see what your opponent declares and then try to stop them."
+          "text": "Must be used before blockers are declared in order to affect blocking decisions. You can't wait to see what your opponent declares and then try to stop them."
         },
         {
           "date": "2004-10-04",
-          "text": "You can use it after combat or even on a creature which can’t possibly block this turn because it’s that player’s turn to attack, but it generally has no effect other than to let you draw a card."
+          "text": "You can use it after combat or even on a creature which can't possibly block this turn because it's that player's turn to attack, but it generally has no effect other than to let you draw a card."
         }
       ],
       "text": "Target creature can't block this turn.\nDraw a card.",
@@ -21701,11 +21709,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -21877,7 +21885,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"They are ‘between' in every way.\"\n—Lyna, Soltari emissary",
+      "flavor": "\"They are 'between' in every way.\"\n—Lyna, Soltari emissary",
       "id": "becf72ef618870cac6f08b64c29127ef3aec81b5",
       "imageName": "thalakos mistfolk",
       "layout": "normal",
@@ -22185,7 +22193,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Target player takes an extra turn after this one.",
@@ -22575,7 +22583,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If the targeted permanent is an illegal target by the time Twitch resolves, the entire spell is countered. You don’t draw a card."
+          "text": "If the targeted permanent is an illegal target by the time Twitch resolves, the entire spell is countered. You don't draw a card."
         }
       ],
       "text": "You may tap or untap target artifact, creature, or land.\nDraw a card.",
@@ -22641,7 +22649,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When it changes “shape” to a new creature, any “enters the battlefield” abilities of the creature do not trigger."
+          "text": "When it changes \"shape\" to a new creature, any \"enters the battlefield\" abilities of the creature do not trigger."
         },
         {
           "date": "2008-08-01",
@@ -22649,7 +22657,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If an Unstable Shapeshifter is on the battlefield when another Unstable Shapeshifter enters the battlefield, the first one gets the second one’s triggered ability, so will copy the next creature that enters the battlefield twice. It will only do so the next time a creature enters the battlefield, because the second “becomes a copy” effect to resolve will erase the extra triggered ability."
+          "text": "If an Unstable Shapeshifter is on the battlefield when another Unstable Shapeshifter enters the battlefield, the first one gets the second one's triggered ability, so will copy the next creature that enters the battlefield twice. It will only do so the next time a creature enters the battlefield, because the second \"becomes a copy\" effect to resolve will erase the extra triggered ability."
         }
       ],
       "subtypes": [
@@ -22763,7 +22771,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Verdant Force’s controller gets the tokens. That is the controller at the beginning of upkeep."
+          "text": "Verdant Force's controller gets the tokens. That is the controller at the beginning of upkeep."
         },
         {
           "date": "2005-08-01",
@@ -22889,11 +22897,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You don’t choose whether to affect the targeted creature’s power or its toughness until the ability resolves."
+          "text": "You don't choose whether to affect the targeted creature's power or its toughness until the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -22958,7 +22966,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -23226,7 +23234,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -23238,11 +23246,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t change proper nouns (i.e. card names) such as “Island Fish Jasconius”."
+          "text": "You can't change proper nouns (i.e. card names) such as \"Island Fish Jasconius\"."
         },
         {
           "date": "2004-10-04",
-          "text": "It can be used to change a land’s type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn’t change the name of any permanent."
+          "text": "It can be used to change a land's type from one basic land type to another. For example, Forest can be changed to Island so it produces blue mana. It doesn't change the name of any permanent."
         }
       ],
       "text": "Buyback {2} (You may pay an additional {2} as you cast this spell. If you do, put this card into your hand as it resolves.)\nChange the text of target permanent by replacing all instances of one color word with another or one basic land type with another until end of turn. (For example, you may change \"nonred creature\" to \"nongreen creature\" or \"plainswalk\" to \"swampwalk.\")",
@@ -23543,7 +23551,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "A creature is “enchanted” if it has any Auras attached to it."
+          "text": "A creature is \"enchanted\" if it has any Auras attached to it."
         }
       ],
       "text": "Destroy all creatures that aren't enchanted. They can't be regenerated.",
@@ -23599,11 +23607,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [

--- a/json/TOR.json
+++ b/json/TOR.json
@@ -269,7 +269,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Auras returning to the battlefield can only enchant something that was already on the battlefield. An Enchant Enchantment returning to the battlefield can’t be placed on an enchantment that is also in the process of returning to the battlefield."
+          "text": "Auras returning to the battlefield can only enchant something that was already on the battlefield. An Enchant Enchantment returning to the battlefield can't be placed on an enchantment that is also in the process of returning to the battlefield."
         }
       ],
       "text": "Destroy all enchantments.\nThreshold — If seven or more cards are in your graveyard, instead destroy all enchantments, then return all cards in your graveyard destroyed this way to the battlefield.",
@@ -976,7 +976,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Pay No Heed doesn’t target anything. You can choose a source with hexproof, for example. You choose the damage source as Pay No Heed resolves."
+          "text": "Pay No Heed doesn't target anything. You can choose a source with hexproof, for example. You choose the damage source as Pay No Heed resolves."
         },
         {
           "date": "2013-07-01",
@@ -1143,7 +1143,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You must already have seven or more cards in your graveyard before Reborn Hero is put into the graveyard in order for its Threshold ability to trigger; you don’t include Reborn Hero itself in the count."
+          "text": "You must already have seven or more cards in your graveyard before Reborn Hero is put into the graveyard in order for its Threshold ability to trigger; you don't include Reborn Hero itself in the count."
         }
       ],
       "subtypes": [
@@ -1629,7 +1629,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If your life total is 20 or more and you control an effect that states “you can’t lose the game”, then an infinite loop is formed. If neither player wants to end the loop by removing one of these two cards from the battlefield, the game ends in a draw."
+          "text": "If your life total is 20 or more and you control an effect that states \"you can't lose the game\", then an infinite loop is formed. If neither player wants to end the loop by removing one of these two cards from the battlefield, the game ends in a draw."
         }
       ],
       "text": "You don't lose the game for having 0 or less life.\nWhen you have 20 or more life, you lose the game.\nWhenever you lose life, you gain 2 life for each 1 life you lost. (Damage dealt to you causes you to lose life.)",
@@ -1792,7 +1792,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can’t change a word to the same word. It must be a different word."
+          "text": "It can't change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -1984,7 +1984,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -2389,11 +2389,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You draw three cards and discard two cards all while Cephalid Sage’s ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+          "text": "You draw three cards and discard two cards all while Cephalid Sage's ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
         },
         {
           "date": "2016-06-08",
-          "text": "If you don’t have enough cards in your graveyard at the moment Cephalid Sage enters the battlefield, its threshold ability won’t trigger. If the number of cards in your graveyard changes and Cephalid Sage loses the ability once it has triggered, the ability will still resolve."
+          "text": "If you don't have enough cards in your graveyard at the moment Cephalid Sage enters the battlefield, its threshold ability won't trigger. If the number of cards in your graveyard changes and Cephalid Sage loses the ability once it has triggered, the ability will still resolve."
         }
       ],
       "subtypes": [
@@ -3108,15 +3108,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "You control Ghostly Wings even while it enchants an opponent’s creature. Only you can activate the last ability of Ghostly Wings."
+          "text": "You control Ghostly Wings even while it enchants an opponent's creature. Only you can activate the last ability of Ghostly Wings."
         },
         {
           "date": "2016-04-08",
-          "text": "After the last ability of Ghostly Wings resolves, it will be an Aura on the battlefield that isn’t attached to a creature and will immediately be put into its owner’s graveyard."
+          "text": "After the last ability of Ghostly Wings resolves, it will be an Aura on the battlefield that isn't attached to a creature and will immediately be put into its owner's graveyard."
         },
         {
           "date": "2016-04-08",
-          "text": "If Ghostly Wings leaves the battlefield before its activated ability resolves, the creature that was enchanted immediately before Ghostly Wings left is the one that will be returned to its owner’s hand, if it’s still on the battlefield."
+          "text": "If Ghostly Wings leaves the battlefield before its activated ability resolves, the creature that was enchanted immediately before Ghostly Wings left is the one that will be returned to its owner's hand, if it's still on the battlefield."
         },
         {
           "date": "2016-04-08",
@@ -3603,11 +3603,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you target yourself, this spell has no useful effect. It will not cause an infinite loop since a replacement effect can’t modify the same event more than once. This effect will not modify the draw that it has you perform."
+          "text": "If you target yourself, this spell has no useful effect. It will not cause an infinite loop since a replacement effect can't modify the same event more than once. This effect will not modify the draw that it has you perform."
         },
         {
           "date": "2007-07-15",
-          "text": "You draw the card from your library as normal, not from your opponent’s library."
+          "text": "You draw the card from your library as normal, not from your opponent's library."
         },
         {
           "date": "2007-07-15",
@@ -3615,7 +3615,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "If you target a player whose library is empty, any effect or turn-based action that would cause that player to draw a card will cause you to draw a card instead. It doesn’t matter that the other player would be unable to draw."
+          "text": "If you target a player whose library is empty, any effect or turn-based action that would cause that player to draw a card will cause you to draw a card instead. It doesn't matter that the other player would be unable to draw."
         }
       ],
       "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
@@ -3936,11 +3936,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         },
         {
           "date": "2016-06-08",
-          "text": "Unlike many similar abilities, Stupefying Touch’s last ability stops mana abilities from being activated."
+          "text": "Unlike many similar abilities, Stupefying Touch's last ability stops mana abilities from being activated."
         }
       ],
       "subtypes": [
@@ -4815,7 +4815,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If the creature leaves the battlefield, but returns to the battlefield before the triggered ability resolves, you won’t exile it. This is because it is treated as a different object than the one to which the ability refers."
+          "text": "If the creature leaves the battlefield, but returns to the battlefield before the triggered ability resolves, you won't exile it. This is because it is treated as a different object than the one to which the ability refers."
         }
       ],
       "text": "At the beginning of your upkeep, you lose 1 life.\nAt the beginning of your upkeep, you may return target creature card from your graveyard to the battlefield. That creature gains haste until end of turn. Exile it at the beginning of the next end step.",
@@ -5231,7 +5231,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -5319,11 +5319,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If multiple Ichorids are in your graveyard, you can’t exile the same creature card to return each of them to the battlefield."
+          "text": "If multiple Ichorids are in your graveyard, you can't exile the same creature card to return each of them to the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "If one Ichorid’s ability exiles another, the exiled Ichorid’s ability can’t return it to the battlefield."
+          "text": "If one Ichorid's ability exiles another, the exiled Ichorid's ability can't return it to the battlefield."
         }
       ],
       "subtypes": [
@@ -5812,11 +5812,11 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If you don’t have twenty or more creature cards in your graveyard by the time your upkeep starts, the ability won’t trigger that turn."
+          "text": "If you don't have twenty or more creature cards in your graveyard by the time your upkeep starts, the ability won't trigger that turn."
         },
         {
           "date": "2007-07-15",
-          "text": "Mortal Combat’s ability has an “intervening ‘if’ clause,” so the condition is checked again when the triggered ability resolves. If you don’t still have twenty creature cards in your graveyard, the ability does nothing."
+          "text": "Mortal Combat's ability has an \"intervening 'if' clause,\" so the condition is checked again when the triggered ability resolves. If you don't still have twenty creature cards in your graveyard, the ability does nothing."
         }
       ],
       "text": "At the beginning of your upkeep, if twenty or more creature cards are in your graveyard, you win the game.",
@@ -5979,7 +5979,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won’t change later in the turn, even if the number of Swamps you control changes."
+          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won't change later in the turn, even if the number of Swamps you control changes."
         }
       ],
       "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
@@ -6561,15 +6561,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -6732,7 +6732,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The -1/-1 counters you remove don’t have to be the same counters put on the creature by Shambling Swarm."
+          "text": "The -1/-1 counters you remove don't have to be the same counters put on the creature by Shambling Swarm."
         }
       ],
       "subtypes": [
@@ -7941,15 +7941,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -7957,7 +7957,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -7965,11 +7965,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -8211,7 +8211,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The two cards are exiled as the cost of Grim Lavamancer’s ability is paid. Players can’t respond to the paying of costs by trying to move those cards to another zone."
+          "text": "The two cards are exiled as the cost of Grim Lavamancer's ability is paid. Players can't respond to the paying of costs by trying to move those cards to another zone."
         }
       ],
       "subtypes": [
@@ -9546,7 +9546,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t choose zero targets. You must choose at least one target."
+          "text": "You can't choose zero targets. You must choose at least one target."
         }
       ],
       "text": "Violent Eruption deals 4 damage divided as you choose among any number of target creatures and/or players.\nMadness {1}{R}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
@@ -9868,7 +9868,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -9954,11 +9954,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "All creatures under your control when Centaur Chieftain’s triggered ability resolves are affected, including Centaur Chieftain itself. Ones that come under your control or become creatures later in the turn are not."
+          "text": "All creatures under your control when Centaur Chieftain's triggered ability resolves are affected, including Centaur Chieftain itself. Ones that come under your control or become creatures later in the turn are not."
         },
         {
           "date": "2016-06-08",
-          "text": "If you don’t have enough cards in your graveyard at the moment Centaur Chieftain enters the battlefield, its threshold ability won’t trigger. If the number of cards in your graveyard changes and Centaur Chieftain loses the ability once it has triggered, the ability will still resolve."
+          "text": "If you don't have enough cards in your graveyard at the moment Centaur Chieftain enters the battlefield, its threshold ability won't trigger. If the number of cards in your graveyard changes and Centaur Chieftain loses the ability once it has triggered, the ability will still resolve."
         }
       ],
       "subtypes": [
@@ -10277,7 +10277,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         }
       ],
       "subtypes": [
@@ -10359,7 +10359,7 @@
         "TOR"
       ],
       "rarity": "Rare",
-      "text": "The next creature spell you cast this turn can't be countered by spells or abilities.\nDraw a card.",
+      "text": "The next creature spell you cast this turn can't be countered.\nDraw a card.",
       "type": "Sorcery",
       "types": [
         "Sorcery"

--- a/json/TPR.json
+++ b/json/TPR.json
@@ -246,11 +246,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -506,7 +506,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Each permanent not chosen by a player will be sacrificed. If a permanent has none of the listed types (for example, a Planeswalker with no other types), it can’t be chosen."
+          "text": "Each permanent not chosen by a player will be sacrificed. If a permanent has none of the listed types (for example, a Planeswalker with no other types), it can't be chosen."
         }
       ],
       "text": "Each player chooses from among the permanents he or she controls an artifact, a creature, an enchantment, and a land, then sacrifices the rest.",
@@ -633,7 +633,7 @@
       "rulings": [
         {
           "date": "2017-02-09",
-          "text": "Players don’t have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Conviction to its owner’s hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get +1/+3)."
+          "text": "Players don't have priority to cast spells and activate abilities between combat damage being assigned and being dealt. This means that if you want to return Conviction to its owner's hand before combat damage is dealt, you must do so before combat damage is assigned (and the creature will no longer get +1/+3)."
         }
       ],
       "subtypes": [
@@ -857,7 +857,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "A creature card that you own but don’t control will be put into your graveyard if that creature dies, and Field of Souls’s ability will trigger."
+          "text": "A creature card that you own but don't control will be put into your graveyard if that creature dies, and Field of Souls's ability will trigger."
         }
       ],
       "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, create a 1/1 white Spirit creature token with flying.",
@@ -1025,11 +1025,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "This is the current interaction between Humility and Opalescence: The type-changing effect applies at layer 4, but the rest happens in the applicable layers. The rest of it will apply even if the permanent loses its ability before it’s finished applying. So if Opalescence, Humility, and Worship are on the battlefield and Opalescence entered the battlefield before Humility, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments. (Opalescence). Layer 6: Humility and Worship each lose their abilities. (Humility) Layer 7b: Humility becomes 4/4 and Worship becomes 4/4. (Opalescence). Humility becomes 1/1 and Worship becomes 1/1 (Humility). But if Humility entered the battlefield before Opalescence, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments (Opalescence). Layer 6: Humility and Worship each lose their abilities (Humility). Layer 7b: Humility becomes 1/1 and Worship becomes 1/1 (Humility). Humility becomes 4/4 and Worship becomes 4/4 (Opalescence)."
+          "text": "This is the current interaction between Humility and Opalescence: The type-changing effect applies at layer 4, but the rest happens in the applicable layers. The rest of it will apply even if the permanent loses its ability before it's finished applying. So if Opalescence, Humility, and Worship are on the battlefield and Opalescence entered the battlefield before Humility, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments. (Opalescence). Layer 6: Humility and Worship each lose their abilities. (Humility) Layer 7b: Humility becomes 4/4 and Worship becomes 4/4. (Opalescence). Humility becomes 1/1 and Worship becomes 1/1 (Humility). But if Humility entered the battlefield before Opalescence, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments (Opalescence). Layer 6: Humility and Worship each lose their abilities (Humility). Layer 7b: Humility becomes 1/1 and Worship becomes 1/1 (Humility). Humility becomes 4/4 and Worship becomes 4/4 (Opalescence)."
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "text": "All creatures lose all abilities and have base power and toughness 1/1.",
@@ -1271,7 +1271,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It is possible to redirect more damage to a creature than that creature’s toughness."
+          "text": "It is possible to redirect more damage to a creature than that creature's toughness."
         },
         {
           "date": "2004-10-04",
@@ -1720,7 +1720,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It is possible to redirect more damage to a creature than that creature’s toughness."
+          "text": "It is possible to redirect more damage to a creature than that creature's toughness."
         },
         {
           "date": "2004-10-04",
@@ -1803,7 +1803,7 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "A “blocked creature” is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
+          "text": "A \"blocked creature\" is an attacking creature that has been blocked by a creature this combat, or has become blocked as the result of a spell or ability this combat. Unless the attacking creature leaves combat, it continues to be a blocked creature through the end of combat step, even if the creature or creatures that blocked it are no longer on the battlefield or have otherwise left combat by then."
         }
       ],
       "text": "Destroy target blocked creature.",
@@ -1913,7 +1913,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "For a time, the ability that granted it first strike was a triggered ability. It has been restored to a static ability that applies continuously while the Lancer is attacking. There is never a time when the Lancer is attacking but doesn’t have first strike."
+          "text": "For a time, the ability that granted it first strike was a triggered ability. It has been restored to a static ability that applies continuously while the Lancer is attacking. There is never a time when the Lancer is attacking but doesn't have first strike."
         }
       ],
       "subtypes": [
@@ -2160,7 +2160,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It is possible to redirect more damage to a creature than that creature’s toughness."
+          "text": "It is possible to redirect more damage to a creature than that creature's toughness."
         },
         {
           "date": "2004-10-04",
@@ -2416,7 +2416,7 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Wall of Essence’s triggered ability will trigger even if it’s dealt lethal damage. For example, if it’s dealt 7 combat damage, its ability will trigger and you’ll gain 7 life."
+          "text": "Wall of Essence's triggered ability will trigger even if it's dealt lethal damage. For example, if it's dealt 7 combat damage, its ability will trigger and you'll gain 7 life."
         }
       ],
       "subtypes": [
@@ -2484,7 +2484,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It is possible to redirect more damage to a creature than that creature’s toughness."
+          "text": "It is possible to redirect more damage to a creature than that creature's toughness."
         },
         {
           "date": "2004-10-04",
@@ -2555,7 +2555,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "A creature is “enchanted” if it has any Auras attached to it."
+          "text": "A creature is \"enchanted\" if it has any Auras attached to it."
         }
       ],
       "text": "Destroy all creatures that aren't enchanted. They can't be regenerated.",
@@ -2667,7 +2667,8 @@
       "printings": [
         "TMP",
         "pFNM",
-        "TPR"
+        "TPR",
+        "MPS_AKH"
       ],
       "rarity": "Uncommon",
       "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nReturn target permanent to its owner's hand.",
@@ -2819,7 +2820,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If put on your opponent’s creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
+          "text": "If put on your opponent's creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
         },
         {
           "date": "2007-02-01",
@@ -2827,7 +2828,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "“You” refers to the controller of Curiosity, which may be different from the controller of the enchanted creature. “An opponent” refers to an opponent of Curiosity’s controller."
+          "text": "\"You\" refers to the controller of Curiosity, which may be different from the controller of the enchanted creature. \"An opponent\" refers to an opponent of Curiosity's controller."
         },
         {
           "date": "2011-09-22",
@@ -2835,7 +2836,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Curiosity doesn’t trigger if the enchanted creature deals damage to a planeswalker controlled by an opponent."
+          "text": "Curiosity doesn't trigger if the enchanted creature deals damage to a planeswalker controlled by an opponent."
         }
       ],
       "subtypes": [
@@ -3170,7 +3171,8 @@
       "printings": [
         "EXO",
         "pFNM",
-        "TPR"
+        "TPR",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Buyback—Discard two cards. (You may discard two cards in addition to any other costs as you cast this spell. If you do, put this card into your hand as it resolves.)\nCounter target spell.",
@@ -3406,7 +3408,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "Targets an opponent. You choose an opponent during announcement. If you can’t target an opponent, you can’t cast this card."
+          "text": "Targets an opponent. You choose an opponent during announcement. If you can't target an opponent, you can't cast this card."
         }
       ],
       "text": "Search your library for three cards and reveal them. Target opponent chooses one. Put that card into your hand and the rest into your graveyard. Then shuffle your library.",
@@ -3516,7 +3518,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “power less than or equal to the number of treasure counters on this card” restriction is a targeting restriction and will be checked on resolution in addition to on announcement. If the creature’s power changes to be greater than this before the effect resolves, then the Legacy’s Allure triggered ability is countered, but the card stays in the graveyard."
+          "text": "The \"power less than or equal to the number of treasure counters on this card\" restriction is a targeting restriction and will be checked on resolution in addition to on announcement. If the creature's power changes to be greater than this before the effect resolves, then the Legacy's Allure triggered ability is countered, but the card stays in the graveyard."
         }
       ],
       "text": "At the beginning of your upkeep, you may put a treasure counter on Legacy's Allure.\nSacrifice Legacy's Allure: Gain control of target creature with power less than or equal to the number of treasure counters on Legacy's Allure. (This effect lasts indefinitely.)",
@@ -3571,7 +3573,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "You can’t cast Legerdemain unless both targets share a type at that time. It will also check to make sure they share a type as it resolves. If they no longer do so, the exchange will not occur."
+          "text": "You can't cast Legerdemain unless both targets share a type at that time. It will also check to make sure they share a type as it resolves. If they no longer do so, the exchange will not occur."
         }
       ],
       "text": "Exchange control of target artifact or creature and another target permanent that shares one of those types with it. (This effect lasts indefinitely.)",
@@ -3865,11 +3867,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -4283,11 +4285,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Alternative costs, additional costs, cost increases, and cost reductions don’t affect a spell’s converted mana cost."
+          "text": "Alternative costs, additional costs, cost increases, and cost reductions don't affect a spell's converted mana cost."
         },
         {
           "date": "2013-07-01",
-          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast’s mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you’ll need to choose 9 for Spell Blast’s X and pay {9}{U}."
+          "text": "If the target spell has {X} in its mana cost, include the value chosen for that X when determining the value of the {X} in Spell Blast's mana cost. For example, if you wish to counter Volcanic Geyser (a spell with mana cost {X}{R}{R}) whose X is 7, you'll need to choose 9 for Spell Blast's X and pay {9}{U}."
         }
       ],
       "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
@@ -4579,7 +4581,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Target player takes an extra turn after this one.",
@@ -4700,7 +4702,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If the targeted permanent is an illegal target by the time Twitch resolves, the entire spell is countered. You don’t draw a card."
+          "text": "If the targeted permanent is an illegal target by the time Twitch resolves, the entire spell is countered. You don't draw a card."
         }
       ],
       "text": "You may tap or untap target artifact, creature, or land.\nDraw a card.",
@@ -4758,7 +4760,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -5069,11 +5071,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -5245,11 +5247,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -6297,7 +6299,8 @@
         "pARL",
         "TMP",
         "BTD",
-        "TPR"
+        "TPR",
+        "MPS_AKH"
       ],
       "rarity": "Common",
       "text": "Target player sacrifices a creature.",
@@ -6496,6 +6499,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
@@ -6538,7 +6545,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -6705,7 +6712,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures which are sacrificed can’t be regenerated."
+          "text": "The creatures which are sacrificed can't be regenerated."
         },
         {
           "date": "2004-10-04",
@@ -6713,7 +6720,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
+          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
         }
       ],
       "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -6883,7 +6890,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You lose life equal to the converted mana cost of the card you’re bringing back, so if you Reanimate Volrath’s Shapeshifter, you lose three life, regardless of what the next card down is."
+          "text": "You lose life equal to the converted mana cost of the card you're bringing back, so if you Reanimate Volrath's Shapeshifter, you lose three life, regardless of what the next card down is."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
@@ -6940,7 +6947,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "text": "Sacrifice a creature, Return Recurring Nightmare to its owner's hand: Return target creature card from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery.",
@@ -7003,7 +7010,7 @@
       "rulings": [
         {
           "date": "2015-06-22",
-          "text": "The ability that defines Revenant’s power and toughness applies in all zones, not just the battlefield. If Revenant is in your graveyard, its ability will count itself."
+          "text": "The ability that defines Revenant's power and toughness applies in all zones, not just the battlefield. If Revenant is in your graveyard, its ability will count itself."
         }
       ],
       "subtypes": [
@@ -7075,7 +7082,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"They are called ‘fowl' for a reason.\"\n—Mirri of the Weatherlight",
+      "flavor": "\"They are called 'fowl' for a reason.\"\n—Mirri of the Weatherlight",
       "id": "380c49f3f76cfe0640cd01f915985f6b1ad1cd73",
       "imageName": "screeching harpy",
       "layout": "normal",
@@ -7691,11 +7698,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -8459,7 +8466,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You must discard a card as part of the activation cost. You can’t announce the ability unless you have a card in hand."
+          "text": "You must discard a card as part of the activation cost. You can't announce the ability unless you have a card in hand."
         }
       ],
       "subtypes": [
@@ -8641,7 +8648,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -8713,7 +8720,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it’s too late to activate its ability before it’s destroyed."
+          "text": "Once Mogg Fanatic has dealt and been dealt combat damage, it's too late to activate its ability before it's destroyed."
         }
       ],
       "subtypes": [
@@ -8789,7 +8796,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Although Mogg Flunkies can’t attack alone, other attacking creature(s) don’t have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
+          "text": "Although Mogg Flunkies can't attack alone, other attacking creature(s) don't have to attack the same player or planeswalker. For example, Mogg Flunkies could attack an opponent and another creature could attack a planeswalker that opponent controls."
         },
         {
           "date": "2017-03-14",
@@ -8797,7 +8804,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player’s blocking creatures."
+          "text": "In a Two-Headed Giant game (or in another format using the shared team turns option), Mogg Flunkies can attack or block with a creature controlled by your teammate, even if no other creatures you control are attacking or blocking. In any other multiplayer variant, it ignores each other player's blocking creatures."
         }
       ],
       "subtypes": [
@@ -9028,11 +9035,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The triggered ability does not check the creature’s power until the ability resolves. If the creature is not on the battlefield when the ability resolves, it does damage equal to the power of the creature right before it left the battlefield. This means that if a creature enters the battlefield which can destroy itself as a “enters the battlefield” ability, the order of resolution of the triggered abilities does not matter."
+          "text": "The triggered ability does not check the creature's power until the ability resolves. If the creature is not on the battlefield when the ability resolves, it does damage equal to the power of the creature right before it left the battlefield. This means that if a creature enters the battlefield which can destroy itself as a \"enters the battlefield\" ability, the order of resolution of the triggered abilities does not matter."
         },
         {
           "date": "2006-09-25",
-          "text": "If player A controls Pandemonium when a creature enters the battlefield under player B’s control, player A controls the triggered ability even though player B chooses the target and chooses whether to have the creature deal damage, which could be important if multiple abilities controlled by multiple players trigger."
+          "text": "If player A controls Pandemonium when a creature enters the battlefield under player B's control, player A controls the triggered ability even though player B chooses the target and chooses whether to have the creature deal damage, which could be important if multiple abilities controlled by multiple players trigger."
         }
       ],
       "text": "Whenever a creature enters the battlefield, that creature's controller may have it deal damage equal to its power to target creature or player of his or her choice.",
@@ -9216,7 +9223,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If X is greater than 0, you can’t choose zero targets. You must choose between one and X targets. If X is 0, you can’t choose any targets."
+          "text": "If X is greater than 0, you can't choose zero targets. You must choose between one and X targets. If X is 0, you can't choose any targets."
         },
         {
           "date": "2015-08-25",
@@ -9228,7 +9235,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can’t change the way damage is divided."
+          "text": "If Rolling Thunder is copied, the copy will retain the original damage divsion. The spell or ability will likely allow you to choose new targets, but you can't change the way damage is divided."
         }
       ],
       "text": "Rolling Thunder deals X damage divided as you choose among any number of target creatures and/or players.",
@@ -9300,7 +9307,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"I used to describe something stable as ‘rock solid.' So much for that expression.\"\n—Gerrard of the Weatherlight",
+      "flavor": "\"I used to describe something stable as 'rock solid.' So much for that expression.\"\n—Gerrard of the Weatherlight",
       "id": "66db3c33947b9f0b47fa216f9fc67367777f2091",
       "imageName": "sandstone warrior",
       "layout": "normal",
@@ -9881,11 +9888,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Must be used before blockers are declared in order to affect blocking decisions. You can’t wait to see what your opponent declares and then try to stop them."
+          "text": "Must be used before blockers are declared in order to affect blocking decisions. You can't wait to see what your opponent declares and then try to stop them."
         },
         {
           "date": "2004-10-04",
-          "text": "You can use it after combat or even on a creature which can’t possibly block this turn because it’s that player’s turn to attack, but it generally has no effect other than to let you draw a card."
+          "text": "You can use it after combat or even on a creature which can't possibly block this turn because it's that player's turn to attack, but it generally has no effect other than to let you draw a card."
         }
       ],
       "text": "Target creature can't block this turn.\nDraw a card.",
@@ -10004,11 +10011,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t choose to cast a creature as though it had flash via Aluren and still pay the mana cost. You either cast the creature normally, or via Aluren without paying the mana cost."
+          "text": "You can't choose to cast a creature as though it had flash via Aluren and still pay the mana cost. You either cast the creature normally, or via Aluren without paying the mana cost."
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t use Aluren when casting a creature using another alternate means, such as the Morph ability."
+          "text": "You can't use Aluren when casting a creature using another alternate means, such as the Morph ability."
         },
         {
           "date": "2008-08-01",
@@ -10424,7 +10431,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can’t pay this cost more than once to get a multiple effect."
+          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can't pay this cost more than once to get a multiple effect."
         },
         {
           "date": "2004-10-04",
@@ -10432,7 +10439,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
@@ -10659,11 +10666,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -11033,11 +11040,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -11157,7 +11164,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can’t be targeted by this ability unless it’s true, and the ability will be countered on resolution if it’s no longer true at that time."
+          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can't be targeted by this ability unless it's true, and the ability will be countered on resolution if it's no longer true at that time."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player chooses target player who controls more creatures than he or she does and is his or her opponent. The first player may reveal cards from the top of his or her library until he or she reveals a creature card. If he or she does, that player puts that card onto the battlefield and all other cards revealed this way into his or her graveyard.",
@@ -11234,7 +11241,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -11374,7 +11381,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
@@ -11609,7 +11616,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -11968,7 +11975,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"As it moved, the wurm's spines gathered up bits of flowstone, which took the shapes of dead villagers' heads. Each head spoke a single sound, but if taken together, they said, ‘Alas for the living.'\"\n—Dal myth of the wurm",
+      "flavor": "\"As it moved, the wurm's spines gathered up bits of flowstone, which took the shapes of dead villagers' heads. Each head spoke a single sound, but if taken together, they said, 'Alas for the living.'\"\n—Dal myth of the wurm",
       "id": "d34df858b9bae8e9298cffa6fe36c7f805663a93",
       "imageName": "spined wurm",
       "layout": "normal",
@@ -12072,7 +12079,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "{G}, Discard a creature card: Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -12270,7 +12277,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Verdant Force’s controller gets the tokens. That is the controller at the beginning of upkeep."
+          "text": "Verdant Force's controller gets the tokens. That is the controller at the beginning of upkeep."
         },
         {
           "date": "2005-08-01",
@@ -12340,7 +12347,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nTarget land becomes a 2/2 creature that's still a land. (This effect lasts indefinitely.)",
@@ -12510,11 +12517,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -12582,11 +12589,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -12704,11 +12711,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -12972,11 +12979,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -13047,11 +13054,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You don’t choose whether to affect the targeted creature’s power or its toughness until the ability resolves."
+          "text": "You don't choose whether to affect the targeted creature's power or its toughness until the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -13118,11 +13125,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -13316,7 +13323,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Sharing multiple creature types doesn’t give an additional bonus. Coat of Arms counts creatures, not creature types."
+          "text": "Sharing multiple creature types doesn't give an additional bonus. Coat of Arms counts creatures, not creature types."
         }
       ],
       "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
@@ -13415,7 +13422,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you have no cards in hand, you still have to name a card. Then you fail to reveal one (since there aren’t any). Since the named card wasn’t revealed, no damage is dealt."
+          "text": "If you have no cards in hand, you still have to name a card. Then you fail to reveal one (since there aren't any). Since the named card wasn't revealed, no damage is dealt."
         }
       ],
       "text": "{3}, {T}: Choose a card name, then reveal a card at random from your hand. If that card has the chosen name, Cursed Scroll deals 2 damage to target creature or player.",
@@ -13614,11 +13621,11 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The control-change effect has no duration. The targeted player retains control of Jinxed Idol until the game ends, Jinxed Idol leaves the battlefield, or an effect causes someone else to gain control of it (perhaps because Jinxed Idol’s ability is activated again)."
+          "text": "The control-change effect has no duration. The targeted player retains control of Jinxed Idol until the game ends, Jinxed Idol leaves the battlefield, or an effect causes someone else to gain control of it (perhaps because Jinxed Idol's ability is activated again)."
         },
         {
           "date": "2010-08-15",
-          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won’t deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it’ll be destroyed before you get a chance to sacrifice it."
+          "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
         }
       ],
       "text": "At the beginning of your upkeep, Jinxed Idol deals 2 damage to you.\nSacrifice a creature: Target opponent gains control of Jinxed Idol.",
@@ -13713,11 +13720,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -13829,7 +13836,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you don’t discard a land card, Mox Diamond never enters the battlefield. It won’t trigger abilities that look for something entering the battlefield, and you won’t get the opportunity to tap it for mana."
+          "text": "If you don't discard a land card, Mox Diamond never enters the battlefield. It won't trigger abilities that look for something entering the battlefield, and you won't get the opportunity to tap it for mana."
         }
       ],
       "text": "If Mox Diamond would enter the battlefield, you may discard a land card instead. If you do, put Mox Diamond onto the battlefield. If you don't, put it into its owner's graveyard.\n{T}: Add one mana of any color to your mana pool.",
@@ -14644,11 +14651,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{6}: Stalking Stones becomes a 3/3 Elemental artifact creature that's still a land. (This effect lasts indefinitely.)",

--- a/json/TSB.json
+++ b/json/TSB.json
@@ -348,7 +348,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The effect to turn all your non-land cards (including artifacts) white is the effect of a static ability. Thus, a color change on a permanent prior to Celestial Dawn entering the battlefield will be overridden by Celestial Dawn’s effect."
+          "text": "The effect to turn all your non-land cards (including artifacts) white is the effect of a static ability. Thus, a color change on a permanent prior to Celestial Dawn entering the battlefield will be overridden by Celestial Dawn's effect."
         },
         {
           "date": "2004-10-04",
@@ -372,11 +372,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Mana produced by spells you control and nonland permanents you control isn’t affected by Celestial Dawn. Llanowar Elves will produce {G}, for example. However, any colored mana may be spent only on the colorless part of costs."
+          "text": "Mana produced by spells you control and nonland permanents you control isn't affected by Celestial Dawn. Llanowar Elves will produce {G}, for example. However, any colored mana may be spent only on the colorless part of costs."
         },
         {
           "date": "2006-09-25",
-          "text": "Land cards you own that aren’t on the battlefield aren’t changed to Plains."
+          "text": "Land cards you own that aren't on the battlefield aren't changed to Plains."
         },
         {
           "date": "2006-09-25",
@@ -384,15 +384,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "“Enters the battlefield” triggered abilities of lands you play won’t trigger since the lands will enter the battlefield as Plains. Effects that modify how those lands enter the battlefield, however, will still work. For example, if you play a Dimir Aqueduct, it will enter the battlefield tapped as a Plains, but you won’t return a land to your hand."
+          "text": "\"Enters the battlefield\" triggered abilities of lands you play won't trigger since the lands will enter the battlefield as Plains. Effects that modify how those lands enter the battlefield, however, will still work. For example, if you play a Dimir Aqueduct, it will enter the battlefield tapped as a Plains, but you won't return a land to your hand."
         },
         {
           "date": "2006-09-25",
-          "text": "If you use a text-changing effect such as Mind Bend on Celestial Dawn to change the word “Plains” to a different land type, your lands are all of that new land type, and they will produce mana of the appropriate color for that type."
+          "text": "If you use a text-changing effect such as Mind Bend on Celestial Dawn to change the word \"Plains\" to a different land type, your lands are all of that new land type, and they will produce mana of the appropriate color for that type."
         },
         {
           "date": "2006-09-25",
-          "text": "If a permanent enters the battlefield while Celestial Dawn is on the battlefield, and then Celestial Dawn leaves the battlefield, the permanent’s color will revert to the colors in its mana cost."
+          "text": "If a permanent enters the battlefield while Celestial Dawn is on the battlefield, and then Celestial Dawn leaves the battlefield, the permanent's color will revert to the colors in its mana cost."
         }
       ],
       "text": "Lands you control are Plains.\nNonland cards you own that aren't on the battlefield, spells you control, and nonland permanents you control are white.\nYou may spend white mana as though it were mana of any color. You may spend other mana only as though it were colorless mana.",
@@ -501,11 +501,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Consecrate Land enters the battlefield attached to a land that’s enchanted by other Auras, those Auras are put into their owners’ graveyards."
+          "text": "If Consecrate Land enters the battlefield attached to a land that's enchanted by other Auras, those Auras are put into their owners' graveyards."
         },
         {
           "date": "2013-07-01",
-          "text": "A permanent with indestructible can’t be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
+          "text": "A permanent with indestructible can't be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
         }
       ],
       "subtypes": [
@@ -870,7 +870,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Enduring Renewal only affects creature cards that are “drawn”. It doesn’t affect cards that are put into your hand from your library, or from anywhere else."
+          "text": "Enduring Renewal only affects creature cards that are \"drawn\". It doesn't affect cards that are put into your hand from your library, or from anywhere else."
         },
         {
           "date": "2004-10-04",
@@ -890,11 +890,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If, after the last ability triggers, the creature card is removed from your graveyard in response, it won’t be returned to your hand."
+          "text": "If, after the last ability triggers, the creature card is removed from your graveyard in response, it won't be returned to your hand."
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Play with your hand revealed.\nIf you would draw a card, reveal the top card of your library instead. If it's a creature card, put it into your graveyard. Otherwise, draw a card.\nWhenever a creature is put into your graveyard from the battlefield, return it to your hand.",
@@ -1005,11 +1005,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -2467,11 +2467,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Activating the ability creates a continuous effect that works only as long as Giant Oyster remains tapped, a repeating delayed triggered ability that’s in effect only as long as Giant Oyster remains tapped, and a delayed triggered ability that triggers when Giant Oyster untaps or when it leaves the battlefield."
+          "text": "Activating the ability creates a continuous effect that works only as long as Giant Oyster remains tapped, a repeating delayed triggered ability that's in effect only as long as Giant Oyster remains tapped, and a delayed triggered ability that triggers when Giant Oyster untaps or when it leaves the battlefield."
         },
         {
           "date": "2006-09-25",
-          "text": "Giant Oyster’s ability can be activated during your upkeep, and the creature will get a -1/-1 counter during the draw step that follows it."
+          "text": "Giant Oyster's ability can be activated during your upkeep, and the creature will get a -1/-1 counter during the draw step that follows it."
         }
       ],
       "subtypes": [
@@ -2580,7 +2580,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don’t have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
+          "text": "You don't have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
         }
       ],
       "subtypes": [
@@ -2909,7 +2909,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The type “Illusion” is printed on the card’s type line purely for flavor. The Ultimus has every other creature type as well."
+          "text": "The type \"Illusion\" is printed on the card's type line purely for flavor. The Ultimus has every other creature type as well."
         },
         {
           "date": "2006-09-25",
@@ -2917,7 +2917,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Mistform Ultimus has all creature types even if an effect removes its ability. Type-changing static abilities will apply in layer 4 before effects such as Sudden Spoiling’s remove them in layer 6."
+          "text": "Mistform Ultimus has all creature types even if an effect removes its ability. Type-changing static abilities will apply in layer 4 before effects such as Sudden Spoiling's remove them in layer 6."
         }
       ],
       "subtypes": [
@@ -3463,7 +3463,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If the draw is replaced by another effect, none of the rest of Sindbad’s ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
+          "text": "If the draw is replaced by another effect, none of the rest of Sindbad's ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
         },
         {
           "date": "2006-09-25",
@@ -3582,7 +3582,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -3602,7 +3602,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -4145,7 +4145,8 @@
         "ARC",
         "CMD",
         "PD3",
-        "CN2"
+        "CN2",
+        "MPS_AKH"
       ],
       "rarity": "Special",
       "rulings": [
@@ -4373,11 +4374,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "“Legend” is no longer a creature type, and may not be chosen."
+          "text": "\"Legend\" is no longer a creature type, and may not be chosen."
         },
         {
           "date": "2005-08-01",
-          "text": "If you choose Wall, then your creatures can still attack because creature types don’t confer abilities such as defender (any more than, say, choosing creature type Bird would confer flying)."
+          "text": "If you choose Wall, then your creatures can still attack because creature types don't confer abilities such as defender (any more than, say, choosing creature type Bird would confer flying)."
         },
         {
           "date": "2013-09-20",
@@ -5005,7 +5006,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sengir Autocrat’s last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
+          "text": "Sengir Autocrat's last ability exiles all Serf tokens, not just the Serf tokens its first ability created."
         },
         {
           "date": "2016-06-08",
@@ -5444,7 +5445,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -5560,7 +5561,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2016-06-08",
@@ -6431,7 +6432,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “can’t regenerate” is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
+          "text": "The \"can't regenerate\" is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
         },
         {
           "date": "2004-10-04",
@@ -6549,11 +6550,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -6664,15 +6665,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -6896,15 +6897,15 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+          "text": "Cards are discarded in a Magic game only from a player's hand. Effects that put cards from a player's library into that player's graveyard do not cause those cards to be discarded."
         },
         {
           "date": "2016-04-08",
-          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it's put onto the battlefield if it's a permanent card or into its owner's graveyard if it's an instant or sorcery card."
         },
         {
           "date": "2016-04-08",
-          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+          "text": "Casting a spell for its madness cost doesn't change its mana cost or its converted mana cost. You just pay the madness cost instead."
         },
         {
           "date": "2016-04-08",
@@ -6912,7 +6913,7 @@
         },
         {
           "date": "2016-04-08",
-          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+          "text": "Madness works independently of why you're discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can't discard a card with madness just because you want to, though."
         },
         {
           "date": "2016-04-08",
@@ -6920,11 +6921,11 @@
         },
         {
           "date": "2016-04-08",
-          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it's put into your graveyard. You don't get another chance to cast it later."
         },
         {
           "date": "2016-04-08",
-          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card's madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
         },
         {
           "date": "2016-04-08",
@@ -7033,7 +7034,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Remember that you tap the creature as part of the cost of activating Fire Whip’s granted ability. So, if you have two Fire Whips on a creature activating the first one will tap the creature, so you can’t use the second one or any other ability which requires tapping the creature until you find a way to untap it."
+          "text": "Remember that you tap the creature as part of the cost of activating Fire Whip's granted ability. So, if you have two Fire Whips on a creature activating the first one will tap the creature, so you can't use the second one or any other ability which requires tapping the creature until you find a way to untap it."
         },
         {
           "date": "2004-10-04",
@@ -7574,11 +7575,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The triggered ability does not check the creature’s power until the ability resolves. If the creature is not on the battlefield when the ability resolves, it does damage equal to the power of the creature right before it left the battlefield. This means that if a creature enters the battlefield which can destroy itself as a “enters the battlefield” ability, the order of resolution of the triggered abilities does not matter."
+          "text": "The triggered ability does not check the creature's power until the ability resolves. If the creature is not on the battlefield when the ability resolves, it does damage equal to the power of the creature right before it left the battlefield. This means that if a creature enters the battlefield which can destroy itself as a \"enters the battlefield\" ability, the order of resolution of the triggered abilities does not matter."
         },
         {
           "date": "2006-09-25",
-          "text": "If player A controls Pandemonium when a creature enters the battlefield under player B’s control, player A controls the triggered ability even though player B chooses the target and chooses whether to have the creature deal damage, which could be important if multiple abilities controlled by multiple players trigger."
+          "text": "If player A controls Pandemonium when a creature enters the battlefield under player B's control, player A controls the triggered ability even though player B chooses the target and chooses whether to have the creature deal damage, which could be important if multiple abilities controlled by multiple players trigger."
         }
       ],
       "text": "Whenever a creature enters the battlefield, that creature's controller may have it deal damage equal to its power to target creature or player of his or her choice.",
@@ -7801,7 +7802,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
@@ -8118,7 +8119,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Avoid Fate must target an instant spell or an Aura spell as it’s cast, and it must be targeting an instant or an Aura spell at the time it resolves. It will still resolve if it starts out targeting a spell of one type but the target changes to a spell of the other type (thanks to Shunt, for instance) before it resolves."
+          "text": "Avoid Fate must target an instant spell or an Aura spell as it's cast, and it must be targeting an instant or an Aura spell at the time it resolves. It will still resolve if it starts out targeting a spell of one type but the target changes to a spell of the other type (thanks to Shunt, for instance) before it resolves."
         }
       ],
       "text": "Counter target instant or Aura spell that targets a permanent you control.",
@@ -8544,11 +8545,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "When you cast Gaea’s Blessing, you can’t choose it as one of its own targets. This is because you choose the targets when casting this spell, and spells are not put into your graveyard until after they resolve."
+          "text": "When you cast Gaea's Blessing, you can't choose it as one of its own targets. This is because you choose the targets when casting this spell, and spells are not put into your graveyard until after they resolve."
         },
         {
           "date": "2016-06-08",
-          "text": "You must target a player as you cast Gaea’s Blessing. You may target zero, one, two, or three cards in that player’s graveyard."
+          "text": "You must target a player as you cast Gaea's Blessing. You may target zero, one, two, or three cards in that player's graveyard."
         }
       ],
       "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nDraw a card.\nWhen Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
@@ -8656,11 +8657,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When being declared as an attacker, use the “not attacking” power and toughness. It only changes after declaration is complete."
+          "text": "When being declared as an attacker, use the \"not attacking\" power and toughness. It only changes after declaration is complete."
         },
         {
           "date": "2006-09-25",
-          "text": "The activated ability doesn’t affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability “{T}: Add {G} to your mana pool.”"
+          "text": "The activated ability doesn't affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability \"{T}: Add {G} to your mana pool.\""
         },
         {
           "date": "2006-10-15",
@@ -8999,7 +9000,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -9220,7 +9221,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Side-effects of spells that would counter this card will still happen, because they happen even if the spell they’re trying to counter can’t be countered."
+          "text": "Side-effects of spells that would counter this card will still happen, because they happen even if the spell they're trying to counter can't be countered."
         },
         {
           "date": "2004-10-04",
@@ -9652,19 +9653,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You choose whether to kick a spell as you cast it, and you pay that much along with the spell’s mana cost at the same time. Kicking a spell is always optional."
+          "text": "You choose whether to kick a spell as you cast it, and you pay that much along with the spell's mana cost at the same time. Kicking a spell is always optional."
         },
         {
           "date": "2017-03-14",
-          "text": "You can pay any particular kicker cost only once. You can’t pay it multiple times to get multiples of either triggered ability."
+          "text": "You can pay any particular kicker cost only once. You can't pay it multiple times to get multiples of either triggered ability."
         },
         {
           "date": "2017-03-14",
-          "text": "If Thornscape Battlemage is put onto the battlefield as the result of a spell or ability, there’s no opportunity to kick it."
+          "text": "If Thornscape Battlemage is put onto the battlefield as the result of a spell or ability, there's no opportunity to kick it."
         },
         {
           "date": "2017-03-14",
-          "text": "Kicker costs don’t change a spell’s mana cost or converted mana cost."
+          "text": "Kicker costs don't change a spell's mana cost or converted mana cost."
         }
       ],
       "subtypes": [
@@ -9777,7 +9778,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Verdeloth won’t give himself +1/+1 unless he somehow becomes a Saproling."
+          "text": "Verdeloth won't give himself +1/+1 unless he somehow becomes a Saproling."
         }
       ],
       "subtypes": [
@@ -10238,7 +10239,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "The target opponent for the life-gaining effect may also be a target for the damage-dealing effect. If this happens and the damage brings that player’s life total to 0 or less, the life-gaining effect will raise his or her life total above 0 again before the player would lose the game."
+          "text": "The target opponent for the life-gaining effect may also be a target for the damage-dealing effect. If this happens and the damage brings that player's life total to 0 or less, the life-gaining effect will raise his or her life total above 0 again before the player would lose the game."
         }
       ],
       "text": "Fiery Justice deals 5 damage divided as you choose among any number of target creatures and/or players. Target opponent gains 5 life.",
@@ -10562,15 +10563,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Merieke becomes untapped, its “destroy” ability will trigger, but you won’t lose control of the creature you took before it’s destroyed."
+          "text": "If Merieke becomes untapped, its \"destroy\" ability will trigger, but you won't lose control of the creature you took before it's destroyed."
         },
         {
           "date": "2006-09-25",
-          "text": "If another player takes control of Merieke, you will immediately lose control of the creature you took, but Merieke’s “destroy” ability won’t trigger. The affected creature will go back under the control of the appropriate player."
+          "text": "If another player takes control of Merieke, you will immediately lose control of the creature you took, but Merieke's \"destroy\" ability won't trigger. The affected creature will go back under the control of the appropriate player."
         },
         {
           "date": "2006-09-25",
-          "text": "If Merieke leaves the battlefield, you will immediately lose control of the creature you took and Merieke’s “destroy” ability will trigger. The affected creature will go back under the control of the appropriate player, then it will be destroyed."
+          "text": "If Merieke leaves the battlefield, you will immediately lose control of the creature you took and Merieke's \"destroy\" ability will trigger. The affected creature will go back under the control of the appropriate player, then it will be destroyed."
         }
       ],
       "subtypes": [
@@ -10903,7 +10904,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Nicol Bolas’s third ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
+          "text": "Nicol Bolas's third ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -11248,11 +11249,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -11364,7 +11365,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since the discard is a cost, it can’t be used with Library of Leng."
+          "text": "Since the discard is a cost, it can't be used with Library of Leng."
         }
       ],
       "text": "{2}, Discard a card at random: Stormbind deals 2 damage to target creature or player.",
@@ -11576,11 +11577,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You don’t choose whether to affect the targeted creature’s power or its toughness until the ability resolves."
+          "text": "You don't choose whether to affect the targeted creature's power or its toughness until the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -11700,7 +11701,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The target player is chosen as you announce Void, but the number isn’t chosen until it’s resolving. No player may choose to take actions between you choosing a number and the rest of Void’s effects."
+          "text": "The target player is chosen as you announce Void, but the number isn't chosen until it's resolving. No player may choose to take actions between you choosing a number and the rest of Void's effects."
         }
       ],
       "text": "Choose a number. Destroy all artifacts and creatures with converted mana cost equal to that number. Then target player reveals his or her hand and discards all nonland cards with converted mana cost equal to the number.",
@@ -12293,15 +12294,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You may choose to find any kind of card, including a land. You must exile a card (unless the opponent’s library is empty); you can’t fail to find anything."
+          "text": "You may choose to find any kind of card, including a land. You must exile a card (unless the opponent's library is empty); you can't fail to find anything."
         },
         {
           "date": "2006-09-25",
-          "text": "“Until the beginning of your next upkeep” means the effect wears off as soon as your next upkeep starts. Your last chance to play the card is usually the End step of the player who immediately precedes you."
+          "text": "\"Until the beginning of your next upkeep\" means the effect wears off as soon as your next upkeep starts. Your last chance to play the card is usually the End step of the player who immediately precedes you."
         },
         {
           "date": "2006-09-25",
-          "text": "The exiled card is played using the normal rules for timing and priority for its card type, as well as any other applicable restrictions. You’ll have to pay its mana cost. The only thing that’s different is you’re casting it from the Exile zone."
+          "text": "The exiled card is played using the normal rules for timing and priority for its card type, as well as any other applicable restrictions. You'll have to pay its mana cost. The only thing that's different is you're casting it from the Exile zone."
         }
       ],
       "text": "{2}, {T}, Sacrifice Grinning Totem: Search target opponent's library for a card and exile it. Then that player shuffles his or her library. Until the beginning of your next upkeep, you may play that card. At the beginning of your next upkeep, if you haven't played it, put it into its owner's graveyard.",
@@ -12516,11 +12517,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It triggers once per spell, so you can’t get multiple copies of a spell using this card. And since this card is legendary, you can’t control more than one."
+          "text": "It triggers once per spell, so you can't get multiple copies of a spell using this card. And since this card is legendary, you can't control more than one."
         },
         {
           "date": "2004-10-04",
-          "text": "The copy is not “cast” so it will not trigger anything that triggers on a spell being cast."
+          "text": "The copy is not \"cast\" so it will not trigger anything that triggers on a spell being cast."
         },
         {
           "date": "2004-10-04",
@@ -12528,7 +12529,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You are not required to choose new targets. If you do choose, then the targets must be legal. If you don’t change them, the spell is placed on the stack whether or not the targets are legal. The legality of the targets is always checked on resolution of the spell, so the spell may be countered at that time if all of its targets are illegal."
+          "text": "You are not required to choose new targets. If you do choose, then the targets must be legal. If you don't change them, the spell is placed on the stack whether or not the targets are legal. The legality of the targets is always checked on resolution of the spell, so the spell may be countered at that time if all of its targets are illegal."
         }
       ],
       "supertypes": [
@@ -12729,7 +12730,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you’ve somehow manage to get a new arrowhead counter on the Arrows."
+          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you've somehow manage to get a new arrowhead counter on the Arrows."
         }
       ],
       "text": "Serrated Arrows enters the battlefield with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
@@ -13113,11 +13114,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be used on any player’s attacking creatures. This includes your own and creatures in an attack you are not involved in (for multiplayer games)."
+          "text": "The ability can be used on any player's attacking creatures. This includes your own and creatures in an attack you are not involved in (for multiplayer games)."
         },
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -13222,7 +13223,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If the last mining counter is removed from Gemstone Mine in some way other than activating its ability (such as Chisei, Heart of Oceans), Gemstone Mine won’t be sacrificed but its ability can’t be activated."
+          "text": "If the last mining counter is removed from Gemstone Mine in some way other than activating its ability (such as Chisei, Heart of Oceans), Gemstone Mine won't be sacrificed but its ability can't be activated."
         }
       ],
       "text": "Gemstone Mine enters the battlefield with three mining counters on it.\n{T}, Remove a mining counter from Gemstone Mine: Add one mana of any color to your mana pool. If there are no mining counters on Gemstone Mine, sacrifice it.",
@@ -13426,11 +13427,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If changed to another land type, the creature cards are not lost but can’t be released until the land reverts to normal."
+          "text": "If changed to another land type, the creature cards are not lost but can't be released until the land reverts to normal."
         },
         {
           "date": "2004-10-04",
-          "text": "When the creature leaves the battlefield any damage or “will be destroyed at some future time” effects are removed from the creature."
+          "text": "When the creature leaves the battlefield any damage or \"will be destroyed at some future time\" effects are removed from the creature."
         },
         {
           "date": "2004-10-04",

--- a/json/TSP.json
+++ b/json/TSP.json
@@ -330,11 +330,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The last sentence applies only if your life total is being reduced by damage. Other effects or costs (such as “lose 1 life” or “pay 1 life”) can reduce your life total below 1 as normal."
+          "text": "The last sentence applies only if your life total is being reduced by damage. Other effects or costs (such as \"lose 1 life\" or \"pay 1 life\") can reduce your life total below 1 as normal."
         },
         {
           "date": "2006-09-25",
-          "text": "You can’t pay more life than you have."
+          "text": "You can't pay more life than you have."
         },
         {
           "date": "2006-09-25",
@@ -342,11 +342,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "After the effect wears off during the cleanup step, you’ll lose the game if your total is 0 or less (or you have ten or more poison counters)."
+          "text": "After the effect wears off during the cleanup step, you'll lose the game if your total is 0 or less (or you have ten or more poison counters)."
         },
         {
           "date": "2006-09-25",
-          "text": "Angel’s Grace doesn’t prevent damage. It only changes the result of damage dealt to you. For example, a creature with lifelink that deals damage to you will still cause its controller to gain life, even if that damage would reduce your life total to less than 1."
+          "text": "Angel's Grace doesn't prevent damage. It only changes the result of damage dealt to you. For example, a creature with lifelink that deals damage to you will still cause its controller to gain life, even if that damage would reduce your life total to less than 1."
         },
         {
           "date": "2013-06-07",
@@ -354,23 +354,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
@@ -674,7 +674,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a creature without flanking is given flanking by another effect, then this ability will grant a second instance. Similarly, if a creature loses flanking, then it won’t get the Calvary Master instance either."
+          "text": "If a creature without flanking is given flanking by another effect, then this ability will grant a second instance. Similarly, if a creature loses flanking, then it won't get the Calvary Master instance either."
         }
       ],
       "subtypes": [
@@ -785,23 +785,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -906,7 +906,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If your life total drops to 0 or less, it’s too late to use this ability before losing the game."
+          "text": "If your life total drops to 0 or less, it's too late to use this ability before losing the game."
         },
         {
           "date": "2006-09-25",
@@ -1324,11 +1324,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Morph isn’t an activated ability, so Detainment Spell doesn’t prevent face-down creatures from being able to turn face up."
+          "text": "Morph isn't an activated ability, so Detainment Spell doesn't prevent face-down creatures from being able to turn face up."
         },
         {
           "date": "2006-09-25",
-          "text": "Responding to a creature’s activated ability being activated by moving Detainment Spell onto that creature won’t affect the ability that was just activated."
+          "text": "Responding to a creature's activated ability being activated by moving Detainment Spell onto that creature won't affect the ability that was just activated."
         }
       ],
       "subtypes": [
@@ -1430,39 +1430,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1566,39 +1566,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1809,7 +1809,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "The target of the spell is a creature the chosen opponent controls. As Evangelize resolves, if the target isn’t a creature controlled by the chosen opponent, Evangelize will be countered. If Evangelize’s target is changed (via Shunt, for example), the new target must be a creature controlled by the chosen opponent."
+          "text": "The target of the spell is a creature the chosen opponent controls. As Evangelize resolves, if the target isn't a creature controlled by the chosen opponent, Evangelize will be countered. If Evangelize's target is changed (via Shunt, for example), the new target must be a creature controlled by the chosen opponent."
         }
       ],
       "text": "Buyback {2}{W}{W} (You may pay an additional {2}{W}{W} as you cast this spell. If you do, put this card into your hand as it resolves.)\nGain control of target creature of an opponent's choice he or she controls.",
@@ -1910,15 +1910,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When the ability resolves, Flickering Spirit is exiled, then immediately returned to the battlefield. It returns as a “new” creature. Any counters, Auras, and so on are removed. Any spells or abilities targeting Flickering Spirit no longer target it."
+          "text": "When the ability resolves, Flickering Spirit is exiled, then immediately returned to the battlefield. It returns as a \"new\" creature. Any counters, Auras, and so on are removed. Any spells or abilities targeting Flickering Spirit no longer target it."
         },
         {
           "date": "2006-09-25",
-          "text": "If Flickering Spirit’s ability is activated, any “as this enters the battlefield” choices for it are made by its owner, not its previous controller."
+          "text": "If Flickering Spirit's ability is activated, any \"as this enters the battlefield\" choices for it are made by its owner, not its previous controller."
         },
         {
           "date": "2007-02-01",
-          "text": "If a token copy of Flickering Spirit uses its activated ability, the token will not return to the battlefield, because of the rule that says tokens that leave the battlefield can’t return."
+          "text": "If a token copy of Flickering Spirit uses its activated ability, the token will not return to the battlefield, because of the rule that says tokens that leave the battlefield can't return."
         }
       ],
       "subtypes": [
@@ -2027,7 +2027,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If an effect says Foriysian Interceptor can’t block, then it can’t block any creatures."
+          "text": "If an effect says Foriysian Interceptor can't block, then it can't block any creatures."
         }
       ],
       "subtypes": [
@@ -2138,7 +2138,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Creatures that come under your control after Fortify resolves won’t get the chosen bonus."
+          "text": "Creatures that come under your control after Fortify resolves won't get the chosen bonus."
         }
       ],
       "text": "Choose one —\n• Creatures you control get +2/+0 until end of turn.\n• Creatures you control get +0/+2 until end of turn.",
@@ -2339,7 +2339,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide’s ability will trigger."
+          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide's ability will trigger."
         }
       ],
       "subtypes": [
@@ -2642,39 +2642,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -2883,11 +2883,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The second ability essentially means that Knight of the Holy Nimbus always has a regeneration shield. It retains that shield even if it’s used."
+          "text": "The second ability essentially means that Knight of the Holy Nimbus always has a regeneration shield. It retains that shield even if it's used."
         },
         {
           "date": "2006-09-25",
-          "text": "After the third ability resolves, regeneration shields don’t work on Knight of the Holy Nimbus for the remainder of the turn. This includes its own automatic shield as well as shields from other sources."
+          "text": "After the third ability resolves, regeneration shields don't work on Knight of the Holy Nimbus for the remainder of the turn. This includes its own automatic shield as well as shields from other sources."
         }
       ],
       "subtypes": [
@@ -2994,7 +2994,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If an effect gives Magus of the Disk indestructible or regenerates it, it won’t be destroyed by its ability."
+          "text": "If an effect gives Magus of the Disk indestructible or regenerates it, it won't be destroyed by its ability."
         }
       ],
       "subtypes": [
@@ -3218,11 +3218,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Any “as this enters the battlefield” choices for the affected creature are made by its owner, not its old controller."
+          "text": "Any \"as this enters the battlefield\" choices for the affected creature are made by its owner, not its old controller."
         },
         {
           "date": "2007-02-01",
-          "text": "If Momentary Blink is cast on a token creature, the token will not return to the battlefield, because of the rule that says a token that leaves the battlefield can’t come back."
+          "text": "If Momentary Blink is cast on a token creature, the token will not return to the battlefield, because of the rule that says a token that leaves the battlefield can't come back."
         }
       ],
       "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -3322,7 +3322,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Guardian’s effect doesn’t wear off."
+          "text": "Guardian's effect doesn't wear off."
         },
         {
           "date": "2006-09-25",
@@ -3330,11 +3330,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "A face-down creature spell will cause Opal Guardian’s ability to trigger (if it’s an enchantment)."
+          "text": "A face-down creature spell will cause Opal Guardian's ability to trigger (if it's an enchantment)."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a creature spell, if Opal Guardian is an enchantment, Opal Guardian becomes a 3/4 Gargoyle creature with flying and protection from red.",
@@ -3442,7 +3442,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "When damage would be dealt to Outrider en-Kor, its controller chooses which redirection shields to apply out of all the shields that have been created that turn. It doesn’t matter what order they were created in."
+          "text": "When damage would be dealt to Outrider en-Kor, its controller chooses which redirection shields to apply out of all the shields that have been created that turn. It doesn't matter what order they were created in."
         }
       ],
       "subtypes": [
@@ -3851,11 +3851,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Pull from Eternity affects a suspended card, the card loses its time counters and is no longer suspended. (This doesn’t trigger the last ability of suspend.)"
+          "text": "If Pull from Eternity affects a suspended card, the card loses its time counters and is no longer suspended. (This doesn't trigger the last ability of suspend.)"
         },
         {
           "date": "2006-09-25",
-          "text": "If Pull from Eternity affects a card that’s haunting a creature, the haunt effect ends."
+          "text": "If Pull from Eternity affects a card that's haunting a creature, the haunt effect ends."
         }
       ],
       "text": "Put target face-up exiled card into its owner's graveyard.",
@@ -3956,11 +3956,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -4065,11 +4065,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -4169,44 +4169,40 @@
       "rarity": "Rare",
       "rulings": [
         {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "date": "2013-06-07",
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
-        },
-        {
-          "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -4214,11 +4210,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 6—{W} (Rather than cast this card from your hand, pay {W} and exile it with six time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nEach player chooses a number of lands he or she controls equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players sacrifice creatures and discard cards the same way.",
@@ -4321,7 +4317,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there’s only one legal target. If it’s cast at a time other than its controller’s main phase and a second target is chosen, nothing will happen to that target."
+          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there's only one legal target. If it's cast at a time other than its controller's main phase and a second target is chosen, nothing will happen to that target."
         }
       ],
       "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
@@ -4424,7 +4420,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You can cast Serra Avenger during another player’s first, second, or third turns of the game if some other effect (such as Vedalken Orrery) enables that."
+          "text": "You can cast Serra Avenger during another player's first, second, or third turns of the game if some other effect (such as Vedalken Orrery) enables that."
         },
         {
           "date": "2012-07-01",
@@ -4432,7 +4428,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If the game is restarted (by Karn Liberated), you can’t cast Serra Avenger in your first, second, or third turn in the new game."
+          "text": "If the game is restarted (by Karn Liberated), you can't cast Serra Avenger in your first, second, or third turn in the new game."
         }
       ],
       "subtypes": [
@@ -4537,11 +4533,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -4941,11 +4937,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -5049,7 +5045,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Weathered Bodyguards affects only combat damage from unblocked creatures. It won’t affect noncombat damage, and it won’t affect trample damage."
+          "text": "Weathered Bodyguards affects only combat damage from unblocked creatures. It won't affect noncombat damage, and it won't affect trample damage."
         }
       ],
       "subtypes": [
@@ -5154,15 +5150,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When Zealot il-Vec attacks and isn’t blocked, you must choose a target for its ability even if you don’t use it."
+          "text": "When Zealot il-Vec attacks and isn't blocked, you must choose a target for its ability even if you don't use it."
         },
         {
           "date": "2006-09-25",
-          "text": "If you choose to have Zealot il-Vec deal 1 damage to a creature and that damage is prevented or replaced, Zealot il-Vec’s combat damage will still be prevented."
+          "text": "If you choose to have Zealot il-Vec deal 1 damage to a creature and that damage is prevented or replaced, Zealot il-Vec's combat damage will still be prevented."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -5265,44 +5261,40 @@
       "rarity": "Rare",
       "rulings": [
         {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "date": "2013-06-07",
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
-        },
-        {
-          "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -5310,11 +5302,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 4—{U} (Rather than cast this card from your hand, pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nTarget player draws three cards.",
@@ -5512,7 +5504,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Skipping the “next” step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player’s opponents will each skip their next two untap steps."
+          "text": "Skipping the \"next\" step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player's opponents will each skip their next two untap steps."
         }
       ],
       "subtypes": [
@@ -5607,6 +5599,10 @@
         },
         {
           "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
           "legality": "Legal"
         },
         {
@@ -5839,7 +5835,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Clockspinning can affect any kind of counter, not just a time counter. The type of counter isn’t chosen until resolution. Whether to add or remove a counter isn’t chosen until resolution."
+          "text": "Clockspinning can affect any kind of counter, not just a time counter. The type of counter isn't chosen until resolution. Whether to add or remove a counter isn't chosen until resolution."
         },
         {
           "date": "2006-09-25",
@@ -5847,39 +5843,39 @@
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -6089,7 +6085,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -6197,39 +6193,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -6337,11 +6333,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If the triggered ability is countered (the targeted spell becomes an illegal target, for example), Draining Whelk doesn’t get any +1/+1 counters."
+          "text": "If the triggered ability is countered (the targeted spell becomes an illegal target, for example), Draining Whelk doesn't get any +1/+1 counters."
         },
         {
           "date": "2006-10-15",
-          "text": "If the triggered ability doesn’t counter the spell (if it is, for example, uncounterable), Draining Whelk still gets the counters."
+          "text": "If the triggered ability doesn't counter the spell (if it is, for example, uncounterable), Draining Whelk still gets the counters."
         }
       ],
       "subtypes": [
@@ -6649,39 +6645,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -7092,7 +7088,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Fool’s Demise and the enchanted creature go to the graveyard from the battlefield at the same time, both abilities will trigger."
+          "text": "If Fool's Demise and the enchanted creature go to the graveyard from the battlefield at the same time, both abilities will trigger."
         }
       ],
       "subtypes": [
@@ -7204,15 +7200,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "The controller of a face-down creature can look at it at any time, even if it doesn’t have morph. Other players can’t, but the rules for face-down permanents state that “you must ensure at all times that your face-down spells and permanents can be easily differentiated from each other.” As a result, all players must be able to figure out what each of the creatures Ixidron turned face down is."
+          "text": "The controller of a face-down creature can look at it at any time, even if it doesn't have morph. Other players can't, but the rules for face-down permanents state that \"you must ensure at all times that your face-down spells and permanents can be easily differentiated from each other.\" As a result, all players must be able to figure out what each of the creatures Ixidron turned face down is."
         },
         {
           "date": "2006-09-25",
-          "text": "You turn the creatures face-down *as* Ixidron enters the battlefield. There is never a moment when Ixidron is on the battlefield and the creatures are face-up. If a creature on the battlefield has a “whenever another creature enters the battlefield” ability, it won’t trigger because that creature will be face down before Ixidron enters the battlefield."
+          "text": "You turn the creatures face-down *as* Ixidron enters the battlefield. There is never a moment when Ixidron is on the battlefield and the creatures are face-up. If a creature on the battlefield has a \"whenever another creature enters the battlefield\" ability, it won't trigger because that creature will be face down before Ixidron enters the battlefield."
         },
         {
           "date": "2006-09-25",
-          "text": "Turning a face-down creature face-down typically has no effect; the creature’s status is unchanged."
+          "text": "Turning a face-down creature face-down typically has no effect; the creature's status is unchanged."
         }
       ],
       "subtypes": [
@@ -7515,7 +7511,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Moonlace’s effect doesn’t wear off."
+          "text": "Moonlace's effect doesn't wear off."
         },
         {
           "date": "2006-09-25",
@@ -7816,23 +7812,23 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Paradox Haze targets a player when it’s cast, and it enters the battlefield attached to that player."
+          "text": "Paradox Haze targets a player when it's cast, and it enters the battlefield attached to that player."
         },
         {
           "date": "2006-09-25",
-          "text": "If two Paradox Hazes enchant the same player, they’ll both trigger when that player’s first upkeep of the turn begins. The player will get two additional upkeep steps."
+          "text": "If two Paradox Hazes enchant the same player, they'll both trigger when that player's first upkeep of the turn begins. The player will get two additional upkeep steps."
         },
         {
           "date": "2006-09-25",
-          "text": "Abilities that trigger “at the beginning of [your] upkeep” will trigger at the beginning of each additional upkeep as well."
+          "text": "Abilities that trigger \"at the beginning of [your] upkeep\" will trigger at the beginning of each additional upkeep as well."
         },
         {
           "date": "2006-09-25",
-          "text": "If echo triggers during the first upkeep, it won’t trigger again during the second upkeep since the creature won’t have enter the battlefield since that player’s last upkeep."
+          "text": "If echo triggers during the first upkeep, it won't trigger again during the second upkeep since the creature won't have enter the battlefield since that player's last upkeep."
         },
         {
           "date": "2006-09-25",
-          "text": "If an effect causes the enchanted player to skip his or her upkeep step, this ability won’t trigger."
+          "text": "If an effect causes the enchanted player to skip his or her upkeep step, this ability won't trigger."
         }
       ],
       "subtypes": [
@@ -7936,11 +7932,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -8048,39 +8044,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -8289,11 +8285,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -8398,11 +8394,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -9093,7 +9089,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The last ability means that in order for an opponent to cast a spell, it must be that opponent’s turn, during a main phase, and the stack must be empty. This is true even if the player doesn’t have a sorcery he or she is able to cast, or if a rule or effect allows a spell to be cast at another time."
+          "text": "The last ability means that in order for an opponent to cast a spell, it must be that opponent's turn, during a main phase, and the stack must be empty. This is true even if the player doesn't have a sorcery he or she is able to cast, or if a rule or effect allows a spell to be cast at another time."
         },
         {
           "date": "2006-09-25",
@@ -9101,15 +9097,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If an ability lets an opponent cast a spell as part of its effect (such as Isochron Scepter’s ability does), that opponent can’t cast that spell since the currently resolving ability is still on the stack."
+          "text": "If an ability lets an opponent cast a spell as part of its effect (such as Isochron Scepter's ability does), that opponent can't cast that spell since the currently resolving ability is still on the stack."
         },
         {
           "date": "2006-09-25",
-          "text": "Your opponents can’t cast their suspended cards, no matter what phase it is when the last time counter is removed. Your opponents can’t cast cards using the madness ability either, no matter what phase it is when the card is discarded."
+          "text": "Your opponents can't cast their suspended cards, no matter what phase it is when the last time counter is removed. Your opponents can't cast cards using the madness ability either, no matter what phase it is when the card is discarded."
         },
         {
           "date": "2007-05-01",
-          "text": "If you have Teferi on the battlefield and there’s a Split Second spell on the stack (such as Sudden Death), you can’t Suspend creatures until after the Split Second spell resolves."
+          "text": "If you have Teferi on the battlefield and there's a Split Second spell on the stack (such as Sudden Death), you can't Suspend creatures until after the Split Second spell resolves."
         }
       ],
       "subtypes": [
@@ -9218,11 +9214,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -9622,7 +9618,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Trickbind can be used to counter the storm triggered ability. Doing so prevents the copies from being created, but doesn’t counter the original storm spell."
+          "text": "Trickbind can be used to counter the storm triggered ability. Doing so prevents the copies from being created, but doesn't counter the original storm spell."
         },
         {
           "date": "2006-09-25",
@@ -9630,11 +9626,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Trickbind can be used to counter the suspend “remove a counter” ability. If so, the counter won’t get removed, but the ability will trigger again as normal later on. Trickbind can also be used to counter the suspend “play this card” ability. If so, the card stays exiled (the ability won’t trigger again). Using suspend to exile a card in your hand is neither an activated nor a triggered ability, so it can’t be countered this way."
+          "text": "Trickbind can be used to counter the suspend \"remove a counter\" ability. If so, the counter won't get removed, but the ability will trigger again as normal later on. Trickbind can also be used to counter the suspend \"play this card\" ability. If so, the card stays exiled (the ability won't trigger again). Using suspend to exile a card in your hand is neither an activated nor a triggered ability, so it can't be countered this way."
         },
         {
           "date": "2006-09-25",
-          "text": "Trickbind can be used to counter the echo triggered ability. If so, the echo ability won’t trigger again so the echo cost is never paid."
+          "text": "Trickbind can be used to counter the echo triggered ability. If so, the echo ability won't trigger again so the echo cost is never paid."
         },
         {
           "date": "2006-09-25",
@@ -9642,7 +9638,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Trickbind can’t counter or prevent paying the morph cost to turn a face-down creature face up, since that action doesn’t use the stack."
+          "text": "Trickbind can't counter or prevent paying the morph cost to turn a face-down creature face up, since that action doesn't use the stack."
         },
         {
           "date": "2013-06-07",
@@ -9650,27 +9646,27 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nCounter target activated or triggered ability. If a permanent's ability is countered this way, activated abilities of that permanent can't be activated this turn. (Mana abilities can't be targeted.)",
@@ -9769,7 +9765,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Here’s how this works: Step 1: You reveal the top five cards of your library. Step 2: You separate those cards into two piles. (A pile can have zero cards.) Step 3: An opponent of your choice chooses one of those piles. Step 4: You choose one of the cards in the chosen pile. Step 5: You put the chosen card in your hand. Step 6: You put all other revealed cards (from both piles) on the bottom of your library in any order."
+          "text": "Here's how this works: Step 1: You reveal the top five cards of your library. Step 2: You separate those cards into two piles. (A pile can have zero cards.) Step 3: An opponent of your choice chooses one of those piles. Step 4: You choose one of the cards in the chosen pile. Step 5: You put the chosen card in your hand. Step 6: You put all other revealed cards (from both piles) on the bottom of your library in any order."
         }
       ],
       "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put a card from the chosen pile into your hand, then put all other cards revealed this way on the bottom of your library in any order.",
@@ -9869,7 +9865,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Essentially, each time Vesuvan Shapeshifter turns face up, it’s a copy of a new creature. During your upkeep, you may turn it face down in preparation to copy something else."
+          "text": "Essentially, each time Vesuvan Shapeshifter turns face up, it's a copy of a new creature. During your upkeep, you may turn it face down in preparation to copy something else."
         },
         {
           "date": "2006-09-25",
@@ -9877,15 +9873,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Vesuvan Shapeshifter is turned face up, the process of turning face up includes (optionally) choosing another creature on the battlefield. You’ll pay {1}{U} (not the morph cost, if any, of the new creature), then Vesuvan Shapeshifter will turn face up as a copy of that creature, plus the triggered ability it gives itself. It won’t turn face up as a Vesuvan Shapeshifter and then change. If the copied creature has a “when this creature is turned face up” ability, it will trigger for Vesuvan Shapeshifter."
+          "text": "If Vesuvan Shapeshifter is turned face up, the process of turning face up includes (optionally) choosing another creature on the battlefield. You'll pay {1}{U} (not the morph cost, if any, of the new creature), then Vesuvan Shapeshifter will turn face up as a copy of that creature, plus the triggered ability it gives itself. It won't turn face up as a Vesuvan Shapeshifter and then change. If the copied creature has a \"when this creature is turned face up\" ability, it will trigger for Vesuvan Shapeshifter."
         },
         {
           "date": "2006-09-25",
-          "text": "When Vesuvan Shapeshifter is turned face down, its copy effect wears off. While it’s face down, it’s a face-down Vesuvan Shapeshifter that can be turned face up for a morph cost of {1}{U}."
+          "text": "When Vesuvan Shapeshifter is turned face down, its copy effect wears off. While it's face down, it's a face-down Vesuvan Shapeshifter that can be turned face up for a morph cost of {1}{U}."
         },
         {
           "date": "2006-09-25",
-          "text": "If another creature copies Vesuvan Shapeshifter while it’s face up, the new creature will become a copy of whatever Vesuvan Shapeshifter is copying and gain the “you may turn this creature face down” ability. It won’t gain morph {1}{U}. If that creature is then turned face down, its copy effect will continue and it’ll be a face-down version of whatever it’s copying. If the creature it’s copying has morph, it can be turned face up. If the creature it’s copying doesn’t have morph, it’s stuck face down forever unless some other effect (like Break Open) turns it face up again."
+          "text": "If another creature copies Vesuvan Shapeshifter while it's face up, the new creature will become a copy of whatever Vesuvan Shapeshifter is copying and gain the \"you may turn this creature face down\" ability. It won't gain morph {1}{U}. If that creature is then turned face down, its copy effect will continue and it'll be a face-down version of whatever it's copying. If the creature it's copying has morph, it can be turned face up. If the creature it's copying doesn't have morph, it's stuck face down forever unless some other effect (like Break Open) turns it face up again."
         },
         {
           "date": "2006-09-25",
@@ -9893,15 +9889,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "When Vesuvan Shapeshifter copies a creature that has echo, the echo ability will trigger at the beginning of your upkeep if Vesuvan Shapeshifter came under your control since the beginning of your last upkeep. If you’ve controlled Vesuvan Shapeshifter since your last upkeep (regardless of whether it had echo then), the echo ability won’t trigger."
+          "text": "When Vesuvan Shapeshifter copies a creature that has echo, the echo ability will trigger at the beginning of your upkeep if Vesuvan Shapeshifter came under your control since the beginning of your last upkeep. If you've controlled Vesuvan Shapeshifter since your last upkeep (regardless of whether it had echo then), the echo ability won't trigger."
         },
         {
           "date": "2006-09-25",
-          "text": "Turning Vesuvan Shapeshifter face down during your upkeep doesn’t prevent you from needing to pay applicable upkeep costs such as echo."
+          "text": "Turning Vesuvan Shapeshifter face down during your upkeep doesn't prevent you from needing to pay applicable upkeep costs such as echo."
         },
         {
           "date": "2006-09-25",
-          "text": "If you don’t or can’t choose another creature on the battlefield for Vesuvan Shapeshifter to copy, it doesn’t get the triggered ability that turns it face down. It’s just a 0/0 creature with morph {1}{U}."
+          "text": "If you don't or can't choose another creature on the battlefield for Vesuvan Shapeshifter to copy, it doesn't get the triggered ability that turns it face down. It's just a 0/0 creature with morph {1}{U}."
         }
       ],
       "subtypes": [
@@ -10005,39 +10001,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -10147,7 +10143,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "subtypes": [
@@ -10349,23 +10345,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nReturn target permanent to its owner's hand.",
@@ -10566,11 +10562,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -10768,39 +10764,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -10907,39 +10903,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -11048,7 +11044,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a Vesuvan Shapeshifter that’s copying Cyclopean Giant is put into a graveyard, the Shapeshifter will be exiled when the ability resolves even though it’s not a Cyclopean Giant anymore."
+          "text": "If a Vesuvan Shapeshifter that's copying Cyclopean Giant is put into a graveyard, the Shapeshifter will be exiled when the ability resolves even though it's not a Cyclopean Giant anymore."
         }
       ],
       "subtypes": [
@@ -11636,11 +11632,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The second ability is a state trigger. Once it triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "The second ability is a state trigger. Once it triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         },
         {
           "date": "2006-09-25",
-          "text": "When the second ability resolves, Endrek Sahr will be sacrificed regardless of how many Thrulls you control at that time, even if it’s less than seven."
+          "text": "When the second ability resolves, Endrek Sahr will be sacrificed regardless of how many Thrulls you control at that time, even if it's less than seven."
         },
         {
           "date": "2006-09-25",
@@ -11956,7 +11952,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The creature’s controller (not Fallen Ideal’s controller) can activate the “sacrifice a creature” ability."
+          "text": "The creature's controller (not Fallen Ideal's controller) can activate the \"sacrifice a creature\" ability."
         }
       ],
       "subtypes": [
@@ -12348,11 +12344,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You can’t sacrifice Liege of the Pit to its own ability. You can sacrifice one Liege of the Pit to another Liege of the Pit."
+          "text": "You can't sacrifice Liege of the Pit to its own ability. You can sacrifice one Liege of the Pit to another Liege of the Pit."
         },
         {
           "date": "2006-09-25",
-          "text": "If you have another creature on the battlefield when the ability resolves, you must sacrifice it. You can’t choose to be dealt 7 damage instead."
+          "text": "If you have another creature on the battlefield when the ability resolves, you must sacrifice it. You can't choose to be dealt 7 damage instead."
         }
       ],
       "subtypes": [
@@ -12555,47 +12551,43 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
-        },
-        {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -12603,11 +12595,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 3—{2}{B}{B} (Rather than cast this card from your hand, pay {2}{B}{B} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nEach player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -12709,11 +12701,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player’s previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
+          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player's previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says that a player can’t lose life, that player can’t exchange life totals with a player who has a lower life total; in that case, the exchange won’t happen."
+          "text": "If an effect says that a player can't lose life, that player can't exchange life totals with a player who has a lower life total; in that case, the exchange won't happen."
         }
       ],
       "subtypes": [
@@ -12918,11 +12910,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -13025,39 +13017,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -13161,7 +13153,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Nether Traitor and another creature are put into your graveyard at the same time, Nether Traitor’s ability won’t trigger."
+          "text": "If Nether Traitor and another creature are put into your graveyard at the same time, Nether Traitor's ability won't trigger."
         }
       ],
       "subtypes": [
@@ -13375,39 +13367,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -13415,7 +13407,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If the creature’s power is less than 0, use its actual value to determine the total life loss. However, if this total is 0 or less, no life is lost. For example, if Phthisis destroys a -2/3 creature, its controller would lose 1 life. If it destroys a -4/3 creature, its controller would lose no life."
+          "text": "If the creature's power is less than 0, use its actual value to determine the total life loss. However, if this total is 0 or less, no life is lost. For example, if Phthisis destroys a -2/3 creature, its controller would lose 1 life. If it destroys a -4/3 creature, its controller would lose no life."
         }
       ],
       "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5—{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
@@ -13433,7 +13425,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"The undead are not ‘awakened.' They are evicted when there is no room left in the pit for more bodies.\"",
+      "flavor": "\"The undead are not 'awakened.' They are evicted when there is no room left in the pit for more bodies.\"",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -13617,15 +13609,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Each Sliver deals damage to its controller (not to Plague Sliver’s controller)."
+          "text": "Each Sliver deals damage to its controller (not to Plague Sliver's controller)."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -14015,11 +14007,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The Sengir Nosferatu that the Bat token’s ability returns to the battlefield doesn’t have to be the same one that created it, and it doesn’t even have to be owned by the same player."
+          "text": "The Sengir Nosferatu that the Bat token's ability returns to the battlefield doesn't have to be the same one that created it, and it doesn't even have to be owned by the same player."
         },
         {
           "date": "2007-05-01",
-          "text": "If the Nosferatu is copied (by Clone, for example) and then the copy is exiled by the first activated ability, it won’t be able to come back using the second activated ability, since it’s no longer named Sengir Nosferatu in the Exile zone."
+          "text": "If the Nosferatu is copied (by Clone, for example) and then the copy is exiled by the first activated ability, it won't be able to come back using the second activated ability, since it's no longer named Sengir Nosferatu in the Exile zone."
         }
       ],
       "subtypes": [
@@ -14622,23 +14614,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nTarget creature gets -4/-4 until end of turn.",
@@ -14739,11 +14731,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Sudden Spoiling doesn’t counter abilities that have already triggered or been activated. In particular, you can’t cast this fast enough to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering."
+          "text": "Sudden Spoiling doesn't counter abilities that have already triggered or been activated. In particular, you can't cast this fast enough to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering."
         },
         {
           "date": "2006-09-25",
-          "text": "Sudden Spoiling affects only permanents that are creatures on the battlefield under the targeted player’s control at the time Sudden Spoiling resolves. It won’t affect creatures that enter the battlefield later or noncreature permanents that later become creatures."
+          "text": "Sudden Spoiling affects only permanents that are creatures on the battlefield under the targeted player's control at the time Sudden Spoiling resolves. It won't affect creatures that enter the battlefield later or noncreature permanents that later become creatures."
         },
         {
           "date": "2006-09-25",
@@ -14751,7 +14743,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a face-down creature is affected by Sudden Spoiling, it won’t be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/2 creature with no abilities until the turn ends. Its “When this creature turns face up” or “As this creature turns face up” abilities won’t work."
+          "text": "If a face-down creature is affected by Sudden Spoiling, it won't be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/2 creature with no abilities until the turn ends. Its \"When this creature turns face up\" or \"As this creature turns face up\" abilities won't work."
         },
         {
           "date": "2013-06-07",
@@ -14759,23 +14751,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntil end of turn, creatures target player controls lose all abilities and have base power and toughness 0/2.",
@@ -14885,7 +14877,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -15286,19 +15278,19 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a Sliver doesn’t have this ability when it deals damage, but does have it when the damaged creature is put into a graveyard, the ability will trigger."
+          "text": "If a Sliver doesn't have this ability when it deals damage, but does have it when the damaged creature is put into a graveyard, the ability will trigger."
         },
         {
           "date": "2006-09-25",
-          "text": "If Vampiric Sliver is put into a graveyard from the battlefield at the same time as a creature dealt damage by another Sliver, the Vampiric Sliver’s ability will trigger for the other Sliver. That Sliver will get a +1/+1 counter."
+          "text": "If Vampiric Sliver is put into a graveyard from the battlefield at the same time as a creature dealt damage by another Sliver, the Vampiric Sliver's ability will trigger for the other Sliver. That Sliver will get a +1/+1 counter."
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -15504,7 +15496,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Aetherflame Wall gains shadow, it won’t be able to block any creatures (not even those with shadow)."
+          "text": "If Aetherflame Wall gains shadow, it won't be able to block any creatures (not even those with shadow)."
         }
       ],
       "subtypes": [
@@ -16224,11 +16216,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -16334,11 +16326,11 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         },
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -16547,15 +16539,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -16956,11 +16948,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The first ability applies only if your life total is being reduced by damage. Other effects or costs (such as “lose 1 life” or “pay 1 life”) can reduce your life total below 1 as normal."
+          "text": "The first ability applies only if your life total is being reduced by damage. Other effects or costs (such as \"lose 1 life\" or \"pay 1 life\") can reduce your life total below 1 as normal."
         },
         {
           "date": "2006-09-25",
-          "text": "If an effect asks you to pay life, you can’t pay more life than you have."
+          "text": "If an effect asks you to pay life, you can't pay more life than you have."
         },
         {
           "date": "2006-09-25",
@@ -16968,11 +16960,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "The ability doesn’t change how much damage is dealt; it just changes how much life that damage makes you lose. An effect such as Spirit Link will see the full amount of damage being dealt."
+          "text": "The ability doesn't change how much damage is dealt; it just changes how much life that damage makes you lose. An effect such as Spirit Link will see the full amount of damage being dealt."
         },
         {
           "date": "2006-09-25",
-          "text": "Thief won’t prevent you from losing the game if your life total is 0 or less or some other effect causes you to lose the game."
+          "text": "Thief won't prevent you from losing the game if your life total is 0 or less or some other effect causes you to lose the game."
         }
       ],
       "subtypes": [
@@ -17079,11 +17071,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -17186,7 +17178,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If you return Ghitu Firebreathing to its owner’s hand while the +1/+0 ability is on the stack, that ability will still give the creature that was last enchanted by Ghitu Firebreathing +1/+0."
+          "text": "If you return Ghitu Firebreathing to its owner's hand while the +1/+0 ability is on the stack, that ability will still give the creature that was last enchanted by Ghitu Firebreathing +1/+0."
         }
       ],
       "subtypes": [
@@ -17391,15 +17383,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -17508,39 +17500,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -17648,15 +17640,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -17767,7 +17759,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If you don’t actually sacrifice the Goblin (because it was removed from the battlefield before the ability resolved, for example), no damage is dealt."
+          "text": "If you don't actually sacrifice the Goblin (because it was removed from the battlefield before the ability resolved, for example), no damage is dealt."
         }
       ],
       "subtypes": [
@@ -17874,15 +17866,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -17991,7 +17983,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "“Can’t block” abilities apply only as blockers are declared. After Ironclaw Buzzardiers blocks, increasing the blocked creature’s power won’t make it become unblocked."
+          "text": "\"Can't block\" abilities apply only as blockers are declared. After Ironclaw Buzzardiers blocks, increasing the blocked creature's power won't make it become unblocked."
         }
       ],
       "subtypes": [
@@ -18200,39 +18192,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -18350,7 +18342,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "This has an additional cost with an option. Essentially, the card’s cost to cast is either {5}{R} or {R} and a discard. But its mana cost is always {R} and its converted mana cost is always 1."
+          "text": "This has an additional cost with an option. Essentially, the card's cost to cast is either {5}{R} or {R} and a discard. But its mana cost is always {R} and its converted mana cost is always 1."
         },
         {
           "date": "2016-04-08",
@@ -18862,39 +18854,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -19001,39 +18993,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -19233,39 +19225,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -19371,11 +19363,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -19583,23 +19575,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nSudden Shock deals 2 damage to target creature or player.",
@@ -20002,11 +19994,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -20112,7 +20104,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Undying Rage when it’s cast as a spell is an illegal target when Undying Rage tries to resolve, Undying Rage will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Undying Rage when it's cast as a spell is an illegal target when Undying Rage tries to resolve, Undying Rage will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -20315,15 +20307,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -20428,44 +20420,40 @@
       "rarity": "Rare",
       "rulings": [
         {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "date": "2013-06-07",
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
-        },
-        {
-          "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -20473,11 +20461,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 4—{1}{R} (Rather than cast this card from your hand, pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nEach player discards his or her hand, then draws seven cards.",
@@ -20583,23 +20571,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntap target permanent and gain control of it until end of turn. It gains haste until end of turn.",
@@ -20701,7 +20689,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If the enchanted creature has shadow, it won’t be able to block any creatures (not even those with shadow)."
+          "text": "If the enchanted creature has shadow, it won't be able to block any creatures (not even those with shadow)."
         }
       ],
       "subtypes": [
@@ -21094,39 +21082,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -21235,7 +21223,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Durkwood Tracker has left the battlefield before the ability resolves, the ability doesn’t do anything. If the targeted creature has left the battlefield before the ability resolves, the ability is countered."
+          "text": "If Durkwood Tracker has left the battlefield before the ability resolves, the ability doesn't do anything. If the targeted creature has left the battlefield before the ability resolves, the ability is countered."
         }
       ],
       "subtypes": [
@@ -21341,11 +21329,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -21452,11 +21440,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -21561,7 +21549,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "After Glass Asp’s triggered ability resolves, the affected player has the ability to perform a special action of paying {2}. This action may be performed any time the player has priority, and it doesn’t use the stack. It may be performed only once. Once that player’s next draw step begins, the player no longer has the ability to perform this action. If the player performed the action, the delayed “lose 2 life” triggered ability won’t trigger. Otherwise, it will."
+          "text": "After Glass Asp's triggered ability resolves, the affected player has the ability to perform a special action of paying {2}. This action may be performed any time the player has priority, and it doesn't use the stack. It may be performed only once. Once that player's next draw step begins, the player no longer has the ability to perform this action. If the player performed the action, the delayed \"lose 2 life\" triggered ability won't trigger. Otherwise, it will."
         }
       ],
       "subtypes": [
@@ -21960,11 +21948,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn’t end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
-        },
-        {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn't end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
         },
         {
           "date": "2006-10-15",
@@ -21972,39 +21956,39 @@
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -22012,11 +21996,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 3—{1}{G}{G} (Rather than cast this card from your hand, pay {1}{G}{G} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nStarting with you, each player may put an artifact, creature, enchantment, or land card from his or her hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.",
@@ -22125,23 +22109,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
@@ -22342,7 +22326,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If a Might of Old Krosa on the stack is copied, the copy will give only +2/+2, even if it’s your main phase. This is because you didn’t cast the copy."
+          "text": "If a Might of Old Krosa on the stack is copied, the copy will give only +2/+2, even if it's your main phase. This is because you didn't cast the copy."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
@@ -22444,11 +22428,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -22741,39 +22725,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -23582,39 +23566,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -23719,7 +23703,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "”Your next untap…” refers to the player who controls Spectral Force when the triggered ability resolves. That means if it’s temporarily stolen (such as with Word of Seizing) and attacked with, it will untap in its previous controller’s untap step."
+          "text": "\"Your next untap…\" refers to the player who controls Spectral Force when the triggered ability resolves. That means if it's temporarily stolen (such as with Word of Seizing) and attacked with, it will untap in its previous controller's untap step."
         }
       ],
       "subtypes": [
@@ -23824,7 +23808,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -23929,11 +23913,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -24038,7 +24022,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Sporesower Thallid’s triggered ability will put a spore counter on each Fungus creature you control, even if that Fungus doesn’t have any abilities that makes use of them."
+          "text": "Sporesower Thallid's triggered ability will put a spore counter on each Fungus creature you control, even if that Fungus doesn't have any abilities that makes use of them."
         }
       ],
       "subtypes": [
@@ -24334,23 +24318,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from activating mana abilities."
+          "text": "Split second doesn't prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nTarget creature gets +5/+5 and gains shroud until end of turn. (It can't be the target of spells or abilities.)",
@@ -24452,7 +24436,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "The value of X is determined only as Strength in Numbers resolves. It won’t change later in the turn if the number of attacking creatures changes."
+          "text": "The value of X is determined only as Strength in Numbers resolves. It won't change later in the turn if the number of attacking creatures changes."
         }
       ],
       "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of attacking creatures.",
@@ -25057,7 +25041,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The creatures get trample once; they don’t get trample for each basic land type."
+          "text": "The creatures get trample once; they don't get trample for each basic land type."
         },
         {
           "date": "2006-09-25",
@@ -25077,7 +25061,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control — they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
@@ -25572,7 +25556,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You may target yourself with Yavimaya Dryad’s ability."
+          "text": "You may target yourself with Yavimaya Dryad's ability."
         }
       ],
       "subtypes": [
@@ -25678,11 +25662,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -25792,7 +25776,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If you don’t control enough permanents, sacrifice all permanents you control."
+          "text": "If you don't control enough permanents, sacrifice all permanents you control."
         }
       ],
       "subtypes": [
@@ -25903,11 +25887,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -26014,11 +25998,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -26133,11 +26117,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -26243,39 +26227,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -26607,11 +26591,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn’t provide any additional benefit."
+          "text": "Abilities that Slivers grant, as well as power/toughness boosts, are cumulative. However, for some abilities, like flying, having more than one instance of the ability doesn't provide any additional benefit."
         },
         {
           "date": "2013-07-01",
-          "text": "If the creature type of a Sliver changes so it’s no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
+          "text": "If the creature type of a Sliver changes so it's no longer a Sliver, it will no longer be affected by its own ability. Its ability will continue to affect other Sliver creatures."
         }
       ],
       "subtypes": [
@@ -26722,11 +26706,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "The creature is returned to the battlefield under your control if it’s put into *your* graveyard from the battlefield. It doesn’t matter who controlled it when Saffi targeted it."
+          "text": "The creature is returned to the battlefield under your control if it's put into *your* graveyard from the battlefield. It doesn't matter who controlled it when Saffi targeted it."
         },
         {
           "date": "2006-09-25",
-          "text": "Saffi can target itself, but it won’t return itself to the battlefield. It will already be in the graveyard when the ability resolves, so the ability will be countered."
+          "text": "Saffi can target itself, but it won't return itself to the battlefield. It will already be in the graveyard when the ability resolves, so the ability will be countered."
         }
       ],
       "subtypes": [
@@ -27249,7 +27233,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Unless something weird happens, the card that’s drawn will be the card that was revealed."
+          "text": "Unless something weird happens, the card that's drawn will be the card that was revealed."
         }
       ],
       "text": "{4}, {T}: Reveal the top card of your library. If it has the same name as a card in your graveyard, put it into your graveyard. Otherwise, draw a card.",
@@ -27434,7 +27418,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {U} to your mana pool.\n{1}{U}: Chronatog Totem becomes a 1/2 blue Atog artifact creature until end of turn.\n{0}: Chronatog Totem gets +3/+3 until end of turn. You skip your next turn. Activate this ability only once each turn and only if Chronatog Totem is a creature.",
@@ -27628,11 +27612,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If an effect says Foriysian Totem can’t block, then it can’t block any creatures."
+          "text": "If an effect says Foriysian Totem can't block, then it can't block any creatures."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {R} to your mana pool.\n{4}{R}: Foriysian Totem becomes a 4/4 red Giant artifact creature with trample until end of turn.\nAs long as Foriysian Totem is a creature, it can block an additional creature each combat.",
@@ -27818,7 +27802,7 @@
         },
         {
           "date": "2006-10-15",
-          "text": "Turns only your creatures on the battlefield, not in other zones, into Slivers. It won’t allow you to have Root Sliver on the battlefield and make your Grizzly Bears uncounterable, for example."
+          "text": "Turns only your creatures on the battlefield, not in other zones, into Slivers. It won't allow you to have Root Sliver on the battlefield and make your Grizzly Bears uncounterable, for example."
         }
       ],
       "text": "Creatures you control are Slivers in addition to their other creature types.",
@@ -28005,15 +27989,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Locket of Yesterdays reduces only the amount of mana you need to pay to cast a spell. The spell’s mana cost and converted mana cost are not affected."
+          "text": "Locket of Yesterdays reduces only the amount of mana you need to pay to cast a spell. The spell's mana cost and converted mana cost are not affected."
         },
         {
           "date": "2006-09-25",
-          "text": "Colored costs can’t be reduced by this effect. For example, a spell that costs {2}{R} can’t be reduced by more than {2}."
+          "text": "Colored costs can't be reduced by this effect. For example, a spell that costs {2}{R} can't be reduced by more than {2}."
         },
         {
           "date": "2006-09-25",
-          "text": "The spell being cast doesn’t reduce its own cost, even if you’re casting it from a graveyard. At the time the cost is reduced, the spell is on the stack."
+          "text": "The spell being cast doesn't reduce its own cost, even if you're casting it from a graveyard. At the time the cost is reduced, the spell is on the stack."
         }
       ],
       "text": "Spells you cast cost {1} less to cast for each card with the same name as that spell in your graveyard.",
@@ -28105,44 +28089,40 @@
       "rarity": "Rare",
       "rulings": [
         {
-          "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
+          "date": "2013-06-07",
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
+          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
-        },
-        {
-          "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -28150,7 +28130,7 @@
         },
         {
           "date": "2016-09-20",
-          "text": "This has no mana cost, which means its mana cost can’t be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
+          "text": "This has no mana cost, which means its mana cost can't be paid for effects such as replicate from Djinn Illuminatus or flashback from Snapcaster Mage."
         }
       ],
       "text": "Suspend 3—{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color to your mana pool.",
@@ -28335,11 +28315,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When damage is dealt to Phyrexian Totem, its triggered ability will trigger. A number of permanents equal to the amount of damage dealt will be sacrificed when the ability resolves. It doesn’t matter if Phyrexian Totem isn’t on the battlefield when the ability resolves, as long as Phyrexian Totem was a creature as it left the battlefield. If one of the permanents sacrificed is Phyrexian Totem itself, the requisite number of other permanents must still be sacrificed."
+          "text": "When damage is dealt to Phyrexian Totem, its triggered ability will trigger. A number of permanents equal to the amount of damage dealt will be sacrificed when the ability resolves. It doesn't matter if Phyrexian Totem isn't on the battlefield when the ability resolves, as long as Phyrexian Totem was a creature as it left the battlefield. If one of the permanents sacrificed is Phyrexian Totem itself, the requisite number of other permanents must still be sacrificed."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {B} to your mana pool.\n{2}{B}: Phyrexian Totem becomes a 5/5 black Horror artifact creature with trample until end of turn.\nWhenever Phyrexian Totem is dealt damage, if it's a creature, sacrifice that many permanents.",
@@ -28706,7 +28686,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {W} to your mana pool.\n{1}{W}{W}: Thunder Totem becomes a 2/2 white Spirit artifact creature with flying and first strike until end of turn.",
@@ -28988,11 +28968,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Weatherseed Totem will be returned to its owner’s hand if it was a creature at the time it was put into a graveyard from the battlefield."
+          "text": "Weatherseed Totem will be returned to its owner's hand if it was a creature at the time it was put into a graveyard from the battlefield."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {G} to your mana pool.\n{2}{G}{G}{G}: Weatherseed Totem becomes a 5/3 green Treefolk artifact creature with trample until end of turn.\nWhen Weatherseed Totem is put into a graveyard from the battlefield, if it was a creature, return this card to its owner's hand.",
@@ -29538,11 +29518,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If multiple Gemstone Caverns are put onto the battlefield under a single player’s control before the game begins, the “legend rule” won’t put the extras into that player’s graveyard until just before the first player gets priority during his or her first upkeep step. There’s no opportunity to tap the extras for mana."
+          "text": "If multiple Gemstone Caverns are put onto the battlefield under a single player's control before the game begins, the \"legend rule\" won't put the extras into that player's graveyard until just before the first player gets priority during his or her first upkeep step. There's no opportunity to tap the extras for mana."
         },
         {
           "date": "2016-06-08",
-          "text": "A player’s “opening hand” is the hand of cards the player has after all players have taken mulligans and “scryed” if applicable. If players have any cards in hand that allow actions to be taken with them from a player’s opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
+          "text": "A player's \"opening hand\" is the hand of cards the player has after all players have taken mulligans and \"scryed\" if applicable. If players have any cards in hand that allow actions to be taken with them from a player's opening hand, the starting player takes all such actions first in any order, followed by each other player in turn order. Then the first turn begins."
         }
       ],
       "supertypes": [
@@ -30105,7 +30085,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Although Urza’s Factory has the Urza’s land type, it doesn’t interact with Urza’s Tower, Urza’s Mine, or Urza’s Power Plant."
+          "text": "Although Urza's Factory has the Urza's land type, it doesn't interact with Urza's Tower, Urza's Mine, or Urza's Power Plant."
         }
       ],
       "subtypes": [
@@ -30205,11 +30185,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If you don’t choose a land on the battlefield, Vesuva enters the battlefield untapped as itself."
+          "text": "If you don't choose a land on the battlefield, Vesuva enters the battlefield untapped as itself."
         },
         {
           "date": "2006-10-15",
-          "text": "Cornered Market won’t prevent Vesuva from being played (unless there’s a Vesuva on the battlefield copying nothing), since you play it before it becomes named something else."
+          "text": "Cornered Market won't prevent Vesuva from being played (unless there's a Vesuva on the battlefield copying nothing), since you play it before it becomes named something else."
         }
       ],
       "text": "You may have Vesuva enter the battlefield tapped as a copy of any land on the battlefield.",
@@ -34823,7 +34803,27 @@
         {
           "language": "French",
           "name": "Montagne",
+          "multiverseid": 132711
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 132712
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
           "multiverseid": 132713
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 132714
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 133015
         },
         {
           "language": "Italian",
@@ -34904,26 +34904,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 134219
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134517
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134518
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134519
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134520
         }
       ],
       "id": "29586e15e37cfd06224623574a63d9ca59ca690c",
@@ -35208,7 +35188,27 @@
         {
           "language": "French",
           "name": "Montagne",
+          "multiverseid": 132711
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 132712
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
           "multiverseid": 132713
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 132714
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 133015
         },
         {
           "language": "Italian",
@@ -35289,26 +35289,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 134219
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134517
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134518
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134519
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134520
         }
       ],
       "id": "e333794bb78bdb0f5cd9e3da54505a3a728e567a",
@@ -35593,7 +35573,27 @@
         {
           "language": "French",
           "name": "Montagne",
+          "multiverseid": 132711
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 132712
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
           "multiverseid": 132713
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 132714
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 133015
         },
         {
           "language": "Italian",
@@ -35674,26 +35674,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 134219
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134517
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134518
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134519
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134520
         }
       ],
       "id": "23643ddb0fecded15e40bdf9a9dffb5ac65bba28",
@@ -35978,7 +35958,27 @@
         {
           "language": "French",
           "name": "Montagne",
+          "multiverseid": 132711
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 132712
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
           "multiverseid": 132713
+        },
+        {
+          "language": "French",
+          "name": "Montagne",
+          "multiverseid": 132714
+        },
+        {
+          "language": "German",
+          "name": "Gebirge",
+          "multiverseid": 133015
         },
         {
           "language": "Italian",
@@ -36059,26 +36059,6 @@
           "language": "Russian",
           "name": "Гора",
           "multiverseid": 134219
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134517
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134518
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134519
-        },
-        {
-          "language": "Spanish",
-          "name": "Montaña",
-          "multiverseid": 134520
         }
       ],
       "id": "efa89d61d7d2ab10c5754f6b670dd4735a406a67",

--- a/json/UDS.json
+++ b/json/UDS.json
@@ -150,7 +150,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Putting on a counter is optional. If you forget, you can’t go back later even if it is something you usually do."
+          "text": "Putting on a counter is optional. If you forget, you can't go back later even if it is something you usually do."
         }
       ],
       "subtypes": [
@@ -374,7 +374,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "False Prophet only exiles creatures, which means only creature permanents which are on the battlefield. It won’t exile itself since it is already in the graveyard."
+          "text": "False Prophet only exiles creatures, which means only creature permanents which are on the battlefield. It won't exile itself since it is already in the graveyard."
         }
       ],
       "subtypes": [
@@ -541,15 +541,15 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It will trigger “enters the battlefield” abilities and “leaves the battlefield” abilities. Note that the card does not go to the graveyard, so it will not trigger “goes to the graveyard” abilities."
+          "text": "It will trigger \"enters the battlefield\" abilities and \"leaves the battlefield\" abilities. Note that the card does not go to the graveyard, so it will not trigger \"goes to the graveyard\" abilities."
         },
         {
           "date": "2004-10-04",
-          "text": "This could be used to make the target of another spell or ability illegal if this wasn’t a sorcery (which makes it really hard to do that). This is because the Flickered permanent leaves the battlefield and then returns as a completely different permanent, and the targeted spell will not recognize it."
+          "text": "This could be used to make the target of another spell or ability illegal if this wasn't a sorcery (which makes it really hard to do that). This is because the Flickered permanent leaves the battlefield and then returns as a completely different permanent, and the targeted spell will not recognize it."
         },
         {
           "date": "2005-08-01",
-          "text": "This spell effectively “resets” the permanent to being just like it was freshly cast. All counters, Auras, effects, and so on are removed when it is exiled. Then it comes back onto the battlefield like new."
+          "text": "This spell effectively \"resets\" the permanent to being just like it was freshly cast. All counters, Auras, effects, and so on are removed when it is exiled. Then it comes back onto the battlefield like new."
         }
       ],
       "text": "Exile target nontoken permanent, then return it to the battlefield under its owner's control.",
@@ -788,11 +788,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "This is the current interaction between Humility and Opalescence: The type-changing effect applies at layer 4, but the rest happens in the applicable layers. The rest of it will apply even if the permanent loses its ability before it’s finished applying. So if Opalescence, Humility, and Worship are on the battlefield and Opalescence entered the battlefield before Humility, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments. (Opalescence). Layer 6: Humility and Worship each lose their abilities. (Humility) Layer 7b: Humility becomes 4/4 and Worship becomes 4/4. (Opalescence). Humility becomes 1/1 and Worship becomes 1/1 (Humility). But if Humility entered the battlefield before Opalescence, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments (Opalescence). Layer 6: Humility and Worship each lose their abilities (Humility). Layer 7b: Humility becomes 1/1 and Worship becomes 1/1 (Humility). Humility becomes 4/4 and Worship becomes 4/4 (Opalescence)."
+          "text": "This is the current interaction between Humility and Opalescence: The type-changing effect applies at layer 4, but the rest happens in the applicable layers. The rest of it will apply even if the permanent loses its ability before it's finished applying. So if Opalescence, Humility, and Worship are on the battlefield and Opalescence entered the battlefield before Humility, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments. (Opalescence). Layer 6: Humility and Worship each lose their abilities. (Humility) Layer 7b: Humility becomes 4/4 and Worship becomes 4/4. (Opalescence). Humility becomes 1/1 and Worship becomes 1/1 (Humility). But if Humility entered the battlefield before Opalescence, the following is true: Layer 4: Humility and Worship each become creatures that are still enchantments (Opalescence). Layer 6: Humility and Worship each lose their abilities (Humility). Layer 7b: Humility becomes 1/1 and Worship becomes 1/1 (Humility). Humility becomes 4/4 and Worship becomes 4/4 (Opalescence)."
         }
       ],
       "text": "Each other non-Aura enchantment is a creature in addition to its other types and has base power and base toughness each equal to its converted mana cost.",
@@ -906,11 +906,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "You must return Auras if possible, even if this means enchanting an opponent’s permanent with a good enchantment."
+          "text": "You must return Auras if possible, even if this means enchanting an opponent's permanent with a good enchantment."
         },
         {
           "date": "2005-08-01",
-          "text": "Auras can only be placed on permanents that were on the battlefield before this effect started to resolve. You can’t put an enchantment onto the battlefield with Replenish and put an Aura that is also entering the battlefield onto one of those enchantments."
+          "text": "Auras can only be placed on permanents that were on the battlefield before this effect started to resolve. You can't put an enchantment onto the battlefield with Replenish and put an Aura that is also entering the battlefield onto one of those enchantments."
         }
       ],
       "text": "Return all enchantment cards from your graveyard to the battlefield. (Auras with nothing to enchant remain in your graveyard.)",
@@ -970,7 +970,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Gaining life is optional. If you forget, you can’t go back later even if it is something you usually do."
+          "text": "Gaining life is optional. If you forget, you can't go back later even if it is something you usually do."
         }
       ],
       "text": "Whenever an opponent taps a Mountain for mana, you may gain 1 life.",
@@ -1089,7 +1089,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "Scour can target and exile cards that aren’t always enchantments, but are enchantments when Scour is cast and resolves (such as creatures turned into enchantments by Soul Sculptor). Scour’s exile effect only looks for cards by name, not type."
+          "text": "Scour can target and exile cards that aren't always enchantments, but are enchantments when Scour is cast and resolves (such as creatures turned into enchantments by Soul Sculptor). Scour's exile effect only looks for cards by name, not type."
         },
         {
           "date": "2005-02-01",
@@ -1257,7 +1257,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability will trigger if you don’t control an enchantment, even for a brief moment during the resolution of another spell or ability."
+          "text": "The ability will trigger if you don't control an enchantment, even for a brief moment during the resolution of another spell or ability."
         },
         {
           "date": "2004-10-04",
@@ -1532,7 +1532,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Gaining control of an enchantment often isn’t very interesting since it probably won’t change what the enchantment is doing. It only matters if the enchantment does something specifically to “you” or “an opponent” or if the enchantment has an activated ability (which only the controller can use)."
+          "text": "Gaining control of an enchantment often isn't very interesting since it probably won't change what the enchantment is doing. It only matters if the enchantment does something specifically to \"you\" or \"an opponent\" or if the enchantment has an activated ability (which only the controller can use)."
         }
       ],
       "subtypes": [
@@ -2014,7 +2014,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you pick an Aura that can’t legally enchant this card, then the enchantment stays in the graveyard."
+          "text": "If you pick an Aura that can't legally enchant this card, then the enchantment stays in the graveyard."
         },
         {
           "date": "2004-10-04",
@@ -2022,7 +2022,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "This card used to have errata that kept it from triggering if it wasn’t cast from your hand. This errata has since been removed, so the ability will trigger regardless of where the Drake was before entering the battlefield."
+          "text": "This card used to have errata that kept it from triggering if it wasn't cast from your hand. This errata has since been removed, so the ability will trigger regardless of where the Drake was before entering the battlefield."
         }
       ],
       "subtypes": [
@@ -2182,7 +2182,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "Being “enchanted” means there is an Aura on it."
+          "text": "Being \"enchanted\" means there is an Aura on it."
         }
       ],
       "subtypes": [
@@ -2290,7 +2290,8 @@
       "originalType": "Enchantment",
       "printings": [
         "UDS",
-        "7ED"
+        "7ED",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
@@ -2343,7 +2344,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Putting on a counter is optional. If you forget, you can’t go back later even if it is something you usually do."
+          "text": "Putting on a counter is optional. If you forget, you can't go back later even if it is something you usually do."
         }
       ],
       "subtypes": [
@@ -2412,7 +2413,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then it does not get exiled but all the other copies in the graveyard, hand, and library are exiled."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then it does not get exiled but all the other copies in the graveyard, hand, and library are exiled."
         },
         {
           "date": "2005-02-01",
@@ -2420,7 +2421,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "If Quash counters a spell that has had text spliced onto it, only the base spell may be exiled. For example, if you use Quash to counter a Kodama’s Might with a Glacial Ray spliced onto it, you may search for and exile only Kodama’s Might."
+          "text": "If Quash counters a spell that has had text spliced onto it, only the base spell may be exiled. For example, if you use Quash to counter a Kodama's Might with a Glacial Ray spliced onto it, you may search for and exile only Kodama's Might."
         },
         {
           "date": "2005-02-01",
@@ -2482,7 +2483,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The “if” in the card text does not have a special meaning. You check if this card is enchanted when the ability resolves and draw 1 or 2 cards."
+          "text": "The \"if\" in the card text does not have a special meaning. You check if this card is enchanted when the ability resolves and draw 1 or 2 cards."
         },
         {
           "date": "2005-08-01",
@@ -2884,7 +2885,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -3106,7 +3107,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Affects lands with type Swamp, not lands that are named “Swamp.”"
+          "text": "Affects lands with type Swamp, not lands that are named \"Swamp.\""
         },
         {
           "date": "2004-10-04",
@@ -3128,7 +3129,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"‘Davvol, blast those elves.' ‘Davvol, transport those troops.' No one cares that today is my birthday.\"",
+      "flavor": "\"'Davvol, blast those elves.' 'Davvol, transport those troops.' No one cares that today is my birthday.\"",
       "id": "9fbec5013c8aeedff3b2f8661081d49ee13bb719",
       "imageName": "carnival of souls",
       "layout": "normal",
@@ -3462,7 +3463,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "If you manage to turn a land (such as a Forest or Stalking Stones) into a creature, you can indeed use this effect on that basic land type. Eradicate’s exile effect only looks for cards by name, not type."
+          "text": "If you manage to turn a land (such as a Forest or Stalking Stones) into a creature, you can indeed use this effect on that basic land type. Eradicate's exile effect only looks for cards by name, not type."
         },
         {
           "date": "2005-02-01",
@@ -3470,7 +3471,7 @@
         },
         {
           "date": "2012-05-01",
-          "text": "A face-down creature has no name, so no card can possibly share a name with it (not even other cards with no name). If you Eradicate a face-down creature you will still search its controller’s library, but you won’t be able to exile any cards from that library."
+          "text": "A face-down creature has no name, so no card can possibly share a name with it (not even other cards with no name). If you Eradicate a face-down creature you will still search its controller's library, but you won't be able to exile any cards from that library."
         }
       ],
       "text": "Exile target nonblack creature. Search its controller's graveyard, hand, and library for all cards with the same name as that creature and exile them. Then that player shuffles his or her library.",
@@ -3527,7 +3528,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Putting on a counter is optional. If you forget, you can’t go back later even if it is something you usually do."
+          "text": "Putting on a counter is optional. If you forget, you can't go back later even if it is something you usually do."
         }
       ],
       "subtypes": [
@@ -3584,7 +3585,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Once it becomes a creature, it will not change back into an enchantment if your opponent’s life total goes back above 10."
+          "text": "Once it becomes a creature, it will not change back into an enchantment if your opponent's life total goes back above 10."
         },
         {
           "date": "2004-10-04",
@@ -3592,7 +3593,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent has 10 or less life, if Lurking Jackals is an enchantment, it becomes a 3/2 Jackal creature.",
@@ -4609,7 +4610,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability will trigger if you don’t control an artifact, even for a brief moment during the resolution of another spell or ability."
+          "text": "The ability will trigger if you don't control an artifact, even for a brief moment during the resolution of another spell or ability."
         },
         {
           "date": "2004-10-04",
@@ -5117,7 +5118,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Putting on a counter is optional. If you forget, you can’t go back later even if it is something you usually do."
+          "text": "Putting on a counter is optional. If you forget, you can't go back later even if it is something you usually do."
         }
       ],
       "subtypes": [
@@ -5639,7 +5640,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
@@ -5647,7 +5648,7 @@
         },
         {
           "date": "2014-09-20",
-          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you’ve declared attackers usually won’t do anything."
+          "text": "Only creatures that are attacking as Trumpet Blast resolves will receive the bonus. In other words, casting it before you've declared attackers usually won't do anything."
         }
       ],
       "text": "Attacking creatures get +2/+0 until end of turn.",
@@ -5701,7 +5702,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Only looks at the card name, so it will not destroy lands that just share the destroyed land’s type."
+          "text": "Only looks at the card name, so it will not destroy lands that just share the destroyed land's type."
         }
       ],
       "text": "Destroy target land and all other lands with the same name as that land.",
@@ -5991,7 +5992,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "subtypes": [
@@ -6058,7 +6059,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Emperor Crocodile’s ability will trigger if you don’t control another creature, even if it’s only for a brief moment during the resolution of another spell or ability (such as that of Brago, King Eternal)."
+          "text": "Emperor Crocodile's ability will trigger if you don't control another creature, even if it's only for a brief moment during the resolution of another spell or ability (such as that of Brago, King Eternal)."
         },
         {
           "date": "2016-06-08",
@@ -6519,7 +6520,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Putting on a counter is optional. If you forget, you can’t go back later even if it is something you usually do."
+          "text": "Putting on a counter is optional. If you forget, you can't go back later even if it is something you usually do."
         }
       ],
       "subtypes": [
@@ -6627,7 +6628,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -6980,7 +6981,7 @@
         },
         {
           "date": "2005-02-01",
-          "text": "Splinter can target and exile cards that aren’t always artifacts, but are artifacts when Splinter is cast and resolves (such as an animated Stalking Stones). Splinter’s exile effect only looks for cards by name, not type."
+          "text": "Splinter can target and exile cards that aren't always artifacts, but are artifacts when Splinter is cast and resolves (such as an animated Stalking Stones). Splinter's exile effect only looks for cards by name, not type."
         },
         {
           "date": "2005-02-01",
@@ -7104,11 +7105,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -7116,7 +7117,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -7328,7 +7329,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "{2}, {T}, Sacrifice Braidwood Sextant: Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -7722,7 +7723,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This is a mana ability. It does not go on the stack and can’t be responded to."
+          "text": "This is a mana ability. It does not go on the stack and can't be responded to."
         },
         {
           "date": "2004-10-04",
@@ -7780,11 +7781,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Only destroys artifacts and creatures with exactly the specified cost. It does not mean “less than or equal to”."
+          "text": "Only destroys artifacts and creatures with exactly the specified cost. It does not mean \"less than or equal to\"."
         },
         {
           "date": "2004-10-04",
-          "text": "Putting on a counter is optional. If you forget, you can’t go back later even if it is something you usually do."
+          "text": "Putting on a counter is optional. If you forget, you can't go back later even if it is something you usually do."
         }
       ],
       "text": "At the beginning of your upkeep, you may put a fuse counter on Powder Keg.\n{T}, Sacrifice Powder Keg: Destroy each artifact and creature with converted mana cost equal to the number of fuse counters on Powder Keg.",
@@ -7887,7 +7888,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card’s ability does not override effects which prevent a permanent from untapping."
+          "text": "This card's ability does not override effects which prevent a permanent from untapping."
         },
         {
           "date": "2005-08-01",
@@ -7895,7 +7896,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "If another effect limits the number of permanents that untap, that number combines with Storage Matrix’s effect. For example, Imi Statue says “players can’t untap more than one artifact during their untap steps.” If both Imi Statue and an untapped Storage Matrix are on the battlefield, and you choose “artifact,” only one artifact untaps."
+          "text": "If another effect limits the number of permanents that untap, that number combines with Storage Matrix's effect. For example, Imi Statue says \"players can't untap more than one artifact during their untap steps.\" If both Imi Statue and an untapped Storage Matrix are on the battlefield, and you choose \"artifact,\" only one artifact untaps."
         }
       ],
       "text": "As long as Storage Matrix is untapped, each player chooses artifact, creature, or land during his or her untap step. That player can untap only permanents of the chosen type this step.",

--- a/json/UGL.json
+++ b/json/UGL.json
@@ -773,7 +773,7 @@
       "subtypes": [
         "Clamfolk"
       ],
-      "text": "When Clam Session comes into play, choose a word. \nDuring your upkeep, sing at least six words of a song, one of which must be the chosen word, or sacrifice Clam Session. You cannot repeat a song.",
+      "text": "When Clam Session comes into play, choose a word.\nDuring your upkeep, sing at least six words of a song, one of which must be the chosen word, or sacrifice Clam Session. You cannot repeat a song.",
       "toughness": "5",
       "type": "Summon — Clamfolk",
       "types": [
@@ -1986,7 +1986,7 @@
         "UGL"
       ],
       "rarity": "Rare",
-      "text": "Roll a six-sided die for Strategy, Schmategy. On a 1, Strategy, Schmategy has no effect. Otherwise, it has one of the following effects.\n2 Destroy all artifacts.\n3 Destroy all lands.\n4 Strategy, Schmategy deals 3 damage to each creature and player.\n5 Each player discards his or her hand and draws seven cards. \n6 Roll the die two more times.",
+      "text": "Roll a six-sided die for Strategy, Schmategy. On a 1, Strategy, Schmategy has no effect. Otherwise, it has one of the following effects.\n2 Destroy all artifacts.\n3 Destroy all lands.\n4 Strategy, Schmategy deals 3 damage to each creature and player.\n5 Each player discards his or her hand and draws seven cards.\n6 Roll the die two more times.",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -2302,7 +2302,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "MORE TO LOVE: Friendly, nature-loving, Bunyonesque SEM seeks SEF looking for a huge commitment.\n . . .  seeks atog prince",
+      "flavor": "MORE TO LOVE: Friendly, nature-loving, Bunyonesque SEM seeks SEF looking for a huge commitment.\n. . .  seeks atog prince",
       "id": "85ad8b9c825c4c9b3639a88f8343ef43dd07f3bd",
       "imageName": "growth spurt",
       "layout": "normal",

--- a/json/ULG.json
+++ b/json/ULG.json
@@ -354,7 +354,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "It can only target “Enchantment - Aura” cards, which includes cards changed into Auras, such as Licids."
+          "text": "It can only target \"Enchantment - Aura\" cards, which includes cards changed into Auras, such as Licids."
         }
       ],
       "subtypes": [
@@ -855,7 +855,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When you have 10 or less life, if Opal Avenger is an enchantment, Opal Avenger becomes a 3/5 Soldier creature.",
@@ -908,7 +908,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It triggers when the spell is cast, so it becomes a creature before the spell resolves. A creature that would destroy an enchantment when it enters the battlefield can’t be used to destroy this card, since it will no longer be an enchantment when the creature enters the battlefield."
+          "text": "It triggers when the spell is cast, so it becomes a creature before the spell resolves. A creature that would destroy an enchantment when it enters the battlefield can't be used to destroy this card, since it will no longer be an enchantment when the creature enters the battlefield."
         },
         {
           "date": "2004-10-04",
@@ -920,11 +920,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a creature spell, if Opal Champion is an enchantment, Opal Champion becomes a 3/3 Knight creature with first strike.",
@@ -1040,7 +1040,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If this card is not on the battlefield when the ability resolves, then you can’t sacrifice it. However, you still destroy all creatures."
+          "text": "If this card is not on the battlefield when the ability resolves, then you can't sacrifice it. However, you still destroy all creatures."
         }
       ],
       "text": "At the beginning of your upkeep, if there are four or more creatures on the battlefield, sacrifice Planar Collapse and destroy all creatures. They can't be regenerated.",
@@ -1423,7 +1423,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "While Anthroplasm does become 0/0 for a moment while its ability resolves, state-based actions are not checked until the ability has finished resolving. By that time, it will have some +1/+1 counters on it (assuming X was greater than 0), and so will not be put into its owner’s graveyard."
+          "text": "While Anthroplasm does become 0/0 for a moment while its ability resolves, state-based actions are not checked until the ability has finished resolving. By that time, it will have some +1/+1 counters on it (assuming X was greater than 0), and so will not be put into its owner's graveyard."
         }
       ],
       "subtypes": [
@@ -1666,7 +1666,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -1834,7 +1834,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "text": "Draw two cards, then discard two cards. Untap up to three lands.",
@@ -1896,11 +1896,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It means “targeting at least one creature” not “exactly one creature”."
+          "text": "It means \"targeting at least one creature\" not \"exactly one creature\"."
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell’s target leaves the battlefield before this spell resolves, Intervene will be countered since it no longer targets a spell that targets a creature."
+          "text": "If the spell's target leaves the battlefield before this spell resolves, Intervene will be countered since it no longer targets a spell that targets a creature."
         }
       ],
       "text": "Counter target spell that targets a creature.",
@@ -2179,7 +2179,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -2362,11 +2362,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         },
         {
           "date": "2010-06-15",
-          "text": "On resolution of the trigger you have to sacrifice this card if you have 5 life or less. If you can’t (because it is not on the battlefield, for example), then you still take an extra turn after this one."
+          "text": "On resolution of the trigger you have to sacrifice this card if you have 5 life or less. If you can't (because it is not on the battlefield, for example), then you still take an extra turn after this one."
         }
       ],
       "text": "At the beginning of your upkeep, if you have 5 or less life, sacrifice Second Chance and take an extra turn after this one.",
@@ -2481,7 +2481,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "text": "Return target creature to its owner's hand. Untap up to two lands.",
@@ -2591,7 +2591,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Tinker, sacrifice an artifact.\nSearch your library for an artifact card and put that card onto the battlefield. Then shuffle your library.",
@@ -2869,7 +2869,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "You must sacrifice Brink of Madness if possible, but the opponent discards his or her hand even if you can’t sacrifice it for some reason (for example, if it were returned to its owner’s hand before the ability resolved)."
+          "text": "You must sacrifice Brink of Madness if possible, but the opponent discards his or her hand even if you can't sacrifice it for some reason (for example, if it were returned to its owner's hand before the ability resolved)."
         }
       ],
       "text": "At the beginning of your upkeep, if you have no cards in hand, sacrifice Brink of Madness and target opponent discards his or her hand.",
@@ -2974,7 +2974,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This is loss of life, and not damage. It can’t be prevented."
+          "text": "This is loss of life, and not damage. It can't be prevented."
         }
       ],
       "subtypes": [
@@ -3143,7 +3143,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When a creature is put into an opponent's graveyard from the battlefield, if Lurking Skirge is an enchantment, Lurking Skirge becomes a 3/2 Imp creature with flying.",
@@ -3191,7 +3191,8 @@
       "originalText": "Whenever a creature successfully deals damage to you, destroy it.",
       "originalType": "Enchantment",
       "printings": [
-        "ULG"
+        "ULG",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -3252,7 +3253,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Target opponent reveals his or her hand. You choose a creature card from it. That player discards that card.",
@@ -3586,7 +3587,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "{1}{B}, Pay 2 life: Return target creature card from your graveyard to your hand.",
@@ -3865,7 +3866,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This is loss of life, not damage. It can’t be prevented."
+          "text": "This is loss of life, not damage. It can't be prevented."
         }
       ],
       "text": "At the beginning of your upkeep, each opponent loses 1 life. You gain life equal to the life lost this way.",
@@ -4080,7 +4081,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-10-01",
@@ -4138,7 +4139,7 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Note that the wording “Effects that alter the creature’s power alter its toughness instead, and vice versa, this turn” has been removed."
+          "text": "Note that the wording \"Effects that alter the creature's power alter its toughness instead, and vice versa, this turn\" has been removed."
         },
         {
           "date": "2013-04-15",
@@ -4146,7 +4147,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "text": "Switch target creature's power and toughness until end of turn.",
@@ -4287,7 +4288,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"They are called ‘Mi'uto,' which means ‘one use.'\"\n—Jhoira, artificer",
+      "flavor": "\"They are called 'Mi'uto,' which means 'one use.'\"\n—Jhoira, artificer",
       "id": "fe767d668549328411b2626cfb3af22357cc1aec",
       "imageName": "ghitu fire-eater",
       "layout": "normal",
@@ -4663,7 +4664,7 @@
         },
         {
           "date": "2010-06-15",
-          "text": "If this card is not on the battlefield at the times its ability resolves, then you can’t sacrifice it. However, you still destroy all lands."
+          "text": "If this card is not on the battlefield at the times its ability resolves, then you can't sacrifice it. However, you still destroy all lands."
         }
       ],
       "text": "At the beginning of your upkeep, if there are seven or more lands on the battlefield, sacrifice Impending Disaster and destroy all lands.",
@@ -5338,7 +5339,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is returned to its owner’s hand at the end of turn only if it is on the battlefield."
+          "text": "It is returned to its owner's hand at the end of turn only if it is on the battlefield."
         }
       ],
       "subtypes": [
@@ -5454,7 +5455,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is returned to its owner’s hand at the end of turn only if it is on the battlefield."
+          "text": "It is returned to its owner's hand at the end of turn only if it is on the battlefield."
         }
       ],
       "subtypes": [
@@ -5689,11 +5690,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2010-06-15",
-          "text": "If this card is not on the battlefield at the time it resolves, then you can’t sacrifice it. You still perform the search and put any creature cards you find onto the battlefield."
+          "text": "If this card is not on the battlefield at the time it resolves, then you can't sacrifice it. You still perform the search and put any creature cards you find onto the battlefield."
         }
       ],
       "text": "At the beginning of your upkeep, if an opponent controls three or more creatures, sacrifice Defense of the Heart, search your library for up to two creature cards, and put those cards onto the battlefield. Then shuffle your library.",
@@ -5935,7 +5936,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts an instant spell, if Hidden Gibbons is an enchantment, Hidden Gibbons becomes a 4/4 Ape creature.",
@@ -5999,11 +6000,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
-          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can’t split the damage assignment between them."
+          "text": "When assigning combat damage, you choose whether you want to assign all damage to blocking creatures, or if you want to assign all of it to the defending player or planeswalker. You can't split the damage assignment between them."
         },
         {
           "date": "2008-04-01",
@@ -6011,7 +6012,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned “as though it weren’t blocked”."
+          "text": "If blocked by a creature with banding, the defending player decides whether or not the damage is assigned \"as though it weren't blocked\"."
         }
       ],
       "subtypes": [
@@ -6301,7 +6302,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
+          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
         }
       ],
       "subtypes": [
@@ -6357,7 +6358,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2008-10-01",
@@ -6747,7 +6748,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -6910,7 +6911,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Angel’s Trumpet affects creatures with Defender and other creatures that can’t attack for some reason."
+          "text": "Angel's Trumpet affects creatures with Defender and other creatures that can't attack for some reason."
         },
         {
           "date": "2004-10-04",
@@ -7066,11 +7067,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A player affected by this card can sacrifice a permanent any time he or she could cast an instant. This is a special action that doesn’t use the stack and can’t be responded to."
+          "text": "A player affected by this card can sacrifice a permanent any time he or she could cast an instant. This is a special action that doesn't use the stack and can't be responded to."
         },
         {
           "date": "2008-08-01",
-          "text": "A player can only sacrifice a permanent to end this effect if he or she has more permanents than any other player, and he or she hasn’t already sacrificed a permanent to end the effect this turn. The ability to sacrifice a creature is granted by the same effect that is being ended."
+          "text": "A player can only sacrifice a permanent to end this effect if he or she has more permanents than any other player, and he or she hasn't already sacrificed a permanent to end the effect this turn. The ability to sacrifice a creature is granted by the same effect that is being ended."
         }
       ],
       "text": "A player who controls more permanents than each other player can't play lands or cast artifact, creature, or enchantment spells. That player may sacrifice a permanent for that player to ignore this effect until end of turn.",
@@ -7129,7 +7130,7 @@
         },
         {
           "date": "2006-05-01",
-          "text": "In Two-Headed Giant, spells don’t cost extra on your own turn."
+          "text": "In Two-Headed Giant, spells don't cost extra on your own turn."
         }
       ],
       "text": "Each spell costs {3} more to cast except during its controller's turn.",
@@ -7312,7 +7313,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t look at the cards you exiled until they return to your hand."
+          "text": "You can't look at the cards you exiled until they return to your hand."
         }
       ],
       "text": "{T}, Sacrifice Memory Jar: Each player exiles all cards from his or her hand face down and draws seven cards. At the beginning of the next end step, each player discards his or her hand and returns to his or her hand each card he or she exiled this way.",
@@ -7365,7 +7366,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Any ‘X’ in the creature’s cost is treated as zero."
+          "text": "Any 'X' in the creature's cost is treated as zero."
         },
         {
           "date": "2007-05-01",
@@ -7373,11 +7374,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         },
         {
           "date": "2011-09-22",
-          "text": "You don’t pay any costs of that creature card, including additional costs."
+          "text": "You don't pay any costs of that creature card, including additional costs."
         }
       ],
       "text": "{4}, {T}: You may put a creature card from your hand onto the battlefield.",
@@ -7797,11 +7798,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Faerie Conclave enters the battlefield tapped.\n{T}: Add {U} to your mana pool.\n{1}{U}: Faerie Conclave becomes a 2/1 blue Faerie creature with flying until end of turn. It's still a land.",
@@ -7854,11 +7855,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Forbidding Watchtower enters the battlefield tapped.\n{T}: Add {W} to your mana pool.\n{1}{W}: Forbidding Watchtower becomes a 1/5 white Soldier creature until end of turn. It's still a land.",
@@ -7913,11 +7914,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Ghitu Encampment enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\n{1}{R}: Ghitu Encampment becomes a 2/1 red Warrior creature with first strike until end of turn. It's still a land. (It deals combat damage before creatures without first strike.)",
@@ -7970,11 +7971,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Spawning Pool enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\n{1}{B}: Spawning Pool becomes a 1/1 black Skeleton creature with \"{B}: Regenerate this creature\" until end of turn. It's still a land. (If it regenerates, the next time it would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
@@ -8033,11 +8034,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",

--- a/json/UNH.json
+++ b/json/UNH.json
@@ -682,7 +682,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"I said ‘Put him in a core set, not a corset'\"\n—Richard Garfield, Ph.D.",
+      "flavor": "\"I said 'Put him in a core set, not a corset'\"\n—Richard Garfield, Ph.D.",
       "foreignNames": [
         {
           "language": "French",
@@ -2917,7 +2917,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"C'mon, choose ‘monkey.' Everybody loves monkeys\"",
+      "flavor": "\"C'mon, choose 'monkey.' Everybody loves monkeys\"",
       "foreignNames": [
         {
           "language": "French",
@@ -3968,7 +3968,7 @@
       "subtypes": [
         "Elemental"
       ],
-      "text": "Whenever Red-Hot Hottie deals damage to a creature, put a third-degree-burn counter on that creature. It has \"At the end of each turn, sacrifice this creature unless you scream ‘Aaah' at the top of your lungs.\"",
+      "text": "Whenever Red-Hot Hottie deals damage to a creature, put a third-degree-burn counter on that creature. It has \"At the end of each turn, sacrifice this creature unless you scream 'Aaah' at the top of your lungs.\"",
       "toughness": "5",
       "type": "Creature — Elemental",
       "types": [
@@ -4239,7 +4239,7 @@
       "subtypes": [
         "Hound"
       ],
-      "text": "Trample\nWhenever a player plays a spell, put a chip counter on its converted mana cost.  \nB-I-N-G-O gets +9/+9 for each set of three numbers in a row with chip counters on them.",
+      "text": "Trample\nWhenever a player plays a spell, put a chip counter on its converted mana cost.\nB-I-N-G-O gets +9/+9 for each set of three numbers in a row with chip counters on them.",
       "toughness": "1",
       "type": "Creature — Hound",
       "types": [
@@ -4717,7 +4717,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"Two muffins are baking in an oven. One muffin says to the other muffin, ‘It's getting hot in here, huh?' The other muffin says, ‘Aagh A talking muffin'\"",
+      "flavor": "\"Two muffins are baking in an oven. One muffin says to the other muffin, 'It's getting hot in here, huh?' The other muffin says, 'Aagh A talking muffin'\"",
       "foreignNames": [
         {
           "language": "French",
@@ -5933,7 +5933,7 @@
     {
       "artist": "Martina Pilcerova",
       "cmc": 4,
-      "flavor": "\"I would have made a ‘Spin-The-Bottle' joke if I thought anyone reading this had ever played the game.\"\n—Bucky, flavor text writer",
+      "flavor": "\"I would have made a 'Spin-The-Bottle' joke if I thought anyone reading this had ever played the game.\"\n—Bucky, flavor text writer",
       "foreignNames": [
         {
           "language": "French",

--- a/json/USG.json
+++ b/json/USG.json
@@ -1122,11 +1122,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Humble overwrites all previous effects that set the creature’s base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Humble resolves will overwrite this effect."
+          "text": "Humble overwrites all previous effects that set the creature's base power and toughness to specific values. Any power- or toughness-setting effects that start to apply after Humble resolves will overwrite this effect."
         },
         {
           "date": "2016-06-08",
-          "text": "Effects that modify a creature’s power and/or toughness, such as the effect of Seal of Strength, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
+          "text": "Effects that modify a creature's power and/or toughness, such as the effect of Seal of Strength, will apply to the creature no matter when they started to take effect. The same is true for any counters that change its power and/or toughness and effects that switch its power and toughness."
         },
         {
           "date": "2016-06-08",
@@ -1134,7 +1134,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Humble doesn’t counter abilities that have already triggered or been activated. In particular, casting this spell won’t stop a creature’s ability that says “At the beginning of your upkeep,” “When this creature enters the battlefield,” or similar from triggering."
+          "text": "Humble doesn't counter abilities that have already triggered or been activated. In particular, casting this spell won't stop a creature's ability that says \"At the beginning of your upkeep,\" \"When this creature enters the battlefield,\" or similar from triggering."
         }
       ],
       "text": "Until end of turn, target creature loses all abilities and has base power and toughness 0/1.",
@@ -1196,7 +1196,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The power of the creature is checked on activation and on resolution. If the targeted creature’s power is not 4 or greater on resolution, the ability is countered."
+          "text": "The power of the creature is checked on activation and on resolution. If the targeted creature's power is not 4 or greater on resolution, the ability is countered."
         }
       ],
       "subtypes": [
@@ -1383,11 +1383,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Whenever an opponent casts a creature spell, if Opal Acrolith is an enchantment, Opal Acrolith becomes a 2/4 Soldier creature.\n{0}: Opal Acrolith becomes an enchantment.",
@@ -1453,11 +1453,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a creature spell, if Opal Archangel is an enchantment, Opal Archangel becomes a 5/5 Angel creature with flying and vigilance.",
@@ -1522,11 +1522,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a creature spell, if Opal Caryatid is an enchantment, Opal Caryatid becomes a 2/2 Soldier creature.",
@@ -1591,11 +1591,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a creature spell, if Opal Gargoyle is an enchantment, Opal Gargoyle becomes a 2/2 Gargoyle creature with flying.",
@@ -1664,11 +1664,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a creature spell, if Opal Titan is an enchantment, Opal Titan becomes a 4/4 Giant creature with protection from each of that spell's colors.",
@@ -1820,7 +1820,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can attach this to an opponent’s creature, and all damage done to you is instead done to their creature."
+          "text": "You can attach this to an opponent's creature, and all damage done to you is instead done to their creature."
         },
         {
           "date": "2004-10-04",
@@ -1884,7 +1884,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the spell fails because the target is not there or isn’t legal, the owner does not gain any life."
+          "text": "If the spell fails because the target is not there or isn't legal, the owner does not gain any life."
         }
       ],
       "text": "Destroy target creature. Its owner gains 4 life.",
@@ -2166,11 +2166,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2010-03-01",
-          "text": "If a card which is a creature only due to an effect goes to the graveyard, you can search for another copy of that card even though the card in your library won’t be a creature card."
+          "text": "If a card which is a creature only due to an effect goes to the graveyard, you can search for another copy of that card even though the card in your library won't be a creature card."
         }
       ],
       "text": "Whenever a nontoken creature you control dies, you may search your library for a card with the same name as that creature, reveal it, and put it into your hand. If you do, shuffle your library.",
@@ -2223,7 +2223,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2284,7 +2284,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2345,7 +2345,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2406,7 +2406,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2467,7 +2467,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2524,7 +2524,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2585,7 +2585,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn’t need to be capable of dealing damage to be a legal choice."
+          "text": "A source of damage is a permanent, a spell on the stack (including one that creates a permanent), or any object referred to by an object on the stack. A source doesn't need to be capable of dealing damage to be a legal choice."
         },
         {
           "date": "2004-10-04",
@@ -2841,19 +2841,19 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Whether or not the ability triggers depends on if the Avatar has the ability while in the graveyard. If it doesn’t (thanks to Yixlid Jailer, for instance), then the ability won’t trigger. It doesn’t matter whether the Avatar had the ability in its previous zone (it will trigger even if it had been on the battlefield with Humility)."
+          "text": "Whether or not the ability triggers depends on if the Avatar has the ability while in the graveyard. If it doesn't (thanks to Yixlid Jailer, for instance), then the ability won't trigger. It doesn't matter whether the Avatar had the ability in its previous zone (it will trigger even if it had been on the battlefield with Humility)."
         },
         {
           "date": "2012-07-01",
-          "text": "Serra Avatar’s power and toughness are constantly updated as your life total changes."
+          "text": "Serra Avatar's power and toughness are constantly updated as your life total changes."
         },
         {
           "date": "2012-07-01",
-          "text": "The ability that defines Serra Avatar’s power and toughness works in all zones, not just the battlefield."
+          "text": "The ability that defines Serra Avatar's power and toughness works in all zones, not just the battlefield."
         },
         {
           "date": "2012-07-01",
-          "text": "If Serra Avatar is no longer in your graveyard when its triggered ability resolves, you won’t shuffle your library."
+          "text": "If Serra Avatar is no longer in your graveyard when its triggered ability resolves, you won't shuffle your library."
         }
       ],
       "subtypes": [
@@ -3027,11 +3027,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If there is at least one verse counter on this, you can’t choose zero targets. You must choose between 1 and X targets."
+          "text": "If there is at least one verse counter on this, you can't choose zero targets. You must choose between 1 and X targets."
         },
         {
           "date": "2004-10-04",
-          "text": "You can activate the ability (choosing no targets) even if there are no verse counters on it. It doesn’t do anything useful if you do this."
+          "text": "You can activate the ability (choosing no targets) even if there are no verse counters on it. It doesn't do anything useful if you do this."
         },
         {
           "date": "2004-10-04",
@@ -3314,7 +3314,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -3597,7 +3597,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "You can’t put an Aura card from your hand onto the battlefield this way if that Aura can’t legally enchant Academy Researchers. For example, you can’t put an Aura with “enchant land” or “enchant green creature” onto the battlefield attached to Academy Researchers (unless Academy Researchers somehow turned into a land or a green creature before the ability resolved)."
+          "text": "You can't put an Aura card from your hand onto the battlefield this way if that Aura can't legally enchant Academy Researchers. For example, you can't put an Aura with \"enchant land\" or \"enchant green creature\" onto the battlefield attached to Academy Researchers (unless Academy Researchers somehow turned into a land or a green creature before the ability resolved)."
         }
       ],
       "subtypes": [
@@ -4393,7 +4393,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "If you change this card’s target, you can change which Aura is targeted, but you can’t choose where that Aura will be moved."
+          "text": "If you change this card's target, you can change which Aura is targeted, but you can't choose where that Aura will be moved."
         },
         {
           "date": "2005-08-01",
@@ -4517,7 +4517,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures and lands are only prevented from untapping during the targeted player’s next untap step. They can still can untap during other player’s untap steps."
+          "text": "The creatures and lands are only prevented from untapping during the targeted player's next untap step. They can still can untap during other player's untap steps."
         },
         {
           "date": "2009-10-01",
@@ -4583,7 +4583,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If Fog Bank blocks a creature with trample, that creature’s controller must assign 2 damage to Fog Bank (assuming it’s blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
+          "text": "If Fog Bank blocks a creature with trample, that creature's controller must assign 2 damage to Fog Bank (assuming it's blocking no other creatures, there was no damage marked on it, and nothing has changed its toughness). The remainder can be assigned to the defending player or planeswalker."
         }
       ],
       "subtypes": [
@@ -4707,7 +4707,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -4934,7 +4934,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "Imaginary Pet’s ability triggers only if you have cards in your hand as your upkeep begins, and the ability checks again as it resolves. If your hand is empty at both those times, Imaginary Pet stays on the battlefield."
+          "text": "Imaginary Pet's ability triggers only if you have cards in your hand as your upkeep begins, and the ability checks again as it resolves. If your hand is empty at both those times, Imaginary Pet stays on the battlefield."
         }
       ],
       "subtypes": [
@@ -5331,7 +5331,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -5420,7 +5420,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -5650,19 +5650,19 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Rewind targets only a spell. It doesn’t target any lands. The lands are chosen as Rewind resolves."
+          "text": "Rewind targets only a spell. It doesn't target any lands. The lands are chosen as Rewind resolves."
         },
         {
           "date": "2017-03-14",
-          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can’t choose one land and have it untap four times, for example."
+          "text": "You can choose up to four lands, no matter who controls any of them. Those lands untap once. You can't choose one land and have it untap four times, for example."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won’t untap any lands."
+          "text": "If the spell is an illegal target when Rewind tries to resolve, perhaps because it was countered by another spell or ability, Rewind will be countered and none of its effects will happen. You won't untap any lands."
         },
         {
           "date": "2017-03-14",
-          "text": "If Rewind resolves but the target spell can’t be countered, you’ll still untap lands."
+          "text": "If Rewind resolves but the target spell can't be countered, you'll still untap lands."
         }
       ],
       "text": "Counter target spell. Untap up to four lands.",
@@ -6013,7 +6013,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If there is an artifact or enchantment on the battlefield (even your own) when this card enters the battlefield, you must return one to owner’s hand. If not, then simply ignore the “enters the battlefield” ability."
+          "text": "If there is an artifact or enchantment on the battlefield (even your own) when this card enters the battlefield, you must return one to owner's hand. If not, then simply ignore the \"enters the battlefield\" ability."
         },
         {
           "date": "2004-10-04",
@@ -6122,7 +6122,8 @@
       "originalText": "Return all lands to owners' hands.",
       "originalType": "Instant",
       "printings": [
-        "USG"
+        "USG",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -6239,7 +6240,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "text": "Exile Time Spiral. Each player shuffles his or her graveyard and hand into his or her library, then draws seven cards. You untap up to six lands.",
@@ -6417,7 +6418,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a spell, if Veil of Birds is an enchantment, Veil of Birds becomes a 1/1 Bird creature with flying.",
@@ -6486,7 +6487,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a spell, if Veiled Apparition is an enchantment, Veiled Apparition becomes a 3/3 Illusion creature with flying and \"At the beginning of your upkeep, sacrifice Veiled Apparition unless you pay {1}{U}.\"",
@@ -6540,7 +6541,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It can trigger even if a player’s hand is empty momentarily during the middle of the resolution of a spell or ability."
+          "text": "It can trigger even if a player's hand is empty momentarily during the middle of the resolution of a spell or ability."
         },
         {
           "date": "2004-10-04",
@@ -6548,7 +6549,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When a player has no cards in hand, if Veiled Crocodile is an enchantment, Veiled Crocodile becomes a 4/4 Crocodile creature.",
@@ -6678,7 +6679,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2008-10-01",
@@ -7497,7 +7498,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -7864,7 +7865,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If the creature is on the battlefield and is returned to its owner’s hand or is exiled, this card loses track of the creature and has no further effects in the future."
+          "text": "If the creature is on the battlefield and is returned to its owner's hand or is exiled, this card loses track of the creature and has no further effects in the future."
         }
       ],
       "text": "When Diabolic Servitude enters the battlefield, return target creature card from your graveyard to the battlefield.\nWhen the creature put onto the battlefield with Diabolic Servitude dies, exile it and return Diabolic Servitude to its owner's hand.\nWhen Diabolic Servitude leaves the battlefield, exile the creature put onto the battlefield with Diabolic Servitude.",
@@ -8452,7 +8453,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Pay half your life, rounded up: Lurking Evil becomes a 4/4 Horror creature with flying.",
@@ -8563,7 +8564,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "It doesn’t matter who controlled the creature cards when they were on the battlefield. As long as they were put into your graveyard, you get to put them into your hand."
+          "text": "It doesn't matter who controlled the creature cards when they were on the battlefield. As long as they were put into your graveyard, you get to put them into your hand."
         },
         {
           "date": "2007-07-15",
@@ -8849,7 +8850,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -9027,7 +9028,7 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -9486,7 +9487,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -9549,7 +9550,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card is a bit weird. When it enters the battlefield under your control, you give control of it to an opponent. After that it damages them each turn because the “you” on the card means its controller."
+          "text": "This card is a bit weird. When it enters the battlefield under your control, you give control of it to an opponent. After that it damages them each turn because the \"you\" on the card means its controller."
         }
       ],
       "subtypes": [
@@ -9673,7 +9674,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Tainted Aether’s controller is the one that controls its triggered ability, but the controller of the creature that entered the battlefield chooses what creature they sacrifice during resolution."
+          "text": "Tainted Aether's controller is the one that controls its triggered ability, but the controller of the creature that entered the battlefield chooses what creature they sacrifice during resolution."
         }
       ],
       "text": "Whenever a creature enters the battlefield, its controller sacrifices a creature or land.",
@@ -9950,19 +9951,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You must choose two targets. You can’t cast Victimize targeting only one creature card."
+          "text": "You must choose two targets. You can't cast Victimize targeting only one creature card."
         },
         {
           "date": "2016-06-08",
-          "text": "The creature you sacrifice isn’t chosen until Victimize resolves. You can’t return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
+          "text": "The creature you sacrifice isn't chosen until Victimize resolves. You can't return the creature you sacrifice because it will still be on the battlefield at the time targets are chosen."
         },
         {
           "date": "2016-06-08",
-          "text": "As Victimize resolves, you must sacrifice a creature if able. You can’t change your mind and choose not to sacrifice anything."
+          "text": "As Victimize resolves, you must sacrifice a creature if able. You can't change your mind and choose not to sacrifice anything."
         },
         {
           "date": "2016-06-08",
-          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you’ll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won’t sacrifice a creature."
+          "text": "If one of the targeted creature cards is an illegal target (for instance, because it has left your graveyard before Victimize resolves), you'll still sacrifice a creature and put the other card onto the battlefield. If both are illegal targets, Victimize will be countered. You won't sacrifice a creature."
         },
         {
           "date": "2016-06-08",
@@ -10251,7 +10252,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If an effect asks you to discard a card, you can’t “discard” something that is in your graveyard. Those cards are not in your hand. Thus, Cycling abilities of cards in the graveyard can’t be activated."
+          "text": "If an effect asks you to discard a card, you can't \"discard\" something that is in your graveyard. Those cards are not in your hand. Thus, Cycling abilities of cards in the graveyard can't be activated."
         },
         {
           "date": "2004-10-04",
@@ -10259,11 +10260,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you play a card using Yawgmoth’s Will and something triggers only when “cast from your hand”, that something will not trigger. Such things trigger based on where the card came from."
+          "text": "If you play a card using Yawgmoth's Will and something triggers only when \"cast from your hand\", that something will not trigger. Such things trigger based on where the card came from."
         },
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2006-10-15",
@@ -10552,7 +10553,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A token’s owner is the player under whose control it entered the battlefield."
+          "text": "A token's owner is the player under whose control it entered the battlefield."
         }
       ],
       "text": "Gain control of all permanents you own. (This effect lasts indefinitely.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
@@ -11320,7 +11321,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A Goblin permanent card is an artifact, creature, land, and/or enchantment card with the creature type “Goblin”. Usually such cards will be creatures in addition to any other types, but they may be tribal instead. For example, you could put Boggart Shenanigans onto the battlefield with this effect."
+          "text": "A Goblin permanent card is an artifact, creature, land, and/or enchantment card with the creature type \"Goblin\". Usually such cards will be creatures in addition to any other types, but they may be tribal instead. For example, you could put Boggart Shenanigans onto the battlefield with this effect."
         }
       ],
       "subtypes": [
@@ -11385,11 +11386,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type “Summon Goblin” and “Summon Goblins” also count. You can’t search for cards that have Goblin in the name but don’t have the creature type Goblin."
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
         }
       ],
       "subtypes": [
@@ -11449,7 +11450,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The tokens are named “Goblin” and are of creature type “Goblin”."
+          "text": "The tokens are named \"Goblin\" and are of creature type \"Goblin\"."
         }
       ],
       "text": "Create X 1/1 red Goblin creature tokens.",
@@ -12164,7 +12165,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If a creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If a creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
         },
         {
           "date": "2008-04-01",
@@ -12223,7 +12224,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You must target two different lands. You can’t choose to target just one."
+          "text": "You must target two different lands. You can't choose to target just one."
         }
       ],
       "text": "Destroy two target lands.",
@@ -12656,11 +12657,11 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "Only Shiv’s Embrace’s controller (who is not necessarily the enchanted creature’s controller) can activate its activated ability."
+          "text": "Only Shiv's Embrace's controller (who is not necessarily the enchanted creature's controller) can activate its activated ability."
         },
         {
           "date": "2010-08-15",
-          "text": "When Shiv’s Embrace’s activated ability resolves, the creature Shiv’s Embrace is enchanting at that time will get +1/+0 (regardless of what creature Shiv’s Embrace was enchanting when the ability was activated). If Shiv’s Embrace has left the battlefield by then, the creature it was enchanting at the time it left the battlefield will get +1/+0."
+          "text": "When Shiv's Embrace's activated ability resolves, the creature Shiv's Embrace is enchanting at that time will get +1/+0 (regardless of what creature Shiv's Embrace was enchanting when the ability was activated). If Shiv's Embrace has left the battlefield by then, the creature it was enchanting at the time it left the battlefield will get +1/+0."
         }
       ],
       "subtypes": [
@@ -12890,7 +12891,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You only sacrifice the creature if you still control it at end of turn. If that creature has left the battlefield, even if it came back, you don’t sacrifice it. Likewise, if an opponent has gained control of it, it won’t be sacrificed and will remain on the battlefield indefinitely."
+          "text": "You only sacrifice the creature if you still control it at end of turn. If that creature has left the battlefield, even if it came back, you don't sacrifice it. Likewise, if an opponent has gained control of it, it won't be sacrificed and will remain on the battlefield indefinitely."
         },
         {
           "date": "2016-06-08",
@@ -13508,11 +13509,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If no card of the chosen type is found before your library empties, you don’t get a card, but you do get to order all the cards in your library any way you choose."
+          "text": "If no card of the chosen type is found before your library empties, you don't get a card, but you do get to order all the cards in your library any way you choose."
         },
         {
           "date": "2007-07-15",
-          "text": "If your library is empty, Abundance can prevent you from losing the game for being unable to draw a card. If an effect or turn-based action would cause you to draw a card, you can replace that draw with Abundance’s replacement effect. (It doesn’t matter that you’d be unable to actually draw a card.) Since Abundance’s effect has you put a card into your hand instead of drawing a card, you’ll never be forced to draw a card with an empty library."
+          "text": "If your library is empty, Abundance can prevent you from losing the game for being unable to draw a card. If an effect or turn-based action would cause you to draw a card, you can replace that draw with Abundance's replacement effect. (It doesn't matter that you'd be unable to actually draw a card.) Since Abundance's effect has you put a card into your hand instead of drawing a card, you'll never be forced to draw a card with an empty library."
         }
       ],
       "text": "If you would draw a card, you may instead choose land or nonland and reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and put all other cards revealed this way on the bottom of your library in any order.",
@@ -13740,7 +13741,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The ability must target two different lands. It can’t be activated if there is just one land to target."
+          "text": "The ability must target two different lands. It can't be activated if there is just one land to target."
         }
       ],
       "subtypes": [
@@ -13801,15 +13802,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Argothian Enchantress’s last ability will resolve before the spell that caused it to trigger."
+          "text": "Argothian Enchantress's last ability will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "If the enchantment spell is countered, Argothian Enchantress’s last ability still resolves and causes you to draw a card."
+          "text": "If the enchantment spell is countered, Argothian Enchantress's last ability still resolves and causes you to draw a card."
         },
         {
           "date": "2016-06-08",
-          "text": "Enchantments put onto the battlefield without being cast won’t cause Argothian Enchantress’s last ability to trigger."
+          "text": "Enchantments put onto the battlefield without being cast won't cause Argothian Enchantress's last ability to trigger."
         }
       ],
       "subtypes": [
@@ -13922,7 +13923,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When Argothian Wurm enters the battlefield, first the active player gets the option to sacrifice a land. If he or she declines, the next player in turn order gets the option. If a player elects to sacrifice a land, Argothian Wurm is put on top of its owner’s library, but then all remaining players still get the option. If all players decline, then nothing happens and Argothian Wurm stays on the battlefield."
+          "text": "When Argothian Wurm enters the battlefield, first the active player gets the option to sacrifice a land. If he or she declines, the next player in turn order gets the option. If a player elects to sacrifice a land, Argothian Wurm is put on top of its owner's library, but then all remaining players still get the option. If all players decline, then nothing happens and Argothian Wurm stays on the battlefield."
         }
       ],
       "subtypes": [
@@ -14266,7 +14267,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you do choose not to pay, but no longer control Child of Gaea, you cannot sacrifice. It will remain on the battlefield under its current controller’s control."
+          "text": "If you do choose not to pay, but no longer control Child of Gaea, you cannot sacrifice. It will remain on the battlefield under its current controller's control."
         }
       ],
       "subtypes": [
@@ -14928,7 +14929,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for up to two Forest cards, reveal those cards, and put them into your hand. Then shuffle your library.",
@@ -15099,7 +15100,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "You draw cards equal to the creature’s power when you sacrificed it. This includes any bonuses from effects like Giant Growth."
+          "text": "You draw cards equal to the creature's power when you sacrificed it. This includes any bonuses from effects like Giant Growth."
         }
       ],
       "text": "Sacrifice a creature: Draw cards equal to the sacrificed creature's power, then discard three cards.",
@@ -15267,7 +15268,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts an enchantment spell, if Hidden Ancients is an enchantment, Hidden Ancients becomes a 5/5 Treefolk creature.",
@@ -15328,7 +15329,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts an artifact spell, if Hidden Guerrillas is an enchantment, Hidden Guerrillas becomes a 5/3 Soldier creature with trample.",
@@ -15389,7 +15390,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent plays a nonbasic land, if Hidden Herd is an enchantment, Hidden Herd becomes a 3/3 Beast creature.",
@@ -15446,7 +15447,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent controls a creature with power 4 or greater, if Hidden Predators is an enchantment, Hidden Predators becomes a 4/4 Beast creature.",
@@ -15512,7 +15513,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a creature spell with flying, if Hidden Spider is an enchantment, Hidden Spider becomes a 3/5 Spider creature with reach. (It can block creatures with flying.)",
@@ -15573,7 +15574,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Whenever an opponent plays a land, if Hidden Stag is an enchantment, Hidden Stag becomes a 3/2 Elk Beast creature.\nWhenever you play a land, if Hidden Stag is a creature, Hidden Stag becomes an enchantment.",
@@ -16073,7 +16074,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "This card now has Enchant Swamp, which works exactly like any other Enchant ability. This means it can only be cast targeting a Swamp, and it will be put into its owner’s graveyard if the permanent it’s attached to ever stops being a Swamp."
+          "text": "This card now has Enchant Swamp, which works exactly like any other Enchant ability. This means it can only be cast targeting a Swamp, and it will be put into its owner's graveyard if the permanent it's attached to ever stops being a Swamp."
         }
       ],
       "subtypes": [
@@ -16344,7 +16345,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) don’t actually have Flying, so they can’t block this."
+          "text": "Creatures with the Reach ability (such as Giant Spider) don't actually have Flying, so they can't block this."
         }
       ],
       "subtypes": [
@@ -16791,7 +16792,7 @@
         },
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -16849,11 +16850,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "If Chimeric Staff is already an artifact creature when you activate its ability, Chimeric Staff stays an artifact creature but the ability resets its creature types. You always apply the effect from this card before counters or other effects that modify power and toughness. For example, if you pay {3} to make it a 3/3, then someone gives it -1/-1, it will be a 2/2. If you then activate the ability with {4}, you will apply the “4/4” effect before the -1/-1 effect, so the end result will be a 3/3. Damage that was dealt to the creature stays on it."
+          "text": "If Chimeric Staff is already an artifact creature when you activate its ability, Chimeric Staff stays an artifact creature but the ability resets its creature types. You always apply the effect from this card before counters or other effects that modify power and toughness. For example, if you pay {3} to make it a 3/3, then someone gives it -1/-1, it will be a 2/2. If you then activate the ability with {4}, you will apply the \"4/4\" effect before the -1/-1 effect, so the end result will be a 3/3. Damage that was dealt to the creature stays on it."
         }
       ],
       "text": "{X}: Chimeric Staff becomes an X/X Construct artifact creature until end of turn.",
@@ -17343,7 +17344,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -17403,7 +17404,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It works for all players and has errata to remove the “your graveyard” text."
+          "text": "It works for all players and has errata to remove the \"your graveyard\" text."
         },
         {
           "date": "2004-10-04",
@@ -17411,11 +17412,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If multiple creatures are coming back, they come back one at a time, not all at once. This is because Lifeline triggered once for each creature and set up a separate “at end of turn” effect for each."
+          "text": "If multiple creatures are coming back, they come back one at a time, not all at once. This is because Lifeline triggered once for each creature and set up a separate \"at end of turn\" effect for each."
         },
         {
           "date": "2010-03-01",
-          "text": "If more than one creature is on the battlefield and all the creatures on the battlefield go to the graveyard at once, then none of them are returned at end of turn. This is because Lifeline’s ability has an intervening-if clause, which means that there must be at least one creature on the battlefield at the time the ability resolves."
+          "text": "If more than one creature is on the battlefield and all the creatures on the battlefield go to the graveyard at once, then none of them are returned at end of turn. This is because Lifeline's ability has an intervening-if clause, which means that there must be at least one creature on the battlefield at the time the ability resolves."
         }
       ],
       "text": "Whenever a creature dies, if another creature is on the battlefield, return the first card to the battlefield under its owner's control at the beginning of the next end step.",
@@ -17748,7 +17749,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can pay 0 life if you want, but it’s not useful most of the time."
+          "text": "You can pay 0 life if you want, but it's not useful most of the time."
         }
       ],
       "text": "As Phyrexian Processor enters the battlefield, pay any amount of life.\n{4}, {T}: Create an X/X black Minion creature token, where X is the life paid as Phyrexian Processor entered the battlefield.",
@@ -18004,7 +18005,7 @@
         },
         {
           "date": "2011-01-25",
-          "text": "Any of this mana that isn’t spent during your upkeep step will be removed before your draw step begins. You cannot save it to be spent on the card you will draw this turn."
+          "text": "Any of this mana that isn't spent during your upkeep step will be removed before your draw step begins. You cannot save it to be spent on the card you will draw this turn."
         }
       ],
       "text": "At the beginning of your upkeep, you may add {C} or {C}{C} to your mana pool. You can't spend this mana to cast spells.",
@@ -18052,11 +18053,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you only have 1 life, you can’t choose the pay 2 life option."
+          "text": "If you only have 1 life, you can't choose the pay 2 life option."
         },
         {
           "date": "2004-10-04",
-          "text": "If you don’t have a permanent to choose, you can still choose to not pay the life and then just do nothing since there is no permanent to choose."
+          "text": "If you don't have a permanent to choose, you can still choose to not pay the life and then just do nothing since there is no permanent to choose."
         },
         {
           "date": "2004-10-04",
@@ -18214,7 +18215,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It only returns to owner’s hand if it is still on the battlefield at end of combat."
+          "text": "It only returns to owner's hand if it is still on the battlefield at end of combat."
         }
       ],
       "subtypes": [
@@ -18925,7 +18926,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Triggers at the end of every player’s turn."
+          "text": "Triggers at the end of every player's turn."
         }
       ],
       "text": "At the beginning of the end step, if you control no creatures, sacrifice Thran Quarry.\n{T}: Add one mana of any color to your mana pool.",

--- a/json/V09.json
+++ b/json/V09.json
@@ -64,7 +64,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Balance doesn’t have targets, so permanents that can’t be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
+          "text": "Balance doesn't have targets, so permanents that can't be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
         },
         {
           "date": "2016-06-08",
@@ -184,7 +184,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life you don’t have. In other words, you can’t Channel yourself below zero life."
+          "text": "You can't pay life you don't have. In other words, you can't Channel yourself below zero life."
         }
       ],
       "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
@@ -244,7 +244,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "You can choose to find fewer than four cards if you want. If you find one or two cards, your opponent must choose for them to be put into your graveyard, even if he or she doesn’t want to."
+          "text": "You can choose to find fewer than four cards if you want. If you find one or two cards, your opponent must choose for them to be put into your graveyard, even if he or she doesn't want to."
         }
       ],
       "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
@@ -301,7 +301,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A Goblin permanent card is an artifact, creature, land, and/or enchantment card with the creature type “Goblin”. Usually such cards will be creatures in addition to any other types, but they may be tribal instead. For example, you could put Boggart Shenanigans onto the battlefield with this effect."
+          "text": "A Goblin permanent card is an artifact, creature, land, and/or enchantment card with the creature type \"Goblin\". Usually such cards will be creatures in addition to any other types, but they may be tribal instead. For example, you could put Boggart Shenanigans onto the battlefield with this effect."
         }
       ],
       "subtypes": [
@@ -467,7 +467,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for an instant or sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
@@ -526,11 +526,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Necropotence’s last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
+          "text": "Necropotence's last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
         },
         {
           "date": "2016-06-08",
-          "text": "If the discarded card isn’t put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won’t be exiled."
+          "text": "If the discarded card isn't put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won't be exiled."
         }
       ],
       "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
@@ -583,11 +583,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sensei’s Divining Top’s second ability may be activated in response to its first ability. If so, you’ll draw a card, put Sensei’s Divining Top on top of your library, and then look at the top three cards and rearrange them."
+          "text": "Sensei's Divining Top's second ability may be activated in response to its first ability. If so, you'll draw a card, put Sensei's Divining Top on top of your library, and then look at the top three cards and rearrange them."
         },
         {
           "date": "2016-06-08",
-          "text": "If Sensei’s Divining Top leaves the battlefield while its second ability is on the stack, you’ll draw a card and leave Sensei’s Divining Top in the zone it’s moved to."
+          "text": "If Sensei's Divining Top leaves the battlefield while its second ability is on the stack, you'll draw a card and leave Sensei's Divining Top in the zone it's moved to."
         }
       ],
       "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
@@ -794,7 +794,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Tinker, sacrifice an artifact.\nSearch your library for an artifact card and put that card onto the battlefield. Then shuffle your library.",
@@ -848,15 +848,15 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Trinisphere’s ability affects the total cost of the spell. It is applied *after* any other cost increasers or cost reducers are applied: First apply any cost increases. Next apply any cost reducers. Finally look at the amount of mana you have to pay. If it’s less than three mana, you’ll pay three mana."
+          "text": "Trinisphere's ability affects the total cost of the spell. It is applied *after* any other cost increasers or cost reducers are applied: First apply any cost increases. Next apply any cost reducers. Finally look at the amount of mana you have to pay. If it's less than three mana, you'll pay three mana."
         },
         {
           "date": "2004-12-01",
-          "text": "Even with a cost reducer on the battlefield, spells can’t cost less than three mana to cast."
+          "text": "Even with a cost reducer on the battlefield, spells can't cost less than three mana to cast."
         },
         {
           "date": "2004-12-01",
-          "text": "If a spell costs at least three mana due to additional costs, such as kicker costs, that’s fine."
+          "text": "If a spell costs at least three mana due to additional costs, such as kicker costs, that's fine."
         },
         {
           "date": "2004-12-01",
@@ -864,7 +864,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "Casting a creature with morph face down already costs three mana, even though the converted mana cost of the face-down spell is zero, so Trinisphere normally doesn’t modify the total cost of a face-down creature spell. However, if Dream Chisel is reducing that cost while Trinisphere is on the battlefield, you’ll still have to pay three mana for the spell."
+          "text": "Casting a creature with morph face down already costs three mana, even though the converted mana cost of the face-down spell is zero, so Trinisphere normally doesn't modify the total cost of a face-down creature spell. However, if Dream Chisel is reducing that cost while Trinisphere is on the battlefield, you'll still have to pay three mana for the spell."
         }
       ],
       "text": "As long as Trinisphere is untapped, each spell that would cost less than three mana to cast costs three mana to cast. (Additional mana in the cost may be paid with any color of mana or colorless mana. For example, a spell that would cost {1}{B} to cast costs {2}{B} to cast instead.)",

--- a/json/V10.json
+++ b/json/V10.json
@@ -102,7 +102,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise’s ability resolves, the ability just won’t do anything that turn."
+          "text": "If the chosen player has four or fewer cards in his or her hand as Black Vise's ability resolves, the ability just won't do anything that turn."
         }
       ],
       "text": "As Black Vise enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, Black Vise deals X damage to that player, where X is the number of cards in his or her hand minus 4.",
@@ -157,7 +157,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the imprinted card leaves the exile zone while the activated ability is on the stack, the copy can’t be made."
+          "text": "If the imprinted card leaves the exile zone while the activated ability is on the stack, the copy can't be made."
         },
         {
           "date": "2016-06-08",
@@ -169,7 +169,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Because you’re already casting the spell using an alternative cost (by casting it without paying its mana cost), you can’t pay any other alternative costs for the card. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
+          "text": "Because you're already casting the spell using an alternative cost (by casting it without paying its mana cost), you can't pay any other alternative costs for the card. You can pay additional costs, such as kicker costs. If the card has any mandatory additional costs, you must pay those."
         },
         {
           "date": "2016-06-08",
@@ -177,7 +177,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you don’t want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
+          "text": "If you don't want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
         },
         {
           "date": "2017-04-18",
@@ -230,7 +230,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have four or fewer cards in your hand when Ivory Tower’s ability resolves, the ability has no effect."
+          "text": "If you have four or fewer cards in your hand when Ivory Tower's ability resolves, the ability has no effect."
         }
       ],
       "text": "At the beginning of your upkeep, you gain X life, where X is the number of cards in your hand minus 4.",
@@ -341,7 +341,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -449,7 +449,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t look at the cards you exiled until they return to your hand."
+          "text": "You can't look at the cards you exiled until they return to your hand."
         }
       ],
       "text": "{T}, Sacrifice Memory Jar: Each player exiles all cards from his or her hand face down and draws seven cards. At the beginning of the next end step, each player discards his or her hand and returns to his or her hand each card he or she exiled this way.",
@@ -520,11 +520,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It triggers once per spell, so you can’t get multiple copies of a spell using this card. And since this card is legendary, you can’t control more than one."
+          "text": "It triggers once per spell, so you can't get multiple copies of a spell using this card. And since this card is legendary, you can't control more than one."
         },
         {
           "date": "2004-10-04",
-          "text": "The copy is not “cast” so it will not trigger anything that triggers on a spell being cast."
+          "text": "The copy is not \"cast\" so it will not trigger anything that triggers on a spell being cast."
         },
         {
           "date": "2004-10-04",
@@ -532,7 +532,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You are not required to choose new targets. If you do choose, then the targets must be legal. If you don’t change them, the spell is placed on the stack whether or not the targets are legal. The legality of the targets is always checked on resolution of the spell, so the spell may be countered at that time if all of its targets are illegal."
+          "text": "You are not required to choose new targets. If you do choose, then the targets must be legal. If you don't change them, the spell is placed on the stack whether or not the targets are legal. The legality of the targets is always checked on resolution of the spell, so the spell may be countered at that time if all of its targets are illegal."
         }
       ],
       "supertypes": [
@@ -585,7 +585,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If you don’t discard a land card, Mox Diamond never enters the battlefield. It won’t trigger abilities that look for something entering the battlefield, and you won’t get the opportunity to tap it for mana."
+          "text": "If you don't discard a land card, Mox Diamond never enters the battlefield. It won't trigger abilities that look for something entering the battlefield, and you won't get the opportunity to tap it for mana."
         }
       ],
       "text": "If Mox Diamond would enter the battlefield, you may discard a land card instead. If you do, put Mox Diamond onto the battlefield. If you don't, put it into its owner's graveyard.\n{T}: Add one mana of any color to your mana pool.",
@@ -643,7 +643,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -752,11 +752,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Sundering Titan’s two abilities aren’t targeted. When one of the abilities resolves, the Titan’s controller must choose one land for each basic land type (Plains, Island, Swamp, Mountain, and Forest)."
+          "text": "Sundering Titan's two abilities aren't targeted. When one of the abilities resolves, the Titan's controller must choose one land for each basic land type (Plains, Island, Swamp, Mountain, and Forest)."
         },
         {
           "date": "2004-12-01",
-          "text": "If one of the basic land types isn’t present, it isn’t chosen. If the only land of a certain type is one you control, you must choose it."
+          "text": "If one of the basic land types isn't present, it isn't chosen. If the only land of a certain type is one you control, you must choose it."
         },
         {
           "date": "2004-12-01",
@@ -822,7 +822,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "If there are fewer than ten cards in that player’s library, that player puts all the cards from his or her library into his or her graveyard."
+          "text": "If there are fewer than ten cards in that player's library, that player puts all the cards from his or her library into his or her graveyard."
         }
       ],
       "subtypes": [

--- a/json/V11.json
+++ b/json/V11.json
@@ -117,7 +117,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -190,11 +190,11 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Doran’s ability means, for example, that a 2/3 creature will assign 3 damage in combat instead of 2."
+          "text": "Doran's ability means, for example, that a 2/3 creature will assign 3 damage in combat instead of 2."
         },
         {
           "date": "2007-10-01",
-          "text": "Doran’s ability doesn’t actually change creatures’ power; it changes only the value of the combat damage they assign. All other rules and effects that check power or toughness use the real values."
+          "text": "Doran's ability doesn't actually change creatures' power; it changes only the value of the combat damage they assign. All other rules and effects that check power or toughness use the real values."
         },
         {
           "date": "2007-10-01",
@@ -267,11 +267,11 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "As the token is created, it checks the printed values of the creature it’s copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "As the token is created, it checks the printed values of the creature it's copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, or so on."
         },
         {
           "date": "2013-06-07",
-          "text": "Haste is part of the token’s copiable values. Copies of that token will also have haste."
+          "text": "Haste is part of the token's copiable values. Copies of that token will also have haste."
         }
       ],
       "subtypes": [
@@ -476,7 +476,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If a green mana you add to your mana pool has certain restrictions or riders associated with it (for example, if it was produced by Ancient Ziggurat), they’ll apply to that mana no matter when you spend it."
+          "text": "If a green mana you add to your mana pool has certain restrictions or riders associated with it (for example, if it was produced by Ancient Ziggurat), they'll apply to that mana no matter when you spend it."
         },
         {
           "date": "2010-03-01",
@@ -549,7 +549,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "You target the opponent when you activate Oona’s ability. You don’t choose the color until the ability resolves."
+          "text": "You target the opponent when you activate Oona's ability. You don't choose the color until the ability resolves."
         },
         {
           "date": "2008-05-01",
@@ -630,11 +630,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "“Protection from everything” means the following: Progenitus can’t be blocked, Progenitus can’t be enchanted or equipped, Progenitus can’t be the target of spells or abilities, and all damage that would be dealt to Progenitus is prevented."
+          "text": "\"Protection from everything\" means the following: Progenitus can't be blocked, Progenitus can't be enchanted or equipped, Progenitus can't be the target of spells or abilities, and all damage that would be dealt to Progenitus is prevented."
         },
         {
           "date": "2009-02-01",
-          "text": "Progenitus can still be affected by effects that don’t target it or deal damage to it (such as Day of Judgment)."
+          "text": "Progenitus can still be affected by effects that don't target it or deal damage to it (such as Day of Judgment)."
         }
       ],
       "subtypes": [
@@ -710,11 +710,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won’t trigger."
+          "text": "If you attack with multiple creatures, but then all but one are removed from combat, your exalted abilities won't trigger."
         },
         {
           "date": "2008-10-01",
-          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they’re ignored by exalted abilities. They won’t cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
+          "text": "Some effects put creatures onto the battlefield attacking. Since those creatures were never declared as attackers, they're ignored by exalted abilities. They won't cause exalted abilities to trigger. If any exalted abilities have already triggered (because exactly one creature was declared as an attacker), those abilities will resolve as normal even though there may now be multiple attackers."
         },
         {
           "date": "2008-10-01",
@@ -726,7 +726,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "In a Two-Headed Giant game, a creature “attacks alone” if it’s the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate’s exalted abilities won’t."
+          "text": "In a Two-Headed Giant game, a creature \"attacks alone\" if it's the only creature declared as an attacker by your entire team. If you control that attacking creature, your exalted abilities will trigger but your teammate's exalted abilities won't."
         }
       ],
       "subtypes": [
@@ -855,11 +855,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn’t interact with flying or reach."
+          "text": "Despite the similarities between horsemanship and flying, horsemanship doesn't interact with flying or reach."
         },
         {
           "date": "2009-10-01",
-          "text": "Sun Quan’s ability affects Sun Quan itself."
+          "text": "Sun Quan's ability affects Sun Quan itself."
         }
       ],
       "subtypes": [
@@ -927,7 +927,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The last ability means that in order for an opponent to cast a spell, it must be that opponent’s turn, during a main phase, and the stack must be empty. This is true even if the player doesn’t have a sorcery he or she is able to cast, or if a rule or effect allows a spell to be cast at another time."
+          "text": "The last ability means that in order for an opponent to cast a spell, it must be that opponent's turn, during a main phase, and the stack must be empty. This is true even if the player doesn't have a sorcery he or she is able to cast, or if a rule or effect allows a spell to be cast at another time."
         },
         {
           "date": "2006-09-25",
@@ -935,15 +935,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If an ability lets an opponent cast a spell as part of its effect (such as Isochron Scepter’s ability does), that opponent can’t cast that spell since the currently resolving ability is still on the stack."
+          "text": "If an ability lets an opponent cast a spell as part of its effect (such as Isochron Scepter's ability does), that opponent can't cast that spell since the currently resolving ability is still on the stack."
         },
         {
           "date": "2006-09-25",
-          "text": "Your opponents can’t cast their suspended cards, no matter what phase it is when the last time counter is removed. Your opponents can’t cast cards using the madness ability either, no matter what phase it is when the card is discarded."
+          "text": "Your opponents can't cast their suspended cards, no matter what phase it is when the last time counter is removed. Your opponents can't cast cards using the madness ability either, no matter what phase it is when the card is discarded."
         },
         {
           "date": "2007-05-01",
-          "text": "If you have Teferi on the battlefield and there’s a Split Second spell on the stack (such as Sudden Death), you can’t Suspend creatures until after the Split Second spell resolves."
+          "text": "If you have Teferi on the battlefield and there's a Split Second spell on the stack (such as Sudden Death), you can't Suspend creatures until after the Split Second spell resolves."
         }
       ],
       "subtypes": [
@@ -1005,19 +1005,19 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won’t be able to block."
+          "text": "Annihilator abilities trigger and resolve during the declare attackers step. The defending player chooses and sacrifices the required number of permanents before he or she declares blockers. Any creatures sacrificed this way won't be able to block."
         },
         {
           "date": "2010-06-15",
-          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn’t blocked, it simply won’t deal combat damage to anything."
+          "text": "If a creature with annihilator is attacking a planeswalker, and the defending player chooses to sacrifice that planeswalker, the attacking creature continues to attack. It may be blocked. If it isn't blocked, it simply won't deal combat damage to anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it’s too late for anyone to respond."
+          "text": "In a Two-Headed Giant game, the controller of an attacking creature with annihilator chooses which of the defending players is affected by the ability. Only that player sacrifices permanents. The choice is made as the ability resolves; once a player is chosen, it's too late for anyone to respond."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "subtypes": [

--- a/json/V12.json
+++ b/json/V12.json
@@ -93,11 +93,11 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The spell can’t be countered if the mana produced by Boseiju is spent to cover any cost of the spell, even an additional cost such as a splice cost. This is true even if you pay an additional cost while casting a spell “without paying its mana cost.”"
+          "text": "The spell can't be countered if the mana produced by Boseiju is spent to cover any cost of the spell, even an additional cost such as a splice cost. This is true even if you pay an additional cost while casting a spell \"without paying its mana cost.\""
         },
         {
           "date": "2004-12-01",
-          "text": "Suppose mana produced by Boseiju is spent on a spell and an effect creates a copy of that spell. The copy can be countered, even though the original can’t."
+          "text": "Suppose mana produced by Boseiju is spent on a spell and an effect creates a copy of that spell. The copy can be countered, even though the original can't."
         }
       ],
       "supertypes": [
@@ -195,11 +195,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be used on any player’s attacking creatures. This includes your own and creatures in an attack you are not involved in (for multiplayer games)."
+          "text": "The ability can be used on any player's attacking creatures. This includes your own and creatures in an attack you are not involved in (for multiplayer games)."
         },
         {
           "date": "2017-04-18",
-          "text": "Desert is a land subtype with no special meaning. It doesn’t grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+          "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
         }
       ],
       "subtypes": [
@@ -263,19 +263,19 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Dryad Arbor is played as a land. It doesn’t use the stack, it’s not a spell, it can’t be responded to, it has no mana cost, and it counts as your land play for the turn."
+          "text": "Dryad Arbor is played as a land. It doesn't use the stack, it's not a spell, it can't be responded to, it has no mana cost, and it counts as your land play for the turn."
         },
         {
           "date": "2007-05-01",
-          "text": "If a Dryad Arbor gains flash, or you have the ability to play Dryad Arbor as though it had flash (due to Teferi, Mage of Zhalfir or Scout’s Warning, for example), you can ignore the normal timing rules for playing a land, but not any other restrictions. You can’t play Dryad Arbor during another player’s turn, and you can’t play Dryad Arbor if it’s your turn and you’ve already played a land."
+          "text": "If a Dryad Arbor gains flash, or you have the ability to play Dryad Arbor as though it had flash (due to Teferi, Mage of Zhalfir or Scout's Warning, for example), you can ignore the normal timing rules for playing a land, but not any other restrictions. You can't play Dryad Arbor during another player's turn, and you can't play Dryad Arbor if it's your turn and you've already played a land."
         },
         {
           "date": "2011-09-22",
-          "text": "If Dryad Arbor is changed into another basic land type (such as by Sea’s Claim), it continues to be a creature and a Dryad."
+          "text": "If Dryad Arbor is changed into another basic land type (such as by Sea's Claim), it continues to be a creature and a Dryad."
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -375,7 +375,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "When Glacial Chasm’s enters-the-battlefield ability resolves, if you don’t control any other lands, you must sacrifice Glacial Chasm itself."
+          "text": "When Glacial Chasm's enters-the-battlefield ability resolves, if you don't control any other lands, you must sacrifice Glacial Chasm itself."
         }
       ],
       "text": "Cumulative upkeep—Pay 2 life. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Glacial Chasm enters the battlefield, sacrifice a land.\nCreatures you control can't attack.\nPrevent all damage that would be dealt to you.",
@@ -516,11 +516,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The creature isn’t removed from combat; it just has its damage prevented. It’s still an attacking creature until the combat phase is complete."
+          "text": "The creature isn't removed from combat; it just has its damage prevented. It's still an attacking creature until the combat phase is complete."
         },
         {
           "date": "2016-06-08",
-          "text": "You can activate Maze of Ith’s ability targeting an attacking creature you control during the combat damage step or the end of combat step. It’ll be untapped and the damage it had already dealt won’t be undone."
+          "text": "You can activate Maze of Ith's ability targeting an attacking creature you control during the combat damage step or the end of combat step. It'll be untapped and the damage it had already dealt won't be undone."
         }
       ],
       "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
@@ -576,7 +576,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Murmuring Bosk is a Forest, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do. For example, you can’t find Murmuring Bosk with Fertilid’s ability (“searches his or her library for a basic land card”), but you can find Murmuring Bosk with Everbark Shaman’s ability (“search your library for two Forest cards”)."
+          "text": "Murmuring Bosk is a Forest, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do. For example, you can't find Murmuring Bosk with Fertilid's ability (\"searches his or her library for a basic land card\"), but you can find Murmuring Bosk with Everbark Shaman's ability (\"search your library for two Forest cards\")."
         }
       ],
       "subtypes": [
@@ -684,19 +684,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If Urborg, Tomb of Yawgmoth and either Blood Moon or Magus of the Moon are on the battlefield, all nonbasic lands will be Mountains, not Swamps. Urborg, Tomb of Yawgmoth will be a Mountain as well. It will have “{T}: Add {R} to your mana pool” and no other abilities."
+          "text": "If Urborg, Tomb of Yawgmoth and either Blood Moon or Magus of the Moon are on the battlefield, all nonbasic lands will be Mountains, not Swamps. Urborg, Tomb of Yawgmoth will be a Mountain as well. It will have \"{T}: Add {R} to your mana pool\" and no other abilities."
         },
         {
           "date": "2014-07-18",
-          "text": "Urborg, Tomb of Yawgmoth isn’t a Swamp while it’s not on the battlefield."
+          "text": "Urborg, Tomb of Yawgmoth isn't a Swamp while it's not on the battlefield."
         },
         {
           "date": "2014-07-18",
-          "text": "Urborg’s ability causes each land on the battlefield to have the land type Swamp. Each land thus has the ability “{T}: Add {B} to your mana pool.” Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they’re legendary or basic."
+          "text": "Urborg's ability causes each land on the battlefield to have the land type Swamp. Each land thus has the ability \"{T}: Add {B} to your mana pool.\" Nothing else changes about those lands, including their names, other subtypes, other abilities, and whether they're legendary or basic."
         },
         {
           "date": "2014-07-18",
-          "text": "If Urborg loses its abilities (for example, if it becomes a creature and then Turn to Frog targets it), all lands on the battlefield, including Urborg, will still be Swamps, but Urborg won’t have the ability “Each land is a Swamp in addition to its other land types.” Urborg also won’t be able to tap to produce {B}, but other lands (including those that enter the battlefield later in the turn) will. The way continuous effects work, Urborg’s type-changing ability is applied before the effect that removes both the type-changing ability and its own mana ability."
+          "text": "If Urborg loses its abilities (for example, if it becomes a creature and then Turn to Frog targets it), all lands on the battlefield, including Urborg, will still be Swamps, but Urborg won't have the ability \"Each land is a Swamp in addition to its other land types.\" Urborg also won't be able to tap to produce {B}, but other lands (including those that enter the battlefield later in the turn) will. The way continuous effects work, Urborg's type-changing ability is applied before the effect that removes both the type-changing ability and its own mana ability."
         }
       ],
       "supertypes": [
@@ -754,11 +754,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If you don’t choose a land on the battlefield, Vesuva enters the battlefield untapped as itself."
+          "text": "If you don't choose a land on the battlefield, Vesuva enters the battlefield untapped as itself."
         },
         {
           "date": "2006-10-15",
-          "text": "Cornered Market won’t prevent Vesuva from being played (unless there’s a Vesuva on the battlefield copying nothing), since you play it before it becomes named something else."
+          "text": "Cornered Market won't prevent Vesuva from being played (unless there's a Vesuva on the battlefield copying nothing), since you play it before it becomes named something else."
         }
       ],
       "text": "You may have Vesuva enter the battlefield tapped as a copy of any land on the battlefield.",
@@ -813,7 +813,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "At the time the ability resolves, you’ll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered the battlefield attacking (such as a token created by Militia’s Pride) doesn’t count because you never attacked with it."
+          "text": "At the time the ability resolves, you'll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered the battlefield attacking (such as a token created by Militia's Pride) doesn't count because you never attacked with it."
         }
       ],
       "text": "Hideaway (This land enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\n{T}: Add {W} to your mana pool.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",

--- a/json/V13.json
+++ b/json/V13.json
@@ -169,7 +169,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -553,7 +553,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Each pile may contain from zero to five cards; they don’t have to be split “evenly.”"
+          "text": "Each pile may contain from zero to five cards; they don't have to be split \"evenly.\""
         }
       ],
       "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
@@ -771,7 +771,7 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "If, during the combat damage step, a creature is destroyed during combat and Ink-Eyes also deals combat damage to a player, the destroyed creature can be a legal target for Ink-Eyes’s ability."
+          "text": "If, during the combat damage step, a creature is destroyed during combat and Ink-Eyes also deals combat damage to a player, the destroyed creature can be a legal target for Ink-Eyes's ability."
         }
       ],
       "subtypes": [
@@ -894,15 +894,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If Venser’s triggered ability targets a spell cast with flashback, that spell will be exiled instead of returning to its owner’s hand."
+          "text": "If Venser's triggered ability targets a spell cast with flashback, that spell will be exiled instead of returning to its owner's hand."
         },
         {
           "date": "2017-03-14",
-          "text": "If a spell is returned to its owner’s hand, it’s removed from the stack and thus will not resolve. The spell isn’t countered; it just no longer exists. This works against a spell that can’t be countered."
+          "text": "If a spell is returned to its owner's hand, it's removed from the stack and thus will not resolve. The spell isn't countered; it just no longer exists. This works against a spell that can't be countered."
         },
         {
           "date": "2017-03-14",
-          "text": "If a copy of a spell is returned to its owner’s hand, it’s moved there, then it will cease to exist as a state-based action. It can’t be recast."
+          "text": "If a copy of a spell is returned to its owner's hand, it's moved there, then it will cease to exist as a state-based action. It can't be recast."
         }
       ],
       "subtypes": [
@@ -1036,7 +1036,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Cruel Ultimatum’s only target is an opponent. You don’t choose which creature card in your graveyard you’ll return to your hand until Cruel Ultimatum resolves."
+          "text": "Cruel Ultimatum's only target is an opponent. You don't choose which creature card in your graveyard you'll return to your hand until Cruel Ultimatum resolves."
         },
         {
           "date": "2017-03-14",
@@ -1044,7 +1044,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "If, as Cruel Ultimatum begins to resolve, your opponent’s life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent’s life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You’ll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
+          "text": "If, as Cruel Ultimatum begins to resolve, your opponent's life total is 5 or less and you have two or fewer cards in your library, the game will result in a draw. Your opponent's life total will drop to 0 or less, but Cruel Ultimatum must finish resolving completely before state-based actions are performed. You'll then be forced to draw three cards and fail to draw one. When state-based actions are finally performed, you and your opponent will both lose the game at the same time, which means the game is a draw."
         }
       ],
       "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
@@ -1105,11 +1105,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You draw three cards and put two cards back all while Jace’s second ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+          "text": "You draw three cards and put two cards back all while Jace's second ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
         },
         {
           "date": "2016-06-08",
-          "text": "If the targeted player for Jace’s last ability has no cards in hand, that player shuffles nothing into his or her library, and that player’s library will remain empty. That player won’t lose the game until he or she tries to draw from the empty library."
+          "text": "If the targeted player for Jace's last ability has no cards in hand, that player shuffles nothing into his or her library, and that player's library will remain empty. That player won't lose the game until he or she tries to draw from the empty library."
         }
       ],
       "subtypes": [
@@ -1172,19 +1172,19 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner’s library."
+          "text": "If this spell is countered, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
         },
         {
           "date": "2016-06-08",
-          "text": "If Green Sun’s Zenith is countered, none of its effects will happen. Notably, it will be put into its owner’s graveyard rather than shuffled into its owner’s library."
+          "text": "If Green Sun's Zenith is countered, none of its effects will happen. Notably, it will be put into its owner's graveyard rather than shuffled into its owner's library."
         },
         {
           "date": "2016-06-08",
-          "text": "In most cases, if you own Green Sun’s Zenith and cast it, you’ll shuffle your library twice. In practice, shuffling once is sufficient, but effects that care about you shuffling your library (like Psychogenic Probe, for example) will see that you’ve shuffled twice."
+          "text": "In most cases, if you own Green Sun's Zenith and cast it, you'll shuffle your library twice. In practice, shuffling once is sufficient, but effects that care about you shuffling your library (like Psychogenic Probe, for example) will see that you've shuffled twice."
         },
         {
           "date": "2016-06-08",
-          "text": "If you own Green Sun’s Zenith, but an opponent casts it (due to Knowledge Pool’s effect, for example), that opponent searches his or her library for an appropriate creature card, then shuffles that library. That opponent then shuffles Green Sun’s Zenith into your library. You won’t shuffle any library in this case."
+          "text": "If you own Green Sun's Zenith, but an opponent casts it (due to Knowledge Pool's effect, for example), that opponent searches his or her library for an appropriate creature card, then shuffles that library. That opponent then shuffles Green Sun's Zenith into your library. You won't shuffle any library in this case."
         }
       ],
       "text": "Search your library for a green creature card with converted mana cost X or less, put it onto the battlefield, then shuffle your library. Shuffle Green Sun's Zenith into its owner's library.",

--- a/json/V14.json
+++ b/json/V14.json
@@ -60,7 +60,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Mythic Rare",
       "text": "Destroy all lands.",
@@ -116,11 +117,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The lands that will be destroyed aren’t chosen until Burning of Xinye resolves."
+          "text": "The lands that will be destroyed aren't chosen until Burning of Xinye resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye’s destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
+          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye's destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
         },
         {
           "date": "2009-10-01",
@@ -200,7 +201,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Each permanent not chosen by a player will be sacrificed. If a permanent has none of the listed types (for example, a Planeswalker with no other types), it can’t be chosen."
+          "text": "Each permanent not chosen by a player will be sacrificed. If a permanent has none of the listed types (for example, a Planeswalker with no other types), it can't be chosen."
         }
       ],
       "text": "Each player chooses from among the permanents he or she controls an artifact, a creature, an enchantment, and a land, then sacrifices the rest.",
@@ -331,7 +332,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Exile all artifacts, creatures, and lands from the battlefield, all cards from all graveyards, and all cards from all hands.\nCycling {5}{R}{R} ({5}{R}{R}, Discard this card: Draw a card.)\nWhen you cycle Decree of Annihilation, destroy all lands.",
@@ -396,7 +397,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn’t matter how much mana of that color was spent; the effect isn’t multiplied."
+          "text": "This spell checks on resolution to see if any mana of the appropriate colors were spent to pay its cost. It doesn't matter how much mana of that color was spent; the effect isn't multiplied."
         },
         {
           "date": "2016-06-08",
@@ -461,7 +462,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If an artifact or enchantment remains on the battlefield because it was regenerated or has indestructible, you won’t gain life for it."
+          "text": "If an artifact or enchantment remains on the battlefield because it was regenerated or has indestructible, you won't gain life for it."
         }
       ],
       "text": "Destroy all artifacts and enchantments. You gain 2 life for each permanent destroyed this way.",
@@ -521,7 +522,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures which are sacrificed can’t be regenerated."
+          "text": "The creatures which are sacrificed can't be regenerated."
         },
         {
           "date": "2004-10-04",
@@ -529,7 +530,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
+          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
         }
       ],
       "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -593,11 +594,11 @@
         },
         {
           "date": "2009-02-01",
-          "text": "You do what the spell says in order. If X is 5 or more, you’ll put the Soldier tokens onto the battlefield, then you’ll destroy all other creatures."
+          "text": "You do what the spell says in order. If X is 5 or more, you'll put the Soldier tokens onto the battlefield, then you'll destroy all other creatures."
         },
         {
           "date": "2009-02-01",
-          "text": "No one can cast spells or activate abilities between the time the Soldier tokens are put onto the battlefield and the time all other creatures are destroyed. For example, you can’t sacrifice one of those Soldier tokens to regenerate a Skeletal Kathari."
+          "text": "No one can cast spells or activate abilities between the time the Soldier tokens are put onto the battlefield and the time all other creatures are destroyed. For example, you can't sacrifice one of those Soldier tokens to regenerate a Skeletal Kathari."
         }
       ],
       "text": "Create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures.",
@@ -754,7 +755,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Each player chooses the order that creatures he or she owns are put onto the bottom of his or her library. This order isn’t revealed to other players."
+          "text": "Each player chooses the order that creatures he or she owns are put onto the bottom of his or her library. This order isn't revealed to other players."
         }
       ],
       "text": "Put all creatures on the bottom of their owners' libraries.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",

--- a/json/V15.json
+++ b/json/V15.json
@@ -195,7 +195,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Archangel of Strife’s second and third abilities are linked. Similarly, its second and fourth abilities are linked. The bonus a player’s creatures get depends only on the choice that player made when Archangel of Strife entered the battlefield."
+          "text": "Archangel of Strife's second and third abilities are linked. Similarly, its second and fourth abilities are linked. The bonus a player's creatures get depends only on the choice that player made when Archangel of Strife entered the battlefield."
         },
         {
           "date": "2011-09-22",
@@ -203,7 +203,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "Archangel of Strife’s bonuses apply immediately. Depending on your choice, Archangel of Strife will enter the battlefield as either a 9/6 or 6/9 creature."
+          "text": "Archangel of Strife's bonuses apply immediately. Depending on your choice, Archangel of Strife will enter the battlefield as either a 9/6 or 6/9 creature."
         },
         {
           "date": "2011-09-22",
@@ -277,15 +277,15 @@
       "rulings": [
         {
           "date": "2013-01-24",
-          "text": "You untap all creatures you control, including ones that aren’t attacking."
+          "text": "You untap all creatures you control, including ones that aren't attacking."
         },
         {
           "date": "2013-01-24",
-          "text": "You don’t have to attack with any creatures during the additional combat phase."
+          "text": "You don't have to attack with any creatures during the additional combat phase."
         },
         {
           "date": "2013-01-24",
-          "text": "If Aurelia is put onto the battlefield attacking, the triggered ability won’t trigger."
+          "text": "If Aurelia is put onto the battlefield attacking, the triggered ability won't trigger."
         }
       ],
       "subtypes": [
@@ -352,11 +352,11 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Creatures with indestructible still have damage marked on them, even though that damage won’t destroy them. If Avacyn leaves the battlefield, creatures that lose indestructible and have lethal damage marked on them will be destroyed."
+          "text": "Creatures with indestructible still have damage marked on them, even though that damage won't destroy them. If Avacyn leaves the battlefield, creatures that lose indestructible and have lethal damage marked on them will be destroyed."
         },
         {
           "date": "2013-07-01",
-          "text": "A permanent with indestructible can’t be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
+          "text": "A permanent with indestructible can't be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
         }
       ],
       "subtypes": [
@@ -420,7 +420,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "“Protection from Demons and from Dragons” means the following: -- Baneslayer Angel can't be blocked by creatures with the creature type Demon or the creature type Dragon. -- Baneslayer Angel can't be targeted abilities from sources with the creature type Demon or the creature type Dragon, or by spells with either of those types. -- All damage that would be dealt to Baneslayer Angel by sources with the creature type Demon or the creature type Dragon is prevented. -- Baneslayer Angel can't be enchanted by Auras or equipped by artifacts that have somehow gotten the creature type Demon or the creature type Dragon."
+          "text": "\"Protection from Demons and from Dragons\" means the following: -- Baneslayer Angel can't be blocked by creatures with the creature type Demon or the creature type Dragon. -- Baneslayer Angel can't be targeted abilities from sources with the creature type Demon or the creature type Dragon, or by spells with either of those types. -- All damage that would be dealt to Baneslayer Angel by sources with the creature type Demon or the creature type Dragon is prevented. -- Baneslayer Angel can't be enchanted by Auras or equipped by artifacts that have somehow gotten the creature type Demon or the creature type Dragon."
         }
       ],
       "subtypes": [
@@ -487,7 +487,7 @@
         },
         {
           "date": "2017-03-14",
-          "text": "Entreat the Angels’s converted mana cost is based on its mana cost of {X}{X}{W}{W}{W}, even if you’re casting it for its miracle cost. For example, if you cast Entreat the Angels for its miracle cost and choose 4 for X, its converted mana cost is 11."
+          "text": "Entreat the Angels's converted mana cost is based on its mana cost of {X}{X}{W}{W}{W}, even if you're casting it for its miracle cost. For example, if you cast Entreat the Angels for its miracle cost and choose 4 for X, its converted mana cost is 11."
         }
       ],
       "text": "Create X 4/4 white Angel creature tokens with flying.\nMiracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
@@ -608,11 +608,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Iona’s third ability includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It does not include lands or abilities (such as cycling or unearth)."
+          "text": "Iona's third ability includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It does not include lands or abilities (such as cycling or unearth)."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the color is chosen, it’s too late for opponents to respond by casting spells of that color. Iona is not yet in the battlefield at the time the color is chosen, so, for example, there’s no way for an opponent to destroy it by casting Doom Blade if the chosen color is black."
+          "text": "Once the color is chosen, it's too late for opponents to respond by casting spells of that color. Iona is not yet in the battlefield at the time the color is chosen, so, for example, there's no way for an opponent to destroy it by casting Doom Blade if the chosen color is black."
         }
       ],
       "subtypes": [
@@ -677,7 +677,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card has Protection from Black, from Blue, from Red, from White, and from Green. This is the definition of “All Colors”. This means it is possible to use an effect that removes one color of protection, such as just black, on this card."
+          "text": "This card has Protection from Black, from Blue, from Red, from White, and from Green. This is the definition of \"All Colors\". This means it is possible to use an effect that removes one color of protection, such as just black, on this card."
         }
       ],
       "subtypes": [
@@ -873,23 +873,23 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They’ll still work."
+          "text": "Effects that say the game is a draw, such as the _Legends_(TM) card Divine Intervention, are not affected by Platinum Angel. They'll still work."
         },
         {
           "date": "2004-12-01",
-          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can’t prevent you from losing the game)."
+          "text": "You can concede a game while Platinum Angel on the battlefield. A concession causes you to leave the game, which then causes you to lose the game (Once you concede, you no longer control a Platinum Angel, so its ability can't prevent you from losing the game)."
         },
         {
           "date": "2009-10-01",
-          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn’t matter whether you have 0 or less life, you’re forced to draw a card while your library is empty, you have ten or more poison counters, you’re dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
+          "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn't matter whether you have 0 or less life, you're forced to draw a card while your library is empty, you have ten or more poison counters, you're dealt combat damage by Phage the Untouchable, your opponent has Mortal Combat with twenty or more creature cards in his or her graveyard, or so on. You keep playing."
         },
         {
           "date": "2009-10-01",
-          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you’re penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
+          "text": "Other circumstances can still cause you to lose the game, however. You will lose a game if you concede, if you're penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if your _Magic Online_(R) game clock runs out of time."
         },
         {
           "date": "2009-10-01",
-          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can’t lose the game and the opposing team can’t win the game."
+          "text": "If you control Platinum Angel in a Two-Headed Giant game, your team can't lose the game and the opposing team can't win the game."
         }
       ],
       "subtypes": [
@@ -1040,7 +1040,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "The creature card is chosen at random from among creature cards in the target opponent’s graveyard as the ability resolves. Players can respond to the ability knowing the targeted player, but they won’t know which creature card is about to enter the battlefield."
+          "text": "The creature card is chosen at random from among creature cards in the target opponent's graveyard as the ability resolves. Players can respond to the ability knowing the targeted player, but they won't know which creature card is about to enter the battlefield."
         }
       ],
       "subtypes": [

--- a/json/V16.json
+++ b/json/V16.json
@@ -55,7 +55,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you’ve chosen a method of paying for it that includes generic mana."
+          "text": "If an effect reduces the cost to cast a spell by an amount of generic mana, it applies to a monocolored hybrid spell only if you've chosen a method of paying for it that includes generic mana."
         },
         {
           "date": "2008-05-01",
@@ -182,11 +182,11 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "You don’t have to find all five cards."
+          "text": "You don't have to find all five cards."
         },
         {
           "date": "2009-02-01",
-          "text": "You may find multicolored cards with Conflux. The white card you find, for example, can be any number of colors, as long as white is one of them. What colors it is won’t impact what other cards you can find. For example, you may find a white-blue card as the white card and another white-blue card as the blue card."
+          "text": "You may find multicolored cards with Conflux. The white card you find, for example, can be any number of colors, as long as white is one of them. What colors it is won't impact what other cards you can find. For example, you may find a white-blue card as the white card and another white-blue card as the blue card."
         }
       ],
       "text": "Search your library for a white card, a blue card, a black card, a red card, and a green card. Reveal those cards and put them into your hand. Then shuffle your library.",
@@ -239,7 +239,7 @@
         },
         {
           "date": "2006-07-15",
-          "text": "Dark Depths’s last ability is a state trigger. It will not trigger again while the ability is on the stack, but if the ability is countered and Dark Depths is still on the battlefield with no ice counters on it, it will trigger again immediately."
+          "text": "Dark Depths's last ability is a state trigger. It will not trigger again while the ability is on the stack, but if the ability is countered and Dark Depths is still on the battlefield with no ice counters on it, it will trigger again immediately."
         }
       ],
       "supertypes": [
@@ -305,7 +305,7 @@
       "rulings": [
         {
           "date": "2011-06-01",
-          "text": "If an artifact you own and a creature an opponent controls go to the graveyard at the same time, you may choose that artifact card as the target of Glissa, the Traitor’s ability (even if they’re the same card: an artifact creature you own that an opponent controlled)."
+          "text": "If an artifact you own and a creature an opponent controls go to the graveyard at the same time, you may choose that artifact card as the target of Glissa, the Traitor's ability (even if they're the same card: an artifact creature you own that an opponent controlled)."
         }
       ],
       "subtypes": [
@@ -365,7 +365,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Helvault’s first and third abilities are linked. Similarly, Helvault’s second and third abilities are linked. Only cards exiled as a result of Helvault’s first or second abilities will be returned to the battlefield by its third ability."
+          "text": "Helvault's first and third abilities are linked. Similarly, Helvault's second and third abilities are linked. Only cards exiled as a result of Helvault's first or second abilities will be returned to the battlefield by its third ability."
         }
       ],
       "supertypes": [
@@ -425,7 +425,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "The effects of Memnarch’s abilities don’t end at end of turn, and they don’t end when Memnarch leaves the battlefield. Both effects last until the affected permanent leaves the battlefield."
+          "text": "The effects of Memnarch's abilities don't end at end of turn, and they don't end when Memnarch leaves the battlefield. Both effects last until the affected permanent leaves the battlefield."
         },
         {
           "date": "2004-12-01",
@@ -501,15 +501,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -640,11 +640,11 @@
       "rulings": [
         {
           "date": "2010-06-15",
-          "text": "This ability has an “intervening ‘if’ clause.” That means (1) the ability triggers only if you have exactly 1 life as your upkeep begins, and (2) the ability does nothing if your life total is anything other than 1 by the time it resolves."
+          "text": "This ability has an \"intervening 'if' clause.\" That means (1) the ability triggers only if you have exactly 1 life as your upkeep begins, and (2) the ability does nothing if your life total is anything other than 1 by the time it resolves."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, anything that cares about your life total checks your team’s life total. You’ll win the game if your team has exactly 1 life."
+          "text": "In a Two-Headed Giant game, anything that cares about your life total checks your team's life total. You'll win the game if your team has exactly 1 life."
         }
       ],
       "text": "At the beginning of your upkeep, if you have exactly 1 life, you win the game.",
@@ -703,7 +703,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Counterspells can be cast that target it, but when they resolve they simply don’t counter it since it can’t be countered."
+          "text": "Counterspells can be cast that target it, but when they resolve they simply don't counter it since it can't be countered."
         }
       ],
       "text": "Obliterate can't be countered.\nDestroy all artifacts, creatures, and lands. They can't be regenerated.",
@@ -751,7 +751,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can pay 0 life if you want, but it’s not useful most of the time."
+          "text": "You can pay 0 life if you want, but it's not useful most of the time."
         }
       ],
       "text": "As Phyrexian Processor enters the battlefield, pay any amount of life.\n{4}, {T}: Create an X/X black Minion creature token, where X is the life paid as Phyrexian Processor entered the battlefield.",
@@ -856,23 +856,23 @@
       "rulings": [
         {
           "date": "2005-02-01",
-          "text": "Umezawa’s Jitte’s activated ability generates a modal choice. The choice is made when the ability is activated."
+          "text": "Umezawa's Jitte's activated ability generates a modal choice. The choice is made when the ability is activated."
         },
         {
           "date": "2005-02-01",
-          "text": "If the “target creature gets -1/-1 until end of turn” mode is chosen, the target creature must also be announced."
+          "text": "If the \"target creature gets -1/-1 until end of turn\" mode is chosen, the target creature must also be announced."
         },
         {
           "date": "2005-02-01",
-          "text": "The ability can be used any time Umezawa’s Jitte’s controller has priority — only the “target creature” choice has additional requirements. Choosing the “Equipped creature gets +2/+2 until end of turn” mode does nothing if the Jitte isn’t equipped to a creature when the ability resolves."
+          "text": "The ability can be used any time Umezawa's Jitte's controller has priority — only the \"target creature\" choice has additional requirements. Choosing the \"Equipped creature gets +2/+2 until end of turn\" mode does nothing if the Jitte isn't equipped to a creature when the ability resolves."
         },
         {
           "date": "2005-02-01",
-          "text": "If the Jitte is moved after the “+2/+2” mode is announced but before it resolves, the bonus is given to the creature that is equipped when the ability resolves."
+          "text": "If the Jitte is moved after the \"+2/+2\" mode is announced but before it resolves, the bonus is given to the creature that is equipped when the ability resolves."
         },
         {
           "date": "2005-02-01",
-          "text": "If the Jitte leaves the battlefield after the “+2/+2” mode is announced but before it resolves, the bonus is given to the creature that was most recently equipped once the ability resolves."
+          "text": "If the Jitte leaves the battlefield after the \"+2/+2\" mode is announced but before it resolves, the bonus is given to the creature that was most recently equipped once the ability resolves."
         }
       ],
       "subtypes": [

--- a/json/VIS.json
+++ b/json/VIS.json
@@ -80,7 +80,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "Only puts counters on creatures your opponents control, so in the Two-Headed Giant format, won’t put counters on your teammate’s creatures."
+          "text": "Only puts counters on creatures your opponents control, so in the Two-Headed Giant format, won't put counters on your teammate's creatures."
         }
       ],
       "subtypes": [
@@ -135,7 +135,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Anvil of Bogardan onto the battlefield, you’ll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
+          "text": "If multiple effects modify your hand size, apply them in timestamp order. For example, if you put Null Profusion (an enchantment that says your maximum hand size is two) onto the battlefield and then put Anvil of Bogardan onto the battlefield, you'll have no maximum hand size. However, if those permanents entered the battlefield in the opposite order, your maximum hand size would be two."
         },
         {
           "date": "2013-04-15",
@@ -316,7 +316,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If it ever enchants a creature that isn’t controlled by an opponent of Betrayal’s controller, then it’s put into the graveyard as a State-Based Action."
+          "text": "If it ever enchants a creature that isn't controlled by an opponent of Betrayal's controller, then it's put into the graveyard as a State-Based Action."
         }
       ],
       "subtypes": [
@@ -372,7 +372,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The land can now be tapped for black mana in addition to any other abilities it already has. This works just as if the text “{T}: Add {B} to your mana pool” was added to each mana-producing land. In other words, the land can be tapped for its own ability _or_ it can be tapped for black mana. Not both."
+          "text": "The land can now be tapped for black mana in addition to any other abilities it already has. This works just as if the text \"{T}: Add {B} to your mana pool\" was added to each mana-producing land. In other words, the land can be tapped for its own ability _or_ it can be tapped for black mana. Not both."
         },
         {
           "date": "2004-10-04",
@@ -392,7 +392,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The lands do not get the name “Swamp” in addition to their current name. This is a reversal of older rulings."
+          "text": "The lands do not get the name \"Swamp\" in addition to their current name. This is a reversal of older rulings."
         },
         {
           "date": "2004-10-04",
@@ -838,7 +838,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "City of Solitude does not stop triggered abilities from being put on the stack. They are never “activated”."
+          "text": "City of Solitude does not stop triggered abilities from being put on the stack. They are never \"activated\"."
         },
         {
           "date": "2009-10-01",
@@ -1220,7 +1220,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"And the flamingos said, ‘Get out of our nest—we can't be seen with the likes of you!' So, the griffin ate them.\"\n—Azeworai, \"The Ugly Bird\"",
+      "flavor": "\"And the flamingos said, 'Get out of our nest—we can't be seen with the likes of you!' So, the griffin ate them.\"\n—Azeworai, \"The Ugly Bird\"",
       "id": "30e7bf395ec04a249f9ec512ff642d027696e7b4",
       "imageName": "daraja griffin",
       "layout": "normal",
@@ -1412,7 +1412,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The card is put onto the battlefield, but any effects that check if the original card was “cast from your hand” will not trigger or otherwise consider the card to have been cast from your hand. The card was put onto the battlefield by the effect of Desertion instead."
+          "text": "The card is put onto the battlefield, but any effects that check if the original card was \"cast from your hand\" will not trigger or otherwise consider the card to have been cast from your hand. The card was put onto the battlefield by the effect of Desertion instead."
         },
         {
           "date": "2004-10-04",
@@ -1420,7 +1420,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If the spell is not countered (because the spell it targets can’t be countered), then this card’s ability does not put the card onto the battlefield. The spell continues to resolve as normal."
+          "text": "If the spell is not countered (because the spell it targets can't be countered), then this card's ability does not put the card onto the battlefield. The spell continues to resolve as normal."
         }
       ],
       "text": "Counter target spell. If an artifact or creature spell is countered this way, put that card onto the battlefield under your control instead of into its owner's graveyard.",
@@ -1715,7 +1715,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -1772,7 +1772,7 @@
       "rulings": [
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nBlack creatures can't attack you.\nNonblack creatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
@@ -1829,7 +1829,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -2093,7 +2093,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -2368,7 +2368,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -2659,7 +2659,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"‘I've seen hornworms big as a man's fist,' the traveler said, and nodded soberly when our jaws went slack at his ignorance.\"\n—Afari, Tales",
+      "flavor": "\"'I've seen hornworms big as a man's fist,' the traveler said, and nodded soberly when our jaws went slack at his ignorance.\"\n—Afari, Tales",
       "id": "d161afcc787458cdb5a7b0fb8b580910eb7b80da",
       "imageName": "giant caterpillar",
       "layout": "normal",
@@ -2760,7 +2760,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type “Summon Goblin” and “Summon Goblins” also count. You can’t search for cards that have Goblin in the name but don’t have the creature type Goblin."
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
         }
       ],
       "subtypes": [
@@ -2873,7 +2873,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "A creature is only considered an “unblocked creature” if it is an attacker during combat after blockers are declared."
+          "text": "A creature is only considered an \"unblocked creature\" if it is an attacker during combat after blockers are declared."
         }
       ],
       "text": "Return Gossamer Chains to its owner's hand: Prevent all combat damage that would be dealt by target unblocked creature this turn.",
@@ -3114,7 +3114,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -3134,7 +3134,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "text": "Spells cost {1} less to cast.",
@@ -3421,7 +3421,7 @@
       "rulings": [
         {
           "date": "2010-08-15",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         }
       ],
       "subtypes": [
@@ -3487,7 +3487,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If X is greater than 0, you can’t choose zero targets. You must choose between one and X targets. If X is 0, you can’t choose any targets."
+          "text": "If X is greater than 0, you can't choose zero targets. You must choose between one and X targets. If X is 0, you can't choose any targets."
         }
       ],
       "text": "As an additional cost to cast Infernal Harvest, return X Swamps you control to their owner's hand.\nInfernal Harvest deals X damage divided as you choose among any number of target creatures.",
@@ -3800,7 +3800,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "As always, you can’t sacrifice things you do not control."
+          "text": "As always, you can't sacrifice things you do not control."
         }
       ],
       "text": "As an additional cost to cast Kaervek's Spite, sacrifice all permanents you control and discard your hand.\nTarget player loses 5 life.",
@@ -3902,7 +3902,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Phasing (This phases in or out before you untap during each of your untap steps. While it's phased out, it's treated as though it doesn't exist.)\nCreatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.",
@@ -4076,7 +4076,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Can destroy an opponent’s knight."
+          "text": "Can destroy an opponent's knight."
         }
       ],
       "subtypes": [
@@ -4244,7 +4244,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "subtypes": [
@@ -4348,7 +4348,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This card’s effect replaces damage with placement of -1/-1 counters, so side-effects of damage to it will not trigger."
+          "text": "This card's effect replaces damage with placement of -1/-1 counters, so side-effects of damage to it will not trigger."
         }
       ],
       "subtypes": [
@@ -4411,7 +4411,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You pick the target when putting the triggered ability on the stack, but you don’t choose whether or not to pay {R} until the triggered ability resolves."
+          "text": "You pick the target when putting the triggered ability on the stack, but you don't choose whether or not to pay {R} until the triggered ability resolves."
         }
       ],
       "text": "Whenever a player casts a red spell, you may pay {R}. If you do, Lightning Cloud deals 1 damage to target creature or player.",
@@ -4578,7 +4578,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are no other creatures on the battlefield when Man-o’-War enters the battlefield, its ability must target itself."
+          "text": "If there are no other creatures on the battlefield when Man-o'-War enters the battlefield, its ability must target itself."
         }
       ],
       "subtypes": [
@@ -4889,7 +4889,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "subtypes": [
@@ -4948,11 +4948,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Sacrificing a green creature is part of Natural Order’s cost. You can’t sacrifice more creatures to search for more creature cards, and you can’t cast Natural Order at all if you control no green creatures."
+          "text": "Sacrificing a green creature is part of Natural Order's cost. You can't sacrifice more creatures to search for more creature cards, and you can't cast Natural Order at all if you control no green creatures."
         },
         {
           "date": "2016-06-08",
-          "text": "Players can respond to this spell only after it’s been cast and all its costs have been paid. No one can try to destroy the creature you sacrificed to stop you from casting this spell or to make you sacrifice a different one."
+          "text": "Players can respond to this spell only after it's been cast and all its costs have been paid. No one can try to destroy the creature you sacrificed to stop you from casting this spell or to make you sacrifice a different one."
         }
       ],
       "text": "As an additional cost to cast Natural Order, sacrifice a green creature.\nSearch your library for a green creature card and put it onto the battlefield. Then shuffle your library.",
@@ -5016,11 +5016,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If the creature card put onto the battlefield has protection from black (or anything that prevents this from legally being attached), this won’t be able to attach to it. Then this will go to the graveyard as a state-based action, causing the creature to be sacrificed."
+          "text": "If the creature card put onto the battlefield has protection from black (or anything that prevents this from legally being attached), this won't be able to attach to it. Then this will go to the graveyard as a state-based action, causing the creature to be sacrificed."
         },
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "text": "You may cast Necromancy as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.\nWhen Necromancy enters the battlefield, if it's on the battlefield, it becomes an Aura with \"enchant creature put onto the battlefield with Necromancy.\" Put target creature card from a graveyard onto the battlefield under your control and attach Necromancy to it. When Necromancy leaves the battlefield, that creature's controller sacrifices it.",
@@ -5146,7 +5146,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it’s a creature you control."
+          "text": "Nothing happens if there are no nonartifact, nonblack creatures on the battlefield when Nekrataal enters the battlefield, but if there is one, you must target it, even if it's a creature you control."
         }
       ],
       "subtypes": [
@@ -5210,7 +5210,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The check for nonlethal damage is done on a per-source basis. So each source’s damage is checked independently and it is not possible to team up sources (such as creatures) in order to kill it."
+          "text": "The check for nonlethal damage is done on a per-source basis. So each source's damage is checked independently and it is not possible to team up sources (such as creatures) in order to kill it."
         }
       ],
       "subtypes": [
@@ -5388,7 +5388,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "text": "You may cast Parapet as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.\nCreatures you control get +0/+1.",
@@ -5450,11 +5450,11 @@
         },
         {
           "date": "2006-02-01",
-          "text": "Doesn’t skip the Combat Phase, just renders creatures unable to attack."
+          "text": "Doesn't skip the Combat Phase, just renders creatures unable to attack."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "This turn and next turn, creatures can't attack, and players and permanents can't be the targets of spells or activated abilities.",
@@ -5600,7 +5600,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -5715,11 +5715,11 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "A mana ability is an ability that (1) isn’t a loyalty ability, (2) doesn’t target, and (3) could put mana into a player’s mana pool when it resolves."
+          "text": "A mana ability is an ability that (1) isn't a loyalty ability, (2) doesn't target, and (3) could put mana into a player's mana pool when it resolves."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -5881,7 +5881,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -6116,7 +6116,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you manage to cast this during a main phase of your opponent’s turn, that opponent’s creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
+          "text": "If you manage to cast this during a main phase of your opponent's turn, that opponent's creatures will untap and that opponent will be able to attack again. It will not allow you to attack during their turn."
         },
         {
           "date": "2004-10-04",
@@ -6185,7 +6185,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "subtypes": [
@@ -6246,7 +6246,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can’t choose zero targets. You must choose at least one target."
+          "text": "You can't choose zero targets. You must choose at least one target."
         }
       ],
       "text": "Prevent the next 5 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.",
@@ -6366,7 +6366,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"Good is not a ‘thing.' You can neither touch nor own it. No, Good is a vision we all share and strive to make real.\"\n—Asmira, Holy Avenger",
+      "flavor": "\"Good is not a 'thing.' You can neither touch nor own it. No, Good is a vision we all share and strive to make real.\"\n—Asmira, Holy Avenger",
       "id": "165208cb7e98225922d069b80d740af7b3944c06",
       "imageName": "righteous aura",
       "layout": "normal",
@@ -6569,7 +6569,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If X is greater than 0, you can’t choose zero targets. You must choose between one and X targets. If X is 0, you can’t choose any targets."
+          "text": "If X is greater than 0, you can't choose zero targets. You must choose between one and X targets. If X is 0, you can't choose any targets."
         }
       ],
       "text": "Rock Slide deals X damage divided as you choose among any number of target attacking or blocking creatures without flying.",
@@ -6676,11 +6676,11 @@
         },
         {
           "date": "2008-08-01",
-          "text": "Skipping the untap step means that phased out cards won’t phase in, and permanents with phasing won’t phase out."
+          "text": "Skipping the untap step means that phased out cards won't phase in, and permanents with phasing won't phase out."
         },
         {
           "date": "2009-10-01",
-          "text": "You can tap lands for mana before Sands of Time toggles your permanents. The mana you gain is in your mana pool during your upkeep step, but will disappear before your draw step if you don’t spend it. You cannot save it to be spent on the card you will draw this turn."
+          "text": "You can tap lands for mana before Sands of Time toggles your permanents. The mana you gain is in your mana pool during your upkeep step, but will disappear before your draw step if you don't spend it. You cannot save it to be spent on the card you will draw this turn."
         }
       ],
       "text": "Each player skips his or her untap step.\nAt the beginning of each player's upkeep, that player simultaneously untaps each tapped artifact, creature, and land he or she controls and taps each untapped artifact, creature, and land he or she controls.",
@@ -7161,7 +7161,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "subtypes": [
@@ -7273,7 +7273,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can sacrifice a land which can’t produce mana, but you don’t get any mana from this ability."
+          "text": "Can sacrifice a land which can't produce mana, but you don't get any mana from this ability."
         }
       ],
       "text": "Sacrifice a land: Add to your mana pool one mana of any type the sacrificed land could produce.",
@@ -7334,7 +7334,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability that returns a creature doesn’t target anything. You can return a creature with shroud or protection from green, for example. You don’t decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
+          "text": "The ability that returns a creature doesn't target anything. You can return a creature with shroud or protection from green, for example. You don't decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
         },
         {
           "date": "2004-10-04",
@@ -7564,7 +7564,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -7959,11 +7959,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Can affect itself if you choose “non-Aura enchantment”."
+          "text": "Can affect itself if you choose \"non-Aura enchantment\"."
         },
         {
           "date": "2008-10-01",
-          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners’ graveyards. This is a state-based action called the “world rule.” The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they’re both put into their owners’ graveyards."
+          "text": "This has the supertype world. When a world permanent enters the battlefield, any world permanents that were already on the battlefield are put into their owners' graveyards. This is a state-based action called the \"world rule.\" The new world permanent stays on the battlefield. If two world permanents enter the battlefield at the same time, they're both put into their owners' graveyards."
         }
       ],
       "supertypes": [
@@ -8077,11 +8077,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can only play them before the start of your upkeep. Between the start of your upkeep and putting the extra cards into the graveyard, you can’t play them."
+          "text": "You can only play them before the start of your upkeep. Between the start of your upkeep and putting the extra cards into the graveyard, you can't play them."
         },
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         }
       ],
       "text": "Exile the top three cards of your library face down. You may look at those cards for as long as they remain exiled. Until your next turn, you may play those cards. At the beginning of your next upkeep, put any of those cards you didn't play into your graveyard.",
@@ -8231,7 +8231,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Search your library for a Plains card. If target opponent controls more lands than you, you may search your library for an additional Plains card. Reveal those cards and put them into your hand. Then shuffle your library.",
@@ -8445,7 +8445,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Only returns to owner’s hand if it is still on the battlefield at the beginning of its controller’s next untap."
+          "text": "Only returns to owner's hand if it is still on the battlefield at the beginning of its controller's next untap."
         }
       ],
       "text": "{T}: Add one mana of any color to your mana pool. During your next untap step, as you untap your permanents, return Undiscovered Paradise to its owner's hand.",
@@ -8500,7 +8500,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two creatures may have different owners and return to their respective owner’s hands."
+          "text": "The two creatures may have different owners and return to their respective owner's hands."
         }
       ],
       "text": "Return two target creatures to their owners' hands.",
@@ -8555,7 +8555,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -8616,7 +8616,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
@@ -8777,7 +8777,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is returned to its owner’s hand at the end of any turn in which it is on the battlefield."
+          "text": "It is returned to its owner's hand at the end of any turn in which it is on the battlefield."
         }
       ],
       "subtypes": [
@@ -8907,7 +8907,7 @@
       "colors": [
         "Black"
       ],
-      "flavor": "\"So the vulture said to the griffin, ‘You gonna eat that?'\"\n—Azeworai, \"The Ugly Bird\"",
+      "flavor": "\"So the vulture said to the griffin, 'You gonna eat that?'\"\n—Azeworai, \"The Ugly Bird\"",
       "id": "29aaeff06f14acd7baf235e1334b84a253044138",
       "imageName": "wake of vultures",
       "layout": "normal",
@@ -9051,7 +9051,7 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "Warrior’s Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won’t get the bonus."
+          "text": "Warrior's Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won't get the bonus."
         }
       ],
       "text": "Creatures you control get +1/+1 until end of turn.",

--- a/json/VMA.json
+++ b/json/VMA.json
@@ -125,7 +125,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one.",
@@ -180,7 +180,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. (Then put Timetwister into its owner's graveyard.)",
@@ -624,7 +624,8 @@
         "MED",
         "ME4",
         "VMA",
-        "V14"
+        "V14",
+        "MPS_AKH"
       ],
       "rarity": "Mythic Rare",
       "text": "Destroy all lands.",
@@ -680,7 +681,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a player cycles a card during the end step, the creature that is exiled won’t come back until the end of the next turn."
+          "text": "If a player cycles a card during the end step, the creature that is exiled won't come back until the end of the next turn."
         },
         {
           "date": "2008-08-01",
@@ -748,7 +749,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Balance doesn’t have targets, so permanents that can’t be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
+          "text": "Balance doesn't have targets, so permanents that can't be targeted, such as a creature with shroud or protection from white, are valid choices to be sacrificed."
         },
         {
           "date": "2016-06-08",
@@ -1070,7 +1071,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -1078,11 +1079,15 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
+        },
+        {
+          "date": "2017-06-13",
+          "text": "If a choice has no votes, it can't have the most votes. If all choices have zero votes, the voting ability has no effect."
         }
       ],
       "text": "Will of the council — Starting with you, each player votes for a nonland permanent you don't control. Exile each permanent with the most votes or tied for most votes.",
@@ -1132,7 +1137,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, the first ability triggers once during each team’s upkeep."
+          "text": "In a Two-Headed Giant game, the first ability triggers once during each team's upkeep."
         }
       ],
       "text": "At the beginning of each upkeep, put a strife counter on Crescendo of War.\nAttacking creatures get +1/+0 for each strife counter on Crescendo of War.\nBlocking creatures you control get +1/+0 for each strife counter on Crescendo of War.",
@@ -1189,7 +1194,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two X’s in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
+          "text": "The two X's in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
         },
         {
           "date": "2004-10-04",
@@ -1209,7 +1214,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
@@ -1374,7 +1379,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The value of X is recalculated constantly, so this card’s bonus varies as the number of cards in your hand varies."
+          "text": "The value of X is recalculated constantly, so this card's bonus varies as the number of cards in your hand varies."
         }
       ],
       "subtypes": [
@@ -1434,7 +1439,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Plainscycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Plains card. After you find a Plains card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Plainscycling doesn't allow you to draw a card. Instead, it lets you search your library for a Plains card. After you find a Plains card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -1895,11 +1900,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -1907,15 +1912,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         },
         {
           "date": "2008-04-01",
-          "text": "If you control Mistmoon Griffin when it goes to the graveyard, you exile the Griffin and return the top creature card from your graveyard to the battlefield. It doesn’t matter whose graveyard the Griffin goes to."
+          "text": "If you control Mistmoon Griffin when it goes to the graveyard, you exile the Griffin and return the top creature card from your graveyard to the battlefield. It doesn't matter whose graveyard the Griffin goes to."
         }
       ],
       "subtypes": [
@@ -2364,6 +2369,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -2392,7 +2401,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2017-04-18",
@@ -2400,15 +2409,15 @@
         },
         {
           "date": "2017-04-18",
-          "text": "Triggered abilities from cycling a card and the cycling ability itself aren’t spells. Effects that interact with spells (such as that of Cancel) won’t affect them."
+          "text": "Triggered abilities from cycling a card and the cycling ability itself aren't spells. Effects that interact with spells (such as that of Cancel) won't affect them."
         },
         {
           "date": "2017-04-18",
-          "text": "You can cycle a card even if it has a triggered ability from cycling that won’t have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability’s targets have become illegal), the other ability will still resolve."
+          "text": "You can cycle a card even if it has a triggered ability from cycling that won't have a legal target. This is because the cycling ability and the triggered ability are separate. This also means that if either ability is countered (with Disallow, for example, or if the triggered ability's targets have become illegal), the other ability will still resolve."
         },
         {
-          "date": "2017-04-18",
-          "text": "There are many important moments in the story, but the most crucial—called “story spotlights”—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
+          "date": "2017-06-27",
+          "text": "There are many important moments in the story, but the most crucial—called \"story spotlights\"—are shown on cards. You can read more about these events in the official Magic fiction at http://www.mtgstory.com."
         }
       ],
       "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
@@ -2522,7 +2531,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The legality of a spell’s target is checked only as that spell begins to resolve. If Shelter gives the targeted creature protection from white, you’ll still draw a card."
+          "text": "The legality of a spell's target is checked only as that spell begins to resolve. If Shelter gives the targeted creature protection from white, you'll still draw a card."
         }
       ],
       "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
@@ -2929,7 +2938,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature’s power is negative, its controller doesn’t lose or gain life."
+          "text": "If the creature's power is negative, its controller doesn't lose or gain life."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -3041,7 +3050,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "A creature is “enchanted” if it has any Auras attached to it."
+          "text": "A creature is \"enchanted\" if it has any Auras attached to it."
         }
       ],
       "text": "Destroy all creatures that aren't enchanted. They can't be regenerated.",
@@ -3208,7 +3217,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -3267,15 +3276,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -3414,11 +3423,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Tap up to four target creatures.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Choking Tethers, you may tap target creature.",
@@ -3585,7 +3594,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -3652,7 +3661,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Gaining control of a creature doesn’t cause you to gain control of any Auras or Equipment attached to it."
+          "text": "Gaining control of a creature doesn't cause you to gain control of any Auras or Equipment attached to it."
         }
       ],
       "subtypes": [
@@ -3913,7 +3922,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "Each pile may contain from zero to five cards; they don’t have to be split “evenly.”"
+          "text": "Each pile may contain from zero to five cards; they don't have to be split \"evenly.\""
         }
       ],
       "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
@@ -3964,15 +3973,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -4093,7 +4102,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "text": "Draw two cards, then discard two cards. Untap up to three lands.",
@@ -4149,7 +4158,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2016-06-08",
@@ -4161,7 +4170,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability (perhaps because that top card is the card you’re casting) the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability (perhaps because that top card is the card you're casting) the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2016-06-08",
@@ -4334,11 +4343,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You draw three cards and put two cards back all while Jace’s second ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+          "text": "You draw three cards and put two cards back all while Jace's second ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
         },
         {
           "date": "2016-06-08",
-          "text": "If the targeted player for Jace’s last ability has no cards in hand, that player shuffles nothing into his or her library, and that player’s library will remain empty. That player won’t lose the game until he or she tries to draw from the empty library."
+          "text": "If the targeted player for Jace's last ability has no cards in hand, that player shuffles nothing into his or her library, and that player's library will remain empty. That player won't lose the game until he or she tries to draw from the empty library."
         }
       ],
       "subtypes": [
@@ -4567,15 +4576,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell “can’t be countered,” it remains on the stack. Mana Drain continues to resolve. At the beginning of your next main phase, the delayed triggered ability will still add the mana to your mana pool."
+          "text": "If the targeted spell \"can't be countered,\" it remains on the stack. Mana Drain continues to resolve. At the beginning of your next main phase, the delayed triggered ability will still add the mana to your mana pool."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell is an illegal target by the time Mana Drain resolves, Mana Drain is countered. You won’t get any mana later."
+          "text": "If the targeted spell is an illegal target by the time Mana Drain resolves, Mana Drain is countered. You won't get any mana later."
         },
         {
           "date": "2009-10-01",
-          "text": "Mana Drain’s delayed triggered ability will usually trigger at the beginning of your precombat main phase. However, if you cast Mana Drain during your precombat main phase or during your combat phase, its delayed triggered ability will trigger at the beginning of that turn’s postcombat main phase."
+          "text": "Mana Drain's delayed triggered ability will usually trigger at the beginning of your precombat main phase. However, if you cast Mana Drain during your precombat main phase or during your combat phase, its delayed triggered ability will trigger at the beginning of that turn's postcombat main phase."
         }
       ],
       "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} to your mana pool equal to that spell's converted mana cost.",
@@ -4639,7 +4648,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If there are no other creatures on the battlefield when Man-o’-War enters the battlefield, its ability must target itself."
+          "text": "If there are no other creatures on the battlefield when Man-o'-War enters the battlefield, its ability must target itself."
         }
       ],
       "subtypes": [
@@ -4708,15 +4717,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -4826,7 +4835,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "The value of X is determined as the ability resolves. If, at that time, you control no artifacts, you won’t look at any cards."
+          "text": "The value of X is determined as the ability resolves. If, at that time, you control no artifacts, you won't look at any cards."
         }
       ],
       "subtypes": [
@@ -4941,7 +4950,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -5056,7 +5065,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "You choose which lands to untap as the triggered ability resolves. They aren’t targeted, and they don’t have to be lands that you control."
+          "text": "You choose which lands to untap as the triggered ability resolves. They aren't targeted, and they don't have to be lands that you control."
         }
       ],
       "subtypes": [
@@ -5114,7 +5123,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -5122,11 +5131,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "text": "Will of the council — Starting with you, each player votes for time or knowledge. If time gets more votes, take an extra turn after this one. If knowledge gets more votes or the vote is tied, draw three cards.",
@@ -5211,7 +5220,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana”. If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -5431,7 +5440,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, if one of the lands has become an illegal target (because it’s no longer on the battlefield, for example), you return the other one to your hand. If both of the lands have become illegal targets, the ability is countered. This has no effect on Sea Drake."
+          "text": "When the ability resolves, if one of the lands has become an illegal target (because it's no longer on the battlefield, for example), you return the other one to your hand. If both of the lands have become illegal targets, the ability is countered. This has no effect on Sea Drake."
         }
       ],
       "subtypes": [
@@ -5651,15 +5660,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -5953,15 +5962,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When it changes forms, any “enters the battlefield” abilities of the card it “copies” do not trigger."
+          "text": "When it changes forms, any \"enters the battlefield\" abilities of the card it \"copies\" do not trigger."
         },
         {
           "date": "2004-10-04",
-          "text": "A copy of a Volrath’s Shapeshifter will have the shapeshifting ability."
+          "text": "A copy of a Volrath's Shapeshifter will have the shapeshifting ability."
         },
         {
           "date": "2004-10-04",
-          "text": "If the top card in your graveyard isn’t a creature card (meaning a card with the type Creature, which may or may not have other types such as Artifact or Enchantment), then it’s just a 0/1 blue creature. Older cards of type Summon are also Creature cards."
+          "text": "If the top card in your graveyard isn't a creature card (meaning a card with the type Creature, which may or may not have other types such as Artifact or Enchantment), then it's just a 0/1 blue creature. Older cards of type Summon are also Creature cards."
         },
         {
           "date": "2008-08-01",
@@ -6137,7 +6146,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead isn’t on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won’t be returned to the battlefield."
+          "text": "If Animate Dead isn't on the battlefield as its triggered ability resolves, none of its effects happen. The creature card won't be returned to the battlefield."
         },
         {
           "date": "2016-06-08",
@@ -6145,11 +6154,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If the creature put onto the battlefield has protection from black—or if the creature can’t legally be enchanted by Animate Dead for another reason—Animate Dead won’t be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature’s still on the battlefield, its controller will sacrifice it."
+          "text": "If the creature put onto the battlefield has protection from black—or if the creature can't legally be enchanted by Animate Dead for another reason—Animate Dead won't be able to attach to it. It will be put into the graveyard as a state-based action, causing its delayed triggered ability to trigger. When the trigger resolves, if the creature's still on the battlefield, its controller will sacrifice it."
         },
         {
           "date": "2016-06-08",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
         }
       ],
       "subtypes": [
@@ -6844,7 +6853,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don’t reveal the card to your opponent."
+          "text": "You don't reveal the card to your opponent."
         },
         {
           "date": "2004-10-04",
@@ -7218,11 +7227,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If multiple Ichorids are in your graveyard, you can’t exile the same creature card to return each of them to the battlefield."
+          "text": "If multiple Ichorids are in your graveyard, you can't exile the same creature card to return each of them to the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "If one Ichorid’s ability exiles another, the exiled Ichorid’s ability can’t return it to the battlefield."
+          "text": "If one Ichorid's ability exiles another, the exiled Ichorid's ability can't return it to the battlefield."
         }
       ],
       "subtypes": [
@@ -7397,7 +7406,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures which are sacrificed can’t be regenerated."
+          "text": "The creatures which are sacrificed can't be regenerated."
         },
         {
           "date": "2004-10-04",
@@ -7405,7 +7414,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
+          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
         }
       ],
       "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -7468,7 +7477,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "Pay half your life, rounded up: Lurking Evil becomes a 4/4 Horror creature with flying.",
@@ -7627,11 +7636,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Necropotence’s last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
+          "text": "Necropotence's last ability creates a delayed triggered ability that will put the exiled card into your hand. That ability still triggers even if Necropotence is removed from the battlefield before your end step."
         },
         {
           "date": "2016-06-08",
-          "text": "If the discarded card isn’t put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won’t be exiled."
+          "text": "If the discarded card isn't put into your graveyard (due to an effect such as madness) or leaves your graveyard (perhaps because another effect returned it to your hand), it won't be exiled."
         }
       ],
       "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
@@ -7694,7 +7703,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way”. This distinction is important for effects which reduce the generic portion of a spell’s cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
         },
         {
           "date": "2004-10-04",
@@ -7714,7 +7723,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -8014,7 +8023,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You lose life equal to the converted mana cost of the card you’re bringing back, so if you Reanimate Volrath’s Shapeshifter, you lose three life, regardless of what the next card down is."
+          "text": "You lose life equal to the converted mana cost of the card you're bringing back, so if you Reanimate Volrath's Shapeshifter, you lose three life, regardless of what the next card down is."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
@@ -8071,7 +8080,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "text": "Sacrifice a creature, Return Recurring Nightmare to its owner's hand: Return target creature card from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery.",
@@ -8337,15 +8346,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -8411,7 +8420,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -8419,11 +8428,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "text": "Will of the council — Starting with you, each player votes for death or torture. If death gets more votes, each opponent sacrifices a creature. If torture gets more votes or the vote is tied, each opponent loses 4 life.",
@@ -8483,7 +8492,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you chose at least one target and all targets are illegal on resolution, you won’t draw a card."
+          "text": "If you chose at least one target and all targets are illegal on resolution, you won't draw a card."
         }
       ],
       "text": "Return up to two target creature cards from your graveyard to your hand.\nDraw a card.",
@@ -8541,7 +8550,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The “shuffle and put the card on top” is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
+          "text": "The \"shuffle and put the card on top\" is a single action. If an effect causes the top card of the library to be face up, the second card down is not revealed."
         }
       ],
       "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
@@ -8714,7 +8723,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If an effect asks you to discard a card, you can’t “discard” something that is in your graveyard. Those cards are not in your hand. Thus, Cycling abilities of cards in the graveyard can’t be activated."
+          "text": "If an effect asks you to discard a card, you can't \"discard\" something that is in your graveyard. Those cards are not in your hand. Thus, Cycling abilities of cards in the graveyard can't be activated."
         },
         {
           "date": "2004-10-04",
@@ -8722,11 +8731,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you play a card using Yawgmoth’s Will and something triggers only when “cast from your hand”, that something will not trigger. Such things trigger based on where the card came from."
+          "text": "If you play a card using Yawgmoth's Will and something triggers only when \"cast from your hand\", that something will not trigger. Such things trigger based on where the card came from."
         },
         {
           "date": "2004-10-04",
-          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2006-10-15",
@@ -8891,11 +8900,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The lands that will be destroyed aren’t chosen until Burning of Xinye resolves."
+          "text": "The lands that will be destroyed aren't chosen until Burning of Xinye resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye’s destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
+          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye's destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
         },
         {
           "date": "2009-10-01",
@@ -8960,7 +8969,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can’t acquire the Ante cards. They are considered still “in the game” as are cards in the library and the graveyard."
+          "text": "Can't acquire the Ante cards. They are considered still \"in the game\" as are cards in the library and the graveyard."
         },
         {
           "date": "2007-05-01",
@@ -8972,15 +8981,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Can’t acquire cards that are phased out."
+          "text": "Can't acquire cards that are phased out."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t acquire exiled cards because those cards are still in one of the game’s zones."
+          "text": "You can't acquire exiled cards because those cards are still in one of the game's zones."
         },
         {
           "date": "2009-10-01",
-          "text": "In a sanctioned event, a card that’s “outside the game” is one that’s in your sideboard. In an unsanctioned event, you may choose any card from your collection."
+          "text": "In a sanctioned event, a card that's \"outside the game\" is one that's in your sideboard. In an unsanctioned event, you may choose any card from your collection."
         }
       ],
       "text": "You may choose a sorcery card you own from outside the game, reveal that card, and put it into your hand. Exile Burning Wish.",
@@ -9046,7 +9055,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who’s copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
+          "text": "As Chain Lightning resolves, the targeted player or the controller of the targeted creature may copy it. The copy has the same text, target, and color of the resolving spell, though the player who's copying it may choose a new target for it. Once that copy is created (or not), the first Chain Lightning has finished resolving and leaves the stack."
         },
         {
           "date": "2016-06-08",
@@ -9054,11 +9063,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "The copy of Chain Lightning is created on the stack, so it’s not cast. Abilities that trigger when a player casts a spell won’t trigger. Players may respond to that spell before it resolves."
+          "text": "The copy of Chain Lightning is created on the stack, so it's not cast. Abilities that trigger when a player casts a spell won't trigger. Players may respond to that spell before it resolves."
         },
         {
           "date": "2016-06-08",
-          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can’t be copied."
+          "text": "If the targeted creature or player is an illegal target when Chain Lightning tries to resolve, the spell is countered. It can't be copied."
         }
       ],
       "text": "Chain Lightning deals 3 damage to target creature or player. Then that player or that creature's controller may pay {R}{R}. If the player does, he or she may copy this spell and may choose a new target for that copy.",
@@ -9111,7 +9120,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player’s library this way, that player shuffles before revealing the top card of that library."
+          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player's library this way, that player shuffles before revealing the top card of that library."
         },
         {
           "date": "2011-09-22",
@@ -9123,7 +9132,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the revealed card is a permanent card but can’t enter the battlefield (perhaps because it’s an Aura with nothing to enchant), it remains on top of that library."
+          "text": "If the revealed card is a permanent card but can't enter the battlefield (perhaps because it's an Aura with nothing to enchant), it remains on top of that library."
         },
         {
           "date": "2011-09-22",
@@ -9187,7 +9196,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Mountaincycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Mountaincycling doesn't allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -9542,7 +9551,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It will be put into its owner’s graveyard as soon as one of its abilities resolves that puts its toughness at zero (or less than the current amount of damage on it). This is a state-based action, so there is no way to activate its ability any more to increase its power further before it is put into the graveyard."
+          "text": "It will be put into its owner's graveyard as soon as one of its abilities resolves that puts its toughness at zero (or less than the current amount of damage on it). This is a state-based action, so there is no way to activate its ability any more to increase its power further before it is put into the graveyard."
         }
       ],
       "subtypes": [
@@ -9878,7 +9887,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A Goblin permanent card is an artifact, creature, land, and/or enchantment card with the creature type “Goblin”. Usually such cards will be creatures in addition to any other types, but they may be tribal instead. For example, you could put Boggart Shenanigans onto the battlefield with this effect."
+          "text": "A Goblin permanent card is an artifact, creature, land, and/or enchantment card with the creature type \"Goblin\". Usually such cards will be creatures in addition to any other types, but they may be tribal instead. For example, you could put Boggart Shenanigans onto the battlefield with this effect."
         }
       ],
       "subtypes": [
@@ -9942,11 +9951,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type “Summon Goblin” and “Summon Goblins” also count. You can’t search for cards that have Goblin in the name but don’t have the creature type Goblin."
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
         }
       ],
       "subtypes": [
@@ -10819,15 +10828,15 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Scourge of the Throne’s ability has an intervening “if” clause. It must be attacking the player with the most life or tied with the most life both when it’s declared as an attacker and as it starts to resolve for it to have any effect. If, at either time, the player isn’t the one with the most life or tied for the most life, the ability will have no effect. Notably, this is different than how dethrone works. (Dethrone checks only once to see if the ability triggers.)"
+          "text": "Scourge of the Throne's ability has an intervening \"if\" clause. It must be attacking the player with the most life or tied with the most life both when it's declared as an attacker and as it starts to resolve for it to have any effect. If, at either time, the player isn't the one with the most life or tied for the most life, the ability will have no effect. Notably, this is different than how dethrone works. (Dethrone checks only once to see if the ability triggers.)"
         },
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -11014,11 +11023,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
         }
       ],
       "text": "Solar Blast deals 3 damage to target creature or player.\nCycling {1}{R}{R} ({1}{R}{R}, Discard this card: Draw a card.)\nWhen you cycle Solar Blast, you may have it deal 1 damage to target creature or player.",
@@ -11344,15 +11353,15 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "It is possible for Worldgorger Dragon to leave the battlefield before its “enters the battlefield” trigger resolves. If this happens, then the “leaves the battlefield” trigger will have nothing to return. Then its “enters the battlefield” trigger resolves, and all other permanents you control are exiled forever."
+          "text": "It is possible for Worldgorger Dragon to leave the battlefield before its \"enters the battlefield\" trigger resolves. If this happens, then the \"leaves the battlefield\" trigger will have nothing to return. Then its \"enters the battlefield\" trigger resolves, and all other permanents you control are exiled forever."
         },
         {
           "date": "2016-06-08",
-          "text": "If an Aura is exiled with Worldgorger Dragon, the player who controls the Aura when it enters the battlefield chooses what it will enchant. It doesn’t have to go back to the same place. It can’t enter the battlefield enchanting a permanent that enters the battlefield at the same time."
+          "text": "If an Aura is exiled with Worldgorger Dragon, the player who controls the Aura when it enters the battlefield chooses what it will enchant. It doesn't have to go back to the same place. It can't enter the battlefield enchanting a permanent that enters the battlefield at the same time."
         },
         {
           "date": "2016-06-08",
-          "text": "If Animate Dead is put onto the battlefield enchanting Worldgorger Dragon, Worldgorger Dragon’s enters-the-battlefield trigger will exile Animate Dead, which causes you to sacrifice Worldgorger Dragon, which causes Animate Dead to return to the battlefield attached to a creature card in a graveyard of your choice. If you can choose a creature card other than Worldgorger Dragon, you must do so after as many iterations of this loop as you’d like. If you can’t choose a different card, and no player chooses to break the loop, the game ends in a draw."
+          "text": "If Animate Dead is put onto the battlefield enchanting Worldgorger Dragon, Worldgorger Dragon's enters-the-battlefield trigger will exile Animate Dead, which causes you to sacrifice Worldgorger Dragon, which causes Animate Dead to return to the battlefield attached to a creature card in a graveyard of your choice. If you can choose a creature card other than Worldgorger Dragon, you must do so after as many iterations of this loop as you'd like. If you can't choose a different card, and no player chooses to break the loop, the game ends in a draw."
         }
       ],
       "subtypes": [
@@ -11411,7 +11420,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
         }
       ],
       "subtypes": [
@@ -11527,7 +11536,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [
@@ -11753,7 +11762,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t pay life you don’t have. In other words, you can’t Channel yourself below zero life."
+          "text": "You can't pay life you don't have. In other words, you can't Channel yourself below zero life."
         }
       ],
       "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
@@ -11979,11 +11988,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Dreampod Druid’s ability checks to see if it’s enchanted at the beginning of each upkeep. If it’s not, the ability won’t trigger. If the ability triggers but Dreampod Druid isn’t enchanted when that ability resolves, the ability will do nothing."
+          "text": "Dreampod Druid's ability checks to see if it's enchanted at the beginning of each upkeep. If it's not, the ability won't trigger. If the ability triggers but Dreampod Druid isn't enchanted when that ability resolves, the ability will do nothing."
         },
         {
           "date": "2012-06-01",
-          "text": "Notably, if Dreampod Druid leaves the battlefield while its ability is on the stack, that ability will use Dreampod Druid’s last known information to determine whether or not it was enchanted. If it was enchanted when it left the battlefield, the ability will resolve and create a Saproling."
+          "text": "Notably, if Dreampod Druid leaves the battlefield while its ability is on the stack, that ability will use Dreampod Druid's last known information to determine whether or not it was enchanted. If it was enchanted when it left the battlefield, the ability will resolve and create a Saproling."
         }
       ],
       "subtypes": [
@@ -12047,7 +12056,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If Elephant Guide enchants an opponent’s creature, you get the Elephant when that creature dies."
+          "text": "If Elephant Guide enchants an opponent's creature, you get the Elephant when that creature dies."
         }
       ],
       "subtypes": [
@@ -12108,7 +12117,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Forestcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Forestcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -12185,7 +12194,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different player’s creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
+          "text": "In multiplayer games you can choose a different player's creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
         },
         {
           "date": "2004-10-04",
@@ -12249,11 +12258,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The cards are put onto the battlefield and will not trigger effects which trigger on such cards being “cast” or “played”."
+          "text": "The cards are put onto the battlefield and will not trigger effects which trigger on such cards being \"cast\" or \"played\"."
         },
         {
           "date": "2004-10-04",
-          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn’t end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
+          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn't end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
         },
         {
           "date": "2004-10-04",
@@ -12265,7 +12274,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "A “permanent card” is a card that would be a permanent once it’s on the battlefield. Specifically, it’s an artifact, creature, enchantment, land, or planeswalker card."
+          "text": "A \"permanent card\" is a card that would be a permanent once it's on the battlefield. Specifically, it's an artifact, creature, enchantment, land, or planeswalker card."
         }
       ],
       "text": "Starting with you, each player may put a permanent card from his or her hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.",
@@ -12322,11 +12331,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You take damage when you play a land using the “play a land” action. Such an action can be your regular “play a land”, one enabled by Fastbond, or ones enabled through other effects."
+          "text": "You take damage when you play a land using the \"play a land\" action. Such an action can be your regular \"play a land\", one enabled by Fastbond, or ones enabled through other effects."
         },
         {
           "date": "2004-10-04",
-          "text": "You do not take damage when you “put a land onto the battlefield” through the effect of a spell or ability."
+          "text": "You do not take damage when you \"put a land onto the battlefield\" through the effect of a spell or ability."
         }
       ],
       "text": "You may play any number of lands on each of your turns.\nWhenever you play a land, if it wasn't the first land you played this turn, Fastbond deals 1 damage to you.",
@@ -12852,7 +12861,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
         }
       ],
       "subtypes": [
@@ -12973,7 +12982,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2008-08-01",
@@ -13143,7 +13152,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can’t be targeted by this ability unless it’s true, and the ability will be countered on resolution if it’s no longer true at that time."
+          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can't be targeted by this ability unless it's true, and the ability will be countered on resolution if it's no longer true at that time."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player chooses target player who controls more creatures than he or she does and is his or her opponent. The first player may reveal cards from the top of his or her library until he or she reveals a creature card. If he or she does, that player puts that card onto the battlefield and all other cards revealed this way into his or her graveyard.",
@@ -13305,7 +13314,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "If Realm Seekers enters the battlefield directly from a player’s hand without being cast, it counts itself when determining the value of X."
+          "text": "If Realm Seekers enters the battlefield directly from a player's hand without being cast, it counts itself when determining the value of X."
         },
         {
           "date": "2014-05-29",
@@ -13753,7 +13762,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "{G}, Discard a creature card: Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -13808,19 +13817,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player’s draw step."
+          "text": "You always perform your normal draw before this ability. The normal draw occurs before anything can be placed on the stack during a player's draw step."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library’s ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
+          "text": "If you control other triggered abilities that allow you to draw cards during your draw step, you can choose to order Sylvan Library's ability before or after those abilities. Triggered abilities controlled by other players will resolve before triggered abilities you control."
         },
         {
           "date": "2016-06-08",
-          "text": "Any cards drawn prior to Sylvan Library’s ability resolving, including in your upkeep or in response to Sylvan Library’s triggered ability, can be chosen to be put back using this effect. Sylvan Library’s controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
+          "text": "Any cards drawn prior to Sylvan Library's ability resolving, including in your upkeep or in response to Sylvan Library's triggered ability, can be chosen to be put back using this effect. Sylvan Library's controller is responsible for keeping these cards distinguishable in hand, such as by keeping them separate from cards that began the turn in hand."
         },
         {
           "date": "2016-06-08",
-          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don’t get to draw all the cards at once and then put them all back at once."
+          "text": "If you control more than one Sylvan Library, the triggered ability of each will resolve in sequence. You don't get to draw all the cards at once and then put them all back at once."
         },
         {
           "date": "2016-06-08",
@@ -13828,11 +13837,11 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library’s ability still happens. If you’ve actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven’t actually drawn any cards that turn, the rest of the ability has no effect."
+          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library's ability still happens. If you've actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven't actually drawn any cards that turn, the rest of the ability has no effect."
         },
         {
           "date": "2016-06-08",
-          "text": "It’s not possible to take any actions between drawing the cards and choosing two cards. You can’t cast the cards you drew to avoid having two cards to choose."
+          "text": "It's not possible to take any actions between drawing the cards and choosing two cards. You can't cast the cards you drew to avoid having two cards to choose."
         }
       ],
       "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
@@ -14218,11 +14227,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "While Armadillo Cloak’s last ability is similar to lifelink, it isn’t lifelink—it’s a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you’ll gain that much life for lifelink, and then Armadillo Cloak’s triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak’s triggered ability do trigger separately."
+          "text": "While Armadillo Cloak's last ability is similar to lifelink, it isn't lifelink—it's a normal triggered ability. If a creature you control with lifelink wears an Armadillo Cloak and deals damage, first you'll gain that much life for lifelink, and then Armadillo Cloak's triggered ability is put onto the stack. This also means that multiple instances of Armadillo Cloak's triggered ability do trigger separately."
         },
         {
           "date": "2016-06-08",
-          "text": "If Armadillo Cloak enchants a creature you don’t control, you’ll gain life when it deals damage, as long as that damage hasn’t already caused you to lose the game."
+          "text": "If Armadillo Cloak enchants a creature you don't control, you'll gain life when it deals damage, as long as that damage hasn't already caused you to lose the game."
         }
       ],
       "subtypes": [
@@ -14339,7 +14348,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "While Basandra, Battle Seraph is on the battlefield, players can’t cast any spells during the combat phase, including permanent spells with flash."
+          "text": "While Basandra, Battle Seraph is on the battlefield, players can't cast any spells during the combat phase, including permanent spells with flash."
         },
         {
           "date": "2011-09-22",
@@ -14347,7 +14356,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
+          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -14465,7 +14474,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "Brago’s last ability exiles and returns all the targets during the combat damage step, after combat damage is dealt. You can’t target any creature that didn’t survive combat."
+          "text": "Brago's last ability exiles and returns all the targets during the combat damage step, after combat damage is dealt. You can't target any creature that didn't survive combat."
         },
         {
           "date": "2016-06-08",
@@ -14473,7 +14482,7 @@
         },
         {
           "date": "2016-06-08",
-          "text": "If you exile an Aura with Brago’s last ability, the Aura’s owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn’t target anything (so it could be attached to a permanent with shroud, for example), but the Aura’s enchant ability restricts what it can be attached to. The Aura can’t enter the battlefield enchanting a permanent that enters the battlefield at the same time. If the Aura can’t legally be attached to anything, it remains exiled."
+          "text": "If you exile an Aura with Brago's last ability, the Aura's owner chooses what it will enchant as it comes back onto the battlefield. An Aura put onto the battlefield this way doesn't target anything (so it could be attached to a permanent with shroud, for example), but the Aura's enchant ability restricts what it can be attached to. The Aura can't enter the battlefield enchanting a permanent that enters the battlefield at the same time. If the Aura can't legally be attached to anything, it remains exiled."
         }
       ],
       "subtypes": [
@@ -14534,19 +14543,19 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "The targeted player draws two cards and discards two cards all while Dack’s first ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+          "text": "The targeted player draws two cards and discards two cards all while Dack's first ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
         },
         {
           "date": "2016-06-08",
-          "text": "The ability of Dack’s emblem will resolve before the spell that caused it to trigger."
+          "text": "The ability of Dack's emblem will resolve before the spell that caused it to trigger."
         },
         {
           "date": "2016-06-08",
-          "text": "The effect of Dack’s second ability and the effect of the emblem’s ability last indefinitely. You won’t lose control of the permanents if Dack leaves the battlefield."
+          "text": "The effect of Dack's second ability and the effect of the emblem's ability last indefinitely. You won't lose control of the permanents if Dack leaves the battlefield."
         },
         {
           "date": "2016-06-08",
-          "text": "If you gain control of a permanent, and you leave the game, the control-changing effect will end. Unless there’s another control-changing effect affecting that permanent, it will return to its owner’s control."
+          "text": "If you gain control of a permanent, and you leave the game, the control-changing effect will end. Unless there's another control-changing effect affecting that permanent, it will return to its owner's control."
         },
         {
           "date": "2016-06-08",
@@ -14606,15 +14615,15 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Haste and dethrone are part of the copiable values of Dack’s Duplicate. If another creature enters the battlefield as or becomes a copy of Dack’s Duplicate, it will copy whatever Dack’s Duplicate is copying and have haste and dethrone."
+          "text": "Haste and dethrone are part of the copiable values of Dack's Duplicate. If another creature enters the battlefield as or becomes a copy of Dack's Duplicate, it will copy whatever Dack's Duplicate is copying and have haste and dethrone."
         },
         {
           "date": "2014-05-29",
-          "text": "The ability of Dack’s Duplicate doesn’t target the creature."
+          "text": "The ability of Dack's Duplicate doesn't target the creature."
         },
         {
           "date": "2014-05-29",
-          "text": "Dack’s Duplicate copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below), except it will have haste and dethrone. It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+          "text": "Dack's Duplicate copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below), except it will have haste and dethrone. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
         },
         {
           "date": "2014-05-29",
@@ -14622,31 +14631,31 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If the chosen creature is copying something else (for example, if the chosen creature is another Dack’s Duplicate), then Dack’s Duplicate enters the battlefield as whatever the chosen creature is copying. It will have haste and dethrone."
+          "text": "If the chosen creature is copying something else (for example, if the chosen creature is another Dack's Duplicate), then Dack's Duplicate enters the battlefield as whatever the chosen creature is copying. It will have haste and dethrone."
         },
         {
           "date": "2014-05-29",
-          "text": "If the chosen creature is a token, Dack’s Duplicate copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Dack’s Duplicate is not a token, even when copying one."
+          "text": "If the chosen creature is a token, Dack's Duplicate copies the original characteristics of that token as stated by the effect that put the token onto the battlefield. Dack's Duplicate is not a token, even when copying one."
         },
         {
           "date": "2014-05-29",
-          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Dack’s Duplicate enters the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Dack's Duplicate enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2014-05-29",
-          "text": "If Dack’s Duplicate somehow enters the battlefield at the same time as another creature, Dack’s Duplicate can’t become a copy of that creature. You may only choose a creature that’s already on the battlefield."
+          "text": "If Dack's Duplicate somehow enters the battlefield at the same time as another creature, Dack's Duplicate can't become a copy of that creature. You may only choose a creature that's already on the battlefield."
         },
         {
           "date": "2014-05-29",
-          "text": "You can choose to not copy anything. In that case, Dack’s Duplicate enters the battlefield as a 0/0 Shapeshifter creature, and will probably die almost immediately, when state-based actions are next performed."
+          "text": "You can choose to not copy anything. In that case, Dack's Duplicate enters the battlefield as a 0/0 Shapeshifter creature, and will probably die almost immediately, when state-based actions are next performed."
         },
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -14765,7 +14774,7 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Deathreap Ritual’s ability has an intervening “if” clause, so a creature must have died before the end step begins in order for the ability to trigger. Notably, this means that the trigger won’t be on the stack for you to respond to by destroying a creature."
+          "text": "Deathreap Ritual's ability has an intervening \"if\" clause, so a creature must have died before the end step begins in order for the ability to trigger. Notably, this means that the trigger won't be on the stack for you to respond to by destroying a creature."
         },
         {
           "date": "2014-05-29",
@@ -14826,7 +14835,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric’s ability to trigger. The creature’s controller chooses whether to draw a card."
+          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric's ability to trigger. The creature's controller chooses whether to draw a card."
         },
         {
           "date": "2011-09-22",
@@ -14954,7 +14963,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The tokens are named “Goblin Soldier” and have the creature types “Goblin” and “Soldier”."
+          "text": "The tokens are named \"Goblin Soldier\" and have the creature types \"Goblin\" and \"Soldier\"."
         }
       ],
       "text": "{2}, Sacrifice a land: Create two 1/1 red and white Goblin Soldier creature tokens.",
@@ -15007,11 +15016,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Compare Grenzo’s power when the ability resolves with the power of the creature card in your graveyard to determine if you put it onto the battlefield. If Grenzo isn’t on the battlefield at this time, use its power from when it was last on the battlefield."
+          "text": "Compare Grenzo's power when the ability resolves with the power of the creature card in your graveyard to determine if you put it onto the battlefield. If Grenzo isn't on the battlefield at this time, use its power from when it was last on the battlefield."
         },
         {
           "date": "2014-05-29",
-          "text": "If the card you put into your graveyard isn’t a creature card or it’s a creature card with power greater than Grenzo’s power, it stays in your graveyard."
+          "text": "If the card you put into your graveyard isn't a creature card or it's a creature card with power greater than Grenzo's power, it stays in your graveyard."
         }
       ],
       "subtypes": [
@@ -15077,7 +15086,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -15085,11 +15094,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "subtypes": [
@@ -15152,7 +15161,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If the creature card leaves the graveyard before the delayed triggered ability resolves, that card won’t return to the battlefield, even if it’s back in the graveyard when the delayed triggered ability resolves."
+          "text": "If the creature card leaves the graveyard before the delayed triggered ability resolves, that card won't return to the battlefield, even if it's back in the graveyard when the delayed triggered ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -15160,11 +15169,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Dethrone doesn’t trigger if the creature attacks a planeswalker, even if its controller has the most life."
+          "text": "Dethrone doesn't trigger if the creature attacks a planeswalker, even if its controller has the most life."
         },
         {
           "date": "2014-05-29",
-          "text": "Once dethrone triggers, it doesn’t matter what happens to the players’ life totals before the ability resolves. You’ll put a +1/+1 counter on the creature even if the defending player doesn’t have the most life as the ability resolves."
+          "text": "Once dethrone triggers, it doesn't matter what happens to the players' life totals before the ability resolves. You'll put a +1/+1 counter on the creature even if the defending player doesn't have the most life as the ability resolves."
         },
         {
           "date": "2014-05-29",
@@ -15394,11 +15403,11 @@
       "rulings": [
         {
           "date": "2014-05-29",
-          "text": "Selvala’s parley ability is a mana ability. It doesn’t use the stack and can’t be responded to."
+          "text": "Selvala's parley ability is a mana ability. It doesn't use the stack and can't be responded to."
         },
         {
           "date": "2014-05-29",
-          "text": "If you activate Selvala’s ability while casting a spell, and you discover you can’t produce enough mana to pay that spell’s costs, the spell is reversed. The spell returns to whatever zone you were casting it from. You may reverse other mana abilities you activated while casting the spell, but Selvala’s ability can’t be reversed. Whatever mana that ability produced will be in your mana pool and each player will have drawn a card."
+          "text": "If you activate Selvala's ability while casting a spell, and you discover you can't produce enough mana to pay that spell's costs, the spell is reversed. The spell returns to whatever zone you were casting it from. You may reverse other mana abilities you activated while casting the spell, but Selvala's ability can't be reversed. Whatever mana that ability produced will be in your mana pool and each player will have drawn a card."
         },
         {
           "date": "2014-05-29",
@@ -15586,7 +15595,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -15639,7 +15648,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{0}: Tap all lands you control. Chimeric Idol becomes a 3/3 Turtle artifact creature until end of turn.",
@@ -15736,7 +15745,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "You must vote for one of the available options. You can’t abstain."
+          "text": "You must vote for one of the available options. You can't abstain."
         },
         {
           "date": "2014-05-29",
@@ -15744,11 +15753,11 @@
         },
         {
           "date": "2014-05-29",
-          "text": "Players can’t do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
+          "text": "Players can't do anything after they finishing voting but before the spell or ability that included the vote finishes resolving."
         },
         {
           "date": "2014-05-29",
-          "text": "The phrase “the vote is tied” refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn’t tied."
+          "text": "The phrase \"the vote is tied\" refers only to when there is more than one choice that received the most votes. For example, if a 5-player vote from among three different choices ends 3 votes to 1 vote to 1 vote, the vote isn't tied."
         }
       ],
       "text": "Will of the council — At the beginning of your upkeep, starting with you, each player votes for carnage or homage. If carnage gets more votes, sacrifice Coercive Portal and destroy all nonland permanents. If homage gets more votes or the vote is tied, draw a card.",
@@ -15798,7 +15807,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you have no cards in hand, you still have to name a card. Then you fail to reveal one (since there aren’t any). Since the named card wasn’t revealed, no damage is dealt."
+          "text": "If you have no cards in hand, you still have to name a card. Then you fail to reveal one (since there aren't any). Since the named card wasn't revealed, no damage is dealt."
         }
       ],
       "text": "{3}, {T}: Choose a card name, then reveal a card at random from your hand. If that card has the chosen name, Cursed Scroll deals 2 damage to target creature or player.",
@@ -15896,7 +15905,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have four or fewer cards in your hand when Ivory Tower’s ability resolves, the ability has no effect."
+          "text": "If you have four or fewer cards in your hand when Ivory Tower's ability resolves, the ability has no effect."
         }
       ],
       "text": "At the beginning of your upkeep, you gain X life, where X is the number of cards in your hand minus 4.",
@@ -15952,7 +15961,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -16248,7 +16257,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t look at the cards you exiled until they return to your hand."
+          "text": "You can't look at the cards you exiled until they return to your hand."
         }
       ],
       "text": "{T}, Sacrifice Memory Jar: Each player exiles all cards from his or her hand face down and draws seven cards. At the beginning of the next end step, each player discards his or her hand and returns to his or her hand each card he or she exiled this way.",
@@ -16306,7 +16315,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You don’t sacrifice Nevinyrral’s Disk to activate its ability. It’s destroyed as part of the ability’s resolution if it’s still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it stays on the battlefield."
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -16364,11 +16373,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "This effect does not prevent triggered abilities from triggering and it doesn’t stop the effects of static abilities."
+          "text": "This effect does not prevent triggered abilities from triggering and it doesn't stop the effects of static abilities."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Activated abilities of artifacts can't be activated.",
@@ -16720,7 +16729,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -16824,7 +16833,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         },
         {
           "date": "2008-10-01",
@@ -16971,7 +16980,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Bad River enters the battlefield tapped.\n{T}, Sacrifice Bad River: Search your library for an Island or Swamp card and put it onto the battlefield. Then shuffle your library.",
@@ -17024,7 +17033,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land type changing effects that change a dual land’s land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
+          "text": "Land type changing effects that change a dual land's land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
         },
         {
           "date": "2004-10-04",
@@ -17036,7 +17045,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -17155,7 +17164,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -17203,7 +17212,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can’t cast spells or activate mana abilities before discarding the extra cards."
+          "text": "You can't cast spells or activate mana abilities before discarding the extra cards."
         }
       ],
       "text": "{T}: Draw two cards, then discard three cards.",
@@ -17295,7 +17304,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Flood Plain enters the battlefield tapped.\n{T}, Sacrifice Flood Plain: Search your library for a Plains or Island card and put it onto the battlefield. Then shuffle your library.",
@@ -17734,11 +17743,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can spend the mana on costs on the spell’s text."
+          "text": "You can spend the mana on costs on the spell's text."
         },
         {
           "date": "2004-10-04",
-          "text": "The mana can’t be used to pay Echo costs."
+          "text": "The mana can't be used to pay Echo costs."
         },
         {
           "date": "2004-10-04",
@@ -17894,7 +17903,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -17945,7 +17954,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Rocky Tar Pit enters the battlefield tapped.\n{T}, Sacrifice Rocky Tar Pit: Search your library for a Swamp or Mountain card and put it onto the battlefield. Then shuffle your library.",
@@ -18047,7 +18056,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18153,7 +18162,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18359,7 +18368,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18416,7 +18425,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "Thawing Glaciers enters the battlefield tapped.\n{1}, {T}: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library. Return Thawing Glaciers to its owner's hand at the beginning of the next cleanup step.",
@@ -18578,7 +18587,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18639,7 +18648,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18700,7 +18709,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -18760,7 +18769,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [

--- a/json/W16.json
+++ b/json/W16.json
@@ -969,19 +969,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -1120,15 +1120,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -1475,11 +1475,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of the three targets must be different. If there aren’t three different legal targets available, you can’t cast the spell."
+          "text": "Each of the three targets must be different. If there aren't three different legal targets available, you can't cast the spell."
         },
         {
           "date": "2014-07-18",
-          "text": "If one or two of Cone of Flame’s targets are illegal when it resolves, you can’t change how much damage will be dealt to the remaining legal targets."
+          "text": "If one or two of Cone of Flame's targets are illegal when it resolves, you can't change how much damage will be dealt to the remaining legal targets."
         }
       ],
       "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
@@ -1957,7 +1957,7 @@
       "rulings": [
         {
           "date": "2012-05-01",
-          "text": "A creature card that enters the battlefield as a copy of a token creature is still a nontoken creature. You’ll be able to draw a card."
+          "text": "A creature card that enters the battlefield as a copy of a token creature is still a nontoken creature. You'll be able to draw a card."
         }
       ],
       "subtypes": [

--- a/json/W17.json
+++ b/json/W17.json
@@ -111,15 +111,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2009-10-01",
-          "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+          "text": "A \"blocking creature\" is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
         },
         {
           "date": "2012-07-01",
-          "text": "Destroying a blocking creature won’t cause any of the creatures it was blocking to become unblocked. They won’t deal combat damage to the defending player or planeswalker (unless they have trample)."
+          "text": "Destroying a blocking creature won't cause any of the creatures it was blocking to become unblocked. They won't deal combat damage to the defending player or planeswalker (unless they have trample)."
         }
       ],
       "text": "Destroy target attacking or blocking creature.",
@@ -708,7 +708,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Victory’s Herald also gains flying (which will likely be redundant) and lifelink if it’s still attacking when the ability resolves."
+          "text": "Victory's Herald also gains flying (which will likely be redundant) and lifelink if it's still attacking when the ability resolves."
         }
       ],
       "subtypes": [
@@ -1063,7 +1063,7 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "If the targeted creature becomes an illegal target before Drag Under resolves, you won’t draw a card."
+          "text": "If the targeted creature becomes an illegal target before Drag Under resolves, you won't draw a card."
         }
       ],
       "text": "Return target creature to its owner's hand.\nDraw a card.",
@@ -1836,11 +1836,11 @@
       "rulings": [
         {
           "date": "2016-07-13",
-          "text": "The targeted creature will have already left the battlefield before its controller loses 2 life and you gain 2 life. If it has any abilities that care about gaining or losing life, they won’t apply."
+          "text": "The targeted creature will have already left the battlefield before its controller loses 2 life and you gain 2 life. If it has any abilities that care about gaining or losing life, they won't apply."
         },
         {
           "date": "2016-07-13",
-          "text": "If the creature becomes an illegal target for Certain Death, no player gains or loses life. If it’s a legal target but isn’t destroyed, most likely due to having indestructible, its controller still loses 2 life and you gain 2 life."
+          "text": "If the creature becomes an illegal target for Certain Death, no player gains or loses life. If it's a legal target but isn't destroyed, most likely due to having indestructible, its controller still loses 2 life and you gain 2 life."
         }
       ],
       "text": "Destroy target creature. Its controller loses 2 life and you gain 2 life.",
@@ -1968,19 +1968,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner’s graveyard as a state-based action right before the next player gains priority."
+          "text": "If you control 0 swamps, then the Nightmare has 0 toughness and will be put into its owner's graveyard as a state-based action right before the next player gains priority."
         },
         {
           "date": "2009-10-01",
-          "text": "Nightmare’s power and toughness changes as the number of Swamps you control changes."
+          "text": "Nightmare's power and toughness changes as the number of Swamps you control changes."
         },
         {
           "date": "2013-07-01",
-          "text": "The ability that defines Nightmare’s power and toughness works everywhere, not just on the battlefield."
+          "text": "The ability that defines Nightmare's power and toughness works everywhere, not just on the battlefield."
         },
         {
           "date": "2013-07-01",
-          "text": "Nightmare’s ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
+          "text": "Nightmare's ability counts all lands you control with the subtype Swamp, not just ones named Swamp."
         }
       ],
       "subtypes": [
@@ -2116,7 +2116,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature card” is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+          "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
         }
       ],
       "text": "Return target creature card from your graveyard to your hand.",
@@ -2250,15 +2250,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -2835,23 +2835,23 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Normally, Garruk’s Horde allows you to cast the top card of your library if it’s a creature card, it’s your main phase, and the stack is empty. If that creature card has flash, you’ll be able to cast it at the time you could cast an instant, even on an opponent’s turn."
+          "text": "Normally, Garruk's Horde allows you to cast the top card of your library if it's a creature card, it's your main phase, and the stack is empty. If that creature card has flash, you'll be able to cast it at the time you could cast an instant, even on an opponent's turn."
         },
         {
           "date": "2011-09-22",
-          "text": "You’ll still pay all costs for that spell, including additional costs. You may also pay alternative costs."
+          "text": "You'll still pay all costs for that spell, including additional costs. You may also pay alternative costs."
         },
         {
           "date": "2011-09-22",
-          "text": "If the top card of your library is Dryad Arbor (the only card that’s both a creature and a land), you can’t play it this way. Dryad Arbor can’t be cast as a spell."
+          "text": "If the top card of your library is Dryad Arbor (the only card that's both a creature and a land), you can't play it this way. Dryad Arbor can't be cast as a spell."
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -3081,7 +3081,7 @@
       "rulings": [
         {
           "date": "2016-04-08",
-          "text": "If either creature is an illegal target as Rabid Bite tries to resolve, the creature you control won’t deal damage."
+          "text": "If either creature is an illegal target as Rabid Bite tries to resolve, the creature you control won't deal damage."
         }
       ],
       "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
@@ -3196,7 +3196,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
+          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
         }
       ],
       "subtypes": [

--- a/json/WTH.json
+++ b/json/WTH.json
@@ -143,11 +143,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Abeyance does not affect abilities which are not activated, such as static abilities and triggered abilities. It also doesn’t stop the declaration of attackers or blockers."
+          "text": "Abeyance does not affect abilities which are not activated, such as static abilities and triggered abilities. It also doesn't stop the declaration of attackers or blockers."
         },
         {
           "date": "2008-08-01",
-          "text": "This can’t be used as a counterspell. It will have no effect on spells which were on the stack when it was cast, nor on those cast in response to it."
+          "text": "This can't be used as a counterspell. It will have no effect on spells which were on the stack when it was cast, nor on those cast in response to it."
         }
       ],
       "text": "Until end of turn, target player can't cast instant or sorcery spells, and that player can't activate abilities that aren't mana abilities.\nDraw a card.",
@@ -200,7 +200,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You can’t sacrifice more than one permanent."
+          "text": "You can't sacrifice more than one permanent."
         }
       ],
       "text": "As an additional cost to cast Abjure, sacrifice a blue permanent.\nCounter target spell.",
@@ -255,7 +255,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -315,7 +315,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The “sacrifice a creature” effect is not targeted. It can affect creatures with protection from black, for example."
+          "text": "The \"sacrifice a creature\" effect is not targeted. It can affect creatures with protection from black, for example."
         },
         {
           "date": "2008-04-01",
@@ -377,7 +377,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This is not a targeted ability, so it deals damage to creatures that can’t be targeted by spells and abilities."
+          "text": "This is not a targeted ability, so it deals damage to creatures that can't be targeted by spells and abilities."
         }
       ],
       "text": "Whenever a creature enters the battlefield, Aether Flash deals 2 damage to it.",
@@ -485,7 +485,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "This will always be shuffled into its owner’s library."
+          "text": "This will always be shuffled into its owner's library."
         }
       ],
       "subtypes": [
@@ -542,11 +542,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -554,11 +554,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "text": "{1}, Exile the top card of your graveyard: Prevent the next 1 damage that would be dealt to target creature this turn.",
@@ -661,11 +661,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card goes to the graveyard at the same time as a creature or sometime between when the creature left the battlefield and when the triggered ability resolves, then you will not be able to sacrifice this card and the creature can’t be returned to the battlefield."
+          "text": "If this card goes to the graveyard at the same time as a creature or sometime between when the creature left the battlefield and when the triggered ability resolves, then you will not be able to sacrifice this card and the creature can't be returned to the battlefield."
         },
         {
           "date": "2008-04-01",
-          "text": "If an animated permanent that’s not normally a creature is put into your graveyard from the battlefield, Angelic Renewal can return that card to the battlefield."
+          "text": "If an animated permanent that's not normally a creature is put into your graveyard from the battlefield, Angelic Renewal can return that card to the battlefield."
         },
         {
           "date": "2008-04-01",
@@ -778,7 +778,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -1110,11 +1110,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The player who controlled Barishi when it left the battlefield is the player who controls the ability. It doesn’t matter whose graveyard Barishi is put into."
+          "text": "The player who controlled Barishi when it left the battlefield is the player who controls the ability. It doesn't matter whose graveyard Barishi is put into."
         },
         {
           "date": "2008-04-01",
-          "text": "If Barishi isn’t in your graveyard by the time the ability resolves, you still shuffle all creature cards from your graveyard into your library."
+          "text": "If Barishi isn't in your graveyard by the time the ability resolves, you still shuffle all creature cards from your graveyard into your library."
         }
       ],
       "subtypes": [
@@ -1172,11 +1172,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -1184,15 +1184,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         },
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -1254,7 +1254,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -1289,7 +1289,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"We called them ‘armored lightning.'\"\n—Gerrard of the Weatherlight",
+      "flavor": "\"We called them 'armored lightning.'\"\n—Gerrard of the Weatherlight",
       "id": "6cf70535a9c0415ad44e1a8a70927b87e5f0cc1a",
       "imageName": "benalish knight",
       "layout": "normal",
@@ -1384,7 +1384,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Works even if the creature is “blocked” by an effect rather than actual creatures."
+          "text": "Works even if the creature is \"blocked\" by an effect rather than actual creatures."
         }
       ],
       "subtypes": [
@@ -1441,7 +1441,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you control Betrothed of Fire, but it’s attached to a creature you don’t control, no one can activate the last ability. The creature’s controller can’t activate it because that player doesn’t control the Aura. You can’t activate it because you can’t pay the cost — you can’t sacrifice a creature you don’t control."
+          "text": "If you control Betrothed of Fire, but it's attached to a creature you don't control, no one can activate the last ability. The creature's controller can't activate it because that player doesn't control the Aura. You can't activate it because you can't pay the cost — you can't sacrifice a creature you don't control."
         }
       ],
       "subtypes": [
@@ -1504,7 +1504,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "There is no penalty if it can’t attack."
+          "text": "There is no penalty if it can't attack."
         }
       ],
       "subtypes": [
@@ -1727,11 +1727,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -1739,15 +1739,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -1845,7 +1845,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When you cast Briar Shield’s activated ability, Briar Shield is put into the graveyard as a cost. The +1/+1 effect immediately ends, but the +3/+3 effect won’t begin until the ability resolves. The enchanted creature gets no bonus while Briar Shield’s ability is on the stack. If its toughness is 0 during this time, it’ll be put into the graveyard."
+          "text": "When you cast Briar Shield's activated ability, Briar Shield is put into the graveyard as a cost. The +1/+1 effect immediately ends, but the +3/+3 effect won't begin until the ability resolves. The enchanted creature gets no bonus while Briar Shield's ability is on the stack. If its toughness is 0 during this time, it'll be put into the graveyard."
         }
       ],
       "subtypes": [
@@ -2049,11 +2049,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If the first ability is activated and resolves, then the second ability is activated and resolves, Chimeric Sphere will be a 3/2 creature. It won’t have flying."
+          "text": "If the first ability is activated and resolves, then the second ability is activated and resolves, Chimeric Sphere will be a 3/2 creature. It won't have flying."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{2}: Until end of turn, Chimeric Sphere becomes a 2/1 Construct artifact creature with flying.\n{2}: Until end of turn, Chimeric Sphere becomes a 3/2 Construct artifact creature and loses flying.",
@@ -2113,7 +2113,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Choking Vines isn’t particularly effective against creatures with trample. Since the creature with trample has no blocker to assign damage to, all the damage will be assigned to the defending player."
+          "text": "Choking Vines isn't particularly effective against creatures with trample. Since the creature with trample has no blocker to assign damage to, all the damage will be assigned to the defending player."
         },
         {
           "date": "2008-04-01",
@@ -2121,7 +2121,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If a previously unblocked creature becomes blocked as a result of Choking Vines, any “When this creature becomes blocked” abilities that creature has will trigger. Any “When this creature becomes blocked by a creature” abilities that creature has won’t trigger."
+          "text": "If a previously unblocked creature becomes blocked as a result of Choking Vines, any \"When this creature becomes blocked\" abilities that creature has will trigger. Any \"When this creature becomes blocked by a creature\" abilities that creature has won't trigger."
         }
       ],
       "text": "Cast Choking Vines only during the declare blockers step.\nX target attacking creatures become blocked. Choking Vines deals 1 damage to each of those creatures. (This spell works on creatures that can't be blocked.)",
@@ -2285,11 +2285,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -2297,15 +2297,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         },
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -2313,7 +2313,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Circling Vultures’s discard ability is a static ability, not an activated ability. Although it acts like an activated ability that says “Discard Circling Vultures: Nothing happens,” it is not one and cards like Pithing Needle or Abeyance won’t prevent you from being able to discard it."
+          "text": "Circling Vultures's discard ability is a static ability, not an activated ability. Although it acts like an activated ability that says \"Discard Circling Vultures: Nothing happens,\" it is not one and cards like Pithing Needle or Abeyance won't prevent you from being able to discard it."
         }
       ],
       "subtypes": [
@@ -2489,11 +2489,11 @@
       "rulings": [
         {
           "date": "2014-07-18",
-          "text": "Each of the three targets must be different. If there aren’t three different legal targets available, you can’t cast the spell."
+          "text": "Each of the three targets must be different. If there aren't three different legal targets available, you can't cast the spell."
         },
         {
           "date": "2014-07-18",
-          "text": "If one or two of Cone of Flame’s targets are illegal when it resolves, you can’t change how much damage will be dealt to the remaining legal targets."
+          "text": "If one or two of Cone of Flame's targets are illegal when it resolves, you can't change how much damage will be dealt to the remaining legal targets."
         }
       ],
       "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
@@ -2547,19 +2547,19 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Casting Debt of Loyalty puts a regeneration shield on a creature. If, later in the turn, that creature would be destroyed, instead it regenerates and you gain control of it. Note that it will be tapped when you gain control of it. The control change has no duration; you’ll retain control of that creature until the game ends or until some other effect causes it to change control."
+          "text": "Casting Debt of Loyalty puts a regeneration shield on a creature. If, later in the turn, that creature would be destroyed, instead it regenerates and you gain control of it. Note that it will be tapped when you gain control of it. The control change has no duration; you'll retain control of that creature until the game ends or until some other effect causes it to change control."
         },
         {
           "date": "2008-04-01",
-          "text": "If you cast Debt of Loyalty but nothing happens to the targeted creature for the rest of the turn that would cause it to be destroyed, Debt of Loyalty has no visible effect. The regeneration shield wears off at the end of the turn. If the creature regenerates during a later turn, you won’t gain control of it."
+          "text": "If you cast Debt of Loyalty but nothing happens to the targeted creature for the rest of the turn that would cause it to be destroyed, Debt of Loyalty has no visible effect. The regeneration shield wears off at the end of the turn. If the creature regenerates during a later turn, you won't gain control of it."
         },
         {
           "date": "2008-04-01",
-          "text": "If a creature has two regeneration shields on it — one from a Debt of Loyalty you cast and one from another effect — and it would be destroyed, its controller chooses which regeneration shield to use. If that player chooses to use the Debt of Loyalty shield, you’ll gain control of the creature. If the player chooses to use the other shield, you won’t gain control of the creature, but the Debt of Loyalty shield will remain on that creature for the rest of the turn (in case it would be destroyed again)."
+          "text": "If a creature has two regeneration shields on it — one from a Debt of Loyalty you cast and one from another effect — and it would be destroyed, its controller chooses which regeneration shield to use. If that player chooses to use the Debt of Loyalty shield, you'll gain control of the creature. If the player chooses to use the other shield, you won't gain control of the creature, but the Debt of Loyalty shield will remain on that creature for the rest of the turn (in case it would be destroyed again)."
         },
         {
           "date": "2008-04-01",
-          "text": "You may cast Debt of Loyalty targeting a creature you already control. If you do, and that creature would be destroyed later in the turn, it will regenerate and you’ll gain control of it (though gaining control of a creature you already control usually has no visible effect)."
+          "text": "You may cast Debt of Loyalty targeting a creature you already control. If you do, and that creature would be destroyed later in the turn, it will regenerate and you'll gain control of it (though gaining control of a creature you already control usually has no visible effect)."
         },
         {
           "date": "2013-07-01",
@@ -2667,7 +2667,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The chosen source may be a permanent, a spell on the stack, or anything referred to by something on the stack (such as a Prodigal Pyromancer that’s left the battlefield while its ability is still on the stack)"
+          "text": "The chosen source may be a permanent, a spell on the stack, or anything referred to by something on the stack (such as a Prodigal Pyromancer that's left the battlefield while its ability is still on the stack)"
         }
       ],
       "text": "Choose a source you control and flip a coin. If you win the flip, the next time that source would deal damage this turn, it deals double that damage instead. If you lose the flip, the next time it would deal damage this turn, prevent that damage.",
@@ -2813,7 +2813,8 @@
       "originalType": "Sorcery",
       "printings": [
         "WTH",
-        "6ED"
+        "6ED",
+        "MPS_AKH"
       ],
       "rarity": "Rare",
       "rulings": [
@@ -2823,7 +2824,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If your graveyard and library combined contain five or more cards, you must choose five cards from among them. You can’t choose to find fewer than that."
+          "text": "If your graveyard and library combined contain five or more cards, you must choose five cards from among them. You can't choose to find fewer than that."
         },
         {
           "date": "2008-04-01",
@@ -3032,7 +3033,7 @@
       "rulings": [
         {
           "date": "2005-11-01",
-          "text": "Note that the wording “Effects that alter the creature’s power alter its toughness instead, and vice versa, this turn” has been removed."
+          "text": "Note that the wording \"Effects that alter the creature's power alter its toughness instead, and vice versa, this turn\" has been removed."
         },
         {
           "date": "2013-04-15",
@@ -3040,7 +3041,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -3100,7 +3101,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The value of X is recalculated constantly, so this card’s bonus varies as the number of cards in your hand varies."
+          "text": "The value of X is recalculated constantly, so this card's bonus varies as the number of cards in your hand varies."
         }
       ],
       "subtypes": [
@@ -3157,7 +3158,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Activating the activated ability will prevent Ertai’s Familiar from phasing out for any reason, not just due to its own phasing ability."
+          "text": "Activating the activated ability will prevent Ertai's Familiar from phasing out for any reason, not just due to its own phasing ability."
         }
       ],
       "subtypes": [
@@ -3215,7 +3216,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -3278,7 +3279,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When combined with an effect that reads “Each creature you control can’t be blocked except by two or more creatures,” none of your creatures can be blocked."
+          "text": "When combined with an effect that reads \"Each creature you control can't be blocked except by two or more creatures,\" none of your creatures can be blocked."
         }
       ],
       "text": "Each creature you control can't be blocked by more than one creature.",
@@ -3332,7 +3333,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Fatal Blow can’t target a creature that hasn’t been dealt damage this turn."
+          "text": "Fatal Blow can't target a creature that hasn't been dealt damage this turn."
         },
         {
           "date": "2008-04-01",
@@ -3396,7 +3397,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If an attacking creature loses haste, perhaps because Fervor leaves the battlefield after attackers have been declared, it won’t be removed from combat."
+          "text": "If an attacking creature loses haste, perhaps because Fervor leaves the battlefield after attackers have been declared, it won't be removed from combat."
         }
       ],
       "text": "Creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
@@ -3503,7 +3504,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Remember that you tap the creature as part of the cost of activating Fire Whip’s granted ability. So, if you have two Fire Whips on a creature activating the first one will tap the creature, so you can’t use the second one or any other ability which requires tapping the creature until you find a way to untap it."
+          "text": "Remember that you tap the creature as part of the cost of activating Fire Whip's granted ability. So, if you have two Fire Whips on a creature activating the first one will tap the creature, so you can't use the second one or any other ability which requires tapping the creature until you find a way to untap it."
         },
         {
           "date": "2004-10-04",
@@ -3568,11 +3569,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The value of X can’t exceed the number of cards in your hand or the number of available legal targets, whichever is smaller. X can be 0."
+          "text": "The value of X can't exceed the number of cards in your hand or the number of available legal targets, whichever is smaller. X can be 0."
         },
         {
           "date": "2008-04-01",
-          "text": "The same creature or player can’t be targeted more than once."
+          "text": "The same creature or player can't be targeted more than once."
         }
       ],
       "text": "As an additional cost to cast Firestorm, discard X cards.\nFirestorm deals X damage to each of X target creatures and/or players.",
@@ -3967,11 +3968,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "When you cast Gaea’s Blessing, you can’t choose it as one of its own targets. This is because you choose the targets when casting this spell, and spells are not put into your graveyard until after they resolve."
+          "text": "When you cast Gaea's Blessing, you can't choose it as one of its own targets. This is because you choose the targets when casting this spell, and spells are not put into your graveyard until after they resolve."
         },
         {
           "date": "2016-06-08",
-          "text": "You must target a player as you cast Gaea’s Blessing. You may target zero, one, two, or three cards in that player’s graveyard."
+          "text": "You must target a player as you cast Gaea's Blessing. You may target zero, one, two, or three cards in that player's graveyard."
         }
       ],
       "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nDraw a card.\nWhen Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
@@ -4026,7 +4027,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -4091,7 +4092,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If the last mining counter is removed from Gemstone Mine in some way other than activating its ability (such as Chisei, Heart of Oceans), Gemstone Mine won’t be sacrificed but its ability can’t be activated."
+          "text": "If the last mining counter is removed from Gemstone Mine in some way other than activating its ability (such as Chisei, Heart of Oceans), Gemstone Mine won't be sacrificed but its ability can't be activated."
         }
       ],
       "text": "Gemstone Mine enters the battlefield with three mining counters on it.\n{T}, Remove a mining counter from Gemstone Mine: Add one mana of any color to your mana pool. If there are no mining counters on Gemstone Mine, sacrifice it.",
@@ -4247,15 +4248,15 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Both a creature and a land must be targeted when the ability triggers. If there aren’t enough legal targets, the ability doesn’t go on the stack and Goblin Grenadiers can’t be sacrificed this way."
+          "text": "Both a creature and a land must be targeted when the ability triggers. If there aren't enough legal targets, the ability doesn't go on the stack and Goblin Grenadiers can't be sacrificed this way."
         },
         {
           "date": "2008-04-01",
-          "text": "A permanent that’s both a land and a creature may be chosen as both of this ability’s targets."
+          "text": "A permanent that's both a land and a creature may be chosen as both of this ability's targets."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -4313,11 +4314,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If the defending player controls no artifacts that you can target, the ability doesn’t go on the stack and you can’t pay {R}."
+          "text": "If the defending player controls no artifacts that you can target, the ability doesn't go on the stack and you can't pay {R}."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -4428,7 +4429,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -4590,7 +4591,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "This doesn’t trigger until the end of combat."
+          "text": "This doesn't trigger until the end of combat."
         }
       ],
       "text": "At end of combat, destroy each creature that blocked or was blocked this turn.",
@@ -4707,7 +4708,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -4910,7 +4911,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Giving a creature flanking after blockers have been declared won’t have any effect. Specifically: — If you give flanking to an attacking creature after blockers have been declared, it’s too late for flanking to trigger. — If you give flanking to a creature that’s blocking an attacking creature with flanking, it’s too late to prevent the blocking creature from getting -1/-1, even if the attacker’s flanking ability hasn’t resolved yet."
+          "text": "Giving a creature flanking after blockers have been declared won't have any effect. Specifically: — If you give flanking to an attacking creature after blockers have been declared, it's too late for flanking to trigger. — If you give flanking to a creature that's blocking an attacking creature with flanking, it's too late to prevent the blocking creature from getting -1/-1, even if the attacker's flanking ability hasn't resolved yet."
         }
       ],
       "text": "{1}, {T}: Target creature gains flanking until end of turn. (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
@@ -5234,7 +5235,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Since the activated ability doesn’t have a tap symbol in its cost, you can tap a creature (including Llanowar Behemoth itself) that hasn’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the activated ability doesn't have a tap symbol in its cost, you can tap a creature (including Llanowar Behemoth itself) that hasn't been under your control since your most recent turn began to pay the cost."
         }
       ],
       "subtypes": [
@@ -5292,7 +5293,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Llanowar Druid’s ability untaps all Forests on the battlefield, not just the ones you control."
+          "text": "Llanowar Druid's ability untaps all Forests on the battlefield, not just the ones you control."
         }
       ],
       "subtypes": [
@@ -5356,11 +5357,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         },
         {
           "date": "2007-07-15",
-          "text": "Llanowar Sentinels can “chain”: If you put a second Llanowar Sentinel onto the battlefield as a result of this ability, that creature’s enters-the-battlefield ability triggers and allows you to search for yet another Llanowar Sentinel."
+          "text": "Llanowar Sentinels can \"chain\": If you put a second Llanowar Sentinel onto the battlefield as a result of this ability, that creature's enters-the-battlefield ability triggers and allows you to search for yet another Llanowar Sentinel."
         }
       ],
       "subtypes": [
@@ -5410,7 +5411,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you don’t sacrifice the lands, Lotus Vale never enters the battlefield — it goes directly to your graveyard."
+          "text": "If you don't sacrifice the lands, Lotus Vale never enters the battlefield — it goes directly to your graveyard."
         }
       ],
       "text": "If Lotus Vale would enter the battlefield, sacrifice two untapped lands instead. If you do, put Lotus Vale onto the battlefield. If you don't, put it into its owner's graveyard.\n{T}: Add three mana of any one color to your mana pool.",
@@ -5517,11 +5518,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The lands that are tapped by Mana Web’s ability don’t produce mana as a result."
+          "text": "The lands that are tapped by Mana Web's ability don't produce mana as a result."
         },
         {
           "date": "2008-04-01",
-          "text": "The opponent can tap his or her lands for mana in response to Mana Web’s ability triggering."
+          "text": "The opponent can tap his or her lands for mana in response to Mana Web's ability triggering."
         }
       ],
       "text": "Whenever a land an opponent controls is tapped for mana, tap all lands that player controls that could produce any type of mana that land could produce.",
@@ -5627,7 +5628,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A permanent that’s more than one of these types (such as an artifact creature) counts only once."
+          "text": "A permanent that's more than one of these types (such as an artifact creature) counts only once."
         }
       ],
       "subtypes": [
@@ -5908,11 +5909,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -5920,15 +5921,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         },
         {
           "date": "2008-04-01",
-          "text": "If you control Mistmoon Griffin when it goes to the graveyard, you exile the Griffin and return the top creature card from your graveyard to the battlefield. It doesn’t matter whose graveyard the Griffin goes to."
+          "text": "If you control Mistmoon Griffin when it goes to the graveyard, you exile the Griffin and return the top creature card from your graveyard to the battlefield. It doesn't matter whose graveyard the Griffin goes to."
         }
       ],
       "subtypes": [
@@ -5987,7 +5988,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -6053,7 +6054,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you choose not to pay Mwonvuli Ooze’s cumulative upkeep, it will still get an age counter before being sacrificed. Its power and toughness will momentarily increase before being put into the graveyard, which might matter to certain other cards (such as Proper Burial)."
+          "text": "If you choose not to pay Mwonvuli Ooze's cumulative upkeep, it will still get an age counter before being sacrificed. Its power and toughness will momentarily increase before being put into the graveyard, which might matter to certain other cards (such as Proper Burial)."
         }
       ],
       "subtypes": [
@@ -6110,11 +6111,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -6122,11 +6123,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -6232,11 +6233,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -6244,11 +6245,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [
@@ -6367,11 +6368,11 @@
         },
         {
           "date": "2013-07-01",
-          "text": "This effect does not prevent triggered abilities from triggering and it doesn’t stop the effects of static abilities."
+          "text": "This effect does not prevent triggered abilities from triggering and it doesn't stop the effects of static abilities."
         },
         {
           "date": "2016-06-08",
-          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder text."
+          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
         }
       ],
       "text": "Activated abilities of artifacts can't be activated.",
@@ -6425,7 +6426,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Odylic Wraith’s ability triggers when it deals any kind of damage to a player, not just when it deals combat damage."
+          "text": "Odylic Wraith's ability triggers when it deals any kind of damage to a player, not just when it deals combat damage."
         }
       ],
       "subtypes": [
@@ -6486,7 +6487,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6560,7 +6561,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"Barrin always said that reality is relative. ‘The world,' he cautioned, ‘is but pieces of one's perception.'\"\n—Ertai, wizard adept",
+      "flavor": "\"Barrin always said that reality is relative. 'The world,' he cautioned, 'is but pieces of one's perception.'\"\n—Ertai, wizard adept",
       "id": "a186a26533226c1a609c8c606d26621f32c71a72",
       "imageName": "paradigm shift",
       "layout": "normal",
@@ -6596,7 +6597,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Exile all cards from your library. Then shuffle your graveyard into your library.",
@@ -6651,7 +6652,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -6659,7 +6660,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Peacekeeper’s ability doesn’t cause the combat phase or the declare attackers step to be skipped."
+          "text": "Peacekeeper's ability doesn't cause the combat phase or the declare attackers step to be skipped."
         }
       ],
       "subtypes": [
@@ -6717,7 +6718,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -6806,7 +6807,7 @@
       "colors": [
         "Blue"
       ],
-      "flavor": "\"But you said ‘when goats fly!'\" Squee whined.",
+      "flavor": "\"But you said 'when goats fly!'\" Squee whined.",
       "id": "7e7f4cf30944a1981e160b212cfd7dd1cbcd388c",
       "imageName": "phantom wings",
       "layout": "normal",
@@ -6941,11 +6942,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Psychic Vortex’s cumulative upkeep ability has you draw cards as a cost. If you choose to do so, and some or all of those draws are replaced by replacement effects, you are still considered to have paid the cumulative upkeep cost."
+          "text": "Psychic Vortex's cumulative upkeep ability has you draw cards as a cost. If you choose to do so, and some or all of those draws are replaced by replacement effects, you are still considered to have paid the cumulative upkeep cost."
         },
         {
           "date": "2008-04-01",
-          "text": "You may choose to draw cards to pay the cumulative upkeep cost even if the number of cards you’d have to draw exceeds the number of cards in your library. If enough of those draws are replaced by replacement effects so you don’t actually attempt to draw a card with an empty library, everything’s fine. However, if you do attempt to draw a card with an empty library this way, Psychic Vortex will remain on the battlefield but you’ll lose the game as a state-based action as soon as the cumulative upkeep ability finishes resolving."
+          "text": "You may choose to draw cards to pay the cumulative upkeep cost even if the number of cards you'd have to draw exceeds the number of cards in your library. If enough of those draws are replaced by replacement effects so you don't actually attempt to draw a card with an empty library, everything's fine. However, if you do attempt to draw a card with an empty library this way, Psychic Vortex will remain on the battlefield but you'll lose the game as a state-based action as soon as the cumulative upkeep ability finishes resolving."
         }
       ],
       "text": "Cumulative upkeep—Draw a card. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nAt the beginning of your end step, sacrifice a land and discard your hand.",
@@ -7160,11 +7161,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Revered Unicorn’s leaves-the-battlefield ability triggers no matter how it leaves the battlefield, not just when you don’t pay its cumulative upkeep."
+          "text": "Revered Unicorn's leaves-the-battlefield ability triggers no matter how it leaves the battlefield, not just when you don't pay its cumulative upkeep."
         },
         {
           "date": "2008-04-01",
-          "text": "If you choose not to pay Revered Unicorn’s cumulative upkeep, it will still get an age counter before being sacrificed, which impacts the amount of life you gain."
+          "text": "If you choose not to pay Revered Unicorn's cumulative upkeep, it will still get an age counter before being sacrificed, which impacts the amount of life you gain."
         }
       ],
       "subtypes": [
@@ -7273,7 +7274,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can’t perform the other action, then you must sacrifice the creature."
+          "text": "When the ability resolves, you choose whether to sacrifice the creature or perform the other action. If you can't perform the other action, then you must sacrifice the creature."
         },
         {
           "date": "2008-04-01",
@@ -7445,7 +7446,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If you don’t sacrifice the lands, Scorched Ruins never enters the battlefield — it goes directly to your graveyard."
+          "text": "If you don't sacrifice the lands, Scorched Ruins never enters the battlefield — it goes directly to your graveyard."
         }
       ],
       "text": "If Scorched Ruins would enter the battlefield, sacrifice two untapped lands instead. If you do, put Scorched Ruins onto the battlefield. If you don't, put it into its owner's graveyard.\n{T}: Add {C}{C}{C}{C} to your mana pool.",
@@ -7499,7 +7500,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Serenity’s triggered ability destroys itself too."
+          "text": "Serenity's triggered ability destroys itself too."
         }
       ],
       "text": "At the beginning of your upkeep, destroy all artifacts and enchantments. They can't be regenerated.",
@@ -7601,7 +7602,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If Serrated Biskelion leaves the battlefield before its ability resolves, you’ll still put a -1/-1 counter on the targeted creature. If the target leaves the battlefield or otherwise becomes an illegal target before the ability resolves, the ability is countered and you won’t put a -1/-1 counter on Serrated Biskelion."
+          "text": "If Serrated Biskelion leaves the battlefield before its ability resolves, you'll still put a -1/-1 counter on the targeted creature. If the target leaves the battlefield or otherwise becomes an illegal target before the ability resolves, the ability is countered and you won't put a -1/-1 counter on Serrated Biskelion."
         }
       ],
       "subtypes": [
@@ -7723,7 +7724,7 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"The sidar who raised me had a saying: ‘The first step into death is the hardest.'\"\n—Gerrard of the Weatherlight",
+      "flavor": "\"The sidar who raised me had a saying: 'The first step into death is the hardest.'\"\n—Gerrard of the Weatherlight",
       "id": "12cf75ee15b195a28cea3560b6810d8d64727675",
       "imageName": "soul shepherd",
       "layout": "normal",
@@ -7864,11 +7865,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -7876,11 +7877,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "text": "You may exile the top three black cards of your graveyard rather than pay Spinning Darkness's mana cost.\nSpinning Darkness deals 3 damage to target nonblack creature. You gain 3 life.",
@@ -7941,7 +7942,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -8043,7 +8044,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A “creature spell” is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
+          "text": "A \"creature spell\" is any spell with the type Creature, even if it has other types such as Artifact or Enchantment. Older cards of type Summon are also Creature spells."
         }
       ],
       "subtypes": [
@@ -8157,7 +8158,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you control Sylvan Hierophant when it goes to the graveyard, you exile the Hierophant and return a creature card from your graveyard to your hand. It doesn’t matter whose graveyard the Hierophant goes to."
+          "text": "If you control Sylvan Hierophant when it goes to the graveyard, you exile the Hierophant and return a creature card from your graveyard to your hand. It doesn't matter whose graveyard the Hierophant goes to."
         },
         {
           "date": "2008-04-01",
@@ -8231,11 +8232,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "First the active player identifies the creature he or she controls with the highest mana cost (and chooses one if there’s a tie) and chooses whether to sacrifice it or pay mana. Then each other player in turn order does the same. All creatures sacrificed this way are sacrificed at the same time."
+          "text": "First the active player identifies the creature he or she controls with the highest mana cost (and chooses one if there's a tie) and chooses whether to sacrifice it or pay mana. Then each other player in turn order does the same. All creatures sacrificed this way are sacrificed at the same time."
         },
         {
           "date": "2008-04-01",
-          "text": "Although Tariff checks the converted mana cost of the creatures on the battlefield, you need to pay the creature’s actual mana cost (including color) to keep it on the battlefield."
+          "text": "Although Tariff checks the converted mana cost of the creatures on the battlefield, you need to pay the creature's actual mana cost (including color) to keep it on the battlefield."
         }
       ],
       "text": "Each player sacrifices the creature he or she controls with the highest converted mana cost unless he or she pays that creature's mana cost. If two or more creatures a player controls are tied for highest cost, that player chooses one.",
@@ -8288,7 +8289,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The “at end of combat” ability triggers after combat damage resolves. Creatures dealt lethal damage in combat won’t be saved this way."
+          "text": "The \"at end of combat\" ability triggers after combat damage resolves. Creatures dealt lethal damage in combat won't be saved this way."
         }
       ],
       "text": "Whenever a creature you control attacks, it phases out at end of combat. (While it's phased out, it's treated as though it doesn't exist. It phases in before you untap during your next untap step.)",
@@ -8400,7 +8401,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If Thran Forge’s ability is activated targeting a nonartifact creature, then it’s activated again in response targeting the same creature, the second instance will resolve. The first instance will then be countered for having an illegal target, since the target is no longer a nonartifact creature."
+          "text": "If Thran Forge's ability is activated targeting a nonartifact creature, then it's activated again in response targeting the same creature, the second instance will resolve. The first instance will then be countered for having an illegal target, since the target is no longer a nonartifact creature."
         }
       ],
       "text": "{2}: Until end of turn, target nonartifact creature gets +1/+0 and becomes an artifact in addition to its other types.",
@@ -8448,7 +8449,7 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "It does not target the cards, but it targets the opponent. If you can’t target an opponent, you can’t activate this ability."
+          "text": "It does not target the cards, but it targets the opponent. If you can't target an opponent, you can't activate this ability."
         },
         {
           "date": "2007-05-01",
@@ -8733,7 +8734,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The control change has no duration; you’ll retain control of that creature until the game ends or until some other effect causes it to change control. It doesn’t matter if Tolarian Entrancer leaves the battlefield, or if Tolarian Entrancer has already left the battlefield by the time the “at end of combat” ability triggers."
+          "text": "The control change has no duration; you'll retain control of that creature until the game ends or until some other effect causes it to change control. It doesn't matter if Tolarian Entrancer leaves the battlefield, or if Tolarian Entrancer has already left the battlefield by the time the \"at end of combat\" ability triggers."
         }
       ],
       "subtypes": [
@@ -8940,7 +8941,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         }
       ],
       "subtypes": [
@@ -9057,11 +9058,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Urborg Stalker’s ability will trigger at the beginning of your upkeep as well."
+          "text": "Urborg Stalker's ability will trigger at the beginning of your upkeep as well."
         },
         {
           "date": "2008-04-01",
-          "text": "This ability checks whether the player controls any nonblack, nonland permanents twice: once when it would trigger, and once when it resolves. If all the player’s nonland permanents are black at the time the ability would trigger, it doesn’t trigger at all. If all the player’s nonland permanents are black at the time the ability would resolve, it’s countered."
+          "text": "This ability checks whether the player controls any nonblack, nonland permanents twice: once when it would trigger, and once when it resolves. If all the player's nonland permanents are black at the time the ability would trigger, it doesn't trigger at all. If all the player's nonland permanents are black at the time the ability would resolve, it's countered."
         }
       ],
       "subtypes": [
@@ -9281,7 +9282,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a “band.” The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers’ damage is assigned."
+          "text": "If a creature with banding attacks, it can team up with any number of other attacking creatures with banding (and up to one nonbanding creature) and attack as a unit called a \"band.\" The band can be blocked by any creature that could block a single creature in the band. Blocking any creature in a band blocks the entire band. If a creature with banding is blocked, the attacking player chooses how the blockers' damage is assigned."
         },
         {
           "date": "2008-10-01",
@@ -9293,7 +9294,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "Paying cumulative upkeep is always optional. If it’s not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can’t be made. For example, if a permanent with “cumulative upkeep {1}” has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
+          "text": "Paying cumulative upkeep is always optional. If it's not paid, the permanent with cumulative upkeep is sacrificed. Partial payments of the total cumulative upkeep cost can't be made. For example, if a permanent with \"cumulative upkeep {1}\" has three age counters on it when its cumulative upkeep ability triggers, it gets another age counter and then its controller chooses to either pay {4} or sacrifice the permanent."
         },
         {
           "date": "2009-10-01",
@@ -9364,7 +9365,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If you don’t pay the cumulative upkeep, you’ll sacrifice Wave of Terror before your draw step begins. It won’t destroy any creatures that turn."
+          "text": "If you don't pay the cumulative upkeep, you'll sacrifice Wave of Terror before your draw step begins. It won't destroy any creatures that turn."
         }
       ],
       "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nAt the beginning of your draw step, destroy each creature with converted mana cost equal to the number of age counters on Wave of Terror. They can't be regenerated.",
@@ -9411,7 +9412,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Each player may use this ability as many times as they choose during their turn’s draw step."
+          "text": "Each player may use this ability as many times as they choose during their turn's draw step."
         }
       ],
       "text": "{2}: Draw a card. Any player may activate this ability but only during his or her draw step.",
@@ -9456,7 +9457,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The ability isn’t limited to creature cards in your hand. If an effect allows you to cast creature cards from some other zone, then Winding Canyons will allow you to do so as though they had flash."
+          "text": "The ability isn't limited to creature cards in your hand. If an effect allows you to cast creature cards from some other zone, then Winding Canyons will allow you to do so as though they had flash."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{2}, {T}: Until end of turn, you may cast creature spells as though they had flash.",
@@ -9504,7 +9505,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
         }
       ],
       "text": "{5}: Until end of turn, Xanthic Statue becomes an 8/8 Golem artifact creature with trample.",
@@ -9558,11 +9559,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The “top” card of your graveyard is the card that was put there most recently."
+          "text": "The \"top\" card of your graveyard is the card that was put there most recently."
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -9570,11 +9571,11 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. —Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         }
       ],
       "subtypes": [

--- a/json/WWK.json
+++ b/json/WWK.json
@@ -132,7 +132,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -140,11 +140,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "Admonition Angel’s landfall ability and its last ability are linked. The last ability refers only to cards exiled with its landfall ability."
+          "text": "Admonition Angel's landfall ability and its last ability are linked. The last ability refers only to cards exiled with its landfall ability."
         },
         {
           "date": "2010-03-01",
-          "text": "If Admonition Angel’s landfall ability triggers, but the Angel leaves the battlefield before it resolves, its last ability will trigger and resolve first. All previously exiled cards will be returned to the battlefield. Then the landfall ability will resolve and exile the targeted permanent forever."
+          "text": "If Admonition Angel's landfall ability triggers, but the Angel leaves the battlefield before it resolves, its last ability will trigger and resolve first. All previously exiled cards will be returned to the battlefield. Then the landfall ability will resolve and exile the targeted permanent forever."
         }
       ],
       "subtypes": [
@@ -348,7 +348,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The creature’s power is determined as the triggered ability resolves, so it will take into account any effects that modify it. If the creature has left the battlefield by the time the triggered ability resolves, its last existence on the battlefield is checked to determine its power."
+          "text": "The creature's power is determined as the triggered ability resolves, so it will take into account any effects that modify it. If the creature has left the battlefield by the time the triggered ability resolves, its last existence on the battlefield is checked to determine its power."
         }
       ],
       "subtypes": [
@@ -552,7 +552,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -664,7 +664,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-03-01",
@@ -672,15 +672,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon and the land it’s enchanting are destroyed at the same time (due to Akroma’s Vengeance, for example), the Zendikon’s last ability will still trigger."
+          "text": "If a Zendikon and the land it's enchanting are destroyed at the same time (due to Akroma's Vengeance, for example), the Zendikon's last ability will still trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon’s last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
+          "text": "If a Zendikon's last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
         }
       ],
       "subtypes": [
@@ -1382,7 +1382,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Loam Lion either gets +1/+2 or it doesn’t. It doesn’t get the bonus for each Forest you control."
+          "text": "Loam Lion either gets +1/+2 or it doesn't. It doesn't get the bonus for each Forest you control."
         }
       ],
       "subtypes": [
@@ -1780,11 +1780,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Refraction Trap’s only target is the creature or player it may deal damage to. You choose that target as you cast Refraction Trap, not at the time it prevents damage."
+          "text": "Refraction Trap's only target is the creature or player it may deal damage to. You choose that target as you cast Refraction Trap, not at the time it prevents damage."
         },
         {
           "date": "2010-03-01",
-          "text": "Refraction Trap doesn’t target the source of the damage it prevents. You choose that source as Refraction Trap resolves. If you cast Refraction Trap for {W}, the source you choose doesn’t have to be the red instant or sorcery spell an opponent cast."
+          "text": "Refraction Trap doesn't target the source of the damage it prevents. You choose that source as Refraction Trap resolves. If you cast Refraction Trap for {W}, the source you choose doesn't have to be the red instant or sorcery spell an opponent cast."
         },
         {
           "date": "2010-03-01",
@@ -1796,23 +1796,23 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If the chosen source would simultaneously deal damage to multiple permanents you control, or would simultaneously deal damage to you and at least one permanent you control, you choose which of that damage to prevent. For example, if the chosen source is Earthquake, you might choose to prevent the next 2 damage it would deal to you and the next 1 damage it would deal to a creature you control. You don’t decide until the point at which the source would deal its damage."
+          "text": "If the chosen source would simultaneously deal damage to multiple permanents you control, or would simultaneously deal damage to you and at least one permanent you control, you choose which of that damage to prevent. For example, if the chosen source is Earthquake, you might choose to prevent the next 2 damage it would deal to you and the next 1 damage it would deal to a creature you control. You don't decide until the point at which the source would deal its damage."
         },
         {
           "date": "2010-03-01",
-          "text": "Refraction Trap’s effect is not a redirection effect. If it prevents damage, Refraction Trap (not the chosen source) deals damage to the targeted creature or player as part of that prevention effect. Refraction Trap is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don’t affect this damage. The new damage is not combat damage, even if the prevented damage was. Since you control the source of the new damage, if you targeted an opponent with Refraction Trap, you may have Refraction Trap deal its damage to a planeswalker that opponent controls."
+          "text": "Refraction Trap's effect is not a redirection effect. If it prevents damage, Refraction Trap (not the chosen source) deals damage to the targeted creature or player as part of that prevention effect. Refraction Trap is the source of the new damage, so the characteristics of the original source (such as its color, or whether it had lifelink or deathtouch) don't affect this damage. The new damage is not combat damage, even if the prevented damage was. Since you control the source of the new damage, if you targeted an opponent with Refraction Trap, you may have Refraction Trap deal its damage to a planeswalker that opponent controls."
         },
         {
           "date": "2010-03-01",
-          "text": "If the chosen source would deal damage, Refraction Trap prevents 3 of that source’s damage and the source deals its excess damage (if any) at the same time. Immediately afterward, as part of that same prevention effect, Refraction Trap deals its damage. This happens before state-based actions are checked, and before the spell or ability that caused damage to be dealt resumes its resolution."
+          "text": "If the chosen source would deal damage, Refraction Trap prevents 3 of that source's damage and the source deals its excess damage (if any) at the same time. Immediately afterward, as part of that same prevention effect, Refraction Trap deals its damage. This happens before state-based actions are checked, and before the spell or ability that caused damage to be dealt resumes its resolution."
         },
         {
           "date": "2010-03-01",
-          "text": "Whether the targeted creature or player is still a legal target is no longer checked after Refraction Trap resolves. For example, if a creature targeted by Refraction Trap gains shroud after Refraction Trap resolves but before it prevents damage, Refraction Trap will still prevent damage and still deal damage to that creature. If Refraction Trap can’t deal damage to the targeted creature or player (because the creature has gained protection from white, is no longer on the battlefield, or is no longer a creature, or the player is no longer in the game, for example), it will still prevent damage. It just won’t deal any damage itself."
+          "text": "Whether the targeted creature or player is still a legal target is no longer checked after Refraction Trap resolves. For example, if a creature targeted by Refraction Trap gains shroud after Refraction Trap resolves but before it prevents damage, Refraction Trap will still prevent damage and still deal damage to that creature. If Refraction Trap can't deal damage to the targeted creature or player (because the creature has gained protection from white, is no longer on the battlefield, or is no longer a creature, or the player is no longer in the game, for example), it will still prevent damage. It just won't deal any damage itself."
         },
         {
           "date": "2010-03-01",
-          "text": "If Refraction Trap doesn’t prevent any damage (perhaps because a different prevention effect is applied to the damage the source would deal, or because the damage is unpreventable), Refraction Trap won’t deal any damage itself."
+          "text": "If Refraction Trap doesn't prevent any damage (perhaps because a different prevention effect is applied to the damage the source would deal, or because the damage is unpreventable), Refraction Trap won't deal any damage itself."
         }
       ],
       "subtypes": [
@@ -1923,7 +1923,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The landfall ability checks for an action that has happened in the past. It doesn’t matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
+          "text": "The landfall ability checks for an action that has happened in the past. It doesn't matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
         },
         {
           "date": "2010-03-01",
@@ -1931,7 +1931,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The effect of this spell’s landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
+          "text": "The effect of this spell's landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
         }
       ],
       "text": "Target player gains 4 life.\nLandfall — If you had a land enter the battlefield under your control this turn, that player gains 8 life instead.",
@@ -2032,11 +2032,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "As Ruin Ghost’s ability resolves, the targeted land is exiled, then immediately returned to the battlefield. The land that enters the battlefield is a different permanent from the one that left. Any counters, Auras, and so on that were affecting the old land won’t affect the new one. Any spells or abilities that were targeting the old land don’t target the new one. Whether the old land was tapped or untapped has no bearing on the new one."
+          "text": "As Ruin Ghost's ability resolves, the targeted land is exiled, then immediately returned to the battlefield. The land that enters the battlefield is a different permanent from the one that left. Any counters, Auras, and so on that were affecting the old land won't affect the new one. Any spells or abilities that were targeting the old land don't target the new one. Whether the old land was tapped or untapped has no bearing on the new one."
         },
         {
           "date": "2010-03-01",
-          "text": "The returned land behaves like any other land that’s put onto the battlefield. If it has an ability that says it enters the battlefield tapped, it does so. (Otherwise it enters the battlefield untapped.) If it has an enters-the-battlefield triggered ability, that ability triggers."
+          "text": "The returned land behaves like any other land that's put onto the battlefield. If it has an ability that says it enters the battlefield tapped, it does so. (Otherwise it enters the battlefield untapped.) If it has an enters-the-battlefield triggered ability, that ability triggers."
         },
         {
           "date": "2010-03-01",
@@ -2138,13 +2138,14 @@
       "originalType": "Creature — Kor Artificer",
       "power": "1",
       "printings": [
+        "pGPX",
         "WWK"
       ],
       "rarity": "Rare",
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "When Stoneforge Mystic’s second ability resolves, you may put any Equipment card from your hand onto the battlefield, not just the one you searched for with its first ability. The Equipment is put onto the battlefield unattached."
+          "text": "When Stoneforge Mystic's second ability resolves, you may put any Equipment card from your hand onto the battlefield, not just the one you searched for with its first ability. The Equipment is put onto the battlefield unattached."
         }
       ],
       "subtypes": [
@@ -2250,7 +2251,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The choices you make as Talus Paladin’s ability resolves are made individually. First you decide whether to have Allies you control gain lifelink until end of turn. Then, regardless of that decision, you decide whether to put a +1/+1 counter on Talus Paladin."
+          "text": "The choices you make as Talus Paladin's ability resolves are made individually. First you decide whether to have Allies you control gain lifelink until end of turn. Then, regardless of that decision, you decide whether to put a +1/+1 counter on Talus Paladin."
         }
       ],
       "subtypes": [
@@ -2356,7 +2357,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Effects that say “destroy” won’t cause a land with indestructible to be put into its owner’s graveyard. If that land is also a creature, lethal damage won’t cause it to be put into its owner’s graveyard either. However, a land with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary land with the same name is controlled by the same player, or if it’s also a creature and its toughness is 0 or less."
+          "text": "Effects that say \"destroy\" won't cause a land with indestructible to be put into its owner's graveyard. If that land is also a creature, lethal damage won't cause it to be put into its owner's graveyard either. However, a land with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary land with the same name is controlled by the same player, or if it's also a creature and its toughness is 0 or less."
         }
       ],
       "text": "All lands have indestructible.",
@@ -2559,7 +2560,7 @@
       "rulings": [
         {
           "date": "2016-09-20",
-          "text": "If one target permanent becomes an illegal target, the other will be returned to its owner’s hand. If both targets become illegal, Aether Tradewinds will be countered."
+          "text": "If one target permanent becomes an illegal target, the other will be returned to its owner's hand. If both targets become illegal, Aether Tradewinds will be countered."
         }
       ],
       "text": "Return target permanent you control and target permanent you don't control to their owners' hands.",
@@ -2659,7 +2660,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -2671,7 +2672,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -3183,7 +3184,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Protection from lands works like any other protection ability. Horizon Drake can’t be blocked by land creatures, all damage that would be dealt to it by lands (including combat damage from land creatures) is prevented, and it can’t be the target of activated or triggered abilities from lands (including your own Teetering Peaks, for example)."
+          "text": "Protection from lands works like any other protection ability. Horizon Drake can't be blocked by land creatures, all damage that would be dealt to it by lands (including combat damage from land creatures) is prevented, and it can't be the target of activated or triggered abilities from lands (including your own Teetering Peaks, for example)."
         }
       ],
       "subtypes": [
@@ -3290,11 +3291,11 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "You draw three cards and put two cards back all while Jace’s second ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+          "text": "You draw three cards and put two cards back all while Jace's second ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
         },
         {
           "date": "2016-06-08",
-          "text": "If the targeted player for Jace’s last ability has no cards in hand, that player shuffles nothing into his or her library, and that player’s library will remain empty. That player won’t lose the game until he or she tries to draw from the empty library."
+          "text": "If the targeted player for Jace's last ability has no cards in hand, that player shuffles nothing into his or her library, and that player's library will remain empty. That player won't lose the game until he or she tries to draw from the empty library."
         }
       ],
       "subtypes": [
@@ -3398,7 +3399,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Jwari Shapeshifter copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn’t copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+          "text": "Jwari Shapeshifter copies exactly what was printed on the original creature and nothing more (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
         },
         {
           "date": "2010-03-01",
@@ -3527,7 +3528,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The landfall ability checks for an action that has happened in the past. It doesn’t matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
+          "text": "The landfall ability checks for an action that has happened in the past. It doesn't matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
         },
         {
           "date": "2010-03-01",
@@ -3535,7 +3536,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The effect of this spell’s landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
+          "text": "The effect of this spell's landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
         }
       ],
       "text": "Draw two cards.\nLandfall — If you had a land enter the battlefield under your control this turn, draw three cards instead.",
@@ -3634,15 +3635,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "You may target any two (or fewer) creatures. It’s okay if any of them are already tapped. If you cast Permafrost Trap for {U}, you don’t have to target the green creature that entered the battlefield under an opponent’s control."
+          "text": "You may target any two (or fewer) creatures. It's okay if any of them are already tapped. If you cast Permafrost Trap for {U}, you don't have to target the green creature that entered the battlefield under an opponent's control."
         },
         {
           "date": "2010-03-01",
-          "text": "If a targeted creature is untapped at the time its controller’s next untap step begins, the second part of the ability has no effect on it."
+          "text": "If a targeted creature is untapped at the time its controller's next untap step begins, the second part of the ability has no effect on it."
         },
         {
           "date": "2010-03-01",
-          "text": "If an affected creature changes controllers before its previous controller’s next untap step, this ability will prevent it from untapping during its new controller’s next untap step."
+          "text": "If an affected creature changes controllers before its previous controller's next untap step, this ability will prevent it from untapping during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -3744,11 +3745,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "When the first ability resolves, you may look at the top card of your library. If you don’t, nothing happens. If you look at it and it’s not a creature card, it simply stays hidden. If you look at it and it is a creature card, you may reveal it and put a quest counter on Quest for Ula’s Temple, or you may choose to leave it hidden. In all cases, the card remains on top of your library."
+          "text": "When the first ability resolves, you may look at the top card of your library. If you don't, nothing happens. If you look at it and it's not a creature card, it simply stays hidden. If you look at it and it is a creature card, you may reveal it and put a quest counter on Quest for Ula's Temple, or you may choose to leave it hidden. In all cases, the card remains on top of your library."
         },
         {
           "date": "2010-03-01",
-          "text": "If an ability (from Future Sight or Oracle of Mul Daya, for example) causes you to play with the top card of your library revealed, you may still put a quest counter on Quest for Ula’s Temple when the first ability resolves if the top card of your library is a creature card."
+          "text": "If an ability (from Future Sight or Oracle of Mul Daya, for example) causes you to play with the top card of your library revealed, you may still put a quest counter on Quest for Ula's Temple when the first ability resolves if the top card of your library is a creature card."
         },
         {
           "date": "2010-03-01",
@@ -4044,11 +4045,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If the targeted spell is an illegal target by the time Spell Contortion resolves, Spell Contortion is countered. You won’t draw any cards."
+          "text": "If the targeted spell is an illegal target by the time Spell Contortion resolves, Spell Contortion is countered. You won't draw any cards."
         },
         {
           "date": "2010-03-01",
-          "text": "If Spell Contortion resolves, you draw a card for each time Spell Contortion was kicked, regardless of whether the targeted spell’s controller pays {2} or whether the targeted spell is countered this way."
+          "text": "If Spell Contortion resolves, you draw a card for each time Spell Contortion was kicked, regardless of whether the targeted spell's controller pays {2} or whether the targeted spell is countered this way."
         }
       ],
       "text": "Multikicker {1}{U} (You may pay an additional {1}{U} any number of times as you cast this spell.)\nCounter target spell unless its controller pays {2}. Draw a card for each time Spell Contortion was kicked.",
@@ -4248,15 +4249,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "When the triggered ability resolves, you must search that player’s library (and he or she must shuffle it) even if there are no artifact cards in it or you choose not to find one."
+          "text": "When the triggered ability resolves, you must search that player's library (and he or she must shuffle it) even if there are no artifact cards in it or you choose not to find one."
         },
         {
           "date": "2010-03-01",
-          "text": "The exiled card is played using the normal timing rules for an artifact, as well as any other applicable restrictions. For example, you can’t play the card during your combat phase unless it has flash. Similarly, if the exiled card is an artifact land, you can’t play it if you’ve already played a land that turn. If it’s a nonland card, you’ll have to pay its mana cost. The only thing that’s different is you’re playing it from the exile zone."
+          "text": "The exiled card is played using the normal timing rules for an artifact, as well as any other applicable restrictions. For example, you can't play the card during your combat phase unless it has flash. Similarly, if the exiled card is an artifact land, you can't play it if you've already played a land that turn. If it's a nonland card, you'll have to pay its mana cost. The only thing that's different is you're playing it from the exile zone."
         },
         {
           "date": "2010-03-01",
-          "text": "If you don’t play the card before the turn ends, it simply remains exiled."
+          "text": "If you don't play the card before the turn ends, it simply remains exiled."
         }
       ],
       "subtypes": [
@@ -4365,7 +4366,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -4479,7 +4480,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If all the cards left in your library are lands, you’ll reveal all of them and put them all into your hand."
+          "text": "If all the cards left in your library are lands, you'll reveal all of them and put them all into your hand."
         }
       ],
       "text": "Reveal cards from the top of your library until you reveal a nonland card, then put all cards revealed this way into your hand.",
@@ -4586,7 +4587,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If the targeted permanent is an illegal target by the time Twitch resolves, the entire spell is countered. You don’t draw a card."
+          "text": "If the targeted permanent is an illegal target by the time Twitch resolves, the entire spell is countered. You don't draw a card."
         }
       ],
       "text": "You may tap or untap target artifact, creature, or land.\nDraw a card.",
@@ -4883,7 +4884,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-03-01",
@@ -4891,15 +4892,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon and the land it’s enchanting are destroyed at the same time (due to Akroma’s Vengeance, for example), the Zendikon’s last ability will still trigger."
+          "text": "If a Zendikon and the land it's enchanting are destroyed at the same time (due to Akroma's Vengeance, for example), the Zendikon's last ability will still trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon’s last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
+          "text": "If a Zendikon's last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
         }
       ],
       "subtypes": [
@@ -5004,11 +5005,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "No game effect can cause you to win the game or cause any opponent to lose the game while you control Abyssal Persecutor. It doesn’t matter whether an opponent has 0 or less life, an opponent is forced to draw a card while his or her library is empty, an opponent has ten or more poison counters, an opponent is dealt combat damage by Phage the Untouchable, you control Felidar Sovereign and have 40 or more life, or so on. You keep playing."
+          "text": "No game effect can cause you to win the game or cause any opponent to lose the game while you control Abyssal Persecutor. It doesn't matter whether an opponent has 0 or less life, an opponent is forced to draw a card while his or her library is empty, an opponent has ten or more poison counters, an opponent is dealt combat damage by Phage the Untouchable, you control Felidar Sovereign and have 40 or more life, or so on. You keep playing."
         },
         {
           "date": "2010-03-01",
-          "text": "Other circumstances can still cause an opponent to lose the game, however. An opponent will lose a game if he or she concedes, if that player is penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if that player’s _Magic Online_(R) game clock runs out of time."
+          "text": "Other circumstances can still cause an opponent to lose the game, however. An opponent will lose a game if he or she concedes, if that player is penalized with a Game Loss or a Match Loss during a sanctioned tournament due to a DCI rules infraction, or if that player's _Magic Online_(R) game clock runs out of time."
         },
         {
           "date": "2010-03-01",
@@ -5016,7 +5017,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "Abyssal Persecutor won’t preclude an opponent’s life total from reaching 0 or less. It will just preclude that player from losing the game as a result."
+          "text": "Abyssal Persecutor won't preclude an opponent's life total from reaching 0 or less. It will just preclude that player from losing the game as a result."
         },
         {
           "date": "2010-03-01",
@@ -5024,11 +5025,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "Even though your opponents can’t lose the game, a player can’t pay an amount of life that’s greater than his or her life total. If a player’s life total is 0 or less, that player can’t pay life at all, with one exception: a player may always pay 0 life."
+          "text": "Even though your opponents can't lose the game, a player can't pay an amount of life that's greater than his or her life total. If a player's life total is 0 or less, that player can't pay life at all, with one exception: a player may always pay 0 life."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control Abyssal Persecutor in a Two-Headed Giant game, your team can’t win the game and the opposing team can’t lose the game."
+          "text": "If you control Abyssal Persecutor in a Two-Headed Giant game, your team can't win the game and the opposing team can't lose the game."
         }
       ],
       "subtypes": [
@@ -5132,7 +5133,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "You may target any creature card in an opponent’s graveyard with Agadeem Occultist’s ability. You check whether the targeted card’s converted mana cost is less than or equal to the number of Allies you control when the ability resolves. If you control too few Allies at that point, the ability does nothing."
+          "text": "You may target any creature card in an opponent's graveyard with Agadeem Occultist's ability. You check whether the targeted card's converted mana cost is less than or equal to the number of Allies you control when the ability resolves. If you control too few Allies at that point, the ability does nothing."
         }
       ],
       "subtypes": [
@@ -5239,11 +5240,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "When the triggered ability resolves, first you choose which creature you’ll sacrifice (if you control any non-Vampire creatures), then each other player in turn order does the same, then all chosen creatures are sacrificed at the same time."
+          "text": "When the triggered ability resolves, first you choose which creature you'll sacrifice (if you control any non-Vampire creatures), then each other player in turn order does the same, then all chosen creatures are sacrificed at the same time."
         },
         {
           "date": "2010-03-01",
-          "text": "If a player controls no creatures, or if all creatures a player controls are Vampires, that player simply doesn’t sacrifice anything."
+          "text": "If a player controls no creatures, or if all creatures a player controls are Vampires, that player simply doesn't sacrifice anything."
         }
       ],
       "subtypes": [
@@ -5552,19 +5553,19 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Brink of Disaster may target and may enchant a permanent that’s already tapped. It won’t do anything until the enchanted permanent changes from being untapped to being tapped."
+          "text": "Brink of Disaster may target and may enchant a permanent that's already tapped. It won't do anything until the enchanted permanent changes from being untapped to being tapped."
         },
         {
           "date": "2010-03-01",
-          "text": "When the enchanted permanent becomes tapped, Brink of Disaster’s ability triggers. That permanent will be destroyed when the ability resolves, even if Brink of Disaster has left the battlefield or is somehow enchanting a different permanent by then."
+          "text": "When the enchanted permanent becomes tapped, Brink of Disaster's ability triggers. That permanent will be destroyed when the ability resolves, even if Brink of Disaster has left the battlefield or is somehow enchanting a different permanent by then."
         },
         {
           "date": "2010-03-01",
-          "text": "If the enchanted permanent is tapped as a cost to activate a mana ability, the mana ability resolves immediately, then Brink of Disaster’s ability goes on the stack."
+          "text": "If the enchanted permanent is tapped as a cost to activate a mana ability, the mana ability resolves immediately, then Brink of Disaster's ability goes on the stack."
         },
         {
           "date": "2010-03-01",
-          "text": "If the enchanted permanent is tapped as a cost to activate an ability that’s not a mana ability, Brink of Disaster’s ability will go on the stack on top of that activated ability. Brink of Disaster’s ability resolves first (destroying that permanent), then the permanent’s activated ability resolves."
+          "text": "If the enchanted permanent is tapped as a cost to activate an ability that's not a mana ability, Brink of Disaster's ability will go on the stack on top of that activated ability. Brink of Disaster's ability resolves first (destroying that permanent), then the permanent's activated ability resolves."
         }
       ],
       "subtypes": [
@@ -5678,15 +5679,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners’ graveyards at the same time, Butcher of Malakir’s triggered ability will trigger that many times."
+          "text": "If multiple creatures you control (possibly including Butcher of Malakir itself) are put into their owners' graveyards at the same time, Butcher of Malakir's triggered ability will trigger that many times."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers’ abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
+          "text": "If you control more than one Butcher of Malakir and a creature you control is put into a graveyard, each of those Butchers' abilities will trigger. Each opponent will sacrifice a creature each time one of those abilities resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player’s Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player’s Butcher to trigger, and so on."
+          "text": "If you and an opponent each control a Butcher of Malakir and a creature is put into a graveyard, a chain reaction happens. First the ability of one player's Butcher will trigger, causing each opponent to sacrifice a creature. That sacrifice causes the ability of the other player's Butcher to trigger, and so on."
         }
       ],
       "subtypes": [
@@ -5792,7 +5793,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -5903,7 +5904,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-03-01",
@@ -5911,15 +5912,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon and the land it’s enchanting are destroyed at the same time (due to Akroma’s Vengeance, for example), the Zendikon’s last ability will still trigger."
+          "text": "If a Zendikon and the land it's enchanting are destroyed at the same time (due to Akroma's Vengeance, for example), the Zendikon's last ability will still trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon’s last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
+          "text": "If a Zendikon's last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
         }
       ],
       "subtypes": [
@@ -6022,15 +6023,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "You must choose two targets as you cast Dead Reckoning: a creature card in your graveyard and a creature on the battlefield. If you can’t, then you can’t cast the spell."
+          "text": "You must choose two targets as you cast Dead Reckoning: a creature card in your graveyard and a creature on the battlefield. If you can't, then you can't cast the spell."
         },
         {
           "date": "2010-03-01",
-          "text": "If the targeted creature card is an illegal target as Dead Reckoning resolves (because it’s no longer in your graveyard, perhaps), you can’t choose to put it on top of your library. No damage will be dealt."
+          "text": "If the targeted creature card is an illegal target as Dead Reckoning resolves (because it's no longer in your graveyard, perhaps), you can't choose to put it on top of your library. No damage will be dealt."
         },
         {
           "date": "2010-03-01",
-          "text": "If the targeted creature is an illegal target as Dead Reckoning resolves (because it’s no longer on the battlefield, perhaps), you may still put the targeted creature card from your graveyard on top of your library. No damage will be dealt."
+          "text": "If the targeted creature is an illegal target as Dead Reckoning resolves (because it's no longer on the battlefield, perhaps), you may still put the targeted creature card from your graveyard on top of your library. No damage will be dealt."
         },
         {
           "date": "2010-03-01",
@@ -6136,23 +6137,23 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Death’s Shadow’s ability applies only while Death’s Shadow is on the battlefield. In all other zones, its power and toughness are 13."
+          "text": "Death's Shadow's ability applies only while Death's Shadow is on the battlefield. In all other zones, its power and toughness are 13."
         },
         {
           "date": "2017-03-14",
-          "text": "The value of X changes as you gain and lose life. It’s not locked in as Death’s Shadow enters the battlefield."
+          "text": "The value of X changes as you gain and lose life. It's not locked in as Death's Shadow enters the battlefield."
         },
         {
           "date": "2017-03-14",
-          "text": "If your life total is 13 or greater and nothing else is boosting the toughness of Death’s Shadow, it’s put into its owner’s graveyard as a state-based action."
+          "text": "If your life total is 13 or greater and nothing else is boosting the toughness of Death's Shadow, it's put into its owner's graveyard as a state-based action."
         },
         {
           "date": "2017-03-14",
-          "text": "If your life total is less than 0 and an effect (such as the one from an opponent’s Abyssal Persecutor) is keeping you from losing the game, Death’s Shadow’s ability will actually increase its power and toughness. For example, if your life total is -2, Death’s Shadow gets +2/+2."
+          "text": "If your life total is less than 0 and an effect (such as the one from an opponent's Abyssal Persecutor) is keeping you from losing the game, Death's Shadow's ability will actually increase its power and toughness. For example, if your life total is -2, Death's Shadow gets +2/+2."
         },
         {
           "date": "2017-03-14",
-          "text": "In a Two-Headed Giant game, your life total is your team’s life total."
+          "text": "In a Two-Headed Giant game, your life total is your team's life total."
         }
       ],
       "subtypes": [
@@ -6357,7 +6358,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If multiple Vampires you control (possibly including Kalastria Highborn itself) are put into their owners’ graveyards at the same time, Kalastria Highborn’s ability triggers that many times."
+          "text": "If multiple Vampires you control (possibly including Kalastria Highborn itself) are put into their owners' graveyards at the same time, Kalastria Highborn's ability triggers that many times."
         },
         {
           "date": "2010-03-01",
@@ -6365,7 +6366,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If the targeted player is an illegal target by the time the ability resolves (for example, if that player has left a multiplayer game), the entire ability is countered. You can’t pay {B} and you don’t gain life."
+          "text": "If the targeted player is an illegal target by the time the ability resolves (for example, if that player has left a multiplayer game), the entire ability is countered. You can't pay {B} and you don't gain life."
         }
       ],
       "subtypes": [
@@ -6471,7 +6472,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If the number of Swamps you control exceeds the number of cards in the targeted player’s hand, that player reveals all the cards in his or her hand."
+          "text": "If the number of Swamps you control exceeds the number of cards in the targeted player's hand, that player reveals all the cards in his or her hand."
         }
       ],
       "text": "Target player reveals a number of cards from his or her hand equal to the number of Swamps you control. You choose one of them. That player discards that card.",
@@ -6575,15 +6576,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast Nemesis Trap during your opponent’s declare attackers step, you’ll put the token onto the battlefield before the declare blockers step begins and you can block with it this combat. If you cast Nemesis Trap later in the combat phase a, you won’t be able to block with the token."
+          "text": "If you cast Nemesis Trap during your opponent's declare attackers step, you'll put the token onto the battlefield before the declare blockers step begins and you can block with it this combat. If you cast Nemesis Trap later in the combat phase a, you won't be able to block with the token."
         },
         {
           "date": "2010-03-01",
-          "text": "The token you put onto the battlefield copies exactly what was printed on the exiled creature and nothing more (unless it was copying something else or it was a token; see below). It doesn’t copy whether the exiled creature was tapped or untapped, whether it had any counters on it or Auras attached to it, or any non-copy effects that changed its power, toughness, types, color, or so on. For example, if Nemesis Trap targets an animated Celestial Colonnade, the token you put onto the battlefield will be a Celestial Colonnade that’s just a land. (Because of this, Nemesis Trap has received minor errata to specify that you put a token, not a “creature token,” onto the battlefield.)"
+          "text": "The token you put onto the battlefield copies exactly what was printed on the exiled creature and nothing more (unless it was copying something else or it was a token; see below). It doesn't copy whether the exiled creature was tapped or untapped, whether it had any counters on it or Auras attached to it, or any non-copy effects that changed its power, toughness, types, color, or so on. For example, if Nemesis Trap targets an animated Celestial Colonnade, the token you put onto the battlefield will be a Celestial Colonnade that's just a land. (Because of this, Nemesis Trap has received minor errata to specify that you put a token, not a \"creature token,\" onto the battlefield.)"
         },
         {
           "date": "2010-03-01",
@@ -6599,11 +6600,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "Any enters-the-battlefield abilities of the exiled creature will trigger when the token is put onto the battlefield. Any “as [this creature] enters the battlefield” or “[this creature] enters the battlefield with” abilities of the chosen creature will also work."
+          "text": "Any enters-the-battlefield abilities of the exiled creature will trigger when the token is put onto the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
         },
         {
           "date": "2010-03-01",
-          "text": "If the targeted creature is an illegal target by the time Nemesis Trap resolves, the entire spell is countered. You won’t get a token."
+          "text": "If the targeted creature is an illegal target by the time Nemesis Trap resolves, the entire spell is countered. You won't get a token."
         }
       ],
       "subtypes": [
@@ -6906,7 +6907,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The second ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless, as an opponent’s upkeep starts, that player has no cards in hand and Quest for the Nihil Stone has two or more quest counters on it, and (2) the ability will do nothing if that player has at least one card in hand and/or Quest for the Nihil Stone has fewer than two quest counters on it by the time it resolves. (If Quest for the Nihil Stone is no longer on the battlefield by that point, its last existence on the battlefield is checked to see how many quest counters were on it.)"
+          "text": "The second ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless, as an opponent's upkeep starts, that player has no cards in hand and Quest for the Nihil Stone has two or more quest counters on it, and (2) the ability will do nothing if that player has at least one card in hand and/or Quest for the Nihil Stone has fewer than two quest counters on it by the time it resolves. (If Quest for the Nihil Stone is no longer on the battlefield by that point, its last existence on the battlefield is checked to see how many quest counters were on it.)"
         }
       ],
       "text": "Whenever an opponent discards a card, you may put a quest counter on Quest for the Nihil Stone.\nAt the beginning of each opponent's upkeep, if that player has no cards in hand and Quest for the Nihil Stone has two or more quest counters on it, you may have that player lose 5 life.",
@@ -7106,7 +7107,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -7320,7 +7321,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A creature’s converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is copying something else; see below). If its mana cost includes {X}, X is considered to be 0. If it has no mana symbols in its upper right corner (because it’s an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
+          "text": "A creature's converted mana cost is determined solely by the mana symbols printed in its upper right corner (unless that creature is copying something else; see below). If its mana cost includes {X}, X is considered to be 0. If it has no mana symbols in its upper right corner (because it's an animated land, for example), its converted mana cost is 0. Ignore any alternative costs or additional costs (such as kicker) paid when the creature was cast."
         },
         {
           "date": "2010-03-01",
@@ -7328,7 +7329,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If a creature is copying something else, its converted mana cost is the converted mana cost of whatever it’s copying."
+          "text": "If a creature is copying something else, its converted mana cost is the converted mana cost of whatever it's copying."
         }
       ],
       "text": "Destroy target creature with converted mana cost 3 or less. It can't be regenerated.",
@@ -7435,7 +7436,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The landfall ability checks for an action that has happened in the past. It doesn’t matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
+          "text": "The landfall ability checks for an action that has happened in the past. It doesn't matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
         },
         {
           "date": "2010-03-01",
@@ -7443,7 +7444,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The effect of this spell’s landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
+          "text": "The effect of this spell's landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
         }
       ],
       "text": "Target creature gets -2/-2 until end of turn.\nLandfall — If you had a land enter the battlefield under your control this turn, that creature gets -4/-4 until end of turn instead.",
@@ -7543,15 +7544,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "You don’t choose which untapped Vampire creatures you control to tap (if any) until Urge to Feed resolves."
+          "text": "You don't choose which untapped Vampire creatures you control to tap (if any) until Urge to Feed resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast Urge to Feed targeting an untapped Vampire creature you control with toughness 3, its toughness will be reduced to 0 by the -3/-3 effect. However, state-based actions aren’t checked until the spell has finished resolving. You may then tap that Vampire and put a +1/+1 counter on it, raising its toughness to 1. It will remain on the battlefield."
+          "text": "If you cast Urge to Feed targeting an untapped Vampire creature you control with toughness 3, its toughness will be reduced to 0 by the -3/-3 effect. However, state-based actions aren't checked until the spell has finished resolving. You may then tap that Vampire and put a +1/+1 counter on it, raising its toughness to 1. It will remain on the battlefield."
         },
         {
           "date": "2010-03-01",
-          "text": "If the targeted creature is an illegal target by the time Urge to Feed resolves, the entire spell is countered. You can’t tap any Vampires."
+          "text": "If the targeted creature is an illegal target by the time Urge to Feed resolves, the entire spell is countered. You can't tap any Vampires."
         }
       ],
       "text": "Target creature gets -3/-3 until end of turn. You may tap any number of untapped Vampire creatures you control. If you do, put a +1/+1 counter on each of those Vampires.",
@@ -7756,11 +7757,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If either the targeted player or the targeted permanent is an illegal target by the time the ability resolves, the ability does nothing. The player won’t gain control of the permanent."
+          "text": "If either the targeted player or the targeted permanent is an illegal target by the time the ability resolves, the ability does nothing. The player won't gain control of the permanent."
         },
         {
           "date": "2010-03-01",
-          "text": "You may target yourself with Bazaar Trader’s ability. Normally, this won’t have any visible effect. However, the ability would override an effect with a limited duration that gave you control of a permanent. For example, if you temporarily gained control of a creature with Act of Treason, targeting yourself and that creature with Bazaar Trader’s ability would then cause you to gain control of the creature indefinitely."
+          "text": "You may target yourself with Bazaar Trader's ability. Normally, this won't have any visible effect. However, the ability would override an effect with a limited duration that gave you control of a permanent. For example, if you temporarily gained control of a creature with Act of Treason, targeting yourself and that creature with Bazaar Trader's ability would then cause you to gain control of the creature indefinitely."
         }
       ],
       "subtypes": [
@@ -8162,7 +8163,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The number of targets you choose for Comet Storm is one more than the number of times it’s kicked. First you declare how many times you’re going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you’ll kick the spell and the time you choose the targets."
+          "text": "The number of targets you choose for Comet Storm is one more than the number of times it's kicked. First you declare how many times you're going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you'll kick the spell and the time you choose the targets."
         },
         {
           "date": "2010-03-01",
@@ -8170,7 +8171,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you’re kicking the spell twice. You’ll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
+          "text": "For example, if you want Comet Storm to deal 4 damage to each of three different targets, that means X is 4 and you're kicking the spell twice. You'll pay a mana cost of {4}{R}{R}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{R}{R}."
         },
         {
           "date": "2010-03-01",
@@ -8276,7 +8277,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -8387,7 +8388,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-03-01",
@@ -8395,15 +8396,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon and the land it’s enchanting are destroyed at the same time (due to Akroma’s Vengeance, for example), the Zendikon’s last ability will still trigger."
+          "text": "If a Zendikon and the land it's enchanting are destroyed at the same time (due to Akroma's Vengeance, for example), the Zendikon's last ability will still trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon’s last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
+          "text": "If a Zendikon's last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
         }
       ],
       "subtypes": [
@@ -8920,7 +8921,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "Grotag Thrasher’s ability can target any creature, not just one the defending player controls. For example, if you want that player’s creatures to be able to block this turn, you can target Grotag Thrasher with its own ability."
+          "text": "Grotag Thrasher's ability can target any creature, not just one the defending player controls. For example, if you want that player's creatures to be able to block this turn, you can target Grotag Thrasher with its own ability."
         }
       ],
       "subtypes": [
@@ -9026,15 +9027,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "You’re the defending player if a creature is attacking you or a planeswalker you control."
+          "text": "You're the defending player if a creature is attacking you or a planeswalker you control."
         },
         {
           "date": "2010-03-01",
-          "text": "If you’re the defending player, Kazuul’s ability triggers once for each creature that attacks, not just once per combat. The attacking player chooses whether to pay {3} or let you have an Ogre token each time one of those abilities resolves."
+          "text": "If you're the defending player, Kazuul's ability triggers once for each creature that attacks, not just once per combat. The attacking player chooses whether to pay {3} or let you have an Ogre token each time one of those abilities resolves."
         },
         {
           "date": "2010-03-01",
-          "text": "As the ability resolves, you can’t put the Ogre token onto the battlefield without explicitly giving the attacking player the option to pay {3}, even if the attacking player has forgotten about this ability."
+          "text": "As the ability resolves, you can't put the Ogre token onto the battlefield without explicitly giving the attacking player the option to pay {3}, even if the attacking player has forgotten about this ability."
         },
         {
           "date": "2010-03-01",
@@ -9042,11 +9043,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If an attacking creature has a “Whenever this creature attacks” ability, that ability is put on the stack first, then Kazuul’s ability is put on the stack. Although Kazuul’s ability will resolve first, and potentially create an Ogre token, any target of the other ability will already have been chosen at this point, and thus could not have been the new Ogre token."
+          "text": "If an attacking creature has a \"Whenever this creature attacks\" ability, that ability is put on the stack first, then Kazuul's ability is put on the stack. Although Kazuul's ability will resolve first, and potentially create an Ogre token, any target of the other ability will already have been chosen at this point, and thus could not have been the new Ogre token."
         },
         {
           "date": "2010-03-01",
-          "text": "In a multiplayer game, the ability checks whether you’re the defending player for each individual attacking creature. For example, if one creature attacks you and two creatures attack another player, Kazuul’s ability triggers just once."
+          "text": "In a multiplayer game, the ability checks whether you're the defending player for each individual attacking creature. For example, if one creature attacks you and two creatures attack another player, Kazuul's ability triggers just once."
         }
       ],
       "subtypes": [
@@ -9347,27 +9348,27 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If you cast Ricochet Trap for {R}, you don’t have to target the blue spell an opponent cast."
+          "text": "If you cast Ricochet Trap for {R}, you don't have to target the blue spell an opponent cast."
         },
         {
           "date": "2010-03-01",
-          "text": "Ricochet Trap targets only the spell whose target will be changed. It doesn’t directly affect the original target of that spell or the new target of that spell."
+          "text": "Ricochet Trap targets only the spell whose target will be changed. It doesn't directly affect the original target of that spell or the new target of that spell."
         },
         {
           "date": "2010-03-01",
-          "text": "You don’t choose the new target for the spell until Ricochet Trap resolves. You must change the target if possible. However, you can’t change the target to an illegal target. If there are no legal targets to choose from, the target isn’t changed. It doesn’t matter if the original target of that spell has somehow become illegal itself."
+          "text": "You don't choose the new target for the spell until Ricochet Trap resolves. You must change the target if possible. However, you can't change the target to an illegal target. If there are no legal targets to choose from, the target isn't changed. It doesn't matter if the original target of that spell has somehow become illegal itself."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast Ricochet Trap targeting a spell that targets a spell on the stack (like Cancel does, for example), you can’t change that spell’s target to itself. You can, however, change that spell’s target to Ricochet Trap. If you do, that spell will be countered when it tries to resolve because Ricochet Trap will have left the stack by then."
+          "text": "If you cast Ricochet Trap targeting a spell that targets a spell on the stack (like Cancel does, for example), you can't change that spell's target to itself. You can, however, change that spell's target to Ricochet Trap. If you do, that spell will be countered when it tries to resolve because Ricochet Trap will have left the stack by then."
         },
         {
           "date": "2010-03-01",
-          "text": "If a spell targets multiple things, you can’t target it with Ricochet Trap, even if all but one of those targets have become illegal."
+          "text": "If a spell targets multiple things, you can't target it with Ricochet Trap, even if all but one of those targets have become illegal."
         },
         {
           "date": "2010-03-01",
-          "text": "If a spell targets the same player or object multiple times, you can’t target it with Ricochet Trap."
+          "text": "If a spell targets the same player or object multiple times, you can't target it with Ricochet Trap."
         }
       ],
       "subtypes": [
@@ -9474,11 +9475,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The effects of the spell happen in sequence. By the time Roiling Terrain checks how many land cards are in the affected player’s graveyard, the land Roiling Terrain destroyed is (most likely) already in that graveyard."
+          "text": "The effects of the spell happen in sequence. By the time Roiling Terrain checks how many land cards are in the affected player's graveyard, the land Roiling Terrain destroyed is (most likely) already in that graveyard."
         },
         {
           "date": "2013-07-01",
-          "text": "If the targeted land regenerates or has indestructible, Roiling Terrain still deals damage to the targeted land’s controller."
+          "text": "If the targeted land regenerates or has indestructible, Roiling Terrain still deals damage to the targeted land's controller."
         }
       ],
       "text": "Destroy target land, then Roiling Terrain deals damage to that land's controller equal to the number of land cards in that player's graveyard.",
@@ -9578,7 +9579,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If you cast a kicked spell, Rumbling Aftershocks’s ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
+          "text": "If you cast a kicked spell, Rumbling Aftershocks's ability triggers and goes on the stack on top of it. The ability will resolve before the spell does."
         },
         {
           "date": "2010-03-01",
@@ -9691,7 +9692,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The landfall ability checks for an action that has happened in the past. It doesn’t matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
+          "text": "The landfall ability checks for an action that has happened in the past. It doesn't matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
         },
         {
           "date": "2010-03-01",
@@ -9699,11 +9700,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The effect of this spell’s landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
+          "text": "The effect of this spell's landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
         },
         {
           "date": "2010-03-01",
-          "text": "You must choose two targets as you cast Searing Blaze: a player and a creature that player controls. If you can’t (because there are no creatures on the battlefield, perhaps), then you can’t cast the spell."
+          "text": "You must choose two targets as you cast Searing Blaze: a player and a creature that player controls. If you can't (because there are no creatures on the battlefield, perhaps), then you can't cast the spell."
         },
         {
           "date": "2010-03-01",
@@ -10006,23 +10007,23 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "This Trap doesn’t work the same way as other Traps. Rather than having an optional alternative cost, Stone Idol Trap has a mandatory cost-reduction ability."
+          "text": "This Trap doesn't work the same way as other Traps. Rather than having an optional alternative cost, Stone Idol Trap has a mandatory cost-reduction ability."
         },
         {
           "date": "2010-03-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast Stone Idol Trap during your opponent’s declare attackers step, the Construct token you put onto the battlefield will be able to block that turn."
+          "text": "If you cast Stone Idol Trap during your opponent's declare attackers step, the Construct token you put onto the battlefield will be able to block that turn."
         },
         {
           "date": "2010-03-01",
-          "text": "The Construct token isn’t exiled until the beginning of *your* end step. If you cast Stone Idol Trap during another player’s turn, the token remains on the battlefield after that player’s turn ends. During your next turn, it will no longer have “summoning sickness” and you’ll be able to attack with it. Then, at the beginning of that turn’s end step, it’ll be exiled."
+          "text": "The Construct token isn't exiled until the beginning of *your* end step. If you cast Stone Idol Trap during another player's turn, the token remains on the battlefield after that player's turn ends. During your next turn, it will no longer have \"summoning sickness\" and you'll be able to attack with it. Then, at the beginning of that turn's end step, it'll be exiled."
         },
         {
           "date": "2010-03-01",
-          "text": "The cost-reduction ability doesn’t care who controls the attacking creatures. If you like, you may cast Stone Idol Trap during your own combat phase, in which case it will count your attacking creatures. If you do, however, the token you put onto the battlefield will be unable to attack that combat and will be exiled later that turn."
+          "text": "The cost-reduction ability doesn't care who controls the attacking creatures. If you like, you may cast Stone Idol Trap during your own combat phase, in which case it will count your attacking creatures. If you do, however, the token you put onto the battlefield will be unable to attack that combat and will be exiled later that turn."
         }
       ],
       "subtypes": [
@@ -10125,11 +10126,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A token permanent that’s destroyed is put into its owner’s graveyard before it ceases to exist. If a token is destroyed by Tuktuk Scrapper’s ability, Tuktuk Scrapper deals damage to that token’s controller."
+          "text": "A token permanent that's destroyed is put into its owner's graveyard before it ceases to exist. If a token is destroyed by Tuktuk Scrapper's ability, Tuktuk Scrapper deals damage to that token's controller."
         },
         {
           "date": "2013-07-01",
-          "text": "If the targeted artifact hass indestructible or regenerates (or you choose not to destroy it), Tuktuk Scrapper doesn’t deal damage to that artifact’s controller. Similarly, if the targeted artifact is destroyed but a replacement effect moves it to a different zone instead of its owner’s graveyard, Tuktuk Scrapper doesn’t deal damage to that artifact’s controller."
+          "text": "If the targeted artifact hass indestructible or regenerates (or you choose not to destroy it), Tuktuk Scrapper doesn't deal damage to that artifact's controller. Similarly, if the targeted artifact is destroyed but a replacement effect moves it to a different zone instead of its owner's graveyard, Tuktuk Scrapper doesn't deal damage to that artifact's controller."
         }
       ],
       "subtypes": [
@@ -10338,7 +10339,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -10541,7 +10542,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "This is not the same as hexproof. If, for example, you target one of your opponent’s creatures, your opponents won’t be able to target their own creature with spells or abilities."
+          "text": "This is not the same as hexproof. If, for example, you target one of your opponent's creatures, your opponents won't be able to target their own creature with spells or abilities."
         }
       ],
       "subtypes": [
@@ -10647,15 +10648,15 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Explore’s effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don’t get to play a land as Explore resolves; Explore fully resolves first and draws a card, perhaps a land you’ll play later."
+          "text": "Explore's effect allows you to play an additional land during your main phase. Doing so follows the normal timing rules for playing lands. In particular, you don't get to play a land as Explore resolves; Explore fully resolves first and draws a card, perhaps a land you'll play later."
         },
         {
           "date": "2017-03-14",
-          "text": "The effects of multiple Explores in the same turn are cumulative. They’re also cumulative with other effects that let you play additional lands, such as the one from Urban Evolution."
+          "text": "The effects of multiple Explores in the same turn are cumulative. They're also cumulative with other effects that let you play additional lands, such as the one from Urban Evolution."
         },
         {
           "date": "2017-03-14",
-          "text": "If you somehow manage to cast Explore when it’s not your turn, you’ll draw a card when it resolves, but you won’t be able to play a land that turn."
+          "text": "If you somehow manage to cast Explore when it's not your turn, you'll draw a card when it resolves, but you won't be able to play a land that turn."
         }
       ],
       "text": "You may play an additional land this turn.\nDraw a card.",
@@ -10755,27 +10756,27 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "You must choose two targets as you cast Feral Contest: a creature you control and any other creature. If you can’t (because there’s only one creature on the battlefield, perhaps), then you can’t cast the spell. Note that the second target may also be a creature you control."
+          "text": "You must choose two targets as you cast Feral Contest: a creature you control and any other creature. If you can't (because there's only one creature on the battlefield, perhaps), then you can't cast the spell. Note that the second target may also be a creature you control."
         },
         {
           "date": "2010-03-01",
-          "text": "If just the first targeted creature is an illegal target by the time Feral Contest resolves, it won’t get a +1/+1 counter. However, the second targeted creature is still affected by the blocking restriction the spell imposes, so it’ll have to block the first targeted creature that turn if able."
+          "text": "If just the first targeted creature is an illegal target by the time Feral Contest resolves, it won't get a +1/+1 counter. However, the second targeted creature is still affected by the blocking restriction the spell imposes, so it'll have to block the first targeted creature that turn if able."
         },
         {
           "date": "2010-03-01",
-          "text": "If just the second targeted creature is an illegal target by the time Feral Contest resolves, the first targeted creature will get a +1/+1 counter, but the second targeted creature won’t have to block it that turn."
+          "text": "If just the second targeted creature is an illegal target by the time Feral Contest resolves, the first targeted creature will get a +1/+1 counter, but the second targeted creature won't have to block it that turn."
         },
         {
           "date": "2010-03-01",
-          "text": "Casting Feral Contest doesn’t force you to attack with the first targeted creature that turn. If that creature doesn’t attack, the second targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "Casting Feral Contest doesn't force you to attack with the first targeted creature that turn. If that creature doesn't attack, the second targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2010-03-01",
-          "text": "If you attack with the first targeted creature but the second targeted creature isn’t able to block it (for example, because the first targeted creature has flying and the second one doesn’t), the requirement to block does nothing. The second targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "If you attack with the first targeted creature but the second targeted creature isn't able to block it (for example, because the first targeted creature has flying and the second one doesn't), the requirement to block does nothing. The second targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2010-03-01",
-          "text": "Tapped creatures, creatures that can’t block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren’t controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Feral Contest, but the requirement to block does nothing."
+          "text": "Tapped creatures, creatures that can't block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren't controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Feral Contest, but the requirement to block does nothing."
         }
       ],
       "text": "Put a +1/+1 counter on target creature you control. Another target creature blocks it this turn if able.",
@@ -11185,7 +11186,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The landfall ability checks for an action that has happened in the past. It doesn’t matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
+          "text": "The landfall ability checks for an action that has happened in the past. It doesn't matter if a land that entered the battlefield under your control previously in the turn is still on the battlefield, is still under your control, or is still a land."
         },
         {
           "date": "2010-03-01",
@@ -11193,7 +11194,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "The effect of this spell’s landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
+          "text": "The effect of this spell's landfall ability replaces its normal effect. If you had a land enter the battlefield under your control this turn, only the landfall-based effect happens."
         }
       ],
       "text": "Target creature gets +2/+2 until end of turn.\nLandfall — If you had a land enter the battlefield under your control this turn, that creature gets +4/+4 until end of turn instead.",
@@ -11294,7 +11295,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Harabaz Druid’s activated ability is a mana ability, so it doesn’t use the stack and players can’t respond to it."
+          "text": "Harabaz Druid's activated ability is a mana ability, so it doesn't use the stack and players can't respond to it."
         }
       ],
       "subtypes": [
@@ -11608,7 +11609,7 @@
       "rulings": [
         {
           "date": "2016-06-08",
-          "text": "If the targeted artifact or enchantment is an illegal target when Nature’s Claim tries to resolve, the entire spell is countered. No one gains any life."
+          "text": "If the targeted artifact or enchantment is an illegal target when Nature's Claim tries to resolve, the entire spell is countered. No one gains any life."
         }
       ],
       "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
@@ -11714,7 +11715,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "If a green mana you add to your mana pool has certain restrictions or riders associated with it (for example, if it was produced by Ancient Ziggurat), they’ll apply to that mana no matter when you spend it."
+          "text": "If a green mana you add to your mana pool has certain restrictions or riders associated with it (for example, if it was produced by Ancient Ziggurat), they'll apply to that mana no matter when you spend it."
         },
         {
           "date": "2010-03-01",
@@ -11824,19 +11825,19 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Creatures put onto the battlefield tapped don’t cause Quest for Renewal’s first ability to trigger."
+          "text": "Creatures put onto the battlefield tapped don't cause Quest for Renewal's first ability to trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "As another player’s untap step begins, if there are four or more quest counters on Quest for Renewal, all your creatures untap during that untap step. You have no choice about what untaps. Those creatures untap at the same time as the active player’s permanents."
+          "text": "As another player's untap step begins, if there are four or more quest counters on Quest for Renewal, all your creatures untap during that untap step. You have no choice about what untaps. Those creatures untap at the same time as the active player's permanents."
         },
         {
           "date": "2010-03-01",
-          "text": "During another player’s untap step, effects that would otherwise cause your creatures to stay tapped don’t apply because they apply only during *your* untap step. For example, if you control a Quest for Renewal with four or more quest counters on it and a Deep-Slumber Titan (a creature that says “Deep-Slumber Titan doesn’t untap during your untap step”), you untap Deep-Slumber Titan during each other player’s untap step."
+          "text": "During another player's untap step, effects that would otherwise cause your creatures to stay tapped don't apply because they apply only during *your* untap step. For example, if you control a Quest for Renewal with four or more quest counters on it and a Deep-Slumber Titan (a creature that says \"Deep-Slumber Titan doesn't untap during your untap step\"), you untap Deep-Slumber Titan during each other player's untap step."
         },
         {
           "date": "2010-03-01",
-          "text": "Controlling more than one Quest for Renewal with four or more quest counters on it is redundant. You can’t untap your permanents more than once in a single untap step."
+          "text": "Controlling more than one Quest for Renewal with four or more quest counters on it is redundant. You can't untap your permanents more than once in a single untap step."
         }
       ],
       "text": "Whenever a creature you control becomes tapped, you may put a quest counter on Quest for Renewal.\nAs long as there are four or more quest counters on Quest for Renewal, untap all creatures you control during each other player's untap step.",
@@ -11940,7 +11941,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
         }
       ],
       "subtypes": [
@@ -12044,7 +12045,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -12151,7 +12152,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The number of targets you choose for Strength of the Tajuru is one more than the number of times it’s kicked. First you declare how many times you’re going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you’ll kick the spell and the time you choose the targets."
+          "text": "The number of targets you choose for Strength of the Tajuru is one more than the number of times it's kicked. First you declare how many times you're going to kick the spell (at the same time you declare the value of X), then you choose the targets accordingly, then you pay the costs. No player can respond between the time you declare how many times you'll kick the spell and the time you choose the targets."
         },
         {
           "date": "2010-03-01",
@@ -12159,11 +12160,11 @@
         },
         {
           "date": "2010-03-01",
-          "text": "For example, if you want to put four +1/+1 counters on each of three different targets, that means X is 4 and you’re kicking the spell twice. You’ll pay a mana cost of {4}{G}{G}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{G}{G}."
+          "text": "For example, if you want to put four +1/+1 counters on each of three different targets, that means X is 4 and you're kicking the spell twice. You'll pay a mana cost of {4}{G}{G}, plus a kicker cost of {1}, plus another kicker cost of {1}, for a total of {6}{G}{G}."
         },
         {
           "date": "2010-03-01",
-          "text": "As long as any of its targets are legal at the time Strength of the Tajuru resolves, you’ll put X +1/+1 counters on each of those legal targets."
+          "text": "As long as any of its targets are legal at the time Strength of the Tajuru resolves, you'll put X +1/+1 counters on each of those legal targets."
         }
       ],
       "text": "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\nChoose target creature, then choose another target creature for each time Strength of the Tajuru was kicked. Put X +1/+1 counters on each of them.",
@@ -12264,7 +12265,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Whether you control a Mountain matters only as the defending player declares blockers. Once it’s blocked, gaining or losing control of a Mountain won’t affect Summit Apes’s blockers."
+          "text": "Whether you control a Mountain matters only as the defending player declares blockers. Once it's blocked, gaining or losing control of a Mountain won't affect Summit Apes's blockers."
         }
       ],
       "subtypes": [
@@ -12378,7 +12379,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If a targeted permanent has indestructible or regenerates, its controller won’t get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner’s graveyard, its controller won’t get an Elephant token for it."
+          "text": "If a targeted permanent has indestructible or regenerates, its controller won't get an Elephant token for it. Similarly, if the targeted permanent is destroyed but a replacement effect moves it to a different zone instead of its owner's graveyard, its controller won't get an Elephant token for it."
         }
       ],
       "subtypes": [
@@ -12483,19 +12484,19 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "The value of X is determined as Vastwood Animist’s activated ability resolves. The power and toughness of the Elemental won’t change if the number of Allies you control changes later in the turn."
+          "text": "The value of X is determined as Vastwood Animist's activated ability resolves. The power and toughness of the Elemental won't change if the number of Allies you control changes later in the turn."
         },
         {
           "date": "2010-03-01",
-          "text": "If you control no Allies when the ability resolves, the land becomes a 0/0 creature and is put into its owner’s graveyard as a state-based action. However, since Vastwood Animist is itself an Ally, the land will usually be at least a 1/1."
+          "text": "If you control no Allies when the ability resolves, the land becomes a 0/0 creature and is put into its owner's graveyard as a state-based action. However, since Vastwood Animist is itself an Ally, the land will usually be at least a 1/1."
         }
       ],
       "subtypes": [
@@ -12605,7 +12606,7 @@
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-03-01",
@@ -12613,15 +12614,15 @@
         },
         {
           "date": "2010-03-01",
-          "text": "An ability that turns a land into a creature also sets that creature’s power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "An ability that turns a land into a creature also sets that creature's power and toughness. If the land was already a creature, this will overwrite the previous effect that set its power and toughness. Effects that modify its power or toughness, such as the effects of Disfigure or Glorious Anthem, will continue to apply, no matter when they started to take effect. The same is true for counters that change its power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon and the land it’s enchanting are destroyed at the same time (due to Akroma’s Vengeance, for example), the Zendikon’s last ability will still trigger."
+          "text": "If a Zendikon and the land it's enchanting are destroyed at the same time (due to Akroma's Vengeance, for example), the Zendikon's last ability will still trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "If a Zendikon’s last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
+          "text": "If a Zendikon's last ability triggers, but the land card it refers to leaves the graveyard before it resolves, it will resolve but do nothing."
         }
       ],
       "subtypes": [
@@ -12829,15 +12830,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Novablast Wurm’s ability triggers and resolves during the declare attackers step, before blockers can be declared."
+          "text": "Novablast Wurm's ability triggers and resolves during the declare attackers step, before blockers can be declared."
         },
         {
           "date": "2010-03-01",
-          "text": "Novablast Wurm’s ability destroys all players’ creatures (except Novablast Wurm), including yours."
+          "text": "Novablast Wurm's ability destroys all players' creatures (except Novablast Wurm), including yours."
         },
         {
           "date": "2010-03-01",
-          "text": "If two Novablast Wurms attack, they’ll destroy each other. This happens before they can deal combat damage."
+          "text": "If two Novablast Wurms attack, they'll destroy each other. This happens before they can deal combat damage."
         }
       ],
       "subtypes": [
@@ -12944,19 +12945,19 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If you want to cast the targeted card, you cast it as part of the resolution of Wrexial’s triggered ability. Timing restrictions based on the card’s type are ignored. Other restrictions are not (such as “Cast [this card] only during your end step”)."
+          "text": "If you want to cast the targeted card, you cast it as part of the resolution of Wrexial's triggered ability. Timing restrictions based on the card's type are ignored. Other restrictions are not (such as \"Cast [this card] only during your end step\")."
         },
         {
           "date": "2010-03-01",
-          "text": "If you are unable to cast the targeted card (there are no legal targets for the spell, for example), nothing happens when the ability resolves, and the card remains in its owner’s graveyard."
+          "text": "If you are unable to cast the targeted card (there are no legal targets for the spell, for example), nothing happens when the ability resolves, and the card remains in its owner's graveyard."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. On the other hand, if the card has additional costs (such as kicker or multikicker), you may pay those."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. On the other hand, if the card has additional costs (such as kicker or multikicker), you may pay those."
         },
         {
           "date": "2010-03-01",
-          "text": "If you cast the targeted card and it would be put into its owner’s graveyard from the stack for any reason (either because it resolves or because it’s countered), that card is exiled instead."
+          "text": "If you cast the targeted card and it would be put into its owner's graveyard from the stack for any reason (either because it resolves or because it's countered), that card is exiled instead."
         }
       ],
       "subtypes": [
@@ -13057,11 +13058,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "If you control more than one Amulet of Vigor, each Amulet’s ability triggers when a permanent enters the battlefield tapped and under your control. The first ability that resolves will untap that permanent. If the permanent somehow becomes tapped again before the next ability resolves, the next ability will untap it as well (and so on)."
+          "text": "If you control more than one Amulet of Vigor, each Amulet's ability triggers when a permanent enters the battlefield tapped and under your control. The first ability that resolves will untap that permanent. If the permanent somehow becomes tapped again before the next ability resolves, the next ability will untap it as well (and so on)."
         },
         {
           "date": "2010-03-01",
-          "text": "For Amulet of Vigor’s ability to trigger, a permanent must enter the battlefield tapped due to an effect that says “put [the permanent] onto the battlefield tapped,” “[this permanent] enters the battlefield tapped,” or the like. If it enters the battlefield untapped, the ability won’t trigger, even if you tap that permanent afterward."
+          "text": "For Amulet of Vigor's ability to trigger, a permanent must enter the battlefield tapped due to an effect that says \"put [the permanent] onto the battlefield tapped,\" \"[this permanent] enters the battlefield tapped,\" or the like. If it enters the battlefield untapped, the ability won't trigger, even if you tap that permanent afterward."
         }
       ],
       "text": "Whenever a permanent enters the battlefield tapped and under your control, untap it.",
@@ -13438,7 +13439,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -13638,15 +13639,15 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The ability affects each spell that’s not an artifact spell, including your own."
+          "text": "The ability affects each spell that's not an artifact spell, including your own."
         },
         {
           "date": "2010-03-01",
-          "text": "The ability affects the total cost of each nonartifact spell, but it doesn’t change that spell’s mana cost or converted mana cost. The extra mana also doesn’t change how many times you kicked the spell or what the value of X is (if applicable)."
+          "text": "The ability affects the total cost of each nonartifact spell, but it doesn't change that spell's mana cost or converted mana cost. The extra mana also doesn't change how many times you kicked the spell or what the value of X is (if applicable)."
         },
         {
           "date": "2010-03-01",
-          "text": "When determining a spell’s total cost, effects that increase the cost are applied before effects that reduce the cost."
+          "text": "When determining a spell's total cost, effects that increase the cost are applied before effects that reduce the cost."
         }
       ],
       "subtypes": [
@@ -13853,19 +13854,19 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The source of the damage is Razor Boomerang, not the equipped creature. However, the equipped creature’s ability is what targets the creature or player. If Razor Boomerang is equipped to a red creature, for example, the ability couldn’t target a creature with protection from red. It could target a creature with protection from artifacts, but all the damage would be prevented."
+          "text": "The source of the damage is Razor Boomerang, not the equipped creature. However, the equipped creature's ability is what targets the creature or player. If Razor Boomerang is equipped to a red creature, for example, the ability couldn't target a creature with protection from red. It could target a creature with protection from artifacts, but all the damage would be prevented."
         },
         {
           "date": "2010-03-01",
-          "text": "Unattaching Razor Boomerang is a cost to activate the equipped creature’s ability."
+          "text": "Unattaching Razor Boomerang is a cost to activate the equipped creature's ability."
         },
         {
           "date": "2010-03-01",
-          "text": "If Razor Boomerang is no longer on the battlefield by time the equipped creature’s ability resolves, it’s not returned to its owner’s hand. The rest of the ability resolves as normal, so Razor Boomerang will still deal damage to the targeted creature."
+          "text": "If Razor Boomerang is no longer on the battlefield by time the equipped creature's ability resolves, it's not returned to its owner's hand. The rest of the ability resolves as normal, so Razor Boomerang will still deal damage to the targeted creature."
         },
         {
           "date": "2010-03-01",
-          "text": "If the targeted creature is an illegal target by the time the equipped creature’s ability resolves, the entire ability is countered. Razor Boomerang remains on the battlefield unattached."
+          "text": "If the targeted creature is an illegal target by the time the equipped creature's ability resolves, the entire ability is countered. Razor Boomerang remains on the battlefield unattached."
         }
       ],
       "subtypes": [
@@ -13967,7 +13968,7 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2010-03-01",
@@ -14070,11 +14071,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "The word “artifact” was inadvertently omitted from Walking Atlas’s type line. The card has received errata to correct this omission; it is an artifact creature."
+          "text": "The word \"artifact\" was inadvertently omitted from Walking Atlas's type line. The card has received errata to correct this omission; it is an artifact creature."
         },
         {
           "date": "2010-03-01",
-          "text": "Putting a land onto the battlefield as a result of Walking Atlas’s ability isn’t the same as playing a land. You may do put a land onto the battlefield even if it’s an opponent’s turn or you’ve played a land this turn. Similarly, putting a land onto the battlefield during your turn doesn’t preclude you from playing a land later in that turn."
+          "text": "Putting a land onto the battlefield as a result of Walking Atlas's ability isn't the same as playing a land. You may do put a land onto the battlefield even if it's an opponent's turn or you've played a land this turn. Similarly, putting a land onto the battlefield during your turn doesn't preclude you from playing a land later in that turn."
         }
       ],
       "subtypes": [
@@ -14267,11 +14268,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         }
       ],
       "text": "Celestial Colonnade enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.\n{3}{W}{U}: Until end of turn, Celestial Colonnade becomes a 4/4 white and blue Elemental creature with flying and vigilance. It's still a land.",
@@ -14366,11 +14367,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         }
       ],
       "text": "Creeping Tar Pit enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.\n{1}{U}{B}: Creeping Tar Pit becomes a 3/2 blue and black Elemental creature until end of turn and can't be blocked this turn. It's still a land.",
@@ -14464,11 +14465,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{4}: Dread Statuary becomes a 4/2 Golem artifact creature until end of turn. It's still a land.",
@@ -14562,11 +14563,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Eye of Ugin doesn’t have a mana ability."
+          "text": "Eye of Ugin doesn't have a mana ability."
         },
         {
           "date": "2010-03-01",
-          "text": "Eye of Ugin’s second ability lets you find any colorless creature card in your deck, such as an artifact creature card that has no colored mana symbols in its mana cost, or a creature card that’s become colorless due to Mycosynth Lattice."
+          "text": "Eye of Ugin's second ability lets you find any colorless creature card in your deck, such as an artifact creature card that has no colored mana symbols in its mana cost, or a creature card that's become colorless due to Mycosynth Lattice."
         },
         {
           "date": "2013-04-15",
@@ -14850,11 +14851,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         }
       ],
       "text": "Lavaclaw Reaches enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.\n{1}{B}{R}: Until end of turn, Lavaclaw Reaches becomes a 2/2 black and red Elemental creature with \"{X}: This creature gets +X/+0 until end of turn.\" It's still a land.",
@@ -15043,19 +15044,19 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         },
         {
           "date": "2010-03-01",
-          "text": "Each time you activate Raging Ravine’s last ability, it gains an instance of the triggered ability “Whenever this creature attacks, put a +1/+1 counter on it.” For example, if you activate the last ability twice and then attack with Raging Ravine, both of the triggered abilities it gained will trigger. It will get a total of two +1/+1 counters."
+          "text": "Each time you activate Raging Ravine's last ability, it gains an instance of the triggered ability \"Whenever this creature attacks, put a +1/+1 counter on it.\" For example, if you activate the last ability twice and then attack with Raging Ravine, both of the triggered abilities it gained will trigger. It will get a total of two +1/+1 counters."
         },
         {
           "date": "2010-03-01",
-          "text": "Any +1/+1 counters put on Raging Ravine remain on it even after it stops being a creature. They’ll have no effect until it becomes a creature again."
+          "text": "Any +1/+1 counters put on Raging Ravine remain on it even after it stops being a creature. They'll have no effect until it becomes a creature again."
         }
       ],
       "text": "Raging Ravine enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.\n{2}{R}{G}: Until end of turn, Raging Ravine becomes a 3/3 red and green Elemental creature with \"Whenever this creature attacks, put a +1/+1 counter on it.\" It's still a land.",
@@ -15329,11 +15330,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "A land that becomes a creature may be affected by “summoning sickness.” You can’t attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
+          "text": "A land that becomes a creature may be affected by \"summoning sickness.\" You can't attack with it or use any of its {T} abilities (including its mana abilities) unless it began your most recent turn on the battlefield under your control. Note that summoning sickness cares about when that permanent came under your control, not when it became a creature."
         },
         {
           "date": "2010-03-01",
-          "text": "When a land becomes a creature, that doesn’t count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won’t trigger."
+          "text": "When a land becomes a creature, that doesn't count as having a creature enter the battlefield. The permanent was already on the battlefield; it only changed its types. Abilities that trigger whenever a creature enters the battlefield won't trigger."
         }
       ],
       "text": "Stirring Wildwood enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.\n{1}{G}{W}: Until end of turn, Stirring Wildwood becomes a 3/4 green and white Elemental creature with reach. It's still a land.",
@@ -15428,11 +15429,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Tectonic Edge’s second ability checks how many lands an opponent controls only at the time you activate the ability."
+          "text": "Tectonic Edge's second ability checks how many lands an opponent controls only at the time you activate the ability."
         },
         {
           "date": "2010-03-01",
-          "text": "Assuming you can activate Tectonic Edge’s second ability, you can target any nonbasic land with it (not just one controlled by an opponent that controls four or more lands)."
+          "text": "Assuming you can activate Tectonic Edge's second ability, you can target any nonbasic land with it (not just one controlled by an opponent that controls four or more lands)."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{1}, {T}, Sacrifice Tectonic Edge: Destroy target nonbasic land. Activate this ability only if an opponent controls four or more lands.",

--- a/json/ZEN.json
+++ b/json/ZEN.json
@@ -231,11 +231,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -349,7 +349,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature doesn’t have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won’t prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
+          "text": "If a creature doesn't have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won't prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
         }
       ],
       "text": "Kicker {3}{W} (You may pay an additional {3}{W} as you cast this spell.)\nCreatures you control get +1/+1 until end of turn. If Bold Defense was kicked, instead creatures you control get +2/+2 and gain first strike until end of turn.",
@@ -452,11 +452,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You choose a color as Brave the Elements resolves. Once the color is chosen, it’s too late for players to respond."
+          "text": "You choose a color as Brave the Elements resolves. Once the color is chosen, it's too late for players to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "Only white creatures you control at the time Brave the Elements resolves gain the protection ability. Creatures that come under your control later in the turn, or that turn white later in the turn, won’t have it."
+          "text": "Only white creatures you control at the time Brave the Elements resolves gain the protection ability. Creatures that come under your control later in the turn, or that turn white later in the turn, won't have it."
         }
       ],
       "text": "Choose a color. White creatures you control gain protection from the chosen color until end of turn.",
@@ -655,23 +655,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "At the time the ability triggers, determine which creature Celestial Mantle is enchanting. As the ability resolves, determine who currently controls that creature (or, if it’s no longer on the battlefield, determine who controlled it when it left). That’s the player whose life total is doubled. It doesn’t matter who controls Celestial Mantle, who controlled the creature at the time the ability triggered, or what creature Celestial Mantle enchants at the time the ability resolves."
+          "text": "At the time the ability triggers, determine which creature Celestial Mantle is enchanting. As the ability resolves, determine who currently controls that creature (or, if it's no longer on the battlefield, determine who controlled it when it left). That's the player whose life total is doubled. It doesn't matter who controls Celestial Mantle, who controlled the creature at the time the ability triggered, or what creature Celestial Mantle enchants at the time the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "If a creature dealing combat damage at the same time as the enchanted creature has lifelink, the life gained due to lifelink happens before Celestial Mantle’s triggered ability resolves."
+          "text": "If a creature dealing combat damage at the same time as the enchanted creature has lifelink, the life gained due to lifelink happens before Celestial Mantle's triggered ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "If the enchanted creature’s controller has a life total below 0 (which is possible if that player controls Platinum Angel, for example), Celestial Mantle’s triggered ability multiplies that number by two. For example, if the player had -4 life, that player’s life total becomes -8."
+          "text": "If the enchanted creature's controller has a life total below 0 (which is possible if that player controls Platinum Angel, for example), Celestial Mantle's triggered ability multiplies that number by two. For example, if the player had -4 life, that player's life total becomes -8."
         },
         {
           "date": "2009-10-01",
-          "text": "If a player’s life total is doubled, that player actually gains or loses the necessary amount of life. For example, if the life total of the enchanted creature’s controller is 14 when Celestial Mantle’s triggered ability resolves, the ability causes that player to gain 14 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "If a player's life total is doubled, that player actually gains or loses the necessary amount of life. For example, if the life total of the enchanted creature's controller is 14 when Celestial Mantle's triggered ability resolves, the ability causes that player to gain 14 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, Celestial Mantle’s essentially doubles the team’s life total. Specifically, the triggered ability will affect one player’s life total, and then the team’s life total is adjusted by the amount of life the player gains as a result of this ability. Suppose a creature enchanted by Celestial Mantle deals combat damage to an opponent, and that creature’s controller’s team has 11 life. That player then has 11 life, so it’s doubled to 22, for a net gain of 11 life. The team’s life total becomes 22 (11 + 11)."
+          "text": "In a Two-Headed Giant game, Celestial Mantle's essentially doubles the team's life total. Specifically, the triggered ability will affect one player's life total, and then the team's life total is adjusted by the amount of life the player gains as a result of this ability. Suppose a creature enchanted by Celestial Mantle deals combat damage to an opponent, and that creature's controller's team has 11 life. That player then has 11 life, so it's doubled to 22, for a net gain of 11 life. The team's life total becomes 22 (11 + 11)."
         }
       ],
       "subtypes": [
@@ -1066,7 +1066,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Devout Lightcaster’s triggered ability isn’t optional. When it enters the battlefield, if you’re the only player that controls a black permanent, you’ll have to target a black permanent you control."
+          "text": "Devout Lightcaster's triggered ability isn't optional. When it enters the battlefield, if you're the only player that controls a black permanent, you'll have to target a black permanent you control."
         }
       ],
       "subtypes": [
@@ -1173,7 +1173,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -1292,11 +1292,11 @@
       "rulings": [
         {
           "date": "2015-08-25",
-          "text": "Felidar Sovereign’s triggered ability checks to see if you have 40 or more life as your upkeep begins. If you don’t, the ability won’t trigger at all. If you do, the ability will check again as it tries to resolve. If you don’t have 40 or more life at that time, the ability won’t do anything."
+          "text": "Felidar Sovereign's triggered ability checks to see if you have 40 or more life as your upkeep begins. If you don't, the ability won't trigger at all. If you do, the ability will check again as it tries to resolve. If you don't have 40 or more life at that time, the ability won't do anything."
         },
         {
           "date": "2015-08-25",
-          "text": "In a Two-Headed Giant game, your life total is the same as your team’s life total. As such, the ability triggers if your team has 40 or more life."
+          "text": "In a Two-Headed Giant game, your life total is the same as your team's life total. As such, the ability triggers if your team has 40 or more life."
         }
       ],
       "subtypes": [
@@ -1404,11 +1404,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Iona’s third ability includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It does not include lands or abilities (such as cycling or unearth)."
+          "text": "Iona's third ability includes permanent spells (artifacts, creatures, enchantments, and planeswalkers), not just instant and sorcery spells. It does not include lands or abilities (such as cycling or unearth)."
         },
         {
           "date": "2009-10-01",
-          "text": "Once the color is chosen, it’s too late for opponents to respond by casting spells of that color. Iona is not yet in the battlefield at the time the color is chosen, so, for example, there’s no way for an opponent to destroy it by casting Doom Blade if the chosen color is black."
+          "text": "Once the color is chosen, it's too late for opponents to respond by casting spells of that color. Iona is not yet in the battlefield at the time the color is chosen, so, for example, there's no way for an opponent to destroy it by casting Doom Blade if the chosen color is black."
         }
       ],
       "subtypes": [
@@ -1616,7 +1616,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You choose a color (or choose not to) as the triggered ability resolves. Once the color is chosen, it’s too late for players to respond."
+          "text": "You choose a color (or choose not to) as the triggered ability resolves. Once the color is chosen, it's too late for players to respond."
         }
       ],
       "subtypes": [
@@ -2137,7 +2137,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Kor Hookmaster’s ability can target a creature that’s already tapped. It still won’t untap during its controller’s next untap step."
+          "text": "Kor Hookmaster's ability can target a creature that's already tapped. It still won't untap during its controller's next untap step."
         }
       ],
       "subtypes": [
@@ -2247,7 +2247,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If either target is illegal by the time the ability resolves, the ability won’t do anything. If both targets are illegal, the ability is countered."
+          "text": "If either target is illegal by the time the ability resolves, the ability won't do anything. If both targets are illegal, the ability is countered."
         }
       ],
       "subtypes": [
@@ -2460,7 +2460,7 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "Kor Skyfisher’s triggered ability doesn’t target a permanent. You choose which one to return to its owner’s hand as the ability resolves. No one can respond to the choice."
+          "text": "Kor Skyfisher's triggered ability doesn't target a permanent. You choose which one to return to its owner's hand as the ability resolves. No one can respond to the choice."
         },
         {
           "date": "2017-03-14",
@@ -2662,23 +2662,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Luminarch Ascension’s first ability has an “intervening ‘if’ clause.” It checks whether you’ve lost life during the turn both as it would trigger and as it resolves."
+          "text": "Luminarch Ascension's first ability has an \"intervening 'if' clause.\" It checks whether you've lost life during the turn both as it would trigger and as it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "Life lost during the end step after Luminarch Ascension’s first ability resolves has no bearing on it."
+          "text": "Life lost during the end step after Luminarch Ascension's first ability resolves has no bearing on it."
         },
         {
           "date": "2009-10-01",
-          "text": "Luminarch Ascension’s first ability checks only whether life was lost. It doesn’t care whether life was also gained. For example, if you lost 4 life and gained 6 life during the turn, you’ll have a higher life total than you started the turn with — but Luminarch Ascension’s first ability won’t trigger."
+          "text": "Luminarch Ascension's first ability checks only whether life was lost. It doesn't care whether life was also gained. For example, if you lost 4 life and gained 6 life during the turn, you'll have a higher life total than you started the turn with — but Luminarch Ascension's first ability won't trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "Luminarch Ascension’s second ability checks how many quest counters are on it only at the time you activate the ability. Once activated, the ability will resolve as normal even if quest counters are removed from Luminarch Ascension."
+          "text": "Luminarch Ascension's second ability checks how many quest counters are on it only at the time you activate the ability. Once activated, the ability will resolve as normal even if quest counters are removed from Luminarch Ascension."
         },
         {
           "date": "2009-10-01",
-          "text": "In a Two-Headed Giant game, Luminarch Ascension’s first ability will trigger twice at the beginning of the opposing team’s end step if you didn’t lose life that turn. If both abilities resolve, it will get two quest counters. (It doesn’t matter whether your teammate lost life or not.)"
+          "text": "In a Two-Headed Giant game, Luminarch Ascension's first ability will trigger twice at the beginning of the opposing team's end step if you didn't lose life that turn. If both abilities resolve, it will get two quest counters. (It doesn't matter whether your teammate lost life or not.)"
         }
       ],
       "text": "At the beginning of each opponent's end step, if you didn't lose life this turn, you may put a quest counter on Luminarch Ascension. (Damage causes loss of life.)\n{1}{W}: Create a 4/4 white Angel creature token with flying. Activate this ability only if Luminarch Ascension has four or more quest counters on it.",
@@ -3384,11 +3384,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -3494,15 +3494,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you cast a creature spell, Quest for the Holy Relic’s triggered ability triggers and goes on the stack on top of it. The triggered ability will resolve before the spell does."
+          "text": "If you cast a creature spell, Quest for the Holy Relic's triggered ability triggers and goes on the stack on top of it. The triggered ability will resolve before the spell does."
         },
         {
           "date": "2009-10-01",
-          "text": "The activated ability doesn’t target the creature the Equipment will be attached to. It may be attached to a creature with shroud, for example. You don’t choose which creature it will be attached to until you actually attach it. Once you choose which creature to attach it to, it’s too late for players to respond."
+          "text": "The activated ability doesn't target the creature the Equipment will be attached to. It may be attached to a creature with shroud, for example. You don't choose which creature it will be attached to until you actually attach it. Once you choose which creature to attach it to, it's too late for players to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "You may activate Quest for the Holy Relic’s activated ability even if you control no creatures, or you control no creatures that can be equipped. In that case, you’ll simply put the Equipment card you find onto the battlefield without attaching it to anything."
+          "text": "You may activate Quest for the Holy Relic's activated ability even if you control no creatures, or you control no creatures that can be equipped. In that case, you'll simply put the Equipment card you find onto the battlefield without attaching it to anything."
         }
       ],
       "text": "Whenever you cast a creature spell, you may put a quest counter on Quest for the Holy Relic.\nRemove five quest counters from Quest for the Holy Relic and sacrifice it: Search your library for an Equipment card, put it onto the battlefield, and attach it to a creature you control. Then shuffle your library.",
@@ -3796,7 +3796,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -3903,7 +3903,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -4008,7 +4008,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You must target two creatures you control as you cast Windborne Charge. If you can’t (because you control just one creature, perhaps), you can’t cast the spell."
+          "text": "You must target two creatures you control as you cast Windborne Charge. If you can't (because you control just one creature, perhaps), you can't cast the spell."
         }
       ],
       "text": "Two target creatures you control each get +2/+2 and gain flying until end of turn.",
@@ -4109,11 +4109,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You don’t choose a card type until the ability resolves. Once you choose a type, it’s too late for players to respond."
+          "text": "You don't choose a card type until the ability resolves. Once you choose a type, it's too late for players to respond."
         },
         {
           "date": "2009-10-01",
-          "text": "First you choose which permanent you’ll sacrifice (if you control any of the chosen type), then each other player in turn order does the same, then all chosen permanents are sacrificed at the same time."
+          "text": "First you choose which permanent you'll sacrifice (if you control any of the chosen type), then each other player in turn order does the same, then all chosen permanents are sacrificed at the same time."
         },
         {
           "date": "2013-07-01",
@@ -4318,11 +4318,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -4330,19 +4330,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Archive Trap checks only whether an opponent searched his or her library. It doesn’t matter whether that player found a card during the search."
+          "text": "Archive Trap checks only whether an opponent searched his or her library. It doesn't matter whether that player found a card during the search."
         },
         {
           "date": "2009-10-01",
-          "text": "A spell or ability causes a player to search his or her library only if it specifically contains the word “search” in its text. For example, if a spell or ability lets a player look at the top four cards of his or her library and do something with one of those cards, that’s not a search."
+          "text": "A spell or ability causes a player to search his or her library only if it specifically contains the word \"search\" in its text. For example, if a spell or ability lets a player look at the top four cards of his or her library and do something with one of those cards, that's not a search."
         },
         {
           "date": "2009-10-01",
-          "text": "If a search effect is affected by Aven Mindcensor’s ability (which causes a player to search the top four cards of his or her library instead), that still counts as searching that library."
+          "text": "If a search effect is affected by Aven Mindcensor's ability (which causes a player to search the top four cards of his or her library instead), that still counts as searching that library."
         },
         {
           "date": "2009-10-01",
-          "text": "The opponent you target doesn’t have to be the opponent who searched his or her library."
+          "text": "The opponent you target doesn't have to be the opponent who searched his or her library."
         },
         {
           "date": "2009-10-01",
@@ -4448,19 +4448,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Archmage Ascension’s first ability has an “intervening ‘if’ clause.” It won’t trigger at all unless you’ve already drawn two or more cards by the time the end step begins."
+          "text": "Archmage Ascension's first ability has an \"intervening 'if' clause.\" It won't trigger at all unless you've already drawn two or more cards by the time the end step begins."
         },
         {
           "date": "2009-10-01",
-          "text": "If an effect would cause you to draw multiple cards while Archmage Ascension has six or more quest counters on it, each individual draw may be replaced by Archmage Ascension’s effect. Process the draws one at a time. Even if you use the reasonable shortcut of finding all of the cards at once and only physically shuffling once, the game will consider you to have searched and shuffled once per card."
+          "text": "If an effect would cause you to draw multiple cards while Archmage Ascension has six or more quest counters on it, each individual draw may be replaced by Archmage Ascension's effect. Process the draws one at a time. Even if you use the reasonable shortcut of finding all of the cards at once and only physically shuffling once, the game will consider you to have searched and shuffled once per card."
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word “draw,” Archmage Ascension’s abilities ignore it."
+          "text": "If a spell or ability causes you to put cards in your hand without specifically using the word \"draw,\" Archmage Ascension's abilities ignore it."
         },
         {
           "date": "2009-10-01",
-          "text": "If two or more replacement effects would apply to a card-drawing event, the player who’s drawing the card chooses what order to apply them. It’s possible that after applying one of them, the others will no longer be applicable because the player would no longer draw a card. For example, if you control more than one Archmage Ascension with six quest counters on it and you would draw a card, each Archmage Ascension’s replacement effect could apply. Once you use one, the rest are no longer applicable."
+          "text": "If two or more replacement effects would apply to a card-drawing event, the player who's drawing the card chooses what order to apply them. It's possible that after applying one of them, the others will no longer be applicable because the player would no longer draw a card. For example, if you control more than one Archmage Ascension with six quest counters on it and you would draw a card, each Archmage Ascension's replacement effect could apply. Once you use one, the rest are no longer applicable."
         }
       ],
       "text": "At the beginning of each end step, if you drew two or more cards this turn, you may put a quest counter on Archmage Ascension.\nAs long as Archmage Ascension has six or more quest counters on it, if you would draw a card, you may instead search your library for a card, put that card into your hand, then shuffle your library.",
@@ -4655,6 +4655,10 @@
           "legality": "Legal"
         },
         {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
           "format": "Time Spiral Block",
           "legality": "Legal"
         },
@@ -4791,15 +4795,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Cosi’s Trickster’s ability triggers when an opponent shuffles his or her library because that player was instructed to do so by a spell or ability that specifically contains the word “shuffle” in its text or (in the case of a keyword ability) in its rules."
+          "text": "Cosi's Trickster's ability triggers when an opponent shuffles his or her library because that player was instructed to do so by a spell or ability that specifically contains the word \"shuffle\" in its text or (in the case of a keyword ability) in its rules."
         },
         {
           "date": "2009-10-01",
-          "text": "The cascade ability doesn’t cause a player to shuffle his or her library, even if that player revealed his or her entire library. The revealed cards are put on the bottom of their owner’s library in a random order, but they’re not “shuffled.”"
+          "text": "The cascade ability doesn't cause a player to shuffle his or her library, even if that player revealed his or her entire library. The revealed cards are put on the bottom of their owner's library in a random order, but they're not \"shuffled.\""
         },
         {
           "date": "2009-10-01",
-          "text": "If an opponent’s library is empty or has just a single card in it when a spell or ability instructs that player to shuffle his or her library, Cosi’s Trickster’s ability will still trigger."
+          "text": "If an opponent's library is empty or has just a single card in it when a spell or ability instructs that player to shuffle his or her library, Cosi's Trickster's ability will still trigger."
         }
       ],
       "subtypes": [
@@ -4906,11 +4910,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Gomazoa’s ability can be activated any time its controller has priority. It doesn’t need to be blocking any creatures."
+          "text": "Gomazoa's ability can be activated any time its controller has priority. It doesn't need to be blocking any creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "If Gomazoa isn’t blocking a creature at the time its ability resolves, only Gomazoa is put on top of its owner’s library, and only that player shuffles his or her library."
+          "text": "If Gomazoa isn't blocking a creature at the time its ability resolves, only Gomazoa is put on top of its owner's library, and only that player shuffles his or her library."
         }
       ],
       "subtypes": [
@@ -5015,7 +5019,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -5125,7 +5129,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted permanent is an illegal target by the time Into the Roil resolves, the entire spell is countered. You don’t draw a card."
+          "text": "If the targeted permanent is an illegal target by the time Into the Roil resolves, the entire spell is countered. You don't draw a card."
         }
       ],
       "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If Into the Roil was kicked, draw a card.",
@@ -5225,7 +5229,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -5428,11 +5432,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -5640,15 +5644,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target any eight (or fewer) permanents. It’s okay if any of them are already tapped, and it’s okay if any of them are controlled by someone other than the defending player."
+          "text": "You may target any eight (or fewer) permanents. It's okay if any of them are already tapped, and it's okay if any of them are controlled by someone other than the defending player."
         },
         {
           "date": "2009-10-01",
-          "text": "If a targeted permanent is untapped at the time its controller’s next untap step begins, this ability has no effect on it. It won’t apply at some later time when the targeted permanent is tapped."
+          "text": "If a targeted permanent is untapped at the time its controller's next untap step begins, this ability has no effect on it. It won't apply at some later time when the targeted permanent is tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "If an affected permanent changes controllers before its old controller’s next untap step, this ability will prevent it from being untapped during its new controller’s next untap step."
+          "text": "If an affected permanent changes controllers before its old controller's next untap step, this ability will prevent it from being untapped during its new controller's next untap step."
         }
       ],
       "subtypes": [
@@ -5756,15 +5760,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A spell or ability counters a spell only if it specifically contains the word “counter” in its text. If a spell or ability you control causes all the targets of a spell to become illegal, that spell is countered by the game rules, not the spell or ability you control. For example, if you control Lullmage Mentor and cast Doom Blade to destroy a creature targeted by Giant Growth, you do not get a Merfolk token when the game rules counter Giant Growth."
+          "text": "A spell or ability counters a spell only if it specifically contains the word \"counter\" in its text. If a spell or ability you control causes all the targets of a spell to become illegal, that spell is countered by the game rules, not the spell or ability you control. For example, if you control Lullmage Mentor and cast Doom Blade to destroy a creature targeted by Giant Growth, you do not get a Merfolk token when the game rules counter Giant Growth."
         },
         {
           "date": "2009-10-01",
-          "text": "Lullmage Mentor’s second ability will cause its first ability to trigger."
+          "text": "Lullmage Mentor's second ability will cause its first ability to trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "Since the second ability doesn’t have a tap symbol in its cost, you can tap creatures (including Lullmage Mentor itself) that haven’t been under your control since your most recent turn began to pay the cost."
+          "text": "Since the second ability doesn't have a tap symbol in its cost, you can tap creatures (including Lullmage Mentor itself) that haven't been under your control since your most recent turn began to pay the cost."
         }
       ],
       "subtypes": [
@@ -5970,7 +5974,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are three or fewer cards in your library, you’ll reveal all of them."
+          "text": "If there are three or fewer cards in your library, you'll reveal all of them."
         }
       ],
       "subtypes": [
@@ -6075,11 +6079,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -6087,11 +6091,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Mindbreak Trap’s alternative cost condition checks whether an opponent cast three or more spells this turn, not whether those spells have resolved."
+          "text": "Mindbreak Trap's alternative cost condition checks whether an opponent cast three or more spells this turn, not whether those spells have resolved."
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell is exiled, it’s removed from the stack and thus will not resolve. The spell isn’t countered; it just no longer exists. This works on spells that can’t be countered, such as Terra Stomper."
+          "text": "If a spell is exiled, it's removed from the stack and thus will not resolve. The spell isn't countered; it just no longer exists. This works on spells that can't be countered, such as Terra Stomper."
         }
       ],
       "subtypes": [
@@ -6511,15 +6515,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Rite of Replication resolves, the entire spell is countered. You won’t get any tokens."
+          "text": "If the targeted creature is an illegal target by the time Rite of Replication resolves, the entire spell is countered. You won't get any tokens."
         },
         {
           "date": "2009-10-01",
-          "text": "As the token or tokens are created, they check the printed values of the creature they’re copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won’t copy counters on the creature, nor will it copy other effects that have changed the creature’s power, toughness, types, color, or so on."
+          "text": "As the token or tokens are created, they check the printed values of the creature they're copying — or, if that creature is itself a token, the original characteristics of that token as stated by the effect that put it onto the battlefield — as well as any copy effects that have been applied to it. It won't copy counters on the creature, nor will it copy other effects that have changed the creature's power, toughness, types, color, or so on."
         },
         {
           "date": "2009-10-01",
-          "text": "The tokens see each other enter the battlefield. If they have a triggered ability that triggers when a creature enters the battlefield, they’ll all trigger for one another."
+          "text": "The tokens see each other enter the battlefield. If they have a triggered ability that triggers when a creature enters the battlefield, they'll all trigger for one another."
         }
       ],
       "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nCreate a token that's a copy of target creature. If Rite of Replication was kicked, create five of those tokens instead.",
@@ -6620,7 +6624,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -6632,11 +6636,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Roil Elemental ceases to be under your control before its ability resolves, you won’t gain control of the targeted creature at all."
+          "text": "If Roil Elemental ceases to be under your control before its ability resolves, you won't gain control of the targeted creature at all."
         },
         {
           "date": "2009-10-01",
-          "text": "You may target a creature you already control with Roil Elemental’s ability. This will usually have no visible effect, but it will overwrite any previous control-change effects. For example, if you gain control of Roil Elemental until the end of the turn (with Mark of Mutiny, perhaps), then its landfall ability triggers and you target Roil Elemental itself, you’ll gain control of it indefinitely (since its control-change effect will last for as long as you control it)."
+          "text": "You may target a creature you already control with Roil Elemental's ability. This will usually have no visible effect, but it will overwrite any previous control-change effects. For example, if you gain control of Roil Elemental until the end of the turn (with Mark of Mutiny, perhaps), then its landfall ability triggers and you target Roil Elemental itself, you'll gain control of it indefinitely (since its control-change effect will last for as long as you control it)."
         }
       ],
       "subtypes": [
@@ -6949,7 +6953,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -7255,11 +7259,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Essentially, Sphinx of Jwar Isle lets you play with the top card of your library revealed only to you. Knowing what that card is becomes part of the information you have access to, just like you can look at the cards in your hand. You may look at the top card of your library whenever you want, even if you don’t have priority. This action doesn’t use the stack."
+          "text": "Essentially, Sphinx of Jwar Isle lets you play with the top card of your library revealed only to you. Knowing what that card is becomes part of the information you have access to, just like you can look at the cards in your hand. You may look at the top card of your library whenever you want, even if you don't have priority. This action doesn't use the stack."
         },
         {
           "date": "2009-10-01",
-          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, you can’t look at the new top card until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
+          "text": "If the top card of your library changes during the process of casting a spell or activating an ability, you can't look at the new top card until the process of casting the spell or activating the ability ends (all targets are chosen, all costs are paid, and so on)."
         }
       ],
       "subtypes": [
@@ -7467,7 +7471,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Island and has the ability to tap to add {U} to its controller’s mana pool. Spreading Seas doesn’t change the enchanted land’s name or whether it’s legendary, basic, or snow."
+          "text": "The enchanted land loses its existing land types and any abilities printed on it. It now has the land type Island and has the ability to tap to add {U} to its controller's mana pool. Spreading Seas doesn't change the enchanted land's name or whether it's legendary, basic, or snow."
         }
       ],
       "subtypes": [
@@ -7571,7 +7575,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell is an illegal target by the time Summoner’s Bane resolves, the entire spell is countered. You won’t get a creature token."
+          "text": "If the targeted spell is an illegal target by the time Summoner's Bane resolves, the entire spell is countered. You won't get a creature token."
         },
         {
           "date": "2009-10-01",
@@ -7675,7 +7679,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If Tempest Owl was kicked, you may target zero, one, two, or three permanents. They don’t have to be untapped."
+          "text": "If Tempest Owl was kicked, you may target zero, one, two, or three permanents. They don't have to be untapped."
         }
       ],
       "subtypes": [
@@ -8175,11 +8179,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -8187,7 +8191,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You must target two creatures as you cast Whiplash Trap. If you can’t (because just one creature is on the battlefield, perhaps), you can’t cast the spell."
+          "text": "You must target two creatures as you cast Whiplash Trap. If you can't (because just one creature is on the battlefield, perhaps), you can't cast the spell."
         },
         {
           "date": "2009-10-01",
@@ -8296,7 +8300,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -8408,7 +8412,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the number of Allies you control as the ability resolves is greater than the number of cards in the targeted player’s hand, that player reveals his or her entire hand. You choose one of the cards revealed this way and that player discards it."
+          "text": "If the number of Allies you control as the ability resolves is greater than the number of cards in the targeted player's hand, that player reveals his or her entire hand. You choose one of the cards revealed this way and that player discards it."
         }
       ],
       "subtypes": [
@@ -8516,7 +8520,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "Life loss is not the same as damage. Blood Seeker’s ability will not cause creatures with bloodthirst to enter the battlefield with +1/+1 counters."
+          "text": "Life loss is not the same as damage. Blood Seeker's ability will not cause creatures with bloodthirst to enter the battlefield with +1/+1 counters."
         }
       ],
       "subtypes": [
@@ -8620,7 +8624,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You can tap a creature that hasn’t been under your control since your most recent turn began to pay the kicker cost."
+          "text": "You can tap a creature that hasn't been under your control since your most recent turn began to pay the kicker cost."
         }
       ],
       "text": "Kicker—Tap an untapped Vampire you control. (You may tap a Vampire you control in addition to any other costs as you cast this spell.)\nTarget opponent loses half his or her life, rounded up. If Blood Tribute was kicked, you gain life equal to the life lost this way.",
@@ -8719,23 +8723,23 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Bloodchief Ascension’s first ability has an “intervening ‘if’ clause.” It won’t trigger at all unless an opponent has already lost 2 or more life by the time the end step begins."
+          "text": "Bloodchief Ascension's first ability has an \"intervening 'if' clause.\" It won't trigger at all unless an opponent has already lost 2 or more life by the time the end step begins."
         },
         {
           "date": "2009-10-01",
-          "text": "Bloodchief Ascension’s first ability checks how much life was lost by each opponent over the course of the entire turn, even if Bloodchief Ascension wasn’t on the battlefield the whole time."
+          "text": "Bloodchief Ascension's first ability checks how much life was lost by each opponent over the course of the entire turn, even if Bloodchief Ascension wasn't on the battlefield the whole time."
         },
         {
           "date": "2009-10-01",
-          "text": "For the first ability to trigger, a single opponent must have lost 2 life. Two opponents each losing 1 life won’t cause it to trigger. It will trigger a maximum of once per turn, no matter how many opponents have lost 2 or more life."
+          "text": "For the first ability to trigger, a single opponent must have lost 2 life. Two opponents each losing 1 life won't cause it to trigger. It will trigger a maximum of once per turn, no matter how many opponents have lost 2 or more life."
         },
         {
           "date": "2009-10-01",
-          "text": "Bloodchief Ascension’s first ability checks only whether life was lost. It doesn’t care whether life was also gained. For example, if an opponent lost 4 life and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Bloodchief Ascension’s first ability will still trigger."
+          "text": "Bloodchief Ascension's first ability checks only whether life was lost. It doesn't care whether life was also gained. For example, if an opponent lost 4 life and gained 6 life during the turn, that player will have a higher life total than he or she started the turn with — but Bloodchief Ascension's first ability will still trigger."
         },
         {
           "date": "2009-10-01",
-          "text": "Bloodchief Ascension’s second ability doesn’t behave like a leaves-the-battlefield triggered ability, since the card put into an opponent’s graveyard may come from anywhere. If a Bloodchief Ascension with three quest counters on it and a permanent an opponent owns are destroyed at the same time, for example, the game will not “look back in time” at the game state, and Bloodchief Ascension’s second ability won’t trigger."
+          "text": "Bloodchief Ascension's second ability doesn't behave like a leaves-the-battlefield triggered ability, since the card put into an opponent's graveyard may come from anywhere. If a Bloodchief Ascension with three quest counters on it and a permanent an opponent owns are destroyed at the same time, for example, the game will not \"look back in time\" at the game state, and Bloodchief Ascension's second ability won't trigger."
         }
       ],
       "text": "At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension. (Damage causes loss of life.)\nWhenever a card is put into an opponent's graveyard from anywhere, if Bloodchief Ascension has three or more quest counters on it, you may have that player lose 2 life. If you do, you gain 2 life.",
@@ -8835,7 +8839,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -8843,7 +8847,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Bloodghast’s landfall ability triggers only if it’s already in your graveyard at the time a land enters the battlefield under your control."
+          "text": "Bloodghast's landfall ability triggers only if it's already in your graveyard at the time a land enters the battlefield under your control."
         }
       ],
       "subtypes": [
@@ -9342,11 +9346,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Whether you control two or more Vampires is checked only as you try to move Feast of Blood to the stack as the first step of casting it. It doesn’t matter whether you still control two or more Vampires as you finish casting Feast of Blood (in case you somehow sacrifice one to produce mana) or as Feast of Blood resolves."
+          "text": "Whether you control two or more Vampires is checked only as you try to move Feast of Blood to the stack as the first step of casting it. It doesn't matter whether you still control two or more Vampires as you finish casting Feast of Blood (in case you somehow sacrifice one to produce mana) or as Feast of Blood resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Feast of Blood resolves, the entire spell is countered. You don’t gain life."
+          "text": "If the targeted creature is an illegal target by the time Feast of Blood resolves, the entire spell is countered. You don't gain life."
         }
       ],
       "text": "Cast Feast of Blood only if you control two or more Vampires.\nDestroy target creature. You gain 4 life.",
@@ -9844,11 +9848,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Intimidate looks at the current colors of a creature that has it. Normally, if Guul Draz Vampire has intimidate, it can’t be blocked except by artifact creatures and/or black creatures. If it’s turned white, then it can’t be blocked except by artifact creatures and/or white creatures."
+          "text": "Intimidate looks at the current colors of a creature that has it. Normally, if Guul Draz Vampire has intimidate, it can't be blocked except by artifact creatures and/or black creatures. If it's turned white, then it can't be blocked except by artifact creatures and/or white creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it’s blocked, changing its colors won’t change that."
+          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it's blocked, changing its colors won't change that."
         }
       ],
       "subtypes": [
@@ -9954,7 +9958,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -10170,15 +10174,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Intimidate looks at the current colors of a creature that has it. Normally, Halo Hunter can’t be blocked except by artifact creatures and/or black creatures. If it’s turned white, then it can’t be blocked except by artifact creatures and/or white creatures."
+          "text": "Intimidate looks at the current colors of a creature that has it. Normally, Halo Hunter can't be blocked except by artifact creatures and/or black creatures. If it's turned white, then it can't be blocked except by artifact creatures and/or white creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it’s blocked, changing its colors won’t change that."
+          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it's blocked, changing its colors won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "Halo Hunter’s triggered ability isn’t optional. When it enters the battlefield, if you’re the only player that controls an Angel, you’ll have to target an Angel you control."
+          "text": "Halo Hunter's triggered ability isn't optional. When it enters the battlefield, if you're the only player that controls an Angel, you'll have to target an Angel you control."
         }
       ],
       "subtypes": [
@@ -10490,11 +10494,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The power and toughness of the token are based on the destroyed creature’s last existence on the battlefield. The token doesn’t have any of the destroyed creature’s other characteristics."
+          "text": "The power and toughness of the token are based on the destroyed creature's last existence on the battlefield. The token doesn't have any of the destroyed creature's other characteristics."
         },
         {
           "date": "2013-07-01",
-          "text": "If the targeted creature has indestructible or regenerates, you won’t get a Vampire token. Similarly, if the targeted creature is destroyed but a replacement effect moves it to a different zone instead of its owner’s graveyard, you won’t get a Vampire token."
+          "text": "If the targeted creature has indestructible or regenerates, you won't get a Vampire token. Similarly, if the targeted creature is destroyed but a replacement effect moves it to a different zone instead of its owner's graveyard, you won't get a Vampire token."
         }
       ],
       "subtypes": [
@@ -10897,7 +10901,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Whether you control a Vampire matters only at the time you declare blockers. Once Mindless Null blocks a creature, that won’t change, even if all the Vampires you control leave the battlefield."
+          "text": "Whether you control a Vampire matters only at the time you declare blockers. Once Mindless Null blocks a creature, that won't change, even if all the Vampires you control leave the battlefield."
         }
       ],
       "subtypes": [
@@ -11001,11 +11005,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Mire Blight’s ability triggers when the enchanted creature is dealt any kind of damage, not just combat damage."
+          "text": "Mire Blight's ability triggers when the enchanted creature is dealt any kind of damage, not just combat damage."
         },
         {
           "date": "2009-10-01",
-          "text": "If Mire Blight’s ability triggers, the creature it was enchanting at that time is the one that will be destroyed when the ability resolves. It doesn’t matter if Mire Blight leaves the battlefield or somehow becomes attached to another creature by that time."
+          "text": "If Mire Blight's ability triggers, the creature it was enchanting at that time is the one that will be destroyed when the ability resolves. It doesn't matter if Mire Blight leaves the battlefield or somehow becomes attached to another creature by that time."
         }
       ],
       "subtypes": [
@@ -11108,11 +11112,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -11120,7 +11124,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Needlebite Trap’s alternative cost condition checks only whether life was gained. It doesn’t care whether life was also lost. For example, if an opponent gained 4 life and lost 6 life during the turn, that player will have a lower life total than he or she started the turn with — but you can still cast Needlebite Trap by paying {B}."
+          "text": "Needlebite Trap's alternative cost condition checks only whether life was gained. It doesn't care whether life was also lost. For example, if an opponent gained 4 life and lost 6 life during the turn, that player will have a lower life total than he or she started the turn with — but you can still cast Needlebite Trap by paying {B}."
         }
       ],
       "subtypes": [
@@ -11331,7 +11335,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -11442,7 +11446,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Quest for the Gravelord’s first ability triggers regardless of who controlled the creature and whose graveyard it was put into."
+          "text": "Quest for the Gravelord's first ability triggers regardless of who controlled the creature and whose graveyard it was put into."
         }
       ],
       "text": "Whenever a creature dies, you may put a quest counter on Quest for the Gravelord.\nRemove three quest counters from Quest for the Gravelord and sacrifice it: Create a 5/5 black Zombie Giant creature token.",
@@ -11541,11 +11545,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -11746,15 +11750,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Sorin’s first ability resolves, the entire ability is countered. You won’t gain life."
+          "text": "If the targeted creature or player is an illegal target by the time Sorin's first ability resolves, the entire ability is countered. You won't gain life."
         },
         {
           "date": "2009-10-01",
-          "text": "For a player’s life total to become 10, what actually happens is that the player gains or loses the appropriate amount of life. For example, if the targeted opponent’s life total is 4 when this ability resolves, it will cause that player to gain 6 life; alternately, if the targeted player’s life total is 17 when this ability resolves, it will cause that player to lose 7 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For a player's life total to become 10, what actually happens is that the player gains or loses the appropriate amount of life. For example, if the targeted opponent's life total is 4 when this ability resolves, it will cause that player to gain 6 life; alternately, if the targeted player's life total is 17 when this ability resolves, it will cause that player to lose 7 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2009-10-01",
-          "text": "Sorin’s third ability allows you to control another player. This effect applies to the next turn that the affected player actually takes."
+          "text": "Sorin's third ability allows you to control another player. This effect applies to the next turn that the affected player actually takes."
         },
         {
           "date": "2009-10-01",
@@ -11770,23 +11774,23 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t make the affected player concede. That player may choose to concede at any time, even while you’re controlling his or her turn."
+          "text": "You can't make the affected player concede. That player may choose to concede at any time, even while you're controlling his or her turn."
         },
         {
           "date": "2009-10-01",
-          "text": "You can’t make any illegal decisions or illegal choices — you can’t do anything that player couldn’t do. You can’t make choices or decisions for that player that aren’t called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the affected player would normally make (such as Master Warcraft does), that effect takes precedence. (In other words, if the affected player wouldn’t make a decision, you wouldn’t make that decision on his or her behalf.) You also can’t make any choices or decisions for the player that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
+          "text": "You can't make any illegal decisions or illegal choices — you can't do anything that player couldn't do. You can't make choices or decisions for that player that aren't called for by the game rules or by any cards, permanents, spells, abilities, and so on. If an effect causes another player to make decisions that the affected player would normally make (such as Master Warcraft does), that effect takes precedence. (In other words, if the affected player wouldn't make a decision, you wouldn't make that decision on his or her behalf.) You also can't make any choices or decisions for the player that would be called for by the tournament rules (such as whether to take an intentional draw or whether to call a judge)."
         },
         {
           "date": "2009-10-01",
-          "text": "You can use only the affected player’s resources (cards, mana, and so on) to pay costs for that player; you can’t use your own. Similarly, you can use the affected player’s resources only to pay that player’s costs; you can’t spend them on your costs."
+          "text": "You can use only the affected player's resources (cards, mana, and so on) to pay costs for that player; you can't use your own. Similarly, you can use the affected player's resources only to pay that player's costs; you can't spend them on your costs."
         },
         {
           "date": "2009-10-01",
-          "text": "You only control the player. You don’t control any of the other player’s permanents, spells, or abilities."
+          "text": "You only control the player. You don't control any of the other player's permanents, spells, or abilities."
         },
         {
           "date": "2009-10-01",
-          "text": "If the player affected by Sorin’s third ability skips his or her next turn, the ability will wait. You’ll control the next turn the affected player actually takes."
+          "text": "If the player affected by Sorin's third ability skips his or her next turn, the ability will wait. You'll control the next turn the affected player actually takes."
         },
         {
           "date": "2009-10-01",
@@ -11794,19 +11798,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You could gain control of yourself using Sorin’s third ability, but unless you do so to overwrite someone else’s player-controlling effect, this doesn’t do anything."
+          "text": "You could gain control of yourself using Sorin's third ability, but unless you do so to overwrite someone else's player-controlling effect, this doesn't do anything."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, Sorin’s second ability causes the targeted opponent’s team’s life total to become 10. Only the targeted player is actually considered to have actually gained or lost life."
+          "text": "In a Two-Headed Giant game, Sorin's second ability causes the targeted opponent's team's life total to become 10. Only the targeted player is actually considered to have actually gained or lost life."
         },
         {
           "date": "2016-07-13",
-          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player’s hand, face-down cards that player controls, and any cards in that player’s library the player may look at."
+          "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
         },
         {
           "date": "2016-07-13",
-          "text": "Controlling a player doesn’t allow you to look at that player’s sideboard. If an effect instructs that player to choose a card from outside the game, you can’t have that player choose any card."
+          "text": "Controlling a player doesn't allow you to look at that player's sideboard. If an effect instructs that player to choose a card from outside the game, you can't have that player choose any card."
         }
       ],
       "subtypes": [
@@ -11908,7 +11912,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -12012,15 +12016,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Intimidate looks at the current colors of a creature that has it. Normally, if Surrakar Marauder has intimidate, it can’t be blocked except by artifact creatures and/or black creatures. If it’s turned white, then it can’t be blocked except by artifact creatures and/or white creatures."
+          "text": "Intimidate looks at the current colors of a creature that has it. Normally, if Surrakar Marauder has intimidate, it can't be blocked except by artifact creatures and/or black creatures. If it's turned white, then it can't be blocked except by artifact creatures and/or white creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it’s blocked, changing its colors won’t change that."
+          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it's blocked, changing its colors won't change that."
         },
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -12135,7 +12139,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If all loyalty counters are removed from a planeswalker, that planeswalker is put into its owner’s graveyard as a state-based action."
+          "text": "If all loyalty counters are removed from a planeswalker, that planeswalker is put into its owner's graveyard as a state-based action."
         }
       ],
       "subtypes": [
@@ -12556,11 +12560,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Intimidate looks at the current colors of a creature that has it. Normally, Bladetusk Boar can’t be blocked except by artifact creatures and/or red creatures. If it’s turned blue, then it can’t be blocked except by artifact creatures and/or blue creatures."
+          "text": "Intimidate looks at the current colors of a creature that has it. Normally, Bladetusk Boar can't be blocked except by artifact creatures and/or red creatures. If it's turned blue, then it can't be blocked except by artifact creatures and/or blue creatures."
         },
         {
           "date": "2009-10-01",
-          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it’s blocked, changing its colors won’t change that."
+          "text": "If an attacking creature has intimidate, what colors it is matters only as the defending player declares blockers. Once it's blocked, changing its colors won't change that."
         }
       ],
       "subtypes": [
@@ -12759,27 +12763,27 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you activate Chandra Ablaze’s first ability, you don’t discard a card until the ability resolves. You may activate the ability even if your hand is empty. You choose a target as you activate the ability even if you have no red cards in hand at that time."
+          "text": "If you activate Chandra Ablaze's first ability, you don't discard a card until the ability resolves. You may activate the ability even if your hand is empty. You choose a target as you activate the ability even if you have no red cards in hand at that time."
         },
         {
           "date": "2009-10-01",
-          "text": "As the first ability resolves, nothing happens if your hand is empty. But if you have any cards in hand, you must discard one. If you discard a nonred card, Chandra doesn’t deal any damage."
+          "text": "As the first ability resolves, nothing happens if your hand is empty. But if you have any cards in hand, you must discard one. If you discard a nonred card, Chandra doesn't deal any damage."
         },
         {
           "date": "2009-10-01",
-          "text": "If the creature targeted by the first ability is an illegal target by the time it resolves, the entire ability is countered. You won’t discard a card."
+          "text": "If the creature targeted by the first ability is an illegal target by the time it resolves, the entire ability is countered. You won't discard a card."
         },
         {
           "date": "2009-10-01",
-          "text": "You may activate Chandra’s second ability even if your hand is empty. As it resolves, a player whose hand is empty simply draws three cards."
+          "text": "You may activate Chandra's second ability even if your hand is empty. As it resolves, a player whose hand is empty simply draws three cards."
         },
         {
           "date": "2009-10-01",
-          "text": "You cast red instant cards and red sorcery cards from your graveyard as part of the resolution of Chandra Ablaze’s third ability. You don’t choose which ones to cast until you’re actually doing so as the ability resolves. You cast only the ones you want to, and you may cast them in any order. Timing restrictions based on the card’s type (if it’s a sorcery) are ignored. Other restrictions are not (such as “Cast [this card] only during combat”). Each card you cast this way is put on the stack, then the ability finishes resolving. Those spells will then resolve as normal, one at a time, in the opposite order that they were put on the stack. They’ll go back to the graveyard as they resolve."
+          "text": "You cast red instant cards and red sorcery cards from your graveyard as part of the resolution of Chandra Ablaze's third ability. You don't choose which ones to cast until you're actually doing so as the ability resolves. You cast only the ones you want to, and you may cast them in any order. Timing restrictions based on the card's type (if it's a sorcery) are ignored. Other restrictions are not (such as \"Cast [this card] only during combat\"). Each card you cast this way is put on the stack, then the ability finishes resolving. Those spells will then resolve as normal, one at a time, in the opposite order that they were put on the stack. They'll go back to the graveyard as they resolve."
         },
         {
           "date": "2009-10-01",
-          "text": "If you cast a card “without paying its mana cost,” you can’t pay any alternative costs. You can pay additional costs, such as kicker costs."
+          "text": "If you cast a card \"without paying its mana cost,\" you can't pay any alternative costs. You can pay additional costs, such as kicker costs."
         }
       ],
       "subtypes": [
@@ -13010,15 +13014,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Once you decide to pay {2}{R}, it’s too late for anyone to respond (such as by activating a regeneration ability the targeted creature has)."
+          "text": "Once you decide to pay {2}{R}, it's too late for anyone to respond (such as by activating a regeneration ability the targeted creature has)."
         },
         {
           "date": "2009-10-01",
-          "text": "If you pay {2}{R}, the creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it’s no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
+          "text": "If you pay {2}{R}, the creature that entered the battlefield deals damage equal to its current power to the targeted creature or player. If it's no longer on the battlefield, its last known existence on the battlefield is checked to determine its power."
         },
         {
           "date": "2009-10-01",
-          "text": "Electropotence is the source of the ability, but the creature is the source of the damage. The ability couldn’t target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, lifelink, deathtouch, and wither are taken into account, even if the creature has left the battlefield by the time it deals damage."
+          "text": "Electropotence is the source of the ability, but the creature is the source of the damage. The ability couldn't target a creature with protection from red, for example. It could target a creature with protection from creatures, but all the damage would be prevented. Since damage is dealt by the creature, lifelink, deathtouch, and wither are taken into account, even if the creature has left the battlefield by the time it deals damage."
         }
       ],
       "text": "Whenever a creature enters the battlefield under your control, you may pay {2}{R}. If you do, that creature deals damage equal to its power to target creature or player.",
@@ -13117,7 +13121,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If Elemental Appeal was kicked, it creates a 7/1 token with trample and haste that gets +7/+0 until end of turn. It doesn’t create a 14/1 token. This matters in case something copies that token (the copy will be just 7/1), or in case Elemental Appeal is somehow cast during an end step (in which case the +7/+0 lasts just for that turn)."
+          "text": "If Elemental Appeal was kicked, it creates a 7/1 token with trample and haste that gets +7/+0 until end of turn. It doesn't create a 14/1 token. This matters in case something copies that token (the copy will be just 7/1), or in case Elemental Appeal is somehow cast during an end step (in which case the +7/+0 lasts just for that turn)."
         }
       ],
       "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nCreate a 7/1 red Elemental creature token with trample and haste. Exile it at the beginning of the next end step. If Elemental Appeal was kicked, that creature gets +7/+0 until end of turn.",
@@ -13219,7 +13223,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -13328,7 +13332,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Only creatures you control as Goblin Bushwhacker’s ability resolves are affected. This includes Goblin Bushwhacker itself, unless it already left the battlefield by then."
+          "text": "Only creatures you control as Goblin Bushwhacker's ability resolves are affected. This includes Goblin Bushwhacker itself, unless it already left the battlefield by then."
         }
       ],
       "subtypes": [
@@ -13845,11 +13849,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Hellfire Mongrel’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless the opponent whose turn it is has two or fewer cards in hand as his or her upkeep starts, and (2) the ability will do nothing if that player has three or more cards in hand by the time it resolves."
+          "text": "Hellfire Mongrel's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless the opponent whose turn it is has two or fewer cards in hand as his or her upkeep starts, and (2) the ability will do nothing if that player has three or more cards in hand by the time it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "In a Two-Headed Giant game, this ability will potentially trigger twice at the beginning of the opposing team’s upkeep — once for each player on that team."
+          "text": "In a Two-Headed Giant game, this ability will potentially trigger twice at the beginning of the opposing team's upkeep — once for each player on that team."
         }
       ],
       "subtypes": [
@@ -13956,7 +13960,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You decide whether to pay {5}{R}{R} as Hellkite Charger’s ability resolves."
+          "text": "You decide whether to pay {5}{R}{R} as Hellkite Charger's ability resolves."
         },
         {
           "date": "2009-10-01",
@@ -13964,7 +13968,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Hellkite Charger’s ability may trigger multiple times in the same turn, since its own ability gives it multiple chances to attack. Each time it resolves, you may create an additional combat phase."
+          "text": "Hellkite Charger's ability may trigger multiple times in the same turn, since its own ability gives it multiple chances to attack. Each time it resolves, you may create an additional combat phase."
         },
         {
           "date": "2009-10-01",
@@ -14181,11 +14185,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -14193,11 +14197,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Inferno Trap’s alternative cost condition checks for any damage, not just combat damage."
+          "text": "Inferno Trap's alternative cost condition checks for any damage, not just combat damage."
         },
         {
           "date": "2009-10-01",
-          "text": "The alternative cost condition doesn’t check who controlled the creatures that dealt damage to you. Damage dealt to you by your own creatures counts."
+          "text": "The alternative cost condition doesn't check who controlled the creatures that dealt damage to you. Damage dealt to you by your own creatures counts."
         },
         {
           "date": "2009-10-01",
@@ -14313,7 +14317,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Unlike other Allies with similar abilities, Kazuul Warlord’s ability lets you put +1/+1 counters on all your Ally creatures, not just itself."
+          "text": "Unlike other Allies with similar abilities, Kazuul Warlord's ability lets you put +1/+1 counters on all your Ally creatures, not just itself."
         }
       ],
       "subtypes": [
@@ -14418,11 +14422,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -14434,7 +14438,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "All creatures are dealt damage, not just ones controlled by the targeted lands’ controller(s)."
+          "text": "All creatures are dealt damage, not just ones controlled by the targeted lands' controller(s)."
         },
         {
           "date": "2009-10-01",
@@ -14638,7 +14642,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may target a creature you already control. You may target a creature that’s already untapped."
+          "text": "You may target a creature you already control. You may target a creature that's already untapped."
         },
         {
           "date": "2009-10-01",
@@ -14953,11 +14957,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As the reminder text indicates, whether the targeted land has the triggered ability that’s been granted to it depends only on whether it has a blaze counter on it, not on whether Obsidian Fireheart is still on the battlefield."
+          "text": "As the reminder text indicates, whether the targeted land has the triggered ability that's been granted to it depends only on whether it has a blaze counter on it, not on whether Obsidian Fireheart is still on the battlefield."
         },
         {
           "date": "2009-10-01",
-          "text": "The ability gained by the land triggers at the beginning of the upkeep of the land’s controller, not the beginning of the upkeep of Obsidian Fireheart’s controller. The player who controls the land at the time the ability triggers is the one who’s dealt damage."
+          "text": "The ability gained by the land triggers at the beginning of the upkeep of the land's controller, not the beginning of the upkeep of Obsidian Fireheart's controller. The player who controls the land at the time the ability triggers is the one who's dealt damage."
         },
         {
           "date": "2009-10-01",
@@ -14965,7 +14969,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If all blaze counters on a land are moved to a different land, the triggered ability doesn’t follow them. The first land no longer has the ability because it no longer has a blaze counter on it. The second land doesn’t have the ability because Obsidian Fireheart didn’t target it."
+          "text": "If all blaze counters on a land are moved to a different land, the triggered ability doesn't follow them. The first land no longer has the ability because it no longer has a blaze counter on it. The second land doesn't have the ability because Obsidian Fireheart didn't target it."
         },
         {
           "date": "2009-10-01",
@@ -15075,7 +15079,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -15184,7 +15188,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Punishing Fire’s triggered ability triggers only if it’s already in your graveyard at the time an opponent gains life. For example, you can cast it in response to a spell or ability that will cause an opponent to gain life. In that case, Punishing Fire will resolve first, so it will be in the graveyard by the time the opponent gains life. However, if you wait until an opponent actually gains life and then cast Punishing Fire, you won’t be able to return it to your hand at that time."
+          "text": "Punishing Fire's triggered ability triggers only if it's already in your graveyard at the time an opponent gains life. For example, you can cast it in response to a spell or ability that will cause an opponent to gain life. In that case, Punishing Fire will resolve first, so it will be in the graveyard by the time the opponent gains life. However, if you wait until an opponent actually gains life and then cast Punishing Fire, you won't be able to return it to your hand at that time."
         },
         {
           "date": "2009-10-01",
@@ -15192,7 +15196,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If Punishing Fire has left your graveyard by the time its triggered ability resolves, you may still pay {R}, but you won’t return it to your hand. This is true even if Punishing Fire has left your graveyard and returned to it by the time its triggered ability resolves."
+          "text": "If Punishing Fire has left your graveyard by the time its triggered ability resolves, you may still pay {R}, but you won't return it to your hand. This is true even if Punishing Fire has left your graveyard and returned to it by the time its triggered ability resolves."
         }
       ],
       "text": "Punishing Fire deals 2 damage to target creature or player.\nWhenever an opponent gains life, you may pay {R}. If you do, return Punishing Fire from your graveyard to your hand.",
@@ -15292,47 +15296,47 @@
       "rulings": [
         {
           "date": "2017-03-14",
-          "text": "If either of Pyromancer Ascension’s abilities triggers, it will go on the stack on top of the spell that caused it to trigger. The ability will resolve first. If it’s Pyromancer Ascension’s second ability that triggered, the copy it creates will also resolve before the original spell. The copy is created even if the original spell has been countered."
+          "text": "If either of Pyromancer Ascension's abilities triggers, it will go on the stack on top of the spell that caused it to trigger. The ability will resolve first. If it's Pyromancer Ascension's second ability that triggered, the copy it creates will also resolve before the original spell. The copy is created even if the original spell has been countered."
         },
         {
           "date": "2017-03-14",
-          "text": "If Pyromancer Ascension’s first ability triggers, you’ll put a quest counter on it even if the card in your graveyard leaves your graveyard by the time the ability resolves or if the spell you cast is countered."
+          "text": "If Pyromancer Ascension's first ability triggers, you'll put a quest counter on it even if the card in your graveyard leaves your graveyard by the time the ability resolves or if the spell you cast is countered."
         },
         {
           "date": "2017-03-14",
-          "text": "If you cast an instant or sorcery spell from your graveyard (due to an ability such as flashback, for example), Pyromancer Ascension’s first ability won’t trigger unless another card with the same name is in your graveyard."
+          "text": "If you cast an instant or sorcery spell from your graveyard (due to an ability such as flashback, for example), Pyromancer Ascension's first ability won't trigger unless another card with the same name is in your graveyard."
         },
         {
           "date": "2017-03-14",
-          "text": "The second ability triggers only if Pyromancer Ascension already has two quest counters on it at the time you cast an instant or sorcery spell. This means a spell can’t cause the second counter to be put on Pyromancer Ascension and then become copied. It also means a player can’t remove Pyromancer Ascension in response to you casting an instant or sorcery spell in order to prevent the ability from triggering."
+          "text": "The second ability triggers only if Pyromancer Ascension already has two quest counters on it at the time you cast an instant or sorcery spell. This means a spell can't cause the second counter to be put on Pyromancer Ascension and then become copied. It also means a player can't remove Pyromancer Ascension in response to you casting an instant or sorcery spell in order to prevent the ability from triggering."
         },
         {
           "date": "2017-03-14",
-          "text": "Pyromancer Ascension’s second ability can copy any instant or sorcery spell, not just one with targets."
+          "text": "Pyromancer Ascension's second ability can copy any instant or sorcery spell, not just one with targets."
         },
         {
           "date": "2017-03-14",
-          "text": "The copy is created on the stack, so it’s not “cast.” Abilities that trigger when a player casts a spell won’t trigger."
+          "text": "The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger."
         },
         {
           "date": "2017-03-14",
-          "text": "The copy will have the same targets as the spell it’s copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can’t choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+          "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell that’s copied is modal (that is, it says “Choose one —” or the like), the copy will have the same mode. A different mode cannot be chosen."
+          "text": "If the spell that's copied is modal (that is, it says \"Choose one —\" or the like), the copy will have the same mode. A different mode cannot be chosen."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell that’s copied has an X whose value was determined as it was cast (like Bonfire of the Damned does), the copy will have the same value of X."
+          "text": "If the spell that's copied has an X whose value was determined as it was cast (like Bonfire of the Damned does), the copy will have the same value of X."
         },
         {
           "date": "2017-03-14",
-          "text": "If the spell has damage divided as it was cast (like Fiery Justice does), the division can’t be changed (although the targets receiving that damage still can)."
+          "text": "If the spell has damage divided as it was cast (like Fiery Justice does), the division can't be changed (although the targets receiving that damage still can)."
         },
         {
           "date": "2017-03-14",
-          "text": "You can’t choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
+          "text": "You can't choose to pay any alternative or additional costs for the copy. However, effects based on any alternative or additional costs that were paid for the original spell are copied as though those same costs were paid for the copy."
         }
       ],
       "text": "Whenever you cast an instant or sorcery spell that has the same name as a card in your graveyard, you may put a quest counter on Pyromancer Ascension.\nWhenever you cast an instant or sorcery spell while Pyromancer Ascension has two or more quest counters on it, you may copy that spell. You may choose new targets for the copy.",
@@ -15431,7 +15435,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Both of Quest for Pure Flame’s abilities interact with any kind of damage, not just combat damage."
+          "text": "Both of Quest for Pure Flame's abilities interact with any kind of damage, not just combat damage."
         },
         {
           "date": "2009-10-01",
@@ -15439,19 +15443,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell causes damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Lightning Bolt says “Lightning Bolt deals 3 damage to target creature or player.”"
+          "text": "If a spell causes damage to be dealt, that spell will always identify the source of the damage. In most cases, the source is the spell itself. For example, Lightning Bolt says \"Lightning Bolt deals 3 damage to target creature or player.\""
         },
         {
           "date": "2009-10-01",
-          "text": "If an ability causes damage to be dealt, that ability will always identify the source of the damage. The ability itself is never the source. However, the source of the ability is often the source of the damage. For example, Prodigal Pyromancer’s ability says “Prodigal Pyromancer deals 1 damage to target creature or player.”"
+          "text": "If an ability causes damage to be dealt, that ability will always identify the source of the damage. The ability itself is never the source. However, the source of the ability is often the source of the damage. For example, Prodigal Pyromancer's ability says \"Prodigal Pyromancer deals 1 damage to target creature or player.\""
         },
         {
           "date": "2009-10-01",
-          "text": "If the source of the damage is a permanent, Quest for Pure Flame checks whether you control that permanent at the time that damage is dealt. If the permanent has left the battlefield by then, its last known information is used. If the source of the damage is a spell, whether you control it is obvious. If the source of the damage is a card in some other zone (such as a cycled Jund Sojourners), Quest for Pure Flame checks whether you’re the card’s owner, rather than whether you’re its controller."
+          "text": "If the source of the damage is a permanent, Quest for Pure Flame checks whether you control that permanent at the time that damage is dealt. If the permanent has left the battlefield by then, its last known information is used. If the source of the damage is a spell, whether you control it is obvious. If the source of the damage is a card in some other zone (such as a cycled Jund Sojourners), Quest for Pure Flame checks whether you're the card's owner, rather than whether you're its controller."
         },
         {
           "date": "2009-10-01",
-          "text": "When the first ability resolves, you may put just one quest counter on Quest for Pure Flame. It doesn’t matter how much damage the source dealt."
+          "text": "When the first ability resolves, you may put just one quest counter on Quest for Pure Flame. It doesn't matter how much damage the source dealt."
         },
         {
           "date": "2009-10-01",
@@ -15463,15 +15467,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, “Prevent the next 4 damage that would be dealt to target creature or player this turn.” Suppose a spell controlled by a player who has activated Quest for Pure Fire’s second ability would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Quest for Pure Fire’s effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
+          "text": "If multiple effects modify how damage will be dealt, the player who would be dealt damage or the controller of the creature that would be dealt damage chooses the order to apply the effects. For example, Mending Hands says, \"Prevent the next 4 damage that would be dealt to target creature or player this turn.\" Suppose a spell controlled by a player who has activated Quest for Pure Fire's second ability would deal 5 damage to a player who has cast Mending Hands targeting him or herself. The player who would be dealt damage can either (a) prevent 4 damage first and then let Quest for Pure Fire's effect double the remaining 1 damage, taking 2 damage, or (b) double the damage to 10 and then prevent 4 damage, taking 6 damage."
         },
         {
           "date": "2009-10-01",
-          "text": "Combat damage that a source you control would deal to a planeswalker is not doubled. However, if a source you control would deal noncombat damage to that player, and that player chooses to apply Quest for Pure Fire’s replacement effect before applying the planeswalker redirection effect, the damage will be doubled before you choose whether to deal it to a planeswalker that player controls. (If your opponents always apply the planeswalker redirection effect first, Quest for Pure Fire’s effect will never double damage that a source you control would deal to a planeswalker.)"
+          "text": "Combat damage that a source you control would deal to a planeswalker is not doubled. However, if a source you control would deal noncombat damage to that player, and that player chooses to apply Quest for Pure Fire's replacement effect before applying the planeswalker redirection effect, the damage will be doubled before you choose whether to deal it to a planeswalker that player controls. (If your opponents always apply the planeswalker redirection effect first, Quest for Pure Fire's effect will never double damage that a source you control would deal to a planeswalker.)"
         },
         {
           "date": "2009-10-01",
-          "text": "If a spell or ability divides damage among multiple recipients (such as Arrow Volley Trap does), the damage is divided before Quest for Pure Fire’s effect doubles it. The same is true for combat damage."
+          "text": "If a spell or ability divides damage among multiple recipients (such as Arrow Volley Trap does), the damage is divided before Quest for Pure Fire's effect doubles it. The same is true for combat damage."
         },
         {
           "date": "2009-10-01",
@@ -15576,7 +15580,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Ruinous Minotaur’s ability triggers when it deals any kind of damage to an opponent, not just combat damage."
+          "text": "Ruinous Minotaur's ability triggers when it deals any kind of damage to an opponent, not just combat damage."
         },
         {
           "date": "2009-10-01",
@@ -15684,11 +15688,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -15696,7 +15700,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The player you target with Runeflare Trap doesn’t have to be the opponent that drew three or more cards this turn."
+          "text": "The player you target with Runeflare Trap doesn't have to be the opponent that drew three or more cards this turn."
         }
       ],
       "subtypes": [
@@ -15909,7 +15913,7 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"Since when did ‘AIIIEEEE!' become a negotiation tactic?\"\n—Nikou, Joraga bard",
+      "flavor": "\"Since when did 'AIIIEEEE!' become a negotiation tactic?\"\n—Nikou, Joraga bard",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -15992,7 +15996,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If a creature doesn’t have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won’t prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
+          "text": "If a creature doesn't have first strike, granting it first strike after combat damage has been dealt in the first combat damage step won't prevent it from dealing combat damage. It will still assign and deal its combat damage in the second combat damage step."
         }
       ],
       "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
@@ -16395,19 +16399,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Unstable Footing’s effect causes damage from all sources to be unpreventable, not just damage from Unstable Footing itself."
+          "text": "Unstable Footing's effect causes damage from all sources to be unpreventable, not just damage from Unstable Footing itself."
         },
         {
           "date": "2009-10-01",
-          "text": "If damage can’t be prevented, damage prevention shields don’t have any effect. If a prevention effect has an additional effect, the additional effect will still work (if possible). Spells that create prevention effects can still be cast, and abilities that create prevention effects can still be activated."
+          "text": "If damage can't be prevented, damage prevention shields don't have any effect. If a prevention effect has an additional effect, the additional effect will still work (if possible). Spells that create prevention effects can still be cast, and abilities that create prevention effects can still be activated."
         },
         {
           "date": "2009-10-01",
-          "text": "If damage can’t be prevented, static abilities that prevent damage (including protection abilities) don’t do so. If they have additional effects that don’t depend on the amount of damage prevented, those additional effects will still work. Such effects are applied only once per source of damage."
+          "text": "If damage can't be prevented, static abilities that prevent damage (including protection abilities) don't do so. If they have additional effects that don't depend on the amount of damage prevented, those additional effects will still work. Such effects are applied only once per source of damage."
         },
         {
           "date": "2009-10-01",
-          "text": "Effects that replace or redirect damage without using the word “prevent” are not affected by Unstable Footing."
+          "text": "Effects that replace or redirect damage without using the word \"prevent\" are not affected by Unstable Footing."
         },
         {
           "date": "2009-10-01",
@@ -16516,11 +16520,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Warren Instigator’s ability triggers when it deals any kind of damage to an opponent, not just combat damage."
+          "text": "Warren Instigator's ability triggers when it deals any kind of damage to an opponent, not just combat damage."
         },
         {
           "date": "2009-10-01",
-          "text": "If Warren Instigator attacks an opponent and isn’t blocked, its double strike ability will cause it to deal combat damage to that opponent twice, once during each combat damage step. Its triggered ability will thus trigger twice: Warren Instigator deals first-strike combat damage, its ability triggers and resolves, it deals regular combat damage, and its ability triggers and resolves again."
+          "text": "If Warren Instigator attacks an opponent and isn't blocked, its double strike ability will cause it to deal combat damage to that opponent twice, once during each combat damage step. Its triggered ability will thus trigger twice: Warren Instigator deals first-strike combat damage, its ability triggers and resolves, it deals regular combat damage, and its ability triggers and resolves again."
         }
       ],
       "subtypes": [
@@ -16624,7 +16628,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -16728,11 +16732,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -16842,7 +16846,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -16951,7 +16955,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If there are three or fewer cards in your library, you’ll reveal all of them."
+          "text": "If there are three or fewer cards in your library, you'll reveal all of them."
         }
       ],
       "text": "Reveal the top three cards of your library. Put all creature cards revealed this way into your hand and the rest into your graveyard.",
@@ -17054,7 +17058,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you attack with multiple creatures, Beastmaster Ascension’s first ability triggers multiple times."
+          "text": "If you attack with multiple creatures, Beastmaster Ascension's first ability triggers multiple times."
         }
       ],
       "text": "Whenever a creature you control attacks, you may put a quest counter on Beastmaster Ascension.\nAs long as Beastmaster Ascension has seven or more quest counters on it, creatures you control get +5/+5.",
@@ -17155,11 +17159,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -17167,7 +17171,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A spell or ability destroys a permanent only if that spell or ability specifically contains the word “destroy” in its text. If a spell or ability an opponent controls exiles a noncreature permanent you control, causes you to sacrifice a noncreature permanent, removes all loyalty counters from a planeswalker you control, or causes an ability you control to trigger (and then that ability destroys a permanent you control), Cobra Trap’s alternative cost condition hasn’t been met."
+          "text": "A spell or ability destroys a permanent only if that spell or ability specifically contains the word \"destroy\" in its text. If a spell or ability an opponent controls exiles a noncreature permanent you control, causes you to sacrifice a noncreature permanent, removes all loyalty counters from a planeswalker you control, or causes an ability you control to trigger (and then that ability destroys a permanent you control), Cobra Trap's alternative cost condition hasn't been met."
         }
       ],
       "subtypes": [
@@ -17370,19 +17374,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the creature targeted by the Gigantiform spell is an illegal target by the time Gigantiform resolves, the spell is countered. It won’t enter the battlefield, so you won’t get to search your library for another Gigantiform."
+          "text": "If the creature targeted by the Gigantiform spell is an illegal target by the time Gigantiform resolves, the spell is countered. It won't enter the battlefield, so you won't get to search your library for another Gigantiform."
         },
         {
           "date": "2009-10-01",
-          "text": "Gigantiform overwrites all previous effects that set the enchanted creature’s power and toughness to specific values. Other effects that set its power or toughness to specific values that start to apply after Gigantiform becomes attached to it will overwrite Gigantiform."
+          "text": "Gigantiform overwrites all previous effects that set the enchanted creature's power and toughness to specific values. Other effects that set its power or toughness to specific values that start to apply after Gigantiform becomes attached to it will overwrite Gigantiform."
         },
         {
           "date": "2009-10-01",
-          "text": "Effects that modify the enchanted creature’s power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature’s power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
+          "text": "Effects that modify the enchanted creature's power or toughness, such as the effects of Giant Growth or Glorious Anthem, will apply to it no matter when they started to take effect. The same is true for counters that change the creature's power or toughness (such as +1/+1 counters) and effects that switch its power and toughness."
         },
         {
           "date": "2009-10-01",
-          "text": "Although the Gigantiform cast as a spell targets a creature, the Gigantiform put onto the battlefield as a result of the first one’s triggered ability does not. It may be attached to a creature with shroud, for example. However, it may not be attached to a creature that couldn’t be enchanted by it, such as a creature with protection from green. You don’t choose which creature it will be attached to until it enters the battlefield. Once you choose which creature to attach it to, it’s too late for players to respond."
+          "text": "Although the Gigantiform cast as a spell targets a creature, the Gigantiform put onto the battlefield as a result of the first one's triggered ability does not. It may be attached to a creature with shroud, for example. However, it may not be attached to a creature that couldn't be enchanted by it, such as a creature with protection from green. You don't choose which creature it will be attached to until it enters the battlefield. Once you choose which creature to attach it to, it's too late for players to respond."
         }
       ],
       "subtypes": [
@@ -17490,7 +17494,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -17715,7 +17719,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can’t pay this cost more than once to get a multiple effect."
+          "text": "The sacrifice of a land is part of the cost of casting Harrow. You can't pay this cost more than once to get a multiple effect."
         },
         {
           "date": "2004-10-04",
@@ -17723,7 +17727,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
+          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
         }
       ],
       "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
@@ -17932,7 +17936,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -18038,7 +18042,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -18249,11 +18253,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may activate Nissa’s first ability even if you know you have no cards named Nissa’s Chosen in your library. You must still shuffle your library in that situation."
+          "text": "You may activate Nissa's first ability even if you know you have no cards named Nissa's Chosen in your library. You must still shuffle your library in that situation."
         },
         {
           "date": "2009-10-01",
-          "text": "You may activate Nissa’s second ability even if you control no Elves."
+          "text": "You may activate Nissa's second ability even if you control no Elves."
         }
       ],
       "subtypes": [
@@ -18462,7 +18466,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Oracle of Mul Daya doesn’t change the times when you can play a land card from the top of your library. You can play a land only during your main phase when you have priority and the stack is empty. Doing so counts as one of your land plays for the turn."
+          "text": "Oracle of Mul Daya doesn't change the times when you can play a land card from the top of your library. You can play a land only during your main phase when you have priority and the stack is empty. Doing so counts as one of your land plays for the turn."
         },
         {
           "date": "2009-10-01",
@@ -18470,11 +18474,11 @@
         },
         {
           "date": "2013-04-15",
-          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2013-04-15",
-          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
         },
         {
           "date": "2013-04-15",
@@ -18794,11 +18798,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the enchanted creature’s ability is activated, that creature is the one that will deal and be dealt damage when the ability resolves. It doesn’t matter if Predatory Urge leaves the battlefield or somehow becomes attached to another creature by that time."
+          "text": "If the enchanted creature's ability is activated, that creature is the one that will deal and be dealt damage when the ability resolves. It doesn't matter if Predatory Urge leaves the battlefield or somehow becomes attached to another creature by that time."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature leaves the battlefield (or otherwise becomes an illegal target) before the ability resolves, the ability is countered. The enchanted creature isn’t dealt damage."
+          "text": "If the targeted creature leaves the battlefield (or otherwise becomes an illegal target) before the ability resolves, the ability is countered. The enchanted creature isn't dealt damage."
         },
         {
           "date": "2009-10-01",
@@ -19002,7 +19006,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "When the first ability resolves, you may put just one quest counter on Quest for the Gemblades. It doesn’t matter how much damage the source dealt."
+          "text": "When the first ability resolves, you may put just one quest counter on Quest for the Gemblades. It doesn't matter how much damage the source dealt."
         },
         {
           "date": "2009-10-01",
@@ -19116,7 +19120,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -19536,7 +19540,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Scute Mob’s ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control five or more lands as your upkeep starts, and (2) the ability will do nothing if you control fewer than five lands by the time it resolves."
+          "text": "Scute Mob's ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control five or more lands as your upkeep starts, and (2) the ability will do nothing if you control fewer than five lands by the time it resolves."
         }
       ],
       "subtypes": [
@@ -19739,11 +19743,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You may ignore a Trap’s alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
+          "text": "You may ignore a Trap's alternative cost condition and simply cast it for its normal mana cost. This is true even if its alternative cost condition has been met."
         },
         {
           "date": "2009-10-01",
-          "text": "Casting a Trap by paying its alternative cost doesn’t change its mana cost or converted mana cost. The only difference is the cost you actually pay."
+          "text": "Casting a Trap by paying its alternative cost doesn't change its mana cost or converted mana cost. The only difference is the cost you actually pay."
         },
         {
           "date": "2009-10-01",
@@ -19751,7 +19755,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If there are seven or fewer cards in your library, you’ll look at all of them."
+          "text": "If there are seven or fewer cards in your library, you'll look at all of them."
         }
       ],
       "subtypes": [
@@ -19965,11 +19969,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Tanglesap prevents combat damage that would be dealt by all creatures without trample, regardless of whether they’re attacking or blocking."
+          "text": "Tanglesap prevents combat damage that would be dealt by all creatures without trample, regardless of whether they're attacking or blocking."
         },
         {
           "date": "2009-10-01",
-          "text": "Creatures are checked to see whether they have trample at the time they’d deal combat damage, not at the time Tanglesap resolves."
+          "text": "Creatures are checked to see whether they have trample at the time they'd deal combat damage, not at the time Tanglesap resolves."
         }
       ],
       "text": "Prevent all combat damage that would be dealt this turn by creatures without trample.",
@@ -20072,7 +20076,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Terra Stomper can be targeted by spells that try to counter it (such as Cancel). Those spells will resolve, but the part of their effect that would counter Terra Stomper won’t do anything. Any other effects those spells have will work as normal."
+          "text": "Terra Stomper can be targeted by spells that try to counter it (such as Cancel). Those spells will resolve, but the part of their effect that would counter Terra Stomper won't do anything. Any other effects those spells have will work as normal."
         }
       ],
       "subtypes": [
@@ -20187,7 +20191,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -20203,7 +20207,7 @@
         },
         {
           "date": "2015-08-25",
-          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land’s type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
+          "text": "If the ability has an additional or replacement effect that depends on the land having a certain basic land type, the ability will check that land's type as the ability resolves. If, at that time, the land that entered the battlefield is no longer on the battlefield, use its types when it left the battlefield to determine what happens."
         }
       ],
       "subtypes": [
@@ -20408,7 +20412,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -20420,19 +20424,19 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Deciding to have the targeted creature block doesn’t force you to attack with Turntimber Basilisk that turn. If Turntimber Basilisk doesn’t attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "Deciding to have the targeted creature block doesn't force you to attack with Turntimber Basilisk that turn. If Turntimber Basilisk doesn't attack, the targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2009-10-01",
-          "text": "If you choose to have the targeted creature block but that creature isn’t able to block Turntimber Basilisk (for example, because the targeted creature can block only creatures with flying), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "If you choose to have the targeted creature block but that creature isn't able to block Turntimber Basilisk (for example, because the targeted creature can block only creatures with flying), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Tapped creatures, creatures that can’t block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren’t controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Turntimber Basilisk’s landfall ability, but the requirement to block does nothing."
+          "text": "Tapped creatures, creatures that can't block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren't controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by Turntimber Basilisk's landfall ability, but the requirement to block does nothing."
         },
         {
           "date": "2009-10-01",
-          "text": "If Turntimber Basilisk’s landfall ability triggers multiple times during the same turn, you can have multiple creatures block it that turn if able."
+          "text": "If Turntimber Basilisk's landfall ability triggers multiple times during the same turn, you can have multiple creatures block it that turn if able."
         }
       ],
       "subtypes": [
@@ -20561,7 +20565,7 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"I've known true ferocity and power. Those brazen ‘planar-walkers' have no idea what wild really means.\"\n—Chadir the Navigator",
+      "flavor": "\"I've known true ferocity and power. Those brazen 'planar-walkers' have no idea what wild really means.\"\n—Chadir the Navigator",
       "foreignNames": [
         {
           "language": "Chinese Simplified",
@@ -20743,7 +20747,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "This is not the same as hexproof. If, for example, you target one of your opponent’s creatures, your opponents won’t be able to target their own creature with spells or abilities."
+          "text": "This is not the same as hexproof. If, for example, you target one of your opponent's creatures, your opponents won't be able to target their own creature with spells or abilities."
         }
       ],
       "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nTarget creature can't be the target of spells or abilities your opponents control this turn. If Vines of Vastwood was kicked, that creature gets +4/+4 until end of turn.",
@@ -20936,7 +20940,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -20944,11 +20948,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The landfall ability gives +2/+2 to the creature that’s equipped by Adventuring Gear at the time that ability resolves. It doesn’t matter what creature Adventuring Gear was attached to (if any) when it triggered. That bonus remains with that creature even if Adventuring Gear leaves the battlefield or becomes attached to a different creature later in the turn."
+          "text": "The landfall ability gives +2/+2 to the creature that's equipped by Adventuring Gear at the time that ability resolves. It doesn't matter what creature Adventuring Gear was attached to (if any) when it triggered. That bonus remains with that creature even if Adventuring Gear leaves the battlefield or becomes attached to a different creature later in the turn."
         },
         {
           "date": "2009-10-01",
-          "text": "If Adventuring Gear leaves the battlefield before its landfall ability resolves, the creature it was attached to at the time it left the battlefield gets +2/+2. If it wasn’t attached to a creature at that time, nothing gets the bonus."
+          "text": "If Adventuring Gear leaves the battlefield before its landfall ability resolves, the creature it was attached to at the time it left the battlefield gets +2/+2. If it wasn't attached to a creature at that time, nothing gets the bonus."
         }
       ],
       "subtypes": [
@@ -21044,7 +21048,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Blade of the Bloodchief’s ability triggers regardless of who controlled the creature and whose graveyard it was put into."
+          "text": "Blade of the Bloodchief's ability triggers regardless of who controlled the creature and whose graveyard it was put into."
         },
         {
           "date": "2009-10-01",
@@ -21052,15 +21056,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The creature that gets the counters is the one that’s equipped by Blade of the Bloodchief at the time the ability resolves. It doesn’t matter what creature Blade of the Bloodchief was attached to (if any) when it triggered."
+          "text": "The creature that gets the counters is the one that's equipped by Blade of the Bloodchief at the time the ability resolves. It doesn't matter what creature Blade of the Bloodchief was attached to (if any) when it triggered."
         },
         {
           "date": "2009-10-01",
-          "text": "If Blade of the Bloodchief leaves the battlefield before its triggered ability resolves, the counters are put on the creature it was attached to at the time it left the battlefield. If it wasn’t attached to a creature at that time, nothing gets the counters."
+          "text": "If Blade of the Bloodchief leaves the battlefield before its triggered ability resolves, the counters are put on the creature it was attached to at the time it left the battlefield. If it wasn't attached to a creature at that time, nothing gets the counters."
         },
         {
           "date": "2009-10-01",
-          "text": "If the equipped creature itself is put into a graveyard, Blade of the Bloodchief’s ability will trigger. However, it won’t do anything when it resolves unless a spell or ability has caused it to become attached to another creature by that time. (Remember that you may activate an equip ability only as a sorcery.)"
+          "text": "If the equipped creature itself is put into a graveyard, Blade of the Bloodchief's ability will trigger. However, it won't do anything when it resolves unless a spell or ability has caused it to become attached to another creature by that time. (Remember that you may activate an equip ability only as a sorcery.)"
         },
         {
           "date": "2009-10-01",
@@ -21165,11 +21169,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If a Blazing Torch controlled by one player somehow winds up equipping a creature a different player controls, the damage ability can’t be activated by either player. Only the creature’s controller may activate the ability — but since that player can’t sacrifice Blazing Torch (a permanent he or she doesn’t control), the ability’s cost can’t be paid."
+          "text": "If a Blazing Torch controlled by one player somehow winds up equipping a creature a different player controls, the damage ability can't be activated by either player. Only the creature's controller may activate the ability — but since that player can't sacrifice Blazing Torch (a permanent he or she doesn't control), the ability's cost can't be paid."
         },
         {
           "date": "2009-10-01",
-          "text": "The source of the damage is Blazing Torch, not the equipped creature. However, the equipped creature’s ability is what targets the creature or player. If Blazing Torch is equipped to a red creature, for example, the ability couldn’t target a creature with protection from red. It could target a creature with protection from artifacts, but all the damage would be prevented."
+          "text": "The source of the damage is Blazing Torch, not the equipped creature. However, the equipped creature's ability is what targets the creature or player. If Blazing Torch is equipped to a red creature, for example, the ability couldn't target a creature with protection from red. It could target a creature with protection from artifacts, but all the damage would be prevented."
         }
       ],
       "subtypes": [
@@ -21357,11 +21361,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you control any creatures as the triggered ability resolves, you must sacrifice one. You can’t choose to sacrifice Eldrazi Monument instead. You sacrifice the Monument only if you had no creatures to sacrifice."
+          "text": "If you control any creatures as the triggered ability resolves, you must sacrifice one. You can't choose to sacrifice Eldrazi Monument instead. You sacrifice the Monument only if you had no creatures to sacrifice."
         },
         {
           "date": "2013-07-01",
-          "text": "Lethal damage and effects that say “destroy” won’t cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it’s sacrificed, if it’s legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
+          "text": "Lethal damage and effects that say \"destroy\" won't cause a creature with indestructible to be put into the graveyard. However, a creature with indestructible can be put into the graveyard for a number of reasons. The most likely reasons are if it's sacrificed, if it's legendary and another legendary creature with the same name is controlled by the same player, or if its toughness is 0 or less."
         }
       ],
       "text": "Creatures you control get +1/+1 and have flying and indestructible.\nAt the beginning of your upkeep, sacrifice a creature. If you can't, sacrifice Eldrazi Monument.",
@@ -21454,7 +21458,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -21462,15 +21466,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Eternity Vessel’s landfall ability cares only about how many charge counters are on it, not what its controller’s life total was as it entered the battlefield. The number of charge counters may be changed by other spells and abilities."
+          "text": "Eternity Vessel's landfall ability cares only about how many charge counters are on it, not what its controller's life total was as it entered the battlefield. The number of charge counters may be changed by other spells and abilities."
         },
         {
           "date": "2009-10-01",
-          "text": "For your life total to become the number of charge counters on Eternity Vessel, you actually gain or lose the necessary amount of life. For example, if your life total is 4 when Eternity Vessel’s landfall ability resolves and Eternity Vessel has 12 charge counters on it, the ability will cause you to gain 8 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
+          "text": "For your life total to become the number of charge counters on Eternity Vessel, you actually gain or lose the necessary amount of life. For example, if your life total is 4 when Eternity Vessel's landfall ability resolves and Eternity Vessel has 12 charge counters on it, the ability will cause you to gain 8 life. Other cards that interact with life gain or life loss will interact with this effect accordingly."
         },
         {
           "date": "2010-06-15",
-          "text": "In a Two-Headed Giant game, your life total is the same as your team’s life total, so Eternity Vessel enters the battlefield with a number of charge counters on it equal to your team’s life total. When its landfall ability resolves, it causes its controller to lose or gain the appropriate amount of life, and the team’s life total is adjusted by the amount of life the player gains or loses as a result of this ability. Suppose Eternity Vessel has 15 charge counters on it when its landfall ability resolves, and its controller’s team has 11 life. That player’s life total is 11, which becomes 15, for a net gain of 4 life. The team’s life total becomes 15."
+          "text": "In a Two-Headed Giant game, your life total is the same as your team's life total, so Eternity Vessel enters the battlefield with a number of charge counters on it equal to your team's life total. When its landfall ability resolves, it causes its controller to lose or gain the appropriate amount of life, and the team's life total is adjusted by the amount of life the player gains or loses as a result of this ability. Suppose Eternity Vessel has 15 charge counters on it when its landfall ability resolves, and its controller's team has 11 life. That player's life total is 11, which becomes 15, for a net gain of 4 life. The team's life total becomes 15."
         }
       ],
       "text": "Eternity Vessel enters the battlefield with X charge counters on it, where X is your life total.\nLandfall — Whenever a land enters the battlefield under your control, you may have your life total become the number of charge counters on Eternity Vessel.",
@@ -21755,15 +21759,15 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If you choose to have the targeted creature block, the creature it must block is the one that was equipped by Grappling Hook at the time the ability triggered. It doesn’t matter if Grappling Hook leaves the battlefield or somehow becomes attached to another creature."
+          "text": "If you choose to have the targeted creature block, the creature it must block is the one that was equipped by Grappling Hook at the time the ability triggered. It doesn't matter if Grappling Hook leaves the battlefield or somehow becomes attached to another creature."
         },
         {
           "date": "2009-10-01",
-          "text": "If you choose to have the targeted creature block the creature that was equipped with Grappling Hook, but it isn’t able to do so as blockers are declared (for example, because the attacking creature has flying and the targeted creature doesn’t), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
+          "text": "If you choose to have the targeted creature block the creature that was equipped with Grappling Hook, but it isn't able to do so as blockers are declared (for example, because the attacking creature has flying and the targeted creature doesn't), the requirement to block does nothing. The targeted creature is free to block whichever creature its controller chooses, or block no creatures at all."
         },
         {
           "date": "2009-10-01",
-          "text": "Tapped creatures, creatures that can’t block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren’t controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by the ability, but the requirement to block does nothing."
+          "text": "Tapped creatures, creatures that can't block as the result of an effect, creatures with unpaid costs to block (such as those from War Cadence), and creatures that aren't controlled by the defending player are exempt from effects that would require them to block. Such creatures can be targeted by the ability, but the requirement to block does nothing."
         }
       ],
       "subtypes": [
@@ -21861,7 +21865,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad’s ability, for example)."
+          "text": "The landfall ability triggers whenever a land enters the battlefield under your control for any reason. It triggers whenever you play a land, as well as whenever a spell or ability (such as Rampant Growth) causes you to put a land onto the battlefield under your control. It will even trigger when a spell or ability causes another player to put a land onto the battlefield under your control (as can happen with Yavimaya Dryad's ability, for example)."
         },
         {
           "date": "2009-10-01",
@@ -21964,7 +21968,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If you don’t control any lands by the time Khalni Gem’s triggered ability resolves, nothing happens. If you control just one, you’ll have to return it to its owner’s hand. Khalni Gem isn’t affected in either case."
+          "text": "If you don't control any lands by the time Khalni Gem's triggered ability resolves, nothing happens. If you control just one, you'll have to return it to its owner's hand. Khalni Gem isn't affected in either case."
         }
       ],
       "text": "When Khalni Gem enters the battlefield, return two lands you control to their owner's hand.\n{T}: Add two mana of any one color to your mana pool.",
@@ -22700,7 +22704,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Emeria, the Sky Ruin’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless you control seven or more Plains as your upkeep starts, and (2) the ability will do nothing if you control fewer than seven Plains by the time it resolves."
+          "text": "Emeria, the Sky Ruin's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless you control seven or more Plains as your upkeep starts, and (2) the ability will do nothing if you control fewer than seven Plains by the time it resolves."
         }
       ],
       "text": "Emeria, the Sky Ruin enters the battlefield tapped.\nAt the beginning of your upkeep, if you control seven or more Plains, you may return target creature card from your graveyard to the battlefield.\n{T}: Add {W} to your mana pool.",
@@ -23166,19 +23170,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "As Magosi’s third ability resolves, you’ll skip your next turn even if you don’t put an eon counter on Magosi (because it’s left the battlefield by then, perhaps)."
+          "text": "As Magosi's third ability resolves, you'll skip your next turn even if you don't put an eon counter on Magosi (because it's left the battlefield by then, perhaps)."
         },
         {
           "date": "2009-10-01",
-          "text": "You can activate Magosi’s fourth ability only if it has an eon counter on it."
+          "text": "You can activate Magosi's fourth ability only if it has an eon counter on it."
         },
         {
           "date": "2009-10-01",
-          "text": "You return Magosi to its owner’s hand as part of the cost to activate its fourth ability. If Magosi has more than one eon counter on it, you can’t activate the ability, untap it, then activate it again."
+          "text": "You return Magosi to its owner's hand as part of the cost to activate its fourth ability. If Magosi has more than one eon counter on it, you can't activate the ability, untap it, then activate it again."
         },
         {
           "date": "2009-10-01",
-          "text": "If you somehow activate Magosi’s third and fourth abilities during the same turn, the effects will cancel each other out. The turn you skip is the next one you would take, which is the turn created by Magosi’s fourth ability. It doesn’t matter in which order the abilities resolved."
+          "text": "If you somehow activate Magosi's third and fourth abilities during the same turn, the effects will cancel each other out. The turn you skip is the next one you would take, which is the turn created by Magosi's fourth ability. It doesn't matter in which order the abilities resolved."
         },
         {
           "date": "2009-10-01",
@@ -23453,11 +23457,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Oran-Rief’s third ability cares about permanents’ characteristics at the time the ability resolves, not their characteristics at the time they entered the battlefield. For example, if a blue creature enters the battlefield, then is turned green by a spell or ability, then Oran-Rief’s second ability resolves, you’ll put a +1/+1 counter on that creature."
+          "text": "Oran-Rief's third ability cares about permanents' characteristics at the time the ability resolves, not their characteristics at the time they entered the battlefield. For example, if a blue creature enters the battlefield, then is turned green by a spell or ability, then Oran-Rief's second ability resolves, you'll put a +1/+1 counter on that creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Oran-Rief’s second ability affects all permanents that are green creatures that entered the battlefield this turn, not just the ones you control."
+          "text": "Oran-Rief's second ability affects all permanents that are green creatures that entered the battlefield this turn, not just the ones you control."
         }
       ],
       "text": "Oran-Rief, the Vastwood enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{T}: Put a +1/+1 counter on each green creature that entered the battlefield this turn.",
@@ -24087,15 +24091,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Valakut, the Molten Pinnacle’s triggered ability has an “intervening ‘if’ clause.” That means (1) the ability won’t trigger at all unless, at the time a Mountain enters the battlefield under your control, you control five or more Mountains other than that new one, and (2) the ability will do nothing if you control fewer than five Mountains other than that new one by the time it resolves."
+          "text": "Valakut, the Molten Pinnacle's triggered ability has an \"intervening 'if' clause.\" That means (1) the ability won't trigger at all unless, at the time a Mountain enters the battlefield under your control, you control five or more Mountains other than that new one, and (2) the ability will do nothing if you control fewer than five Mountains other than that new one by the time it resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "If a Mountain you control leaves the battlefield between the time Valakut’s second ability triggers and the time it resolves, be aware if that was the Mountain that caused Valakut’s ability to trigger or not. If it was, Valakut’s count isn’t affected; if it wasn’t, Valakut’s count goes down by one."
+          "text": "If a Mountain you control leaves the battlefield between the time Valakut's second ability triggers and the time it resolves, be aware if that was the Mountain that caused Valakut's ability to trigger or not. If it was, Valakut's count isn't affected; if it wasn't, Valakut's count goes down by one."
         },
         {
           "date": "2009-10-01",
-          "text": "If multiple Mountains enter the battlefield under your control at the same time, Valakut’s second ability could trigger that many times. Each ability takes into consideration the other Mountains that entered the battlefield at the same time as the one that caused it to trigger."
+          "text": "If multiple Mountains enter the battlefield under your control at the same time, Valakut's second ability could trigger that many times. Each ability takes into consideration the other Mountains that entered the battlefield at the same time as the one that caused it to trigger."
         },
         {
           "date": "2009-10-01",
@@ -33532,47 +33536,47 @@
         {
           "language": "Italian",
           "name": "Montagna",
-          "multiverseid": 207131
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207132
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
           "multiverseid": 207133
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207134
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202989
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207135
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202990
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207136
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202991
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207137
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202992
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207138
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202993
         },
         {
-          "language": "Japanese",
-          "name": "山",
-          "multiverseid": 207217
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202994
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202995
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202996
         }
       ],
       "id": "a4264823cd3b30a549f4fa74e6d2f50fc3854d7e",
@@ -33921,47 +33925,47 @@
         {
           "language": "Italian",
           "name": "Montagna",
-          "multiverseid": 207131
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207132
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
           "multiverseid": 207133
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207134
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202989
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207135
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202990
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207136
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202991
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207137
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202992
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207138
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202993
         },
         {
-          "language": "Japanese",
-          "name": "山",
-          "multiverseid": 207217
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202994
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202995
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202996
         }
       ],
       "id": "780f9d1c16449046f3cd26113f6864f07998b9ee",
@@ -34310,47 +34314,47 @@
         {
           "language": "Italian",
           "name": "Montagna",
-          "multiverseid": 207131
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207132
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
           "multiverseid": 207133
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207134
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202989
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207135
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202990
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207136
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202991
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207137
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202992
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207138
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202993
         },
         {
-          "language": "Japanese",
-          "name": "山",
-          "multiverseid": 207217
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202994
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202995
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202996
         }
       ],
       "id": "2c4c62c75bb259cea8ca4aee55e07fb705e408b5",
@@ -34699,47 +34703,47 @@
         {
           "language": "Italian",
           "name": "Montagna",
-          "multiverseid": 207131
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207132
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
           "multiverseid": 207133
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207134
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202989
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207135
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202990
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207136
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202991
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207137
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202992
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207138
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202993
         },
         {
-          "language": "Japanese",
-          "name": "山",
-          "multiverseid": 207217
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202994
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202995
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202996
         }
       ],
       "id": "847466569ea0dc4d4445a71fc4c2187622171c17",
@@ -35088,47 +35092,47 @@
         {
           "language": "Italian",
           "name": "Montagna",
-          "multiverseid": 207131
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207132
-        },
-        {
-          "language": "Italian",
-          "name": "Montagna",
           "multiverseid": 207133
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207134
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202989
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207135
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202990
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207136
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202991
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207137
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202992
         },
         {
-          "language": "Italian",
-          "name": "Montagna",
-          "multiverseid": 207138
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202993
         },
         {
-          "language": "Japanese",
-          "name": "山",
-          "multiverseid": 207217
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202994
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202995
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña",
+          "multiverseid": 202996
         }
       ],
       "id": "4e83bf9073e42f9876fd92a9efba753ca093d6b2",

--- a/web/changelog.json
+++ b/web/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "3.8.8",
+    "when": "2017-07-13",
+    "changes": [
+      "Rebuild all sets",
+    ],
+    "updatedSetFiles": [
+      "all"
+    ]
+  }
+  {
     "version": "3.8.7",
     "when": "2017-07-10",
     "changes": [

--- a/web/changelog.json
+++ b/web/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "version": "3.8.8",
+    "version": "3.9",
     "when": "2017-07-13",
     "changes": [
       "Rebuild all sets",


### PR DESCRIPTION
~This PR depends on #376 and #377 for code fixes and should not be merged before those have been merged and this has been rebased.~

The major, substantive, change of this PR is the normalization of smart quotes to normal single and double quotes in card rulings and text.

Fix #378 